### PR TITLE
Refine bandit configuration and threshold

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "GoogleFindMy-HA Dev",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.mypy-type-checker",
+        "charliermarsh.ruff",
+        "ms-azuretools.vscode-docker"
+      ],
+      "settings": {
+        "python.testing.pytestArgs": [
+          "--cov",
+          "-q"
+        ],
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": true,
+        "python.formatting.provider": "ruff",
+        "python.analysis.typeCheckingMode": "strict"
+      }
+    }
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -e .[dev] && pre-commit install",
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=pip-cache,target=/home/vscode/.cache/pip,type=volume"
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,30 @@ repos:
     hooks:
       - id: ruff
         args:
+          - check
           - --fix
+          - --exit-non-zero-on-fix
       - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        args:
+          - --strict
+        additional_dependencies:
+          - types-requests>=2.32.0.20240712
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.10
+    hooks:
+      - id: bandit
+        args:
+          - -ll
+          - -c
+          - bandit.yaml
+          - -r
+          - custom_components
+        additional_dependencies:
+          - bandit[toml]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -36,6 +58,12 @@ repos:
         entry: python script/clean_pycache.py
         args:
           - --quiet
+        language: python
+        pass_filenames: false
+        always_run: true
+      - id: pytest
+        name: pytest with coverage
+        entry: python -m pytest --cov -q
         language: python
         pass_filenames: false
         always_run: true

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,4 @@
+# Bandit configuration focusing on integration code with actionable findings.
+exclude_dirs:
+  - tests
+severity: medium

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "bandit[toml]>=1.7.10",
     "mypy>=1.11",
     "pre-commit>=3.7",
     "pytest>=8.3",
@@ -162,7 +163,7 @@ indent-style = "space"
 line-ending = "auto"
 
 [tool.pytest.ini_options]
-addopts = ["-q", "--cov-report=term"]
+addopts = ["-q", "--cov", "--cov-report=term"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 filterwarnings = [


### PR DESCRIPTION
## Summary
- add a shared Bandit configuration to exclude the test suite and raise the reported severity threshold
- update the Bandit pre-commit hook to use the shared config and medium-severity scan level

## Testing
- python -m bandit -ll -c bandit.yaml -r custom_components

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff1162b7c8329be621d09f26ca2bd)