### PR TITLE
Handle invalid AAS tokens during ADM/SPOT refresh

### DIFF
--- a/custom_components/googlefindmy/Auth/adm_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/adm_token_retrieval.py
@@ -51,7 +51,7 @@ from typing import Any, Awaitable, Callable, Optional
 import gpsoauth
 
 # Prefer relative imports inside the package for robustness
-from .token_retrieval import async_request_token
+from .token_retrieval import async_request_token, InvalidAasTokenError
 from .token_cache import (
     TokenCache,
     async_get_cached_value,
@@ -109,6 +109,8 @@ def _normalize_service(service: str) -> str:
 
 def _is_non_retryable_auth(err: Exception) -> bool:
     """Return True if the error indicates a non-recoverable auth problem."""
+    if isinstance(err, InvalidAasTokenError):
+        return True
     text = _clip(err)
     # Typical shapes to consider non-retryable
     if "BadAuthentication" in text:


### PR DESCRIPTION
## Summary
- classify gpsoauth BadAuthentication responses as InvalidAasTokenError and surface them from the async token retriever
- invalidate the cached AAS token and raise NovaAuthError when ADM refresh or generation fails due to a rejected master token
- clear cached AAS tokens during SPOT token selection and treat repeated failures as permanent auth errors

## Testing
- pytest *(fails: missing `homeassistant` dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3a19308e483299e1f3a8a3b981e77