### PR TITLE
Adjust hassfest checkouts to keep merge refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.ref || github.event.pull_request.head.ref || github.ref }}
 
       - name: Detect hassfest auto-fix check
         id: hassfest_autofix
@@ -85,6 +88,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.ref || github.event.pull_request.head.ref || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -118,6 +124,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.ref || github.event.pull_request.head.ref || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/hassfest-auto-fix.yml
+++ b/.github/workflows/hassfest-auto-fix.yml
@@ -14,7 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event_name == 'pull_request' && github.repository || github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.ref || github.event.pull_request.head.ref || github.ref }}
           fetch-depth: 0
 
       - name: Run hassfest (may rewrite manifest)


### PR DESCRIPTION
## Summary
- keep CI hassfest/HACS/test jobs using the default merge ref on pull_request events while retaining fork-aware checkout for other triggers
- apply the same guarded checkout logic to the hassfest auto-fix workflow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693176e0dff083298e37bc6be7fcdb61)