### PR TITLE
Add hybrid low-accuracy polling regression test

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -43,6 +43,14 @@ running decryption in an executor without the surrounding context will cause mul
 Handle `StaleOwnerKeyError` from the decryptor by logging and skipping the update instead of crashing the pipeline so key
 rotation can proceed without interrupting other accounts.
 
+### Hybrid Low-Accuracy Polling
+
+When a poll response fails the accuracy threshold, `coordinator.py` preserves the previous coordinates and accuracy but still
+updates the new `last_seen` timestamp. This keeps map pins stable (no "jumping" to poor fixes) while reflecting that the device
+recently reported. The cold-start drop path (no cached coordinates available) strips `_report_hint` before returning; mirror that
+hint-stripping step in any new helpers that short-circuit low-quality updates so internal metadata never leaks into entity
+state.
+
 ### Authentication failure propagation
 
 When a location decrypt/FCM callback encounters `SpotApiEmptyResponseError`, store the exception on the callback context and

--- a/custom_components/googlefindmy/tests/test_coordinator_hybrid_update.py
+++ b/custom_components/googlefindmy/tests/test_coordinator_hybrid_update.py
@@ -1,0 +1,85 @@
+"""Regression test for hybrid low-accuracy polling updates."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+
+
+@pytest.mark.asyncio
+async def test_hybrid_update_preserves_cached_coordinates() -> None:
+    """Low-accuracy poll updates should reuse cached coordinates but refresh timestamps."""
+
+    now = time.time()
+    previous_timestamp = now - 1000
+    previous_latitude = 50.0
+    previous_longitude = 10.0
+    previous_accuracy = 20.0
+
+    coordinator = cast(Any, GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator))
+    coordinator._poll_lock = asyncio.Lock()
+    coordinator._is_polling = False
+    coordinator._is_fcm_ready_soft = lambda: True
+    coordinator._note_fcm_deferral = lambda *_, **__: None
+    coordinator._schedule_short_retry = lambda *_, **__: None
+    coordinator._clear_fcm_deferral = lambda *_, **__: None
+    coordinator.safe_update_metric = lambda *_, **__: None
+    coordinator._get_google_home_filter = lambda: None
+    coordinator._set_auth_state = lambda **__: None
+    coordinator._should_preserve_precise_home_coordinates = lambda *_, **__: False
+    coordinator._normalize_coords = lambda *_args, **_kwargs: True
+    coordinator._track_device_interval = lambda *_, **__: None
+    coordinator.increment_stat = lambda *_, **__: None
+    coordinator._is_significant_update = lambda *_, **__: True
+    coordinator._apply_report_type_cooldown = lambda *_, **__: None
+    coordinator.push_updated = lambda *_, **__: None
+    coordinator.async_set_updated_data = lambda *_, **__: None
+    coordinator.async_set_update_error = lambda *_, **__: None
+    coordinator._get_ignored_set = lambda: set()
+    coordinator._build_snapshot_from_cache = lambda *_args, **_kwargs: []
+    coordinator.device_poll_delay = 0
+    coordinator._fcm_defer_started_mono = 0.0
+    coordinator._last_poll_result = None
+    coordinator._last_device_list = []
+    coordinator._consecutive_timeouts = 0
+    coordinator._min_accuracy_threshold = 100
+
+    device_id = "device-1"
+    coordinator._device_location_data = {
+        device_id: {
+            "id": device_id,
+            "name": "Tracker",
+            "latitude": previous_latitude,
+            "longitude": previous_longitude,
+            "accuracy": previous_accuracy,
+            "last_seen": previous_timestamp,
+        }
+    }
+
+    coordinator.api = SimpleNamespace(
+        async_get_device_location=AsyncMock(
+            return_value={
+                "id": device_id,
+                "name": "Tracker",
+                "latitude": 51.0,
+                "longitude": 11.0,
+                "accuracy": 5000.0,
+                "last_seen": now,
+            }
+        )
+    )
+
+    await coordinator._async_start_poll_cycle([{"id": device_id, "name": "Tracker"}])
+
+    updated = coordinator._device_location_data[device_id]
+    assert updated["latitude"] == previous_latitude
+    assert updated["longitude"] == previous_longitude
+    assert updated.get("accuracy") == previous_accuracy
+    assert updated["last_seen"] == pytest.approx(now)


### PR DESCRIPTION
## Summary
- add regression coverage for the hybrid low-accuracy poll path to ensure cached coordinates persist while timestamps refresh
- document the hybrid low-accuracy polling behavior and hint-stripping expectation for future contributors

## Testing
- python -m ruff check --fix .
- python -m mypy --strict custom_components/googlefindmy
- python -m pytest --cov=custom_components/googlefindmy --cov-report=term-missing -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e0b12981883298a359763ec18bef3)