### PR TITLE
Normalize FCM canonic IDs during location validation

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -43,6 +43,10 @@ running decryption in an executor without the surrounding context will cause mul
 Handle `StaleOwnerKeyError` from the decryptor by logging and skipping the update instead of crashing the pipeline so key
 rotation can proceed without interrupting other accounts.
 
+Normalize FCM canonic IDs before validation (for example, compare `response_canonic_id.lower()` to
+`canonic_device_id.lower()` and store the lowercase string on decrypted payloads) so tracker updates are not discarded due
+to server-provided hex casing differences.
+
 ### Hybrid Low-Accuracy Polling
 
 When a poll response fails the accuracy threshold, `coordinator.py` preserves the previous coordinates and accuracy but still

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -311,7 +311,7 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                 return
 
             # Validate canonic_id matches what we requested
-            if response_canonic_id != canonic_device_id:
+            if response_canonic_id.lower() != canonic_device_id.lower():
                 _LOGGER.warning(
                     "FCM callback received data for %s, but we requested %s. Ignoring.",
                     response_canonic_id,
@@ -382,8 +382,8 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                         len(location_data),
                         name,
                     )
-                    # Attach canonic_id for validation after wait
-                    location_data[0]["canonic_id"] = response_canonic_id
+                    # Attach normalized canonic_id for validation after wait
+                    location_data[0]["canonic_id"] = response_canonic_id.lower()
                     ctx.data = location_data
                 else:
                     _LOGGER.warning(
@@ -688,7 +688,7 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
                 raise ctx.error
 
         data = ctx.data or []
-        if data and data[0].get("canonic_id") == canonic_device_id:
+        if data and data[0].get("canonic_id", "").lower() == canonic_device_id.lower():
             _LOGGER.info("Successfully received location data for %s", name)
             return data
         if not data:


### PR DESCRIPTION
## Summary
- store lowercase canonic IDs on decrypted FCM payloads to avoid casing mismatches
- validate FCM callback data using a case-insensitive check before returning
- document canonic ID normalization expectations for future contributors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a51120bc832985339a652c24e9af)