### PR TITLE
Update manifest.json - Add missing dependencies

### DIFF
--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -28,5 +28,7 @@
     "undetected_chromedriver>=3.5.5",
     "selenium>=4.27.1"
   ],
-  "version": "1.5.5-1"
+  "dependencies": ["http"],
+  "after_dependencies": ["recorder"],
+  "version": "1.5.5-2"
 }


### PR DESCRIPTION
# manifest: declare `http` dependency, add `after_dependencies=recorder`, bump version

## Why

Hassfest failed with:

* **Using component `http` but it's not in `dependencies` or `after_dependencies`**
* **Using component `recorder` but it's not in `dependencies` or `after_dependencies`**

**Background.**

* `dependencies` ensures other HA integrations are set up **before** ours; use it for required integrations (e.g. `http` if we register HTTP views). `after_dependencies` is for optional-but-used integrations (e.g. `recorder`). ([developers.home-assistant.io][1])

## What changed

* **Add** `"dependencies": ["http"]`
* **Add** `"after_dependencies": ["recorder"]` *(only used for startup ordering; does not force user configuration)*
* **Bump version** (e.g., `1.5.5-2`) to reflect manifest changes

No functional behavior changes beyond correct **startup ordering** and **passing hassfest**.