### PR TITLE
Fix fatal FCM auth detection via runtime data

### DIFF
--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -767,6 +767,14 @@ class GoogleFindMyConnectivitySensor(GoogleFindMyEntity, BinarySensorEntity):
         if connected_at_iso is not None:
             attributes["fcm_connected_at"] = connected_at_iso
 
+        fatal_error: str | None = None
+        fatal_by_entry = getattr(fcm, "_fatal_errors", None)
+        if isinstance(fatal_by_entry, Mapping) and entry_id:
+            fatal_error = fatal_by_entry.get(entry_id)
+        fatal_error = fatal_error or getattr(fcm, "_fatal_error", None)
+        if isinstance(fatal_error, str) and fatal_error:
+            attributes["fcm_fatal_error"] = fatal_error
+
         return attributes or None
 
     @property

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -4403,6 +4403,13 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             fcm = self.hass.data.get(DOMAIN, {}).get("fcm_receiver")
             if not fcm:
                 return False
+            fatal_error: str | None = getattr(fcm, "_fatal_error", None)
+            entry_id = self._entry_id()
+            fatal_by_entry = getattr(fcm, "_fatal_errors", None)
+            if isinstance(fatal_by_entry, Mapping) and entry_id:
+                fatal_error = fatal_by_entry.get(entry_id) or fatal_error
+            if isinstance(fatal_error, str) and fatal_error:
+                return False
             for attr in ("is_ready", "ready"):
                 val = getattr(fcm, attr, None)
                 if isinstance(val, bool):
@@ -4483,6 +4490,24 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             UpdateFailed: For other transient or unexpected errors.
         """
         try:
+            # Check for fatal FCM errors (for example, 404/401 during registration) to trigger re-auth
+            entry = self.config_entry
+            runtime = getattr(entry, "runtime_data", None)
+            fcm_receiver = getattr(runtime, "fcm_receiver", None)
+
+            fatal_error: str | None = None
+            if fcm_receiver is not None:
+                fatal_error = getattr(fcm_receiver, "_fatal_error", None)
+
+                fatal_by_entry = getattr(fcm_receiver, "_fatal_errors", None)
+                entry_id = self._entry_id()
+                if isinstance(fatal_by_entry, Mapping) and entry_id:
+                    fatal_error = fatal_by_entry.get(entry_id) or fatal_error
+
+            if isinstance(fatal_error, str) and fatal_error:
+                self._set_auth_state(failed=True, reason=fatal_error)
+                raise ConfigEntryAuthFailed(fatal_error)
+
             # One-time wait for FCM on first run.
             if not self._startup_complete:
                 fcm_evt = getattr(self, "fcm_ready_event", None)

--- a/custom_components/googlefindmy/exceptions.py
+++ b/custom_components/googlefindmy/exceptions.py
@@ -50,3 +50,10 @@ class MissingNamespaceError(HomeAssistantError):
         super().__init__(_MISSING_NAMESPACE)
         self.translation_domain = DOMAIN
         self.translation_key = "missing_namespace"
+
+
+class FatalRegistrationError(HomeAssistantError):
+    """Raised when FCM registration fails with a fatal status code."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
@@ -16,6 +17,7 @@ from custom_components.googlefindmy.binary_sensor import GoogleFindMyPollingSens
 from custom_components.googlefindmy.const import (
     CONF_GOOGLE_EMAIL,
     DOMAIN,
+    EVENT_AUTH_ERROR,
     EVENT_AUTH_OK,
     ISSUE_AUTH_EXPIRED_KEY,
     SERVICE_SUBENTRY_KEY,
@@ -91,6 +93,7 @@ class _DummyAPI:
     def __init__(self) -> None:
         self.raise_auth = False
         self.device_list: list[dict[str, str]] = []
+        self.fcm: Any | None = None
 
     async def async_get_basic_device_list(self) -> list[dict[str, str]]:
         if self.raise_auth:
@@ -183,6 +186,43 @@ def test_api_auth_error_preserves_fcm_status(
     assert coordinator.config_entry.reauth_calls == 0
     assert coordinator.hass.config_entries.calls == []
     assert "Invalid" in (coordinator.api_status.reason or "")
+
+
+def test_fatal_fcm_registration_triggers_reauth(
+    coordinator: GoogleFindMyCoordinator, dummy_api: _DummyAPI
+) -> None:
+    """A fatal FCM registration error escalates to ConfigEntryAuthFailed."""
+
+    fatal_error = "GCM Registration failed (404): Credentials invalid"
+
+    class _DummyFcm:
+        def __init__(self, message: str) -> None:
+            self._fatal_error = message
+            self._fatal_errors = {coordinator.config_entry.entry_id: message}
+
+    dummy_api.fcm = _DummyFcm(fatal_error)
+    coordinator.config_entry.runtime_data = SimpleNamespace(
+        coordinator=coordinator, fcm_receiver=dummy_api.fcm
+    )
+    coordinator._is_fcm_ready_soft = lambda: False
+
+    loop = coordinator.hass.loop
+    with pytest.raises(ConfigEntryAuthFailed):
+        loop.run_until_complete(coordinator._async_update_data())
+
+    assert coordinator.auth_error_active is True
+    assert coordinator._auth_error_message == fatal_error
+    assert (
+        coordinator.hass.bus.fired[-1]
+        == (
+            EVENT_AUTH_ERROR,
+            {
+                "entry_id": coordinator.config_entry.entry_id,
+                "email": coordinator._get_account_email(),
+                "message": fatal_error,
+            },
+        )
+    )
 
 
 def test_api_status_recovers_after_success(


### PR DESCRIPTION
## Summary
- retrieve fatal FCM registration state from the config entry runtime data instead of the API shim so reauthentication triggers correctly
- align fatal FCM registration test with runtime_data lookup and ensure coverage passes with installed HTTP/2 dependencies

## Testing
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69301630466883299429aaae3da3323e)