### PR TITLE
Log decoder decryption failures and debug cache drops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,6 +246,7 @@ Use the following patterns whenever a module only exists as a `.pyi` stub or whe
 * **Cache cleanup:** Run `make clean` to prune `__pycache__` directories and stale bytecode before rerunning tests.
 * **Connectivity probe:** Follow the [connectivity probe](#connectivity-probe) and capture the output before running tests.
 * **Test stub install:** Use `make test-stubs` to install `homeassistant` and `pytest-homeassistant-custom-component` when you need a minimal bootstrap immediately before `pytest -q`. Plan for several minutes of download time in the hosted environment because the Home Assistant wheels are large.
+* **Lint-in-test requirement:** Every testing cycle must include `python -m ruff check --fix .` so lint autofixes run alongside the rest of the suite.
 * **Pinned stub constraints:** The stub versions are locked in `custom_components/googlefindmy/constraints-test-stubs.txt` to reduce resolver backtracking; reuse that constraint file when installing Home Assistant stubs outside the Makefile targets.
 * **DocToc preinstall:** Run `make bootstrap-doctoc` once per environment to install the DocToc dev dependency non-interactively (cached under `.npm-cache`); subsequent `make doctoc` calls reuse the installation to refresh the AGENTS.md table of contents.
 * **Strict mypy prep:** In a fresh environment, run `make test-stubs` before `mypy --install-types --non-interactive --strict` so the Home Assistant stubs are already present and strict type checking doesn't trip over missing packages.

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -624,8 +624,15 @@ def get_devices_with_location(
                             )
                             or []
                         )
-            except Exception:
-                # Defensive: decryption issues must not break the whole list.
+            except Exception as err:
+                # Defensive: decryption issues must not break the whole list, but log
+                # the root cause so users can debug key or parsing mismatches.
+                _LOGGER.warning(
+                    "Failed to decrypt location for device '%s': %s",
+                    device_name or "<unknown>",
+                    err,
+                    exc_info=err,
+                )
                 location_candidates = []
 
         # If decryption yielded results, select the best one and keep normalized list.

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -5770,7 +5770,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             return True
 
         e_seen_norm = _normalize_epoch_seconds(existing.get("last_seen"))
-        if ( 
+        if (
             n_seen_norm is not None
             and e_seen_norm is not None
             and n_seen_norm < e_seen_norm

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -5653,6 +5653,9 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if not fusion_preapplied and not self._apply_weighted_location_fusion(
             device_id, slot
         ):
+            _LOGGER.debug(
+                "Dropping cache update for %s: weighted fusion rejected payload", device_id
+            )
             return
 
         fused_applied = slot.pop("_fused_applied", False)
@@ -5697,6 +5700,10 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             self.increment_stat("crowd_sourced_updates")
 
         if not self._is_significant_update(device_id, slot):
+            _LOGGER.debug(
+                "Dropping cache update for %s: update failed significance checks",
+                device_id,
+            )
             return
 
         # Ensure last_updated is present
@@ -5733,6 +5740,9 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         """
 
         if not isinstance(new_data, dict):
+            _LOGGER.debug(
+                "Rejecting update for %s: payload is not a dict", device_id
+            )
             return False
 
         n_seen_norm = _normalize_epoch_seconds(new_data.get("last_seen"))
@@ -5740,9 +5750,19 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             if n_seen_norm < 946684800.0:  # < 2000-01-01
                 self.increment_stat("invalid_ts_drop_count")
                 self.increment_stat("drop_reason_invalid_ts")
+                _LOGGER.debug(
+                    "Rejecting update for %s: timestamp too old (%s)",
+                    device_id,
+                    n_seen_norm,
+                )
                 return False
             if n_seen_norm > time.time() + MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S:
                 self.increment_stat("future_ts_drop_count")
+                _LOGGER.debug(
+                    "Rejecting update for %s: timestamp too far in future (%s)",
+                    device_id,
+                    n_seen_norm,
+                )
                 return False
 
         existing = self._device_location_data.get(device_id)
@@ -5750,13 +5770,19 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             return True
 
         e_seen_norm = _normalize_epoch_seconds(existing.get("last_seen"))
-        if (
+        if ( 
             n_seen_norm is not None
             and e_seen_norm is not None
             and n_seen_norm < e_seen_norm
         ):
             self.increment_stat("invalid_ts_drop_count")
             self.increment_stat("drop_reason_invalid_ts")
+            _LOGGER.debug(
+                "Rejecting update for %s: timestamp regressed (%s < %s)",
+                device_id,
+                n_seen_norm,
+                e_seen_norm,
+            )
             return False
 
         return True

--- a/tests/test_decoder_location_ranking.py
+++ b/tests/test_decoder_location_ranking.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
+
+import pytest
 
 from custom_components.googlefindmy.ProtoDecoders import DeviceUpdate_pb2
 from custom_components.googlefindmy.ProtoDecoders.decoder import (
@@ -108,6 +111,37 @@ def test_decoder_promotes_newer_semantic_only_report() -> None:
     assert row["longitude"] == 13.405
     assert row["last_seen"] == 1_700_000_900.0
     assert row["semantic_name"] == "Gym"
+
+
+def test_decoder_logs_decryption_failures(caplog: pytest.LogCaptureFixture) -> None:
+    """Decryption errors surface as warnings instead of silently dropping context."""
+
+    devices_list = DeviceUpdate_pb2.DevicesList()
+    device = devices_list.deviceMetadata.add()
+    device.userDefinedDeviceName = "Tracker"
+    canonic = device.identifierInformation.canonicIds.canonicId.add()
+    canonic.id = "device-456"
+
+    reports = device.information.locationInformation.reports
+    reports.recentLocationAndNetworkLocations.recentLocation.semanticLocation.locationName = (
+        "seed"
+    )
+
+    with patch(
+        "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations.decrypt_location_response_locations",
+        side_effect=ValueError("boom"),
+    ), caplog.at_level(logging.WARNING):
+        rows = get_devices_with_location(
+            devices_list,
+            cache=cast("TokenCache", object()),
+        )
+
+    assert len(rows) == 1
+    assert rows[0]["device_id"] == "device-456"
+    assert any(
+        "Failed to decrypt location for device 'Tracker': boom" in message
+        for message in caplog.messages
+    )
 
 
 def test_semantic_report_outranks_older_coordinate_candidate() -> None:


### PR DESCRIPTION
## Summary
- log decryption failures in `get_devices_with_location` so crowdsourced updates surface errors instead of failing silently
- add debug traces to coordinator cache gating to explain dropped payloads
- extend decoder tests to cover decryption failure logging

## Testing
- python -m pytest tests/test_decoder_location_ranking.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936c4085f2883298980b3cf5b8c410b)