### PR TITLE
Show “Last Known Location” on startup (no network calls) + RestoreEntity + persisted cache

### DIFF
--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from homeassistant.components.device_tracker import SourceType, TrackerEntity
 from homeassistant.const import PERCENTAGE
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .coordinator import GoogleFindMyCoordinator
@@ -33,7 +34,7 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity):
+class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity, RestoreEntity):
     """Representation of a Google Find My Device tracker."""
 
     def __init__(
@@ -53,7 +54,44 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity):
         self._attr_battery_level = None
         self._attr_battery_unit = PERCENTAGE
         # Track last good accuracy location for database writes
-        self._last_good_accuracy_data = None
+        self._last_good_accuracy_data: Optional[dict[str, Any]] = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and seed last-known cache on startup."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if not last_state:
+            return
+
+        lat = last_state.attributes.get("latitude")
+        lon = last_state.attributes.get("longitude")
+        acc = last_state.attributes.get("gps_accuracy")
+        if lat is not None and lon is not None:
+            data = {
+                "latitude": lat,
+                "longitude": lon,
+                "accuracy": acc,
+                "last_seen": None,
+                "last_updated": None,
+            }
+            try:
+                # Seed coordinator's last-known cache so we can render immediately
+                self.coordinator.set_last_known(self._device["id"], data, source="restore")
+                self.async_write_ha_state()
+            except Exception:  # defensive: never break startup on restore
+                pass
+
+    def _live_device_data(self) -> Optional[dict[str, Any]]:
+        """Get current live device data from coordinator (current session)."""
+        return self.coordinator._device_location_data.get(self._device["id"])
+
+    def _last_known_data(self) -> Optional[dict[str, Any]]:
+        """Get last-known (persisted) data from coordinator (across restarts)."""
+        return self.coordinator.get_last_known(self._device["id"])
+
+    def _data_for_read(self) -> Optional[dict[str, Any]]:
+        """Choose best-available data for readout/order: last-good > live > last-known."""
+        return self._last_good_accuracy_data or self._live_device_data() or self._last_known_data()
 
     @property
     def device_info(self) -> dict[str, Any]:
@@ -108,64 +146,44 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity):
         }
 
     @property
-    def _current_device_data(self) -> dict[str, Any] | None:
-        """Get current device data from coordinator's location cache."""
-        # Use cached location data which persists even when polling fails
-        return self.coordinator._device_location_data.get(self._device["id"])
-
-
-    @property
     def available(self) -> bool:
         """Return True if entity has valid location data."""
-        # Stay available as long as we have coordinates, even if they're old
-        device_data = self._current_device_data
-        if device_data:
-            lat = device_data.get("latitude")
-            lon = device_data.get("longitude")
-            semantic_name = device_data.get("semantic_name")
-            _LOGGER.debug(f"Device {self._device['name']} availability check: lat={lat}, lon={lon}, semantic_name={semantic_name}")
-            # Available if we have both coordinates or a semantic location name
-            is_available = (lat is not None and lon is not None) or (semantic_name is not None)
-            _LOGGER.debug(f"Device {self._device['name']} available={is_available}")
-            return is_available
-        _LOGGER.debug(f"Device {self._device['name']} has no device_data - unavailable")
+        data = self._data_for_read()
+        if data:
+            lat = data.get("latitude")
+            lon = data.get("longitude")
+            semantic_name = data.get("semantic_name")
+            _LOGGER.debug(
+                "Device %s availability check: lat=%s, lon=%s, semantic_name=%s",
+                self._device["name"], lat, lon, semantic_name
+            )
+            return (lat is not None and lon is not None) or (semantic_name is not None)
+        _LOGGER.debug("Device %s has no device_data - unavailable", self._device["name"])
         return False
 
     @property
     def latitude(self) -> float | None:
         """Return latitude value of the device."""
-        # Return filtered data for database writes
-        data_to_use = self._last_good_accuracy_data if self._last_good_accuracy_data else self._current_device_data
-        if not data_to_use:
-            return None
-        lat = data_to_use.get("latitude")
-        return lat if lat is not None else None
+        data = self._data_for_read()
+        return data.get("latitude") if data else None
 
     @property
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
-        # Return filtered data for database writes
-        data_to_use = self._last_good_accuracy_data if self._last_good_accuracy_data else self._current_device_data
-        if not data_to_use:
-            return None
-        lon = data_to_use.get("longitude")
-        return lon if lon is not None else None
+        data = self._data_for_read()
+        return data.get("longitude") if data else None
 
     @property
     def location_accuracy(self) -> int | None:
         """Return accuracy of location."""
-        # Return filtered data for database writes
-        data_to_use = self._last_good_accuracy_data if self._last_good_accuracy_data else self._current_device_data
-        if not data_to_use:
-            return None
-        acc = data_to_use.get("accuracy")
-        return acc if acc is not None else None
+        data = self._data_for_read()
+        return data.get("accuracy") if data else None
 
     @property
     def battery_level(self) -> int | None:
         """Return battery level of the device."""
-        device_data = self._current_device_data
-        battery = device_data.get("battery_level") if device_data else None
+        data = self._data_for_read() or self._live_device_data()
+        battery = data.get("battery_level") if data else None
         # Update the attr for consistency
         self._attr_battery_level = battery
         return battery
@@ -173,15 +191,12 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def location_name(self) -> str | None:
         """Return the location name (zone or semantic location)."""
-        device_data = self._current_device_data
-        if not device_data:
+        data = self._data_for_read()
+        if not data:
             return None
-        
-        # If we have a semantic location, use it
-        semantic_name = device_data.get("semantic_name")
+        semantic_name = data.get("semantic_name")
         if semantic_name:
             return semantic_name
-        
         # Otherwise return None to let HA determine zone/home/away
         return None
     
@@ -191,33 +206,37 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
-        attributes = {}
-        device_data = self._current_device_data
-        
-        if device_data:
-            # Add all available location attributes
-            if "last_seen" in device_data and device_data["last_seen"] is not None:
+        attributes: dict[str, Any] = {}
+        data = self._data_for_read()
+
+        if data:
+            # last_seen (epoch seconds) → ISO8601
+            if "last_seen" in data and data["last_seen"] is not None:
                 import datetime
-                attributes["last_seen"] = datetime.datetime.fromtimestamp(device_data["last_seen"]).isoformat()
-            
-            # Don't duplicate battery_level since it's a primary attribute
-            # It will be shown in the UI automatically
-            
-            if "altitude" in device_data and device_data["altitude"] is not None:
-                attributes["altitude"] = device_data["altitude"]
-            
-            if "status" in device_data and device_data["status"] is not None:
-                attributes["device_status"] = device_data["status"]
-            
-            if "is_own_report" in device_data and device_data["is_own_report"] is not None:
-                attributes["is_own_report"] = device_data["is_own_report"]
-            
-            if "semantic_name" in device_data and device_data["semantic_name"] is not None:
-                attributes["semantic_location"] = device_data["semantic_name"]
-            
-            # Add polling status info
-            attributes["polling_status"] = device_data.get("status", "Unknown")
-        
+                try:
+                    attributes["last_seen"] = datetime.datetime.fromtimestamp(float(data["last_seen"])).isoformat()
+                except Exception:
+                    attributes["last_seen"] = data["last_seen"]
+
+            if "altitude" in data and data["altitude"] is not None:
+                attributes["altitude"] = data["altitude"]
+
+            if "status" in data and data["status"] is not None:
+                attributes["device_status"] = data["status"]
+
+            if "is_own_report" in data and data["is_own_report"] is not None:
+                attributes["is_own_report"] = data["is_own_report"]
+
+            if "semantic_name" in data and data["semantic_name"] is not None:
+                attributes["semantic_location"] = data["semantic_name"]
+
+            # Persisted source marker (poll | restore | store)
+            if "source" in data:
+                attributes["gfm_source"] = data["source"]
+
+            # Polling status info (fallback for UI)
+            attributes["polling_status"] = data.get("status", "Unknown")
+
         return attributes
 
     def _get_map_token(self) -> str:
@@ -249,8 +268,8 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity):
         config_data = self.hass.data[DOMAIN].get("config_data", {})
         min_accuracy_threshold = config_data.get("min_accuracy_threshold", 0)
 
-        # Get current device data
-        device_data = self._current_device_data
+        # Prefer live data for evaluating "last good" accuracy
+        device_data = self._live_device_data() or self._last_known_data()
 
         if device_data and min_accuracy_threshold > 0:
             accuracy = device_data.get("accuracy")
@@ -270,11 +289,18 @@ class GoogleFindMyDeviceTracker(CoordinatorEntity, TrackerEntity):
                         "battery_level": device_data.get("battery_level"),
                         "status": device_data.get("status"),
                         "is_own_report": device_data.get("is_own_report"),
-                        "semantic_name": device_data.get("semantic_name")
+                        "semantic_name": device_data.get("semantic_name"),
+                        "source": device_data.get("source"),
                     }
-                    _LOGGER.debug(f"Updated last good accuracy data for {self._device['name']}: accuracy={accuracy}m")
+                    _LOGGER.debug(
+                        "Updated last good accuracy data for %s: accuracy=%sm",
+                        self._device["name"], accuracy
+                    )
                 else:
-                    _LOGGER.info(f"Keeping previous good data for {self._device['name']}: current accuracy={accuracy}m > threshold={min_accuracy_threshold}m")
+                    _LOGGER.info(
+                        "Keeping previous good data for %s: current accuracy=%sm > threshold=%sm",
+                        self._device["name"], accuracy, min_accuracy_threshold
+                    )
         elif device_data:
             # No filtering or no accuracy data - use current data
             self._last_good_accuracy_data = device_data

--- a/custom_components/googlefindmy/storage.py
+++ b/custom_components/googlefindmy/storage.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+from homeassistant.helpers.storage import Store
+
+_KEY = "googlefindmy_last_known"
+_VERSION = 1
+
+
+class LastKnownStore:
+    """Tiny JSON store for last known coordinates per device (HA .storage/)."""
+
+    def __init__(self, hass) -> None:
+        self._store = Store(hass, _VERSION, _KEY)
+
+    async def async_load(self) -> Dict[str, Dict[str, Any]]:
+        data = await self._store.async_load()
+        return data or {}
+
+    async def async_save(self, mapping: Dict[str, Dict[str, Any]]) -> None:
+        await self._store.async_save(mapping)


### PR DESCRIPTION
### Summary (Why)

On Home Assistant startup, entities were *unavailable* until the first scheduled poll. Forcing a poll during setup slows boot and risks hitting Google quotas after repeated restarts. This PR makes device trackers useful **immediately after restart** by restoring and displaying the **last known coordinates** without any startup network calls.

### What’s in this PR

**Core feature**

* **Persisted last-known coordinates** in HA’s `.storage/` via `helpers.storage.Store` (async, non-blocking).
* **RestoreEntity** for device trackers to restore previous state and seed the cache.
* **Coordinator fallback chain**: live data → persisted last-known → current HA state (no DB queries).
* Debounced persistence (5s) to reduce write-amplification.

**Files changed**

* `custom_components/googlefindmy/storage.py` (new): `LastKnownStore` (async load/save JSON map `{device_id: {latitude, longitude, accuracy, last_seen, last_updated}}`).
* `custom_components/googlefindmy/__init__.py`: load `LastKnownStore` during `async_setup_entry` (no network), keep existing comments/logic intact.
* `custom_components/googlefindmy/coordinator.py`:

  * `last_known_locations` cache + `set_last_known()`, `get_last_known()`, `_async_flush_last_known_store()`.
  * Update last-known on each successful poll, fall back to it when building entity data.
  * No startup poll; first network cycle follows the regular schedule.
* `custom_components/googlefindmy/device_tracker.py`:

  * Add `RestoreEntity`; on `async_added_to_hass`, restore last state and seed coordinator cache (`source="restore"`).
  * Centralized data selection (`last-good accuracy › live › last-known`).
  * Extra attribute `gfm_source` for transparency (“poll” | “restore” | “store”).
* (Preexisting compatibility) Works with the previously patched `NovaApi/nova_request.py`.

### How it works

1. On setup, we **only** load a small JSON file from `.storage/` (no I/O on network).
2. Entities render coordinates immediately from **persisted** or **restored** state.
3. The first real poll happens on the **normal coordinator interval**, updating both live data and the persisted cache.

### Performance & Quotas

* **Zero startup network calls.**
* Debounced `.storage` writes to avoid churn.
* Unchanged poll cadence, so no new risk to Google quotas.

### Security & Privacy

* Store contains **only coordinates/accuracy/timestamps**; no secrets/tokens.
* Uses HA’s native storage API with versioning.

### Backwards compatibility

* No breaking changes.
* Entities keep the same unique_ids and behavior once live data arrives.

### Testing checklist

* [ ] Restart HA → trackers show coordinates immediately, status “Last known (cached)” or “restore”.
* [ ] Wait for the normal poll interval → trackers update from live data; cache flushes to `.storage`.
* [ ] Confirm no startup network call is triggered and boot time stays fast.
* [ ] Verify UI attributes: `gps_accuracy`, `device_status`, `gfm_source`.
* [ ] Error paths: if no cache exists, entities remain stable and update after first poll.

### Follow-ups (optional but recommended)

* **Repository config (HACS)**

  * Enable **Issues** and add repository **topics** (e.g., `home-assistant`, `integration`, `find-my-device`).
  * Fix `hacs.json`: remove unsupported keys (`domains`, `iot_class`), keep allowed fields (`name`, `content_in_root`, `render_readme`, `homeassistant`).
  * Fix `manifest.json`: remove unsupported `icon` key; if components like `http`/`recorder` are used, declare them in `dependencies` or `after_dependencies`.

**Docs note:** Add a short “What you’ll see on startup” section explaining that devices may initially show the last known position until the first poll.

**References:**

* Home Assistant Developers (2022). *Storage helper (`helpers.storage.Store`)*, HA Developer Docs (accessed 27 Sep 2025).
