### PR TITLE
Fix hassfest workflows to use PR head refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+
 
       - name: Detect hassfest auto-fix check
         id: hassfest_autofix
@@ -89,8 +90,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -125,8 +127,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/hassfest-auto-fix.yml
+++ b/.github/workflows/hassfest-auto-fix.yml
@@ -14,7 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
           fetch-depth: 0
 
       - name: Run hassfest (may rewrite manifest)


### PR DESCRIPTION
## Summary
- ensure hassfest, HACS, and quality workflows check out PR head repository/ref instead of base
- update hassfest auto-fix checkout to use PR head branch so auto-commit can push changes

## Testing
- not run (workflow changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931808033448329a0fc7a0e7d8d71ca)