### PR TITLE
Improve platinum compliance checks and dev tooling

### DIFF
--- a/custom_components/googlefindmy/FMDNCrypto/_ecdsa_shim.py
+++ b/custom_components/googlefindmy/FMDNCrypto/_ecdsa_shim.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol, cast
 
-import ecdsa  # type: ignore[import-untyped]
+import ecdsa
 
 
 class CurveFpProtocol(Protocol):

--- a/custom_components/googlefindmy/requirements-dev.txt
+++ b/custom_components/googlefindmy/requirements-dev.txt
@@ -14,6 +14,7 @@ pytest>=8.3
 pytest-asyncio>=0.23
 pytest-cov>=5.0
 pytest-homeassistant-custom-component>=0.13
+pyyaml>=6.0.2
 ruff>=0.14.1
 selenium>=4.25.0
 types-requests>=2.32.0.20240712

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,17 @@ module = ["homeassistant.*"]
 follow_imports = "skip"
 
 [[tool.mypy.overrides]]
+module = [
+    "bs4",
+    "Cryptodome.*",
+    "ecdsa",
+    "h2",
+    "selenium",
+    "selenium.*",
+]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["tests.test_fcm_receiver_guard"]
 ignore_errors = false
 


### PR DESCRIPTION
## Summary
- point platinum compliance tests at the repository root so mypy and evidence path checks operate on the correct tree
- add PyYAML as a development dependency and ignore missing imports for untyped external modules to keep strict mypy runs stable
- clean up the ecdsa shim import to align with the new mypy configuration

## Testing
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea20747a8832986ce47f1d5d4d5be)