### PR TITLE
Document auth failure propagation guidance

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -43,6 +43,12 @@ running decryption in an executor without the surrounding context will cause mul
 Handle `StaleOwnerKeyError` from the decryptor by logging and skipping the update instead of crashing the pipeline so key
 rotation can proceed without interrupting other accounts.
 
+### Authentication failure propagation
+
+When a location decrypt/FCM callback encounters `SpotApiEmptyResponseError`, store the exception on the callback context and
+re-raise it after the waiter resumes so the coordinator can translate it into `ConfigEntryAuthFailed`. This keeps invalid
+sessions flowing into Home Assistant's reauthentication UI instead of being swallowed in background threads.
+
 ### Import deferral reminder
 
 Heavyweight runtime dependencies (for example, browser drivers such as `undetected_chromedriver`) must be imported lazily inside


### PR DESCRIPTION
## Summary
- document how SpotApiEmptyResponseError should be bubbled up through the Nova callback and coordinator

## Testing
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest --cov -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc439308c8329b104d34bca1f5eb2)