### PR TITLE
Normalize canonic ID comparison in location callback

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -311,7 +311,7 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                 return
 
             # Validate canonic_id matches what we requested
-            if response_canonic_id != canonic_device_id:
+            if response_canonic_id.lower() != canonic_device_id.lower():
                 _LOGGER.warning(
                     "FCM callback received data for %s, but we requested %s. Ignoring.",
                     response_canonic_id,


### PR DESCRIPTION
## Summary
- compare FCM response canonic IDs case-insensitively to avoid dropping updates with differing hex casing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a51120bc832985339a652c24e9af)