### PR TITLE
Add safety buffer to TTL recalibration

### DIFF
--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -555,9 +555,10 @@ class TTLPolicy:
                     # If clearly shorter than our current model (>10% shorter), recalibrate immediately.
                     if best and (age_sec + self.TTL_MARGIN_SEC) < 0.9 * float(best):
                         self.log.warning(
-                            "Unexpected short TTL – recalibrating best known TTL."
+                            "Unexpected short TTL – recalibrating best known TTL with safety buffer."
                         )
-                        self._set(self.k_bestttl, age_sec)
+                        safe_calibration = age_sec * 0.95
+                        self._set(self.k_bestttl, safe_calibration)
                 except (ValueError, TypeError) as e:
                     self.log.debug("Recalibration check failed: %s", e)
 
@@ -770,9 +771,10 @@ class AsyncTTLPolicy(TTLPolicy):
                     try:
                         if best and (age_sec + self.TTL_MARGIN_SEC) < 0.9 * float(best):
                             self.log.warning(
-                                "Unexpected short TTL – recalibrating best known TTL (async)."
+                                "Unexpected short TTL – recalibrating best known TTL with safety buffer (async)."
                             )
-                            await self._aset(self.k_bestttl, age_sec)
+                            safe_calibration = age_sec * 0.95
+                            await self._aset(self.k_bestttl, safe_calibration)
                     except (ValueError, TypeError) as e:
                         self.log.debug("Recalibration check failed (async): %s", e)
             return await self._do_refresh_async(now)


### PR DESCRIPTION
# Summary
- Type: ☒ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: Nova TTL policy
- Linked issues: None

## Motivation
Avoid over-aggressive downshift when an unplanned 401 occurs by applying a safety buffer during recalibration.

---

## Change Log (human-readable)

### Added
- n/a

### Changed
- Apply a 5% safety buffer when recalibrating best-known TTL after unexpected 401 responses (sync and async paths).

### Fixed
- n/a

### Removed
- n/a

### Performance
- n/a

### Security/Privacy
- n/a

### Compatibility
- n/a

---

## Evidence (optional but helpful)
<details>
<summary>Expand for screenshots/logs</summary>

- `python -m ruff check custom_components/googlefindmy/NovaApi/nova_request.py`

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - n/a

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): n/a
- Impact here: n/a

---

## Risk & Rollback
- Risk level: low
- Rollback plan: revert commit; TTL probe behavior returns to previous model.

---

## Local Verification (run before pushing)
### bash:
- python -m ruff check custom_components/googlefindmy/NovaApi/nova_request.py

---

## Reviewer Notes (optional)

* Edge cases to double-check: none noted
* Follow-up tasks (if any): none


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ec9cc4788329ab4a2f84003c2da0)