### PR TITLE
Prevent owner index overrides for shared devices

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -2905,8 +2905,14 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             canonical = canonical.strip()
             if not canonical:
                 continue
-            owner_index[canonical] = entry_id
-            seen.add(canonical)
+
+            # Do not overwrite an existing routing entry from another account.
+            # Shared devices may appear under multiple entries; keep the first
+            # registration so FCM messages route to the primary owner instead
+            # of the most recently loaded account.
+            if canonical not in owner_index or owner_index[canonical] == entry_id:
+                owner_index[canonical] = entry_id
+                seen.add(canonical)
 
         if owner_index:
             stale = [


### PR DESCRIPTION
## Summary
- avoid overwriting existing owner index entries when syncing devices so shared trackers keep routing to the original account

## Testing
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea9bc42fc8329802f2e130bfb08af)