### PR TITLE
Improve coordinator diagnostics with status snapshots

### DIFF
--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -213,7 +213,7 @@ def _status_snapshot_to_dict(snapshot: Any) -> dict[str, Any] | None:
         return None
 
     try:
-        if is_dataclass(snapshot):
+        if is_dataclass(snapshot) and not isinstance(snapshot, type):
             data = asdict(snapshot)
         else:
             data = {


### PR DESCRIPTION
## Summary
- remove the transient `is_polling` flag from coordinator diagnostics and replace it with serialized API/FCM status snapshots
- add defensive serialization helper for `StatusSnapshot` objects to keep diagnostic JSON stable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931eb1cc9648329a8f02243d7757be7)