### PR TITLE
Ensure pre-commit hooks install required HA dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "GoogleFindMy-HA Dev",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.mypy-type-checker",
+        "charliermarsh.ruff",
+        "ms-azuretools.vscode-docker"
+      ],
+      "settings": {
+        "python.testing.pytestArgs": [
+          "--cov",
+          "-q"
+        ],
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": true,
+        "python.formatting.provider": "ruff",
+        "python.analysis.typeCheckingMode": "strict"
+      }
+    }
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -e .[dev] && pre-commit install",
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=pip-cache,target=/home/vscode/.cache/pip,type=volume"
+  ]
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,31 @@ repos:
     hooks:
       - id: ruff
         args:
+          - check
           - --fix
+          - --exit-non-zero-on-fix
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy (dev extras)
+        entry: python -m mypy --strict
+        language: python
+        pass_filenames: true
+        additional_dependencies:
+          - .[dev]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.10
+    hooks:
+      - id: bandit
+        args:
+          - -ll
+          - -c
+          - bandit.yaml
+          - -r
+          - custom_components
+        additional_dependencies:
+          - bandit[toml]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -37,5 +60,13 @@ repos:
         args:
           - --quiet
         language: python
+        pass_filenames: false
+        always_run: true
+      - id: pytest
+        name: pytest with coverage
+        entry: python -m pytest --cov -q
+        language: python
+        additional_dependencies:
+          - .[dev]
         pass_filenames: false
         always_run: true

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,4 @@
+# Bandit configuration focusing on integration code with actionable findings.
+exclude_dirs:
+  - tests
+severity: medium

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "bandit[toml]>=1.7.10",
+    "homeassistant>=2025.7.0",
     "mypy>=1.11",
     "pre-commit>=3.7",
     "pytest>=8.3",
@@ -162,7 +164,7 @@ indent-style = "space"
 line-ending = "auto"
 
 [tool.pytest.ini_options]
-addopts = ["-q", "--cov-report=term"]
+addopts = ["-q", "--cov", "--cov-report=term"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 filterwarnings = [


### PR DESCRIPTION
## Summary
- configure the mypy pre-commit hook as a local python hook installing the project dev extras so Home Assistant imports resolve
- add Home Assistant to the development extras to align hook environments with integration requirements

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff1162b7c8329be621d09f26ca2bd)