### PR TITLE
Restore stats reset button last pressed state

### DIFF
--- a/custom_components/googlefindmy/button.py
+++ b/custom_components/googlefindmy/button.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Iterable, Mapping
-from typing import Any, NamedTuple
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from homeassistant.components.button import ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -33,6 +34,13 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity as HARestoreEntity
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from .ha_typing import RestoreEntity as RestoreEntityType
+else:
+    RestoreEntityType = HARestoreEntity
 
 try:
     from homeassistant.const import EntityCategory
@@ -741,7 +749,7 @@ async def async_setup_entry(
         )
 
 
-class GoogleFindMyStatsResetButton(GoogleFindMyEntity, ButtonEntity):
+class GoogleFindMyStatsResetButton(GoogleFindMyEntity, ButtonEntity, RestoreEntityType):
     """Button to reset integration statistics counters."""
 
     _attr_entity_description = RESET_STATISTICS_DESCRIPTION
@@ -769,6 +777,29 @@ class GoogleFindMyStatsResetButton(GoogleFindMyEntity, ButtonEntity):
             "reset_statistics",
             separator="_",
         )
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last press timestamp to avoid 'Unknown' state."""
+
+        await super().async_added_to_hass()
+        if (state := await self.async_get_last_state()) is None:
+            return
+
+        parse_datetime = getattr(dt_util, "parse_datetime", None)
+        restored = parse_datetime(state.state) if callable(parse_datetime) else None
+        if restored is None:
+            try:
+                restored = datetime.fromisoformat(state.state)
+            except (TypeError, ValueError):
+                return
+
+        self._attr_last_pressed = restored
+
+    def _update_last_pressed(self) -> None:
+        """Record the current timestamp and push state to Home Assistant."""
+
+        self._attr_last_pressed = dt_util.utcnow()
+        self.async_write_ha_state()
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -810,6 +841,8 @@ class GoogleFindMyStatsResetButton(GoogleFindMyEntity, ButtonEntity):
         else:
             private_issues = getattr(registry, "_issues", None)
             issues_iterable = list(private_issues.items()) if isinstance(private_issues, Mapping) else []
+
+        self._update_last_pressed()
 
         expected_issue_key_size = 2
 
@@ -853,7 +886,9 @@ class GoogleFindMyStatsResetButton(GoogleFindMyEntity, ButtonEntity):
         )
 
 
-class GoogleFindMyButtonEntity(GoogleFindMyDeviceEntity, ButtonEntity):
+class GoogleFindMyButtonEntity(
+    GoogleFindMyDeviceEntity, ButtonEntity, RestoreEntityType
+):
     """Common helpers for all per-device buttons."""
 
     _attr_entity_registry_enabled_default = True
@@ -877,6 +912,29 @@ class GoogleFindMyButtonEntity(GoogleFindMyDeviceEntity, ButtonEntity):
             subentry_identifier=subentry_identifier,
             fallback_label=fallback_label,
         )
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last press timestamp to avoid 'Unknown' state."""
+
+        await super().async_added_to_hass()
+        if (state := await self.async_get_last_state()) is None:
+            return
+
+        parse_datetime = getattr(dt_util, "parse_datetime", None)
+        restored = parse_datetime(state.state) if callable(parse_datetime) else None
+        if restored is None:
+            try:
+                restored = datetime.fromisoformat(state.state)
+            except (TypeError, ValueError):
+                return
+
+        self._attr_last_pressed = restored
+
+    def _update_last_pressed(self) -> None:
+        """Record the current timestamp and push state to Home Assistant."""
+
+        self._attr_last_pressed = dt_util.utcnow()
+        self.async_write_ha_state()
 
     async def async_trigger_coordinator_refresh(self) -> None:
         """Request a coordinator refresh via the entity service placeholder."""
@@ -973,6 +1031,7 @@ class GoogleFindMyPlaySoundButton(GoogleFindMyButtonEntity):
                 {"device_id": device_id},
                 blocking=True,
             )
+            self._update_last_pressed()
             _LOGGER.info("Successfully submitted Play Sound request for %s", device_name)
         except Exception as err:  # Avoid crashing the update loop
             _LOGGER.error("Error playing sound on %s: %s", device_name, err)
@@ -1067,6 +1126,7 @@ class GoogleFindMyStopSoundButton(GoogleFindMyButtonEntity):
                 {"device_id": device_id},
                 blocking=True,
             )
+            self._update_last_pressed()
             _LOGGER.info("Successfully submitted Stop Sound request for %s", device_name)
         except Exception as err:
             _LOGGER.error("Error stopping sound on %s: %s", device_name, err)
@@ -1158,6 +1218,7 @@ class GoogleFindMyLocateButton(GoogleFindMyButtonEntity):
                 {"device_id": device_id},
                 blocking=False,  # non-blocking: avoid UI stall
             )
+            self._update_last_pressed()
             _LOGGER.info("Successfully submitted manual locate for %s", device_name)
         except Exception as err:  # Avoid crashing the update loop
             _LOGGER.error("Error submitting manual locate for %s: %s", device_name, err)

--- a/tests/test_button_restore_state.py
+++ b/tests/test_button_restore_state.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.googlefindmy.button import (
+    GoogleFindMyLocateButton,
+    GoogleFindMyPlaySoundButton,
+)
+from custom_components.googlefindmy.const import (
+    DOMAIN,
+    SERVICE_PLAY_SOUND,
+    SERVICE_SUBENTRY_KEY,
+    TRACKER_SUBENTRY_KEY,
+)
+
+
+@pytest.mark.asyncio
+async def test_button_restores_last_pressed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restoring last state populates ``last_pressed`` when available."""
+
+    hass = SimpleNamespace(data={DOMAIN: {}}, services=SimpleNamespace(), loop=None)
+    coordinator = SimpleNamespace(
+        hass=hass,
+        config_entry=SimpleNamespace(entry_id="entry-id"),
+        is_device_visible_in_subentry=lambda *_args: True,
+        can_request_location=lambda _dev_id: True,
+        async_request_refresh=AsyncMock(),
+    )
+    button = GoogleFindMyLocateButton(
+        coordinator,
+        {"id": "device-1", "name": "Tracker"},
+        "Tracker",
+        subentry_key=TRACKER_SUBENTRY_KEY,
+        subentry_identifier=f"{SERVICE_SUBENTRY_KEY}:tracker",
+    )
+    button.hass = hass
+    button._handle_coordinator_update = lambda: None
+    restored_state = SimpleNamespace(state="2025-01-02T03:04:05+00:00")
+    monkeypatch.setattr(
+        button, "async_get_last_state", AsyncMock(return_value=restored_state)
+    )
+
+    await button.async_added_to_hass()
+
+    assert button._attr_last_pressed == datetime(2025, 1, 2, 3, 4, 5, tzinfo=dt_util.UTC)
+
+
+@pytest.mark.asyncio
+async def test_button_records_last_pressed_on_press() -> None:
+    """Button presses update ``last_pressed`` so availability recovers cleanly."""
+
+    service_call = AsyncMock()
+    hass = SimpleNamespace(
+        services=SimpleNamespace(async_call=service_call),
+        data={DOMAIN: {}},
+        loop=None,
+    )
+    coordinator = SimpleNamespace(
+        hass=hass,
+        config_entry=SimpleNamespace(entry_id="entry-id"),
+        is_device_visible_in_subentry=lambda *_args: True,
+        can_play_sound=lambda _dev_id: True,
+        async_request_refresh=AsyncMock(),
+    )
+    button = GoogleFindMyPlaySoundButton(
+        coordinator,
+        {"id": "device-1", "name": "Tracker"},
+        "Tracker",
+        subentry_key=TRACKER_SUBENTRY_KEY,
+        subentry_identifier=f"{SERVICE_SUBENTRY_KEY}:tracker",
+    )
+    button.hass = hass
+
+    await button.async_press()
+
+    assert button._attr_last_pressed is not None
+    service_call.assert_awaited_once_with(
+        DOMAIN, SERVICE_PLAY_SOUND, {"device_id": "device-1"}, blocking=True
+    )


### PR DESCRIPTION
# Summary
- Type: ☑ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: button restore state / tests
- Linked issues: –

## Change Log (human-readable)
- Added RestoreEntity handling to the stats reset button, restoring `last_pressed` and updating it on press to avoid unknown states.
- Updated button restore-state tests to attach `hass` before lifecycle calls so entity helpers work with Home Assistant stubs.

## Tests (MUST)
- ☑ `python -m ruff check --fix`
- ☑ `python -m mypy --strict`
- ☑ `python -m pytest --cov -q`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931965073f88329a917b304bb439bb7)