### PR TITLE
Clarify network status mapping and move stub constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,7 @@ Use the following patterns whenever a module only exists as a `.pyi` stub or whe
 * **Cache cleanup:** Run `make clean` to prune `__pycache__` directories and stale bytecode before rerunning tests.
 * **Connectivity probe:** Follow the [connectivity probe](#connectivity-probe) and capture the output before running tests.
 * **Test stub install:** Use `make test-stubs` to install `homeassistant` and `pytest-homeassistant-custom-component` when you need a minimal bootstrap immediately before `pytest -q`. Plan for several minutes of download time in the hosted environment because the Home Assistant wheels are large.
+* **Pinned stub constraints:** The stub versions are locked in `custom_components/googlefindmy/constraints-test-stubs.txt` to reduce resolver backtracking; reuse that constraint file when installing Home Assistant stubs outside the Makefile targets.
 * **DocToc preinstall:** Run `make bootstrap-doctoc` once per environment to install the DocToc dev dependency non-interactively (cached under `.npm-cache`); subsequent `make doctoc` calls reuse the installation to refresh the AGENTS.md table of contents.
 * **Strict mypy prep:** In a fresh environment, run `make test-stubs` before `mypy --install-types --non-interactive --strict` so the Home Assistant stubs are already present and strict type checking doesn't trip over missing packages.
 * **Coverage reminder:** After adjusting registry helper fallbacks, rerun `pytest --cov -q` to confirm coverage stays intact before committing.

--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,14 @@ clean-wheelhouse:
 	fi
 
 install-ha-stubs:
-	@echo "[make install-ha-stubs] Installing Home Assistant pytest dependencies"
-	@$(PYTHON) -m pip install --upgrade -r requirements-ha-stubs.txt
+@echo "[make install-ha-stubs] Installing Home Assistant pytest dependencies"
+@$(PYTHON) -m pip install --upgrade -r custom_components/googlefindmy/requirements-ha-stubs.txt
 
 test-stubs:
-	@echo "[make test-stubs] Installing Home Assistant test dependencies"
-	@$(PYTHON) -m pip install --upgrade homeassistant pytest-homeassistant-custom-component
-	@echo "[make test-stubs] Preloading optional integration drivers"
-	@$(PYTHON) -m pip install --upgrade -r custom_components/googlefindmy/requirements-dev.txt
+@echo "[make test-stubs] Installing Home Assistant test dependencies"
+@$(PYTHON) -m pip install --upgrade -r custom_components/googlefindmy/requirements-ha-stubs.txt
+@echo "[make test-stubs] Preloading optional integration drivers"
+@$(PYTHON) -m pip install --upgrade -c custom_components/googlefindmy/constraints-test-stubs.txt -r custom_components/googlefindmy/requirements-dev.txt
 
 test-deps:
 	@echo "[make test-deps] Installing stub and integration development dependencies"
@@ -89,10 +89,10 @@ bootstrap-base-deps: $(BOOTSTRAP_SENTINEL)
 	@echo "[make bootstrap-base-deps] Home Assistant base dependencies are ready"
 
 $(BOOTSTRAP_SENTINEL):
-	@mkdir -p $(dir $(BOOTSTRAP_SENTINEL))
-	@echo "[make bootstrap-base-deps] Pre-installing Home Assistant base dependencies (including common runtime crypto/HTTP helpers)"
-	@$(PYTHON) -m pip install --upgrade $(BASE_BOOTSTRAP_PACKAGES)
-	@touch $(BOOTSTRAP_SENTINEL)
+@mkdir -p $(dir $(BOOTSTRAP_SENTINEL))
+@echo "[make bootstrap-base-deps] Pre-installing Home Assistant base dependencies (including common runtime crypto/HTTP helpers)"
+@$(PYTHON) -m pip install --upgrade -c custom_components/googlefindmy/constraints-test-stubs.txt $(BASE_BOOTSTRAP_PACKAGES)
+@touch $(BOOTSTRAP_SENTINEL)
 
 $(WHEELHOUSE_SENTINEL): $(DEV_REQUIREMENTS)
 	@mkdir -p $(WHEELHOUSE)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For the quickest way to bootstrap Home Assistant test stubs before running `pyte
 - `make lint` — invoke the Ruff lint target for the entire repository using the same settings enforced in CI.
 - `make wheelhouse` — pre-download the Home Assistant development dependencies into `.wheelhouse/` so subsequent virtual environment rebuilds reuse cached wheels instead of re-fetching from PyPI.
 - `make clean-wheelhouse` — delete `.wheelhouse/` (and any manifests or sentinels inside) when you want to prune cached wheels after a bootstrap run or before refreshing dependencies from scratch.
-- `make install-ha-stubs` — install the packages listed in `requirements-ha-stubs.txt` (currently `homeassistant` and `pytest-homeassistant-custom-component`) into the active environment so `pytest` and the regression helpers work immediately after cloning the repository.
+- `make install-ha-stubs` — install the packages listed in `custom_components/googlefindmy/requirements-ha-stubs.txt` (currently `homeassistant` and `pytest-homeassistant-custom-component`) into the active environment so `pytest` and the regression helpers work immediately after cloning the repository.
 - `make test-unload` — activate the managed virtual environment and run the focused parent-unload rollback regression (`tests/test_unload_subentry_cleanup.py`) so you can confirm the recovery guardrails without executing the entire suite.
 - `script/bootstrap_ssot_cached.sh` — stage the Home Assistant Single Source of Truth (SSoT) wheels in `.wheelhouse/ssot` and install them from the local cache. Pass `SKIP_WHEELHOUSE_REFRESH=1` to reuse the cached artifacts on subsequent bootstrap runs or `PYTHON=python3.12` to target an alternate interpreter. The helper also validates `.wheelhouse/ssot` against `script/ssot_wheel_manifest.txt` (override with `SSOT_MANIFEST=…`) so repeated runs can confirm the primary wheels are cached without re-listing the full directory.
 - `python script/list_wheelhouse.py` — print a grouped index of cached wheels (optionally against `--manifest script/ssot_wheel_manifest.txt`) before running lengthy installs so you can confirm the cache satisfies the manifest without scrolling through pip logs. Pass `--allow-missing` to preview the formatter when `.wheelhouse/ssot` has not been generated yet.
@@ -52,7 +52,7 @@ For the quickest way to bootstrap Home Assistant test stubs before running `pyte
 
 The repository already ships a lightweight bootstrap for the real Home Assistant
 test stack. Run `make install-ha-stubs` from the project root to install
-`homeassistant` and `pytest-homeassistant-custom-component` into your current
+`homeassistant` and `pytest-homeassistant-custom-component` from `custom_components/googlefindmy/requirements-ha-stubs.txt` into your current
 Python environment without creating the `.venv` managed by other helpers. This
 is the quickest way to unblock `pytest` after cloning the repository or when a
 CI run reports missing Home Assistant packages.

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -66,3 +66,14 @@ the import in a small getter and call it only from the executor-backed runtime p
 When adding a lazy import helper, **keep the corresponding `import_module` (or other loader) imported in the module** so static
 analysis tools like `ruff` retain full visibility into the call site. Dropping the import and relying solely on dynamic
 resolution causes undefined-name lint failures the next time the file is checked.
+
+### Network Status Codes & Privacy Mapping
+
+Use the proto/network label mapping below when interpreting report provenance or introducing new UI strings so contributor
+privacy semantics remain aligned with Google's contribution settings.
+
+| Proto Enum | Integration Label | Real-world Meaning |
+| --- | --- | --- |
+| `Status.CROWDSOURCED = 2` | `'crowdsourced'` | Location report from a finder contributing with network in **all areas** ("Contribution Settings: With network in all areas"). |
+| `Status.AGGREGATED = 3` | `'aggregated'` | Location report from a finder contributing with network in **high-traffic areas only** ("Contribution Settings: With network in high-traffic areas only"). |
+| `EncryptedReport.isOwnReport = true` or `Status.LAST_KNOWN = 1` | `'owner'` | Owner-sourced location report from the device itself. |

--- a/custom_components/googlefindmy/FMDNCrypto/AGENTS.md
+++ b/custom_components/googlefindmy/FMDNCrypto/AGENTS.md
@@ -10,6 +10,7 @@ This guidance applies to every file under `custom_components/googlefindmy/FMDNCr
 - Cache curve constants (`p`, `a`, `b`, `order`) as `int` locals before any arithmetic so repeated `int()` conversions do not appear inside expressions.
 - When reducing coordinates or scalars modulo the curve prime/order, store the normalized value in a named variable (for example, `Rx_mod: int`) and reuse it for all subsequent calculations.
 - Preserve deterministic "even Y" selection for point decompression: if a modular square root is odd, flip it by `p - y` before returning and store the final value in an `int` variable named `Ry` or `y_even`.
+- Docstring style: when citing FHN behavior, explicitly reference the relevant section (for example, "FHN Accessory Specification v1.3 — Authentication section" or "Table 10: Construction of a pseudorandom number") and summarize how the implementation satisfies that clause. Keep the citation concise and scoped to the helper being described.
 
 ## Testing
 

--- a/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
+++ b/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
@@ -1,3 +1,5 @@
+"""Ephemeral identifier derivation helpers for the FHN Accessory spec."""
+
 from typing import cast
 
 from Cryptodome.Cipher import AES
@@ -15,6 +17,14 @@ _CURVE: CurveParametersProtocol = load_curve()
 
 
 def generate_eid(identity_key: bytes, timestamp: int) -> bytes:
+    """Generate the advertised EID per FHN Accessory Specification v1.3.
+
+    The specification defines ``R = r * G`` (with ``r`` derived from the
+    pseudorandom construction in Table 10) as the public point; the beacon
+    advertises ``Rx`` as the ephemeral identifier for the current rotation
+    period. This helper preserves that flow: compute ``r``, multiply by the
+    curve generator, and emit the x coordinate.
+    """
     # Calculate r
     r = calculate_r(identity_key, timestamp)
 
@@ -28,6 +38,15 @@ def generate_eid(identity_key: bytes, timestamp: int) -> bytes:
 
 
 def calculate_r(identity_key: bytes, timestamp: int) -> int:
+    """Compute the random scalar ``r`` per FHN Accessory Specification v1.3.
+
+    FHN Accessory Specification v1.3 - Table 10: Construction of a
+    pseudorandom number mandates the AES-ECB-256 input layout (``0xFF`` padding,
+    repeated timestamp blocks, and fixed rotation period exponent ``K = 10``)
+    used below. The byte construction ensures the encrypted block satisfies the
+    spec's requirements for producing the pseudorandom value that is later
+    reduced modulo the curve order to obtain ``r``.
+    """
     # ts_bytes is the timestamp in bytes, but the least K significant bits are set to 0
     ts_bytes = get_masked_timestamp(timestamp, K)
     identity_key_bytes = identity_key
@@ -59,6 +78,10 @@ def calculate_r(identity_key: bytes, timestamp: int) -> int:
 
 def get_masked_timestamp(timestamp: int, K: int) -> bytes:
     """Return the timestamp with the least-significant bits masked.
+
+    Table 10 requires clearing the lowest ``K`` bits of the beacon time counter
+    before encrypting the AES input block. This helper mirrors that requirement
+    so the pseudorandom number derives from the rotation-aligned timestamp.
 
     Args:
         timestamp: The original timestamp as an ``int``.

--- a/custom_components/googlefindmy/FMDNCrypto/key_derivation.py
+++ b/custom_components/googlefindmy/FMDNCrypto/key_derivation.py
@@ -14,12 +14,36 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class FMDNOwnerOperations:
+    """Owner-only key derivations defined by the FHN Accessory spec.
+
+    Per the FHN Accessory Specification v1.3 Authentication section, the
+    ephemeral identity key is the root material for three owner operations:
+    recovery, ring, and unwanted tracking protection. Each operation derives
+    an 8-byte key from ``SHA256(EIK || suffix_byte)`` where the suffix encodes
+    the operation being authorized.
+    """
+
     def __init__(self) -> None:
         self.recovery_key: bytes | None = None
         self.ringing_key: bytes | None = None
         self.tracking_key: bytes | None = None
 
     def generate_keys(self, identity_key: bytes) -> None:
+        """Derive owner operation keys per FHN Accessory Specification v1.3.
+
+        FHN Accessory Specification v1.3 — Authentication section:
+
+        * ``0x01`` suffix → recovery key = first 8 bytes of
+          ``SHA256(ephemeral identity key || 0x01)``.
+        * ``0x02`` suffix → ring key = first 8 bytes of
+          ``SHA256(ephemeral identity key || 0x02)``.
+        * ``0x03`` suffix → unwanted tracking protection key = first 8 bytes of
+          ``SHA256(ephemeral identity key || 0x03)``.
+
+        The suffix mapping and truncation above mirror the specification’s
+        terminology so the derived keys align with the authenticated operations
+        defined for owners.
+        """
         if not isinstance(identity_key, (bytes, bytearray, memoryview)):
             msg = (
                 "Identity key must be a bytes-like object, got "

--- a/custom_components/googlefindmy/ProtoDecoders/Common.proto
+++ b/custom_components/googlefindmy/ProtoDecoders/Common.proto
@@ -23,7 +23,9 @@ message SemanticLocation {
 enum Status {
   SEMANTIC = 0;
   LAST_KNOWN = 1;
+  // Finders contributing "with network in all areas" (Contribution Settings: All Areas).
   CROWDSOURCED = 2;
+  // Finders contributing "with network in high-traffic areas only" (Contribution Settings: High Traffic Only).
   AGGREGATED = 3;
 }
 

--- a/custom_components/googlefindmy/constraints-test-stubs.txt
+++ b/custom_components/googlefindmy/constraints-test-stubs.txt
@@ -1,0 +1,3 @@
+# Pinned Home Assistant stub packages to speed up make test-stubs runs
+homeassistant==2025.12.1
+pytest-homeassistant-custom-component==0.13.299

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -340,6 +340,13 @@ def _row_source_label(row: dict[str, Any]) -> tuple[int, str]:
     Determine (rank, label) for the source of a report.
     Rank: 3=owner, 2=crowdsourced, 1=aggregated, 0=semantic/unknown
     Label: 'owner' | 'crowdsourced' | 'aggregated' | 'semantic/unknown'
+
+    Internal label mapping aligns with the protobuf Status enum and Google
+    Contribution Settings:
+    - 'crowdsourced' comes from Status.CROWDSOURCED (finder opted into
+      "with network in all areas").
+    - 'aggregated' comes from Status.AGGREGATED (finder opted into "with
+      network in high-traffic areas only").
     """
     is_own = bool(row.get("is_own_report"))
     status_code = row.get("status_code")

--- a/custom_components/googlefindmy/requirements-dev.txt
+++ b/custom_components/googlefindmy/requirements-dev.txt
@@ -1,3 +1,5 @@
+# Pin Home Assistant stubs to avoid resolver churn during local bootstrap.
+-c constraints-test-stubs.txt
 -r requirements.txt
 # Hassfest runs exclusively in CI (.github/workflows/hassfest-auto-fix.yml);
 # please do not add a local wrapper or dependency for it here.

--- a/custom_components/googlefindmy/requirements-ha-stubs.txt
+++ b/custom_components/googlefindmy/requirements-ha-stubs.txt
@@ -1,0 +1,3 @@
+--constraint constraints-test-stubs.txt
+homeassistant
+pytest-homeassistant-custom-component


### PR DESCRIPTION
## Summary
- move the Home Assistant stub requirements and constraint files next to the integration requirements and update Makefile/README references
- document protobuf status values and coordinator labels to reflect Google contribution settings for crowdsourced vs aggregated reports
- add AGENTS guidance covering status/label/privacy mapping and point stub constraint references to the new location

## Testing
- python -m ruff check --fix

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367d63164483298f08e61e27f06556)