### PR TITLE
Fix blocking runtime imports during setup

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -5948,7 +5948,7 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
         automations referencing these services.
     """
 
-    _ensure_runtime_imports()
+    await hass.async_add_executor_job(_ensure_runtime_imports)
     bucket = _domain_data(hass)
     _ensure_entries_bucket(bucket)  # entry_id -> RuntimeData
     _ensure_device_owner_index(bucket)  # canonical_id -> entry_id (E2.5 scaffold)

--- a/tests/test_blocking_imports.py
+++ b/tests/test_blocking_imports.py
@@ -1,0 +1,35 @@
+import logging
+from collections.abc import Iterable
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from custom_components.googlefindmy.const import DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_async_setup_does_not_log_blocking_imports(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    initial_record_count = len(caplog.records)
+
+    hass.config.components.add("http")
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+
+    new_records: Iterable[logging.LogRecord] = caplog.records[initial_record_count:]
+    blocking_warnings = [
+        record
+        for record in new_records
+        if record.levelno >= logging.WARNING
+        and (
+            "blocking call" in record.getMessage().lower()
+            or "import_module" in record.getMessage().lower()
+        )
+    ]
+
+    assert not blocking_warnings, blocking_warnings


### PR DESCRIPTION
## Summary
- offload runtime imports in async_setup to Home Assistant's executor to avoid blocking the event loop
- add regression test ensuring setup logs no blocking import warnings when initializing the integration

## Testing
- python -m ruff check --fix .
- python -m mypy --strict custom_components/googlefindmy
- timeout 200 pytest --cov=custom_components/googlefindmy --cov-report=term-missing -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5d49bc3c8329a1f7d03d68a54cf0)