### PR TITLE
Redact ignored devices from diagnostics effective configuration

### DIFF
--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -37,8 +37,14 @@ from .const import (
     # secrets in entry.data (must never be exposed)
     CONF_OAUTH_TOKEN,
     # defaults for options (used to avoid hard-coded literals)
+    DEFAULT_DEVICE_POLL_DELAY,
     DEFAULT_ENABLE_STATS_ENTITIES,
+    DEFAULT_GOOGLE_HOME_FILTER_ENABLED,
+    DEFAULT_GOOGLE_HOME_FILTER_KEYWORDS,
+    DEFAULT_LOCATION_POLL_INTERVAL,
     DEFAULT_MAP_VIEW_TOKEN_EXPIRATION,
+    DEFAULT_MIN_ACCURACY_THRESHOLD,
+    DEFAULT_MOVEMENT_THRESHOLD,
     DOMAIN,
     OPT_DEVICE_POLL_DELAY,
     OPT_ENABLE_STATS_ENTITIES,
@@ -432,10 +438,22 @@ async def async_get_config_entry_diagnostics(
             coordinator = candidate
 
     # --- Build a compact, anonymized options snapshot (no raw strings that could contain PII) ---
-    opt = entry.options
-    ignored_raw = (
-        opt.get(OPT_IGNORED_DEVICES) or entry.data.get(OPT_IGNORED_DEVICES) or {}
-    )
+    try:
+        effective_config: dict[str, Any] = dict(entry.data)
+    except Exception:
+        effective_config = {}
+
+    if isinstance(entry.options, Mapping):
+        effective_config.update(entry.options)
+    else:  # pragma: no cover - defensive fallback
+        try:
+            effective_config.update(dict(entry.options))
+        except Exception:
+            effective_config = dict(effective_config)
+
+    ignored_raw = effective_config.get(OPT_IGNORED_DEVICES) or {}
+
+    effective_config_for_diag = dict(effective_config)
 
     # Coerce to handle legacy list[str] format gracefully
     if isinstance(ignored_raw, list):
@@ -445,30 +463,55 @@ async def async_get_config_entry_diagnostics(
     else:
         ignored_count = 0
 
+    if ignored_count:
+        effective_config_for_diag[OPT_IGNORED_DEVICES] = [REDACTED] * ignored_count
+    elif OPT_IGNORED_DEVICES in effective_config_for_diag:
+        effective_config_for_diag[OPT_IGNORED_DEVICES] = []
+
+    redacted_effective_config = async_redact_data(effective_config_for_diag, TO_REDACT)
+
     config_summary = {
         # Durations and numeric thresholds
         "location_poll_interval": _coerce_pos_int(
-            opt.get(OPT_LOCATION_POLL_INTERVAL, 300), 300
+            effective_config.get(
+                OPT_LOCATION_POLL_INTERVAL, DEFAULT_LOCATION_POLL_INTERVAL
+            ),
+            DEFAULT_LOCATION_POLL_INTERVAL,
         ),
-        "device_poll_delay": _coerce_pos_int(opt.get(OPT_DEVICE_POLL_DELAY, 5), 5),
+        "device_poll_delay": _coerce_pos_int(
+            effective_config.get(OPT_DEVICE_POLL_DELAY, DEFAULT_DEVICE_POLL_DELAY),
+            DEFAULT_DEVICE_POLL_DELAY,
+        ),
         "min_accuracy_threshold": _coerce_pos_int(
-            opt.get(OPT_MIN_ACCURACY_THRESHOLD, 100), 100
+            effective_config.get(
+                OPT_MIN_ACCURACY_THRESHOLD, DEFAULT_MIN_ACCURACY_THRESHOLD
+            ),
+            DEFAULT_MIN_ACCURACY_THRESHOLD,
         ),
-        "movement_threshold": _coerce_pos_int(opt.get(OPT_MOVEMENT_THRESHOLD, 50), 50),
+        "movement_threshold": _coerce_pos_int(
+            effective_config.get(OPT_MOVEMENT_THRESHOLD, DEFAULT_MOVEMENT_THRESHOLD),
+            DEFAULT_MOVEMENT_THRESHOLD,
+        ),
         # Feature toggles
         "google_home_filter_enabled": bool(
-            opt.get(OPT_GOOGLE_HOME_FILTER_ENABLED, False)
+            effective_config.get(
+                OPT_GOOGLE_HOME_FILTER_ENABLED, DEFAULT_GOOGLE_HOME_FILTER_ENABLED
+            )
         ),
         "enable_stats_entities": bool(
-            opt.get(OPT_ENABLE_STATS_ENTITIES, DEFAULT_ENABLE_STATS_ENTITIES)
+            effective_config.get(OPT_ENABLE_STATS_ENTITIES, DEFAULT_ENABLE_STATS_ENTITIES)
         ),
         # Token lifetime: store boolean value
         "map_view_token_expiration": bool(
-            opt.get(OPT_MAP_VIEW_TOKEN_EXPIRATION, DEFAULT_MAP_VIEW_TOKEN_EXPIRATION)
+            effective_config.get(
+                OPT_MAP_VIEW_TOKEN_EXPIRATION, DEFAULT_MAP_VIEW_TOKEN_EXPIRATION
+            )
         ),
         # Counts only (never expose strings/IDs)
         "google_home_filter_keywords_count": _count_keywords(
-            opt.get(OPT_GOOGLE_HOME_FILTER_KEYWORDS)
+            effective_config.get(
+                OPT_GOOGLE_HOME_FILTER_KEYWORDS, DEFAULT_GOOGLE_HOME_FILTER_KEYWORDS
+            )
         ),
         "ignored_devices_count": ignored_count,
     }
@@ -585,6 +628,7 @@ async def async_get_config_entry_diagnostics(
             "domain": entry.domain,
         },
         "config": config_summary,
+        "effective_config": redacted_effective_config,
         "registries": {
             "device": device_registry_counts,
             "entity": entity_registry_counts,

--- a/tests/test_diagnostics_buffer_summary.py
+++ b/tests/test_diagnostics_buffer_summary.py
@@ -9,7 +9,18 @@ from types import SimpleNamespace
 import pytest
 
 from custom_components.googlefindmy import diagnostics
-from custom_components.googlefindmy.const import DOMAIN
+from custom_components.googlefindmy.const import (
+    CONF_OAUTH_TOKEN,
+    DOMAIN,
+    OPT_DEVICE_POLL_DELAY,
+    OPT_ENABLE_STATS_ENTITIES,
+    OPT_GOOGLE_HOME_FILTER_ENABLED,
+    OPT_GOOGLE_HOME_FILTER_KEYWORDS,
+    OPT_IGNORED_DEVICES,
+    OPT_LOCATION_POLL_INTERVAL,
+    OPT_MIN_ACCURACY_THRESHOLD,
+    OPT_MOVEMENT_THRESHOLD,
+)
 from tests.helpers import drain_loop
 
 
@@ -66,12 +77,18 @@ class _StubCoordinator:
 class _StubEntry:
     """Minimal config entry stub referencing the coordinator."""
 
-    def __init__(self, coordinator: _StubCoordinator) -> None:
+    def __init__(
+        self,
+        coordinator: _StubCoordinator,
+        *,
+        data: dict[str, object] | None = None,
+        options: dict[str, object] | None = None,
+    ) -> None:
         self.entry_id = "entry-id"
         self.version = 1
         self.domain = DOMAIN
-        self.data: dict[str, object] = {}
-        self.options: dict[str, object] = {}
+        self.data = data or {}
+        self.options = options or {}
         self.runtime_data = SimpleNamespace(coordinator=coordinator)
 
 
@@ -157,3 +174,62 @@ def test_async_get_config_entry_diagnostics_includes_buffer(
     assert "device_name" not in first_error
     assert first_error["detail"].endswith("…")
     assert len(first_error["detail"]) <= 160
+
+
+def test_diagnostics_merge_entry_data_and_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Diagnostics merge entry data defaults with option overrides."""
+
+    coordinator = _StubCoordinator()
+    entry = _StubEntry(
+        coordinator,
+        data={
+            OPT_LOCATION_POLL_INTERVAL: 600,
+            OPT_DEVICE_POLL_DELAY: 10,
+            OPT_MOVEMENT_THRESHOLD: 75,
+            OPT_ENABLE_STATS_ENTITIES: True,
+            OPT_GOOGLE_HOME_FILTER_ENABLED: False,
+            OPT_GOOGLE_HOME_FILTER_KEYWORDS: "legacy",
+            OPT_IGNORED_DEVICES: ["legacy-id"],
+            OPT_MIN_ACCURACY_THRESHOLD: 123,
+            CONF_OAUTH_TOKEN: "secret-token",
+        },
+        options={
+            OPT_LOCATION_POLL_INTERVAL: "45",  # coercion
+            OPT_GOOGLE_HOME_FILTER_ENABLED: True,
+            OPT_GOOGLE_HOME_FILTER_KEYWORDS: "one, two, three",
+            OPT_IGNORED_DEVICES: {"dev1": {}, "dev2": {}},
+            OPT_ENABLE_STATS_ENTITIES: False,
+        },
+    )
+    hass = _StubHass(entry, coordinator)
+
+    async def _fake_get_integration(_hass, _domain):
+        return SimpleNamespace(name="Test Integration", version="1.2.3")
+
+    monkeypatch.setattr(diagnostics, "async_get_integration", _fake_get_integration)
+    monkeypatch.setattr(diagnostics.dr, "async_get", lambda _hass: SimpleNamespace(devices={}))
+    monkeypatch.setattr(
+        diagnostics.er, "async_get", lambda _hass: SimpleNamespace(entities={})
+    )
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+
+    effective_config = payload["effective_config"]
+    assert effective_config[OPT_LOCATION_POLL_INTERVAL] == "45"
+    assert effective_config[OPT_DEVICE_POLL_DELAY] == 10
+    assert effective_config[OPT_MOVEMENT_THRESHOLD] == 75
+    assert effective_config[OPT_GOOGLE_HOME_FILTER_KEYWORDS] == "one, two, three"
+    assert effective_config[OPT_IGNORED_DEVICES] == [diagnostics.REDACTED] * 2
+    assert effective_config[CONF_OAUTH_TOKEN] == diagnostics.REDACTED
+
+    config_summary = payload["config"]
+    assert config_summary["location_poll_interval"] == 45
+    assert config_summary["device_poll_delay"] == 10
+    assert config_summary["min_accuracy_threshold"] == 123
+    assert config_summary["movement_threshold"] == 75
+    assert config_summary["google_home_filter_enabled"] is True
+    assert config_summary["enable_stats_entities"] is False
+    assert config_summary["google_home_filter_keywords_count"] == 3
+    assert config_summary["ignored_devices_count"] == 2


### PR DESCRIPTION
## Summary
- sanitize diagnostics effective configuration by replacing ignored device identifiers with redacted placeholders before redaction
- update diagnostics test expectations to confirm ignored devices are redacted while merged options remain intact

## Testing
- python -m pip install --dry-run --no-deps pip
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4e7874ec8329ace6ae23a11d490c)