### PR TITLE
Feat/storage - Persist last-known device locations, safer cloud/local URL detection, and non-blocking token flow

### DIFF
--- a/custom_components/googlefindmy/storage.py
+++ b/custom_components/googlefindmy/storage.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+from homeassistant.helpers.storage import Store
+
+_KEY = "googlefindmy_last_known"
+_VERSION = 1
+
+
+class LastKnownStore:
+    """Tiny JSON store for last known coordinates per device (HA .storage/)."""
+
+    def __init__(self, hass) -> None:
+        self._store = Store(hass, _VERSION, _KEY)
+
+    async def async_load(self) -> Dict[str, Dict[str, Any]]:
+        data = await self._store.async_load()
+        return data or {}
+
+    async def async_save(self, mapping: Dict[str, Dict[str, Any]]) -> None:
+        await self._store.async_save(mapping)

--- a/storage.py
+++ b/storage.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Dict, Any
+from homeassistant.helpers.storage import Store
+
+_KEY = "googlefindmy_last_known"
+_VERSION = 1
+
+
+class LastKnownStore:
+    """Tiny JSON store for last known coordinates per device (HA .storage/)."""
+
+    def __init__(self, hass) -> None:
+        self._store = Store(hass, _VERSION, _KEY)
+
+    async def async_load(self) -> Dict[str, Dict[str, Any]]:
+        data = await self._store.async_load()
+        return data or {}
+
+    async def async_save(self, mapping: Dict[str, Dict[str, Any]]) -> None:
+        await self._store.async_save(mapping)


### PR DESCRIPTION
This PR makes the integration more resilient after restarts, a bit safer on URL detection, and friendlier to Home Assistant’s async model:

* **Persist last-known locations** so device trackers don’t go “blind” after a reboot.
* **Prefer HA’s `get_url()`** for cloud/local detection, with a clearer private-IP check.
* **Use non-blocking token generation** where possible, keeping the event loop responsive.
* **Small typing/robustness touch-ups** to help readability and maintenance.

Everything is kept **minimal and backward-compatible**. Existing behavior continues to work; the UX just gets smoother.

---

## Why this change?

* After a reboot, entities could appear without coordinates until the next poll. That’s confusing and makes dashboards look “empty.”
* URL redirects should pick the right base URL (cloud vs. local) first via HA helpers, with a safer private-IP check.
* Token retrieval previously used blocking calls in async contexts; switching to non-blocking variants improves responsiveness and aligns with HA best practices.

---

## What changes (beginner-friendly overview)

### 1) Persist last known locations (so data survives restarts)

* Add a tiny storage helper (`LastKnownStore`) that writes/reads a JSON blob in HA’s `.storage/` folder.
* On startup, the coordinator **loads** the last-known positions and seeds its in-memory cache.
* When fresh location data arrives, the coordinator **saves** it in the background.

> Effect: your device tiles can show the most recent valid coordinates immediately after HA restarts—no empty maps while waiting for the first poll.

### 2) Safer cloud/local URL detection for `map_view` redirect

* Prefer `homeassistant.helpers.network.get_url()` to decide external vs. internal URL, which is HA’s recommended path.
* Use a dedicated helper to check if a host is private/loopback/link-local (supports IPv4/IPv6); fall back to common local hostnames.
* Keep existing behavior and logging; only change what’s needed to be more robust.

> Effect: fewer chances of redirecting to the wrong host and clearer debug logs.

### 3) Non-blocking token path (async-friendly)

* Introduce/route to `async_get_adm_token` and `async_request_token` where available, so network I/O doesn’t block HA’s event loop.
* Keep legacy sync functions for compatibility when run in executors/threads.

> Effect: the integration remains responsive while fetching tokens.

### 4) Small quality-of-life items

* Explicit type annotations in a few places (`list[dict[str, Any]]`, `list[str]`, `base_url: str | None`) for readability.
* Log levels tuned where it helps (e.g., redirect URL on `DEBUG`).

---

## Detailed change list (by file)

### `custom_components/googlefindmy/storage.py` (new)

* Adds `LastKnownStore` (using HA’s `Store`) to persist a mapping of `device_id -> last known data`.

### `custom_components/googlefindmy/coordinator.py` (updated)

* `from .storage import LastKnownStore`
* `self._store = LastKnownStore(hass)` and `self.last_known_locations = {}`
* On startup, **async load** last-known positions and **seed** `_device_location_data` so entities render immediately.
* On each new valid location, **update** `last_known_locations` and **save** asynchronously (`self.hass.async_create_task(self._store.async_save(...))`).
* No behavior removed; polling, stats, and data shaping remain the same.

### `custom_components/googlefindmy/map_view.py` (updated)

* Add `_is_private_host()` using `ipaddress` to detect private/loopback/link-local.
* Prefer `get_url()`:

  * External URL when request looks like cloud access (Nabu Casa etc.).
  * Internal URL for local access.
* Only fallback to manual socket/IP detection if `get_url()` fails.
* Keep existing parameters & log messages (formatting preserved unless code required changes).

### Token flow (where present in your branch)

* `adm_token_retrieval.py`: add `async_get_adm_token()`; keep `get_adm_token()` for sync contexts.
* `token_retrieval.py`: add `async_request_token()` wrapper (`asyncio.to_thread`) around `gpsoauth` to avoid blocking.
* `NovaApi/nova_request.py`: in async path, use the non-blocking token helpers where available. Retries preserved; logging clarified slightly.

---

## Behavior before vs. after

* **Before:** After restart, trackers could show no coords until the next poll finishes.

* **After:** Trackers start with the last known coords, then refresh as usual.

* **Before:** Redirect URL logic could be inconsistent across setups.

* **After:** URL selection is centered on HA’s own `get_url()` with safer fallbacks.

* **Before:** Token fetching could block in async contexts.

* **After:** Async wrappers prevent blocking the event loop.

---

## Backward compatibility

* No config changes required.
* Existing services, entities, and options continue to work.
* Storage uses a new internal key; no migration needed.

---

## Security & privacy

* Stored data is the same location info we already expose to HA; now it’s persisted in HA’s `.storage` (standard practice).
* Redirect token behavior unchanged.
* Cloud/local URL detection is stricter and uses HA helpers first.

> Tip: As always, **keep HA secrets and `.storage` private**.

---

## Testing guide (quick)

1. **Cold restart test**

   * Start HA with some known device locations.
   * Restart HA.
   * Confirm trackers still show the last known coordinates immediately, then update after the next poll.

2. **Map redirect test**

   * Access the map from both local network and via Nabu Casa (if available).
   * Confirm redirection uses the expected base URL.
   * Enable `logger: default: debug` and check that redirect info shows on DEBUG level.

3. **Async token test** (optional)

   * In a dev instance, trigger flows that require fresh ADM tokens.
   * Confirm logs show the async path and HA stays responsive.

---

## Implementation notes (for beginners)

* **Why a store?** HA’s `Store` writes JSON inside `.storage/`. It’s a safe, built-in way to keep small amounts of state.
* **Why not write in entities?** Entities derive their state from the coordinator. Persisting at the coordinator level lets *all* entities see the last known values as soon as HA restarts—no code changes in each entity class.
* **Why prefer `get_url()`?** Home Assistant tracks the right external/internal URLs (including Nabu Casa). Using it reduces guesswork.

---

## Future ideas (out of scope, nice to have later)

* A small UI toggle to enable/disable persistence.
* Configurable retention or “staleness” labeling in the UI.
* Optional per-device accuracy thresholds.

---

## Checklist

* [x] Minimal changes; preserve existing formatting/comments unless code required edits.
* [x] Backward compatible.
* [x] Follows HA async best practices (no blocking I/O on the event loop).
* [x] Add tests steps to reproduce and verify.
* [x] Updated logs at sensible levels.

---

*Note:* I’m a computer scientist, not a professional programmer. Parts of this were drafted with assistance from ChatGPT 5 and then manually reviewed. If anything looks off, I’m happy to adjust based on your feedback.
