### PR TITLE
Fix canonical ID extraction for Android FCM responses

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1255,11 +1255,23 @@ class FcmReceiverHA:
         return True
 
     def _extract_canonic_id_from_response(self, hex_response: str) -> str | None:
-        """Extract canonical id via the decoder."""
+        """Extract canonical id via the decoder.
+
+        Handles the schema difference between Android devices (nested in phoneInformation)
+        and Spot/Tracker devices (direct canonicIds), as defined in DeviceUpdate.proto.
+        """
         try:
             device_update = decoder_module.parse_device_update_protobuf(hex_response)
             if device_update.HasField("deviceMetadata"):
-                ids = device_update.deviceMetadata.identifierInformation.canonicIds.canonicId
+                info = device_update.deviceMetadata.identifierInformation
+
+                # Aligns with ProtoDecoders.decoder.get_canonic_ids logic:
+                # type == 1 → Android devices store IDs under phoneInformation.canonicIds.
+                if info.type == 1:
+                    ids = info.phoneInformation.canonicIds.canonicId
+                else:
+                    ids = info.canonicIds.canonicId
+
                 if ids:
                     return ids[0].id
         except Exception as err:  # noqa: BLE001

--- a/tests/test_fcm_receiver_canonic_id.py
+++ b/tests/test_fcm_receiver_canonic_id.py
@@ -1,0 +1,66 @@
+"""Regression tests for canonical ID extraction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy.Auth import fcm_receiver_ha
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
+
+
+class _DummyId:
+    """Simple container for canonical ID values."""
+
+    def __init__(self, identifier: str) -> None:
+        self.id = identifier
+
+
+class _DummyIdentifierInformation:
+    """Stub identifierInformation payload with both ID layouts present."""
+
+    def __init__(
+        self, type_value: int, direct_ids: list[str], phone_ids: list[str]
+    ) -> None:
+        self.type = type_value
+        self.canonicIds = SimpleNamespace(
+            canonicId=[_DummyId(identifier) for identifier in direct_ids]
+        )
+        self.phoneInformation = SimpleNamespace(
+            canonicIds=SimpleNamespace(
+                canonicId=[_DummyId(identifier) for identifier in phone_ids]
+            )
+        )
+
+
+class _DummyDeviceUpdate:
+    """Stub DeviceUpdate protobuf with deviceMetadata populated."""
+
+    def __init__(self, info: _DummyIdentifierInformation) -> None:
+        self.deviceMetadata = SimpleNamespace(identifierInformation=info)
+
+    def HasField(self, name: str) -> bool:  # noqa: N802
+        return name == "deviceMetadata"
+
+
+def test_extract_canonic_id_android_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Android responses use phoneInformation.canonicIds when type == 1."""
+
+    receiver = FcmReceiverHA()
+    expected_id = "android-canonic-id"
+
+    info = _DummyIdentifierInformation(
+        type_value=1,
+        direct_ids=["tracker-id"],
+        phone_ids=[expected_id],
+    )
+    device_update = _DummyDeviceUpdate(info)
+
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        lambda _hex: device_update,
+    )
+
+    assert receiver._extract_canonic_id_from_response("00ff") == expected_id


### PR DESCRIPTION
## Summary
- handle identifierInformation type to read canonical IDs for Android and tracker devices
- update FCM response parsing docstring to describe schema differences

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693698298f408329885c977bcd25092e)