### PR TITLE
Implement GoogleFindMyEIDResolver class

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -148,6 +148,7 @@ from .const import (
     CONTRIBUTOR_MODE_IN_ALL_AREAS,
     DATA_AAS_TOKEN,
     DATA_AUTH_METHOD,
+    DATA_EID_RESOLVER,
     DATA_SECRET_BUNDLE,
     DEFAULT_CONTRIBUTOR_MODE,
     DEFAULT_DELETE_CACHES_ON_REMOVE,
@@ -191,13 +192,6 @@ from .email import normalize_email, unique_account_id
 from .ha_typing import CloudDiscoveryRuntime, callback
 
 # Shared FCM provider (HA-managed singleton)
-from .NovaApi.ExecuteAction.LocateTracker.location_request import (
-    register_fcm_receiver_provider as loc_register_fcm_provider,
-)
-from .NovaApi.ExecuteAction.LocateTracker.location_request import (
-    unregister_fcm_receiver_provider as loc_unregister_fcm_provider,
-)
-
 try:  # pragma: no cover - OperationNotAllowed introduced alongside HA subentry retries
     from homeassistant.config_entries import OperationNotAllowed as _OperationNotAllowed
 except ImportError:  # pragma: no cover - legacy Home Assistant builds
@@ -284,6 +278,9 @@ def get_proto_decoders() -> Mapping[ProtoDecoderModuleName, ModuleType]:
     for proto_name in _PROTO_DECODER_PATHS:
         _import_proto_decoder(proto_name)
     return _PROTO_DECODER_CACHE_PROXY
+
+
+from .eid_resolver import GoogleFindMyEIDResolver  # noqa: E402
 
 
 def __getattr__(name: str) -> Any:
@@ -420,6 +417,11 @@ else:
         RedactAccountForLogCallable,
         _runtime_imports_not_initialized,
     )
+
+loc_register_fcm_provider: Callable[
+    [Callable[[str | None], NovaFcmReceiverProtocol]], None
+] | None = None
+loc_unregister_fcm_provider: Callable[[], None] | None = None
 
 _RUNTIME_IMPORTS_LOADED = False
 _FCM_RECEIVER_CLASS: type[FcmReceiverHAType] | None = None
@@ -2308,6 +2310,7 @@ class GoogleFindMyDomainData(TypedDict, total=False):
 
     device_owner_index: dict[str, str]
     entries: dict[str, RuntimeData]
+    eid_resolver: GoogleFindMyEIDResolver
     fcm_lock: asyncio.Lock
     fcm_receiver: FcmReceiverHAType
     fcm_receivers: dict[str, FcmReceiverHAType]
@@ -5369,11 +5372,26 @@ async def _async_acquire_shared_fcm(
 
             provider_fn: Callable[[str | None], FcmReceiverHAType] = provider
             if not providers_registered:
-                loc_register_fcm_provider(
-                    cast(
-                        Callable[[str | None], NovaFcmReceiverProtocol], provider_fn
+                global loc_register_fcm_provider, loc_unregister_fcm_provider
+                if loc_register_fcm_provider is None:
+                    from .NovaApi.ExecuteAction.LocateTracker.location_request import (
+                        register_fcm_receiver_provider as _loc_register_fcm_provider,
                     )
-                )
+
+                    loc_register_fcm_provider = _loc_register_fcm_provider
+                if loc_unregister_fcm_provider is None:
+                    from .NovaApi.ExecuteAction.LocateTracker.location_request import (
+                        unregister_fcm_receiver_provider as _loc_unregister_fcm_provider,
+                    )
+
+                    loc_unregister_fcm_provider = _loc_unregister_fcm_provider
+
+                if loc_register_fcm_provider is not None:
+                    loc_register_fcm_provider(
+                        cast(
+                            Callable[[str | None], NovaFcmReceiverProtocol], provider_fn
+                        )
+                    )
                 api_register_fcm_provider(
                     cast(
                         Callable[[str | None], ApiFcmReceiverProtocol], provider_fn
@@ -5413,8 +5431,17 @@ async def _async_release_shared_fcm(
 
         # Unregister providers first (consumers will see provider=None immediately)
         if not _get_fcm_receivers(bucket):
+            global loc_unregister_fcm_provider
+            if loc_unregister_fcm_provider is None:
+                from .NovaApi.ExecuteAction.LocateTracker.location_request import (
+                    unregister_fcm_receiver_provider as _loc_unregister_fcm_provider,
+                )
+
+                loc_unregister_fcm_provider = _loc_unregister_fcm_provider
+
             try:
-                loc_unregister_fcm_provider()
+                if loc_unregister_fcm_provider is not None:
+                    loc_unregister_fcm_provider()
             except Exception:
                 pass
             try:
@@ -7257,6 +7284,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
 
     _register_instance(entry.entry_id, cache)
 
+    existing_resolver = domain_bucket.get(DATA_EID_RESOLVER)
+    if isinstance(existing_resolver, GoogleFindMyEIDResolver):
+        await existing_resolver.async_refresh()
+    else:
+        eid_resolver = GoogleFindMyEIDResolver(hass)
+        # Immediate refresh keeps BLE resolution available before the first
+        # boundary-aligned timer fires after startup/reload.
+        await eid_resolver.async_refresh()
+        # Resolver is shared for the entire domain so BLE scans can resolve
+        # devices across all loaded config entries via hass.data[DOMAIN][DATA_EID_RESOLVER].
+        domain_bucket[DATA_EID_RESOLVER] = eid_resolver
+
     parent_platforms_forwarded = bool(
         getattr(entry, "_gfm_parent_platforms_forwarded", False)
     )
@@ -7704,6 +7743,14 @@ async def _async_unload_parent_entry(hass: HomeAssistant, entry: MyConfigEntry) 
         runtime_data.subentry_retry_handles.clear()
         runtime_data.subentry_retry_attempts.clear()
         _cleanup_cloud_discovery_runtime(runtime_data)
+
+    resolver = bucket.get(DATA_EID_RESOLVER)
+    if isinstance(resolver, GoogleFindMyEIDResolver):
+        if not entries_bucket:
+            resolver.stop()
+            bucket.pop(DATA_EID_RESOLVER, None)
+        else:
+            hass.async_create_task(resolver.async_refresh())
 
     subentries = _collect_entry_subentries(entry)
 

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 import hashlib
 import time
 from collections.abc import Mapping, Sequence
+from typing import Final, Literal
 
 # --------------------------------------------------------------------------------------
 # Core identifiers
 # --------------------------------------------------------------------------------------
 DOMAIN: str = "googlefindmy"
+# Shared hass.data key for the global EID resolver instance
+DATA_EID_RESOLVER: Final[Literal["eid_resolver"]] = "eid_resolver"
 # Latest config entry schema version handled by this integration.
 CONFIG_ENTRY_VERSION: int = 2
 # Keep the integration version aligned across the project (match manifest.json)

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -100,7 +100,6 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 
 # IMPORTANT: make Common_pb2 import **mandatory** (integration packaging must include it).
 # This avoids silent type/name drift and keeps source labels stable.
-from . import get_proto_decoder
 from .api import GoogleFindMyAPI
 from .const import (
     CACHE_KEY_CONTRIBUTOR_MODE,
@@ -109,6 +108,7 @@ from .const import (
     CONF_GOOGLE_EMAIL,
     CONTRIBUTOR_MODE_HIGH_TRAFFIC,
     CONTRIBUTOR_MODE_IN_ALL_AREAS,
+    DATA_EID_RESOLVER,
     DEFAULT_CONTRIBUTOR_MODE,
     # Core / options
     DEFAULT_MIN_POLL_INTERVAL,
@@ -331,6 +331,8 @@ _MISSING = object()
 
 def _get_common_pb2() -> Any:
     """Import Common_pb2 lazily to defer protobuf initialization."""
+
+    from . import get_proto_decoder
 
     return get_proto_decoder("Common_pb2")
 
@@ -623,6 +625,23 @@ class SemanticLabelRecord:
         """Return a shallow copy with a cloned device set."""
 
         return replace(self, devices=set(self.devices))
+
+
+@dataclass(slots=True)
+class DeviceIdentity:
+    """Stable identifier and key material for a tracker.
+
+    Attributes:
+        registry_id: Home Assistant device registry identifier for the tracker.
+        canonical_id: Namespaced device identifier used by the integration's API.
+        identity_key: Ephemeral identity key used to derive rotating EIDs.
+        config_entry_id: Parent config entry ID that owns the tracker.
+    """
+
+    registry_id: str
+    canonical_id: str
+    identity_key: bytes
+    config_entry_id: str | None = None
 
 
 class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
@@ -3004,6 +3023,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             len(present),
             len(enabled),
         )
+        self._schedule_eid_resolver_refresh()
 
     # --- NEW: Create/refresh DR entries for end devices (entry-scoped) -----
     def _ensure_registry_for_devices(
@@ -4241,6 +4261,136 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         return snapshot
 
     # ---------------------------- Ignore helpers ----------------------------
+    @staticmethod
+    def _normalize_identity_key(raw: object) -> bytes | None:
+        """Normalize candidate identity key values into bytes."""
+
+        if isinstance(raw, (bytes, bytearray)):
+            return bytes(raw)
+        if isinstance(raw, str):
+            try:
+                return bytes.fromhex(raw)
+            except ValueError:
+                # Silent failure: registry/API payloads are not always trustworthy.
+                return None
+        return None
+
+    def _schedule_eid_resolver_refresh(self) -> None:
+        """Refresh the global EID resolver when active device sets change."""
+
+        hass_data = getattr(self.hass, "data", None)
+        if not isinstance(hass_data, dict):
+            return
+
+        bucket = hass_data.get(DOMAIN)
+        if not isinstance(bucket, dict):
+            return
+
+        resolver = bucket.get(DATA_EID_RESOLVER)
+        refresh = getattr(resolver, "async_refresh", None)
+        if callable(refresh):
+            create_task = getattr(self.hass, "async_create_task", None)
+            if callable(create_task):
+                create_task(refresh())
+
+    def get_active_device_identities(self) -> list[DeviceIdentity]:
+        """Return identity keys for enabled, non-ignored devices.
+
+        Devices disabled in the device registry or ignored via options are
+        excluded from the returned list. Only devices currently eligible for
+        polling (tracked in ``_enabled_poll_device_ids``) are considered for
+        EID resolution. The returned ``registry_id`` refers to the Home
+        Assistant Device Registry identifier for each tracker.
+        """
+
+        enabled_ids = set(self._enabled_poll_device_ids)
+        ignored = self._get_ignored_set()
+        device_ids = [dev_id for dev_id in enabled_ids if dev_id not in ignored]
+        if not device_ids:
+            return []
+
+        entry = self.config_entry
+        entry_id = entry.entry_id if entry is not None else None
+        registry_map: dict[str, tuple[str, bytes | None]] = {}
+        if entry is not None:
+            device_reg = dr.async_get(self.hass)
+            extract_identifier = getattr(self, "_extract_our_identifier", None)
+            for device in dr.async_entries_for_config_entry(device_reg, entry.entry_id):
+                if device.disabled_by is not None:
+                    continue
+
+                canonical_id: str | None = None
+                if callable(extract_identifier):
+                    canonical_id = extract_identifier(device)
+
+                if not canonical_id or canonical_id not in device_ids:
+                    continue
+
+                custom_fields = getattr(device, "custom_fields", None)
+                raw_identity = custom_fields.get("identity_key") if custom_fields else None
+                registry_map[canonical_id] = (
+                    device.id,
+                    self._normalize_identity_key(raw_identity),
+                )
+
+        data_identities: dict[str, bytes] = {}
+        device_data = getattr(self, "data", None)
+        if isinstance(device_data, Iterable):
+            for raw in device_data:
+                if not isinstance(raw, dict):
+                    continue
+                dev_id = raw.get("id")
+                if not isinstance(dev_id, str) or dev_id not in device_ids:
+                    continue
+                parsed = self._normalize_identity_key(
+                    raw.get("identity_key")
+                    or raw.get("identityKey")
+                    or raw.get("eik")
+                )
+                if parsed is not None:
+                    data_identities[dev_id] = parsed
+
+        cache = getattr(self, "_device_location_data", None)
+        cache_identities: dict[str, bytes] = {}
+        if isinstance(cache, dict):
+            for dev_id in device_ids:
+                payload = cache.get(dev_id)
+                if not isinstance(payload, dict):
+                    continue
+                parsed = self._normalize_identity_key(
+                    payload.get("identity_key")
+                    or payload.get("identityKey")
+                    or payload.get("eik")
+                )
+                if parsed is not None:
+                    cache_identities[dev_id] = parsed
+
+        identities: list[DeviceIdentity] = []
+        for canonical_id in device_ids:
+            registry_entry = registry_map.get(canonical_id)
+            if registry_entry is None:
+                continue
+
+            registry_id, registry_key = registry_entry
+            identity_key = registry_key
+            if identity_key is None:
+                identity_key = data_identities.get(canonical_id)
+            if identity_key is None:
+                identity_key = cache_identities.get(canonical_id)
+            if identity_key is None:
+                continue
+
+            identities.append(
+                DeviceIdentity(
+                    registry_id=registry_id,
+                    canonical_id=canonical_id,
+                    identity_key=identity_key,
+                    config_entry_id=entry_id,
+                )
+            )
+
+        return identities
+
     def _get_ignored_set(self) -> set[str]:
         """Return the set of device IDs the user chose to ignore (options-first).
 
@@ -5206,6 +5356,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     visible_devices, wall_now=time.time()
                 )
                 self.async_set_updated_data(end_snapshot)
+                self._schedule_eid_resolver_refresh()
                 if last_exception:
                     self.async_set_update_error(last_exception)
 
@@ -6346,6 +6497,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
         # Settings adjustments may change per-subentry views
         self._refresh_subentry_index()
+        self._schedule_eid_resolver_refresh()
 
     def force_poll_due(self) -> None:
         """Force the next poll to be due immediately (no private access required externally)."""

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -1,0 +1,247 @@
+"""Ephemeral identifier resolver for local BLE scans.
+
+This module exposes a resolver that maps rotating Find My Device Network
+EIDs to Home Assistant devices managed by the integration. The resolver
+precalculates identifiers for the previous, current, and next rotation
+windows so ``resolve_eid`` can respond to scans without performing
+cryptographic work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import NamedTuple, Protocol, runtime_checkable
+
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
+
+from .const import DOMAIN
+from .coordinator import DeviceIdentity, GoogleFindMyCoordinator
+from .FMDNCrypto.eid_generator import ROTATION_PERIOD, generate_eid
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EIDMatch(NamedTuple):
+    """Resolved mapping between an EID and a Home Assistant device.
+
+    The ``device_id`` corresponds to the Home Assistant device registry
+    identifier; ``canonical_id`` retains the integration-specific identifier
+    used by the API payloads.
+    """
+
+    device_id: str
+    config_entry_id: str
+    canonical_id: str
+
+
+@dataclass(slots=True)
+class GoogleFindMyEIDResolver:
+    """Resolver that precalculates rotating EIDs for known trackers.
+
+    The resolver maintains an in-memory lookup table mapping current and
+    recently rotated EIDs to Home Assistant device registry identifiers.
+    It refreshes the table at the rotation cadence so that ``resolve_eid``
+    can respond to BLE scan results without performing cryptographic work
+    on the hot path. The shared instance lives at
+    ``hass.data[DOMAIN][DATA_EID_RESOLVER]`` so other integrations can
+    look up BLE scan results via ``resolve_eid`` or ``get_resolved_eid``.
+    """
+
+    hass: HomeAssistant
+    _lookup: dict[bytes, EIDMatch] = field(init=False, default_factory=dict)
+    _unsub_interval: CALLBACK_TYPE | None = field(init=False, default=None)
+    _unsub_alignment: CALLBACK_TYPE | None = field(init=False, default=None)
+    _refresh_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
+    _pending_refresh: bool = field(init=False, default=False)
+
+    def __post_init__(self) -> None:
+        """Set up caches and schedule the first rotation-aligned refresh."""
+        self._start_alignment_timer()
+
+    def _start_alignment_timer(self) -> None:
+        """Schedule the first refresh on the next rotation boundary."""
+
+        now = int(time.time())
+        seconds_until_boundary = ROTATION_PERIOD - (now % ROTATION_PERIOD)
+        delay = seconds_until_boundary or ROTATION_PERIOD
+        self._unsub_alignment = async_call_later(
+            self.hass, delay, self._handle_alignment_refresh
+        )
+
+    def _start_interval(self) -> None:
+        """Start the recurring refresh interval aligned to rotations."""
+
+        if self._unsub_interval is None:
+            self._unsub_interval = async_track_time_interval(
+                self.hass,
+                self._handle_refresh_interval,
+                timedelta(seconds=ROTATION_PERIOD),
+            )
+
+    async def _handle_alignment_refresh(self, _now: datetime) -> None:
+        """Run the initial rotation-aligned refresh then start the timer."""
+
+        rotation_start = int(time.time())
+        rotation_start -= rotation_start % ROTATION_PERIOD
+        _LOGGER.debug("Boundary-aligned EID cache refresh at %s", rotation_start)
+        await self.async_refresh()
+        self._start_interval()
+
+    async def _handle_refresh_interval(self, _now: datetime) -> None:
+        """Refresh the cached EID lookup table on the rotation cadence."""
+
+        await self.async_refresh()
+
+    async def async_refresh(self) -> None:
+        """Trigger a cache refresh immediately."""
+
+        if self._refresh_lock.locked():
+            self._pending_refresh = True
+            return
+
+        async with self._refresh_lock:
+            await self._refresh_cache()
+            while self._pending_refresh:
+                self._pending_refresh = False
+                await self._refresh_cache()
+
+    async def _refresh_cache(self) -> None:
+        """Rebuild the EID lookup table for enabled, non-ignored devices."""
+
+        identities: list[DeviceIdentity] = self._collect_device_secrets()
+        lookup: dict[bytes, EIDMatch] = {}
+        now = int(time.time())
+        rotation_start = now - (now % ROTATION_PERIOD)
+        windows = (
+            rotation_start,
+            max(0, rotation_start - ROTATION_PERIOD),
+            rotation_start + ROTATION_PERIOD,
+        )
+
+        for identity in identities:
+            if not identity.config_entry_id:
+                continue
+            for timestamp in windows:
+                try:
+                    eid = generate_eid(identity.identity_key, timestamp)
+                except Exception as err:  # noqa: BLE001 - defensive guard
+                    _LOGGER.debug(
+                        "Failed to generate EID for %s at %s: %s",
+                        identity.canonical_id,
+                        timestamp,
+                        err,
+                    )
+                    continue
+
+                lookup[eid] = EIDMatch(
+                    device_id=identity.registry_id,
+                    config_entry_id=identity.config_entry_id,
+                    canonical_id=identity.canonical_id,
+                )
+
+        self._lookup = lookup
+        _LOGGER.debug(
+            "Refreshed EID cache for %d devices (%d cached EIDs)",
+            len(identities),
+            len(lookup),
+        )
+
+    def _collect_device_secrets(self) -> list[DeviceIdentity]:
+        """Retrieve active tracker identities from all loaded coordinators."""
+
+        bucket = self.hass.data.get(DOMAIN)
+        if not isinstance(bucket, dict):
+            return []
+
+        # ``entries`` matches ``GoogleFindMyDomainData.entries`` (entry_id -> RuntimeData).
+        entries = bucket.get("entries")
+        if not isinstance(entries, dict):
+            return []
+
+        identities: list[DeviceIdentity] = []
+        for runtime in entries.values():
+            coordinator: _IdentityProvider | None = None
+            if isinstance(runtime, GoogleFindMyCoordinator):
+                coordinator = runtime
+            else:
+                candidate = getattr(runtime, "coordinator", None)
+                if isinstance(candidate, _IdentityProvider):
+                    coordinator = candidate
+                elif isinstance(runtime, _IdentityProvider):
+                    coordinator = runtime
+
+            if coordinator is None:
+                continue
+
+            identities.extend(coordinator.get_active_device_identities())
+
+        return identities
+
+    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:
+        """Resolve a scanned EID to a Home Assistant device registry ID.
+
+        Returns the matching :class:`EIDMatch` when the identifier was
+        precomputed for a known tracker; otherwise returns ``None``. The
+        ``device_id`` in the returned mapping corresponds to the Home
+        Assistant Device Registry identifier, not an entity ID. The
+        :meth:`get_resolved_eid` helper wraps this method for callers that
+        prefer a ``device_id`` string or ``None``.
+
+        EIDs are not logged to avoid leaking hardware identifiers in debug
+        output.
+        """
+
+        match = self._lookup.get(eid_bytes)
+        if match is not None:
+            # Intentionally avoid logging raw EID bytes for privacy; only the
+            # registry device identifier is included.
+            _LOGGER.debug("Resolved EID to device %s", match.device_id)
+        return match
+
+    def get_resolved_eid(self, eid_bytes: bytes) -> str | None:
+        """Backward compatible convenience wrapper for resolve_eid.
+
+        Returns the Home Assistant device registry identifier for the EID when
+        known; otherwise returns ``None``. This mirrors the legacy string-only
+        contract while :meth:`resolve_eid` exposes the richer mapping.
+        """
+
+        match = self.resolve_eid(eid_bytes)
+        return match.device_id if match is not None else None
+
+    def stop(self) -> None:
+        """Cancel background timers and clear cached state."""
+
+        if self._unsub_alignment is not None:
+            unsub = self._unsub_alignment
+            self._unsub_alignment = None
+            try:
+                if callable(unsub):
+                    unsub()
+                elif asyncio.iscoroutine(unsub):
+                    unsub.close()
+            except Exception as err:  # pragma: no cover - defensive
+                _LOGGER.debug("Failed to cancel alignment timer: %s", err)
+        if self._unsub_interval is not None:
+            unsub = self._unsub_interval
+            self._unsub_interval = None
+            try:
+                if callable(unsub):
+                    unsub()
+                elif asyncio.iscoroutine(unsub):
+                    unsub.close()
+            except Exception as err:  # pragma: no cover - defensive
+                _LOGGER.debug("Failed to cancel refresh interval: %s", err)
+        self._lookup.clear()
+@runtime_checkable
+class _IdentityProvider(Protocol):
+    """Interface for coordinator-like objects that expose device identities."""
+
+    def get_active_device_identities(self) -> list[DeviceIdentity]:
+        """Return eligible device identities for EID resolution."""
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -652,6 +652,7 @@ def _stub_homeassistant() -> None:
     core_module.HomeAssistant = HomeAssistant
     core_module.ServiceCall = ServiceCall
     core_module.Event = Event
+    core_module.CALLBACK_TYPE = Callable[[], None]
     install_homeassistant_core_callback_stub(module=core_module, overwrite=True)
 
     exceptions_module = ModuleType("homeassistant.exceptions")
@@ -768,8 +769,6 @@ def _stub_homeassistant() -> None:
     entity_component_module.split_entity_id = split_entity_id
     sys.modules["homeassistant.helpers.entity_component"] = entity_component_module
     setattr(helpers_pkg, "entity_component", entity_component_module)
-
-    from collections.abc import Callable, Iterable
 
     entity_platform_module = ModuleType("homeassistant.helpers.entity_platform")
     entity_platform_module.AddEntitiesCallback = Callable[[Iterable], None]

--- a/tests/test_eid_resolver.py
+++ b/tests/test_eid_resolver.py
@@ -1,0 +1,314 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import custom_components.googlefindmy.coordinator as coordinator_module
+import custom_components.googlefindmy.eid_resolver as resolver_module
+from custom_components.googlefindmy.const import DOMAIN
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import GoogleFindMyEIDResolver
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import ROTATION_PERIOD
+
+
+class _StubDevice:
+    def __init__(
+        self,
+        identifier: str,
+        *,
+        registry_id: str | None = None,
+        custom_fields: dict | None = None,
+        disabled: bool = False,
+    ) -> None:
+        self.identifier = identifier
+        self.id = registry_id or identifier
+        self.custom_fields = custom_fields
+        self.disabled_by = "user" if disabled else None
+
+
+class _StubDeviceRegistry:
+    def __init__(self, devices: list[_StubDevice]) -> None:
+        self._devices = devices
+
+    def async_entries_for_config_entry(self, _entry_id: str) -> list[_StubDevice]:
+        return list(self._devices)
+
+
+class _StubHass:
+    def __init__(self, data: dict | None = None) -> None:
+        self.data = data or {}
+
+    def async_create_task(self, coro: asyncio.Future, name: str | None = None) -> asyncio.Task:
+        return asyncio.create_task(coro, name=name)
+
+
+@pytest.mark.asyncio
+async def test_active_device_identities_prefer_registry_custom_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = _StubDeviceRegistry(
+        [_StubDevice("dev-1", registry_id="registry-1", custom_fields={"identity_key": "0f0e0d"})]
+    )
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator.hass = _StubHass()
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator._enabled_poll_device_ids = {"dev-1"}
+    coordinator._get_ignored_set = lambda: set()
+    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator.data = []
+    coordinator._device_location_data = {}
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.identity_key == bytes.fromhex("0f0e0d")
+    assert identity.config_entry_id == "entry-1"
+    assert identity.registry_id == "registry-1"
+    assert identity.canonical_id == "dev-1"
+
+
+@pytest.mark.asyncio
+async def test_active_device_identities_fall_back_to_location_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _StubDeviceRegistry(
+        [_StubDevice("dev-2", registry_id="registry-2", custom_fields={})]
+    )
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator.hass = _StubHass()
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-2")
+    coordinator._enabled_poll_device_ids = {"dev-2"}
+    coordinator._get_ignored_set = lambda: set()
+    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator.data = []
+    coordinator._device_location_data = {"dev-2": {"identityKey": "abcd"}}
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.registry_id == "registry-2"
+    assert identity.canonical_id == "dev-2"
+    assert identity.identity_key == bytes.fromhex("abcd")
+    assert identity.config_entry_id == "entry-2"
+
+
+@pytest.mark.asyncio
+async def test_active_device_identities_ignore_opt_out_devices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _StubDeviceRegistry(
+        [_StubDevice("dev-3", registry_id="registry-3", custom_fields={"identity_key": "1234"})]
+    )
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator.hass = _StubHass()
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-3")
+    coordinator._enabled_poll_device_ids = {"dev-3"}
+    coordinator._get_ignored_set = lambda: {"dev-3"}
+    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator.data = []
+    coordinator._device_location_data = {}
+
+    identities = coordinator.get_active_device_identities()
+
+    assert identities == []
+
+
+@pytest.mark.asyncio
+async def test_resolver_refreshes_all_rotation_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_time = 2050
+    recorded_timestamps: list[int] = []
+
+    def _fake_time() -> int:
+        return base_time
+
+    def _fake_generate_eid(key: bytes, timestamp: int) -> bytes:
+        recorded_timestamps.append(timestamp)
+        return f"{key.hex()}-{timestamp}".encode()
+
+    monkeypatch.setattr(resolver_module.time, "time", _fake_time)
+    monkeypatch.setattr(resolver_module, "generate_eid", _fake_generate_eid)
+
+    identity = DeviceIdentity(
+        registry_id="registry-4",
+        canonical_id="device-1",
+        identity_key=b"\x01\x02",
+        config_entry_id="entry-4",
+    )
+
+    coordinator = SimpleNamespace(get_active_device_identities=lambda: [identity])
+    hass = _StubHass({DOMAIN: {"entries": {"entry-4": SimpleNamespace(coordinator=coordinator)}}})
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = hass
+    resolver._lookup = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+
+    await resolver._refresh_cache()
+
+    rotation_start = base_time - (base_time % ROTATION_PERIOD)
+    assert set(recorded_timestamps) == {
+        rotation_start,
+        max(0, rotation_start - ROTATION_PERIOD),
+        rotation_start + ROTATION_PERIOD,
+    }
+
+    expected_eid = f"{identity.identity_key.hex()}-{rotation_start}".encode()
+    match = resolver.resolve_eid(expected_eid)
+    assert match is not None
+    assert match.device_id == "registry-4"
+    assert match.canonical_id == "device-1"
+    assert resolver.get_resolved_eid(expected_eid) == "registry-4"
+    assert resolver.resolve_eid(b"unknown") is None
+    assert resolver.get_resolved_eid(b"unknown") is None
+
+
+@pytest.mark.asyncio
+async def test_resolver_aggregates_multiple_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_time = 4096
+
+    def _fake_time() -> int:
+        return base_time
+
+    def _fake_generate_eid(key: bytes, timestamp: int) -> bytes:
+        return f"{key.hex()}-{timestamp}".encode()
+
+    monkeypatch.setattr(resolver_module.time, "time", _fake_time)
+    monkeypatch.setattr(resolver_module, "generate_eid", _fake_generate_eid)
+
+    identity_one = DeviceIdentity(
+        registry_id="registry-1",
+        canonical_id="can-1",
+        identity_key=b"\x01",
+        config_entry_id="entry-a",
+    )
+    identity_two = DeviceIdentity(
+        registry_id="registry-2",
+        canonical_id="can-2",
+        identity_key=b"\x02",
+        config_entry_id="entry-b",
+    )
+
+    coordinator_one = SimpleNamespace(get_active_device_identities=lambda: [identity_one])
+    coordinator_two = SimpleNamespace(get_active_device_identities=lambda: [identity_two])
+    hass = _StubHass(
+        {
+            DOMAIN: {
+                "entries": {
+                    "entry-a": SimpleNamespace(coordinator=coordinator_one),
+                    "entry-b": SimpleNamespace(coordinator=coordinator_two),
+                }
+            }
+        }
+    )
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = hass
+    resolver._lookup = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+
+    await resolver._refresh_cache()
+
+    rotation_start = base_time - (base_time % ROTATION_PERIOD)
+    eid_one = f"{identity_one.identity_key.hex()}-{rotation_start}".encode()
+    eid_two = f"{identity_two.identity_key.hex()}-{rotation_start}".encode()
+
+    assert resolver.resolve_eid(eid_one).config_entry_id == "entry-a"
+    assert resolver.resolve_eid(eid_two).config_entry_id == "entry-b"
+
+
+@pytest.mark.asyncio
+async def test_resolver_excludes_disabled_or_ignored_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = _StubDeviceRegistry(
+        [
+            _StubDevice("dev-1", registry_id="registry-1", custom_fields={"identity_key": "abcd"}, disabled=True),
+            _StubDevice("dev-2", registry_id="registry-2", custom_fields={"identity_key": "dcba"}),
+        ]
+    )
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator.hass = _StubHass()
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-ignore")
+    coordinator._enabled_poll_device_ids = {"dev-1", "dev-2"}
+    coordinator._get_ignored_set = lambda: {"dev-2"}
+    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator.data = []
+    coordinator._device_location_data = {}
+
+    hass = _StubHass({DOMAIN: {"entries": {"entry-ignore": SimpleNamespace(coordinator=coordinator)}}})
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = hass
+    resolver._lookup = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+
+    await resolver._refresh_cache()
+
+    assert resolver._lookup == {}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_refresh_requests_are_serialized(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_time = 8192
+
+    def _fake_time() -> int:
+        return base_time
+
+    async def _delayed_refresh(_: float) -> None:
+        await asyncio.sleep(0)
+
+    def _fake_generate_eid(key: bytes, timestamp: int) -> bytes:
+        return f"{key.hex()}-{timestamp}".encode()
+
+    monkeypatch.setattr(resolver_module.time, "time", _fake_time)
+    monkeypatch.setattr(resolver_module, "generate_eid", _fake_generate_eid)
+    # Defensive: keep refresh serialization stable even if future implementations
+    # introduce awaits inside the cache rebuild. The current refresh path does not
+    # sleep, but the shim ensures concurrent refreshes would still join correctly.
+    monkeypatch.setattr(resolver_module.asyncio, "sleep", lambda delay: _delayed_refresh(delay))
+
+    identity = DeviceIdentity(
+        registry_id="registry-lock",
+        canonical_id="canonical-lock",
+        identity_key=b"\x0a",
+        config_entry_id="entry-lock",
+    )
+
+    coordinator = SimpleNamespace(get_active_device_identities=lambda: [identity])
+    hass = _StubHass({DOMAIN: {"entries": {"entry-lock": SimpleNamespace(coordinator=coordinator)}}})
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = hass
+    resolver._lookup = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+
+    await asyncio.gather(resolver.async_refresh(), resolver.async_refresh(), resolver.async_refresh())
+
+    rotation_start = base_time - (base_time % ROTATION_PERIOD)
+    expected_eid = f"{identity.identity_key.hex()}-{rotation_start}".encode()
+    assert expected_eid in resolver._lookup
+


### PR DESCRIPTION
## Summary
- expose shared Find My FCM provider hooks as lazily initialized globals that respect existing overrides and unregister cleanly when refcounts drop
- harden resolver lifecycle by guarding hass stubs without data/tasks and by safely canceling coroutine-based timers
- align the Home Assistant test stub with the expected `CALLBACK_TYPE` export to keep resolver imports working under pytest

## Testing
- python -m ruff check --fix .
- python -m mypy --strict custom_components/googlefindmy/__init__.py custom_components/googlefindmy/eid_resolver.py custom_components/googlefindmy/coordinator.py tests/test_eid_resolver.py
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693708b2114c8329b1c7acfe575997f0)