### PR TITLE
Update coordinator.py - Fix Python Syntax

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -289,7 +289,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator):
                         )
                     else:
                         # Guess entity_id from name as last resort
-                        entity_id = f"device_tracker.{device_info['name'].lower().replace(' ', '_').replace(\"'\", \"\")}"
+                        entity_id = f"device_tracker.{device_info['name'].lower().replace(' ', '_').replace(\"'\", '')}"
                         _LOGGER.debug(
                             "No registry entry found, trying '%s' for device '%s'",
                             entity_id, device_info['name']
@@ -309,7 +309,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator):
                                 # Try multiple name formats
                                 entity_patterns = [
                                     entity_id,
-                                    f"device_tracker.{device_info['name'].lower().replace(' ', '_').replace(\"'\", \"\")}",
+                                    f"device_tracker.{device_info['name'].lower().replace(' ', '_').replace(\"'\", '')}",
                                     f"device_tracker.{device_info['name'].lower().replace(' ', '_')}",
                                 ]
 


### PR DESCRIPTION
Python syntax rule for f-strings: backslashes are not allowed inside the expression part (between { and }) unless they're inside a normal string literal.