### PR TITLE
Handle legacy FCM receiver providers gracefully

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -101,13 +101,22 @@ def _import_eid_info_module() -> ModuleType:
     )
 
 
-_fcm_receiver_state: dict[str, Callable[[], FcmReceiverProtocol] | None] = {
+_fcm_receiver_state: dict[
+    str, Callable[[str | None], FcmReceiverProtocol] | Callable[[], FcmReceiverProtocol] | None
+] = {
     "getter": None
 }
-_FCM_ReceiverGetter: Callable[[], FcmReceiverProtocol] | None = None
+_FCM_ReceiverGetter: (
+    Callable[[str | None], FcmReceiverProtocol]
+    | Callable[[], FcmReceiverProtocol]
+    | None
+) = None
 
 
-def register_fcm_receiver_provider(getter: Callable[[], FcmReceiverProtocol]) -> None:
+def register_fcm_receiver_provider(
+    getter: Callable[[str | None], FcmReceiverProtocol]
+    | Callable[[], FcmReceiverProtocol]
+) -> None:
     """Register a callable returning the long-lived FCM receiver instance.
 
     The getter must return an initialized receiver exposing:
@@ -115,7 +124,8 @@ def register_fcm_receiver_provider(getter: Callable[[], FcmReceiverProtocol]) ->
       - async_unregister_for_location_updates(device_id) -> None
 
     Args:
-        getter: A callable that returns the singleton FCM receiver instance.
+        getter: A callable that returns the singleton FCM receiver instance for
+            an optional entry_id context.
     """
     _fcm_receiver_state["getter"] = getter
 
@@ -451,7 +461,16 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
 
     if fcm_getter is None:
         raise RuntimeError("FCM receiver provider has not been registered.")
-    fcm_receiver = fcm_getter()
+    entry_id = getattr(cache, "entry_id", None) if cache else None
+    try:
+        fcm_receiver = cast(Callable[[str | None], FcmReceiverProtocol], fcm_getter)(
+            entry_id
+        )
+    except TypeError:
+        _LOGGER.debug(
+            "FCM receiver provider does not accept entry context; retrying without entry_id."
+        )
+        fcm_receiver = cast(Callable[[], FcmReceiverProtocol], fcm_getter)()
     if fcm_receiver is None:
         raise RuntimeError("FCM receiver provider returned None.")
 
@@ -471,7 +490,7 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
 
         cache_provider = _cache_provider
 
-    resolved_namespace = namespace or getattr(cache_ref, "entry_id", None)
+    resolved_namespace = namespace or entry_id
     if not resolved_namespace:
         raise MissingNamespaceError()
 

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -139,13 +139,23 @@ class CacheProtocol(Protocol):
 
 
 # Module-local FCM provider getter; installed by the integration at setup time.
-_FCM_ReceiverGetter: Callable[[], FcmReceiverProtocol] | None = None
+_FCM_ReceiverGetter: (
+    Callable[[str | None], FcmReceiverProtocol]
+    | Callable[[], FcmReceiverProtocol]
+    | None
+) = None
 
 
-def register_fcm_receiver_provider(getter: Callable[[], FcmReceiverProtocol]) -> None:
+def register_fcm_receiver_provider(
+    getter: Callable[[str | None], FcmReceiverProtocol]
+    | Callable[[], FcmReceiverProtocol],
+) -> None:
     """Register a getter that returns the shared FCM receiver (HA-managed).
 
-    The provider is a zero-arg callable that returns the current receiver instance.
+    The provider accepts an optional entry ID and returns the current receiver
+    instance for that scope. We keep this indirection to avoid importing heavy modules
+    at import time and to stay resilient to reloads (the callable resolves the live
+    object on access).
     We keep this indirection to avoid importing heavy modules at import time and
     to stay resilient to reloads (the callable resolves the live object on access).
 
@@ -631,17 +641,6 @@ class GoogleFindMyAPI:
         if _FCM_ReceiverGetter is None:
             _LOGGER.error("Cannot obtain FCM token: no provider registered.")
             return None
-        try:
-            receiver = _FCM_ReceiverGetter()
-        except Exception as err:
-            _LOGGER.error(
-                "Cannot obtain FCM token: provider callable failed",
-                exc_info=err,
-            )
-            return None
-        if receiver is None:
-            _LOGGER.error("Cannot obtain FCM token: provider returned None.")
-            return None
         entry_id: str | None
         try:
             raw_entry_id = getattr(self._cache, "entry_id", None)
@@ -651,6 +650,32 @@ class GoogleFindMyAPI:
             entry_id = raw_entry_id.strip()
         else:
             entry_id = self._namespace()
+        receiver: FcmReceiverProtocol | None
+        try:
+            receiver = cast(
+                Callable[[str | None], FcmReceiverProtocol], _FCM_ReceiverGetter
+            )(entry_id)
+        except TypeError:
+            _LOGGER.debug(
+                "FCM receiver provider does not accept entry context; retrying without entry_id."
+            )
+            try:
+                receiver = cast(Callable[[], FcmReceiverProtocol], _FCM_ReceiverGetter)()
+            except Exception as err:
+                _LOGGER.error(
+                    "Cannot obtain FCM token: provider callable failed (legacy path)",
+                    exc_info=err,
+                )
+                return None
+        except Exception as err:
+            _LOGGER.error(
+                "Cannot obtain FCM token: provider callable failed",
+                exc_info=err,
+            )
+            return None
+        if receiver is None:
+            _LOGGER.error("Cannot obtain FCM token: provider returned None.")
+            return None
         try:
             if entry_id is not None:
                 token = receiver.get_fcm_token(entry_id)
@@ -687,17 +712,6 @@ class GoogleFindMyAPI:
         if _FCM_ReceiverGetter is None:
             _LOGGER.debug("FCM readiness probe: no provider registered.")
             return None
-        try:
-            receiver = _FCM_ReceiverGetter()
-        except Exception as err:
-            _LOGGER.debug(
-                "FCM readiness probe: provider callable failed",
-                exc_info=err,
-            )
-            return None
-        if receiver is None:
-            _LOGGER.debug("FCM readiness probe: provider returned None.")
-            return None
         entry_id: str | None
         try:
             raw_entry_id = getattr(self._cache, "entry_id", None)
@@ -707,6 +721,32 @@ class GoogleFindMyAPI:
             entry_id = raw_entry_id.strip()
         else:
             entry_id = self._namespace()
+        receiver: FcmReceiverProtocol | None
+        try:
+            receiver = cast(
+                Callable[[str | None], FcmReceiverProtocol], _FCM_ReceiverGetter
+            )(entry_id)
+        except TypeError:
+            _LOGGER.debug(
+                "FCM readiness probe: provider does not accept entry context; retrying without entry_id."
+            )
+            try:
+                receiver = cast(Callable[[], FcmReceiverProtocol], _FCM_ReceiverGetter)()
+            except Exception as err:
+                _LOGGER.debug(
+                    "FCM readiness probe: provider callable failed (legacy path)",
+                    exc_info=err,
+                )
+                return None
+        except Exception as err:
+            _LOGGER.debug(
+                "FCM readiness probe: provider callable failed",
+                exc_info=err,
+            )
+            return None
+        if receiver is None:
+            _LOGGER.debug("FCM readiness probe: provider returned None.")
+            return None
         try:
             if entry_id is not None:
                 token = receiver.get_fcm_token(entry_id)
@@ -1127,8 +1167,25 @@ class GoogleFindMyAPI:
             return False
 
         # Resolve live receiver (may change across reloads)
+        entry_id: str | None
         try:
-            receiver = _FCM_ReceiverGetter()
+            raw_entry_id = getattr(self._cache, "entry_id", None)
+        except Exception:
+            raw_entry_id = None
+        if isinstance(raw_entry_id, str) and raw_entry_id.strip():
+            entry_id = raw_entry_id.strip()
+        else:
+            entry_id = self._namespace()
+
+        try:
+            receiver = cast(
+                Callable[[str | None], FcmReceiverProtocol], _FCM_ReceiverGetter
+            )(entry_id)
+        except TypeError:
+            try:
+                receiver = cast(Callable[[], FcmReceiverProtocol], _FCM_ReceiverGetter)()
+            except Exception:
+                return False
         except Exception:
             return False
         if receiver is None:


### PR DESCRIPTION
## Summary
- allow FCM receiver providers to be registered with either entry-aware or zero-argument signatures while preserving entry_id context
- add backward-compatible receiver resolution in Nova location requests and API token lookups with debug logging when falling back

## Testing
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e892ff8b08329bba95c9b81a41110)