### PR TITLE
Handle encrypted identity keys via owner key metadata

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -18,6 +18,10 @@ from custom_components.googlefindmy import get_proto_decoder
 from custom_components.googlefindmy.Auth.username_provider import username_string
 from custom_components.googlefindmy.const import MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S
 from custom_components.googlefindmy.FMDNCrypto.foreign_tracker_cryptor import decrypt
+from custom_components.googlefindmy.FMDNCrypto.mcu_utils import (
+    flip_bits,
+    is_mcu_tracker,
+)
 from custom_components.googlefindmy.KeyBackup.cloud_key_decryptor import (
     decrypt_aes_gcm,
     decrypt_eik,
@@ -28,15 +32,12 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypte
 from custom_components.googlefindmy.ProtoDecoders.decoder import (
     parse_device_update_protobuf,
 )
-from custom_components.googlefindmy.SpotApi.CreateBleDevice.config import (
-    mcu_fast_pair_model_id,
-)
-from custom_components.googlefindmy.SpotApi.CreateBleDevice.util import flip_bits
 from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
     SpotApiEmptyResponseError,
     async_get_eid_info,
 )
 from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+    OwnerKeyInfo,
     async_get_owner_key,
 )
 from google.protobuf.message import DecodeError
@@ -137,11 +138,6 @@ def create_google_maps_link(latitude: float, longitude: float) -> str | None:
     return f"https://www.google.com/maps/search/?api=1&query={lat_f},{lon_f}"
 
 
-def is_mcu_tracker(device_registration: DeviceRegistration) -> bool:
-    """Return True if device appears to be our custom MCU tracker."""
-    return device_registration.fastPairModelId == mcu_fast_pair_model_id
-
-
 async def async_retrieve_identity_key(
     device_registration: DeviceRegistration,
     *,
@@ -179,12 +175,12 @@ async def async_retrieve_identity_key(
             "TokenCache instance is required to retrieve the tracker identity key."
         )
 
-    owner_key = await async_get_owner_key(cache=cache)
+    owner_key_info: OwnerKeyInfo = await async_get_owner_key(cache=cache)
 
     try:
         # CPU-heavy → do not block the event loop
         eik_bytes = await asyncio.to_thread(
-            decrypt_eik, owner_key, encrypted_identity_key
+            decrypt_eik, owner_key_info.key, encrypted_identity_key
         )
         # Strict sanity: EIK must be exactly 32 bytes
         if not isinstance(eik_bytes, (bytes, bytearray)) or len(eik_bytes) != _EIK_LEN:

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -235,6 +235,9 @@ _DEVICE_STUB_KEYS: tuple[str, ...] = (
     "name",
     "id",
     "device_id",
+    "encrypted_identity_key",
+    "owner_key_version",
+    "device_type",
     "latitude",
     "longitude",
     "altitude",
@@ -259,6 +262,9 @@ def _build_device_stub(device_name: str, canonic_id: str) -> dict[str, Any]:
         "name": device_name,
         "id": canonic_id,
         "device_id": canonic_id,
+        "encrypted_identity_key": None,
+        "owner_key_version": None,
+        "device_type": None,
         "latitude": None,
         "longitude": None,
         "altitude": None,
@@ -610,6 +616,9 @@ def get_devices_with_location(
 
         # Try decryption ONCE per device; share across all its canonic IDs
         location_candidates: list[dict[str, Any]] = []
+        encrypted_identity_key = None
+        owner_key_version = None
+        device_type = None
         if decrypt_location_response_locations is not None and cache is not None:
             try:
                 if device.HasField("information") and device.information.HasField(
@@ -648,6 +657,25 @@ def get_devices_with_location(
                 )
                 location_candidates = []
 
+        if device.HasField("information") and device.information.HasField(
+            "deviceRegistration"
+        ):
+            registration = device.information.deviceRegistration
+            encrypted_user_secrets = registration.encryptedUserSecrets
+
+            if encrypted_user_secrets.encryptedIdentityKey:
+                encrypted_identity_key = (
+                    encrypted_user_secrets.encryptedIdentityKey.hex()
+                )
+
+            if encrypted_user_secrets.HasField("ownerKeyVersion"):
+                owner_key_version = encrypted_user_secrets.ownerKeyVersion
+
+            if registration.HasField("deviceTypeInformation") and (
+                registration.deviceTypeInformation.HasField("deviceType")
+            ):
+                device_type = registration.deviceTypeInformation.deviceType
+
         # If decryption yielded results, select the best one and keep normalized list.
         if location_candidates:
             best, normed = _select_best_location(location_candidates)
@@ -663,6 +691,9 @@ def get_devices_with_location(
                 continue
 
             row = _build_device_stub(device_name, cid)
+            row["encrypted_identity_key"] = encrypted_identity_key
+            row["owner_key_version"] = owner_key_version
+            row["device_type"] = device_type
 
             if best:
                 # best already normalized by selection; merge only known keys

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -33,7 +33,7 @@ import re
 from binascii import Error as BinasciiError
 from binascii import unhexlify
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, NamedTuple
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
@@ -63,6 +63,13 @@ _USERNAME_REDACTION_MIN_LENGTH = 13
 # Cache key base for owner keys. We migrate from legacy "owner_key" to per-user keys.
 _OWNER_KEY_CACHE_PREFIX = "owner_key"
 _OWNER_KEY_LENGTH = 32
+
+
+class OwnerKeyInfo(NamedTuple):
+    """Owner key material with version metadata."""
+
+    key: bytes
+    version: int | None
 
 
 # ---------------------------------------------------------------------------
@@ -128,14 +135,14 @@ async def _retrieve_owner_key(
     cache: TokenCache,
     eid_info_getter: Callable[[], Awaitable[Any]] | None = None,
     shared_key_getter: Callable[[], Awaitable[bytes]] | None = None,
-) -> str:
-    """Retrieve and decrypt the owner key for `username`, returning a hex string.
+) -> dict[str, Any]:
+    """Retrieve and decrypt the owner key for `username`, returning cache payload.
 
     Steps:
         1. Call SPOT GetEidInfoForE2eeDevices (may raise SpotApiEmptyResponseError).
         2. Obtain shared key (bytes).
         3. Decrypt the encrypted owner key to raw bytes.
-        4. Return as lowercase hex string.
+        4. Return a mapping containing lowercase hex key string and owner key version.
 
     The retrieval of EID info and shared key can be provided via async callables;
     when omitted, synchronous helpers are executed in a thread pool.
@@ -200,7 +207,10 @@ async def _retrieve_owner_key(
         ),  # Redact email for privacy
     )
 
-    return bytes(owner_key).hex()
+    return {
+        "key": bytes(owner_key).hex(),
+        "version": owner_key_version if isinstance(owner_key_version, int) else None,
+    }
 
 
 async def _get_or_generate_user_owner_key_hex(
@@ -209,12 +219,13 @@ async def _get_or_generate_user_owner_key_hex(
     cache: TokenCache,
     eid_info_getter: Callable[[], Awaitable[Any]] | None = None,
     shared_key_getter: Callable[[], Awaitable[bytes]] | None = None,
-) -> str:
-    """Return the per-user owner key (hex string), migrating and generating if needed.
+) -> Any:
+    """Return the per-user owner key payload, migrating and generating if needed.
 
     Cache behavior:
         - All operations are performed against the provided entry-scoped cache.
         - Legacy `owner_key` (non-scoped) is migrated *within the same cache scope*.
+        - Cached values may be a string (legacy) or mapping with ``{"key": str, "version": int | None}``.
     """
     user_key_name = _user_cache_key(username)
 
@@ -223,11 +234,22 @@ async def _get_or_generate_user_owner_key_hex(
         raise ValueError("TokenCache instance is required for multi-account safety.")
 
     user_key = await cache.get(user_key_name)
+    if isinstance(user_key, dict) and user_key.get("key"):
+        return user_key
+
     if isinstance(user_key, str) and user_key:
         return user_key
 
     # 2) Legacy migration (within the same cache scope only)
     legacy = await cache.get(_OWNER_KEY_CACHE_PREFIX)
+    if isinstance(legacy, dict) and legacy.get("key"):
+        await cache.set(user_key_name, legacy)
+        _LOGGER.debug(
+            "Migrated legacy 'owner_key' (entry-scoped) to user-scoped cache for %s",
+            username,
+        )
+        return legacy
+
     if isinstance(legacy, str) and legacy:
         await cache.set(user_key_name, legacy)
         _LOGGER.debug(
@@ -253,13 +275,13 @@ async def _get_or_generate_user_owner_key_hex(
 # ---------------------------------------------------------------------------
 
 
-async def async_get_owner_key(
+async def async_get_owner_key(  # noqa: PLR0912,PLR0915
     *,
     cache: TokenCache,
     username: str | None = None,
     eid_info_getter: Callable[[], Awaitable[Any]] | None = None,
     shared_key_getter: Callable[[], Awaitable[bytes]] | None = None,
-) -> bytes:
+) -> OwnerKeyInfo:
     """Return the binary owner key (32 bytes) for the current user (entry-scoped capable).
 
     Behavior:
@@ -271,7 +293,7 @@ async def async_get_owner_key(
         - If `cache` is provided, username resolution will prefer the same cache.
 
     Returns:
-        bytes: the owner key (exactly 32 bytes)
+        OwnerKeyInfo: the owner key (exactly 32 bytes) and version metadata if available.
 
     Raises:
         RuntimeError: if the key is missing/invalid or has incorrect length.
@@ -310,14 +332,34 @@ async def async_get_owner_key(
             " (auth/session issue). Please re-authenticate."
         ) from exc
 
-    # 1) Fast path: try hex (canonical format)
+    cache_version: int | None = None
+    cache_key_value: str | None = None
+    if isinstance(raw_value, dict):
+        version_value = raw_value.get("version")
+        if isinstance(version_value, int):
+            cache_version = version_value
+        elif isinstance(version_value, str) and version_value.isdigit():
+            cache_version = int(version_value)
+
+        key_candidate = raw_value.get("key")
+        cache_key_value = key_candidate if isinstance(key_candidate, str) else None
+    elif isinstance(raw_value, str):
+        cache_key_value = raw_value
+
+    if cache_key_value is None:
+        await cache.set(_user_cache_key(user), None)
+        await cache.set(_OWNER_KEY_CACHE_PREFIX, None)
+        raise RuntimeError("Owner key is missing or invalid; please re-authenticate.")
+
+    decoded_from_non_hex = False
     key_bytes: bytes
     try:
-        key_bytes = _try_hex(raw_value)
+        key_bytes = _try_hex(cache_key_value)
     except (BinasciiError, TypeError):
         # 2) Fallback: try base64/base64url/PEM-like
         try:
-            key_bytes = _try_base64_like(raw_value)
+            key_bytes = _try_base64_like(cache_key_value)
+            decoded_from_non_hex = True
         except Exception as exc:
             _LOGGER.error(
                 "Owner key for user '%s' is not valid hex or base64/base64url. "
@@ -331,12 +373,15 @@ async def async_get_owner_key(
             raise RuntimeError(
                 "Invalid owner_key format (expect 32-byte key in hex or base64)."
             ) from exc
-        else:
-            # Self-heal: normalize the cache to hex for future consistency
-            _LOGGER.info(
-                "Successfully decoded owner key from a non-hex format; normalizing cache to hex."
-            )
-            await cache.set(_user_cache_key(user), key_bytes.hex())
+    normalized_value = {"key": key_bytes.hex(), "version": cache_version}
+    if decoded_from_non_hex:
+        # Self-heal: normalize the cache to hex for future consistency
+        _LOGGER.info(
+            "Successfully decoded owner key from a non-hex format; normalizing cache to hex."
+        )
+
+    if decoded_from_non_hex or not isinstance(raw_value, dict):
+        await cache.set(_user_cache_key(user), normalized_value)
 
     # 3) Final validation: the owner key must be exactly 32 bytes long
     if len(key_bytes) != _OWNER_KEY_LENGTH:
@@ -350,7 +395,7 @@ async def async_get_owner_key(
         await cache.set(_OWNER_KEY_CACHE_PREFIX, None)
         raise RuntimeError("Owner key must be exactly 32 bytes long.")
 
-    return key_bytes
+    return OwnerKeyInfo(key=key_bytes, version=cache_version)
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/googlefindmy/SpotApi/UploadPrecomputedPublicKeyIds/upload_precomputed_public_key_ids.py
+++ b/custom_components/googlefindmy/SpotApi/UploadPrecomputedPublicKeyIds/upload_precomputed_public_key_ids.py
@@ -10,8 +10,8 @@ from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
     ROTATION_PERIOD,
     generate_eid,
 )
+from custom_components.googlefindmy.FMDNCrypto.mcu_utils import is_mcu_tracker
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
-    is_mcu_tracker,
     retrieve_identity_key,
 )
 from custom_components.googlefindmy.ProtoDecoders.DeviceUpdate_pb2 import (

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -635,12 +635,18 @@ class DeviceIdentity:
         registry_id: Home Assistant device registry identifier for the tracker.
         canonical_id: Namespaced device identifier used by the integration's API.
         identity_key: Ephemeral identity key used to derive rotating EIDs.
+        encrypted_identity_key: Encrypted EIK blob (hex-decoded) for on-demand decryption.
+        owner_key_version: Version of the owner key used to encrypt the EIK.
+        device_type: SpotDeviceType enum value reported by the tracker, when known.
         config_entry_id: Parent config entry ID that owns the tracker.
     """
 
     registry_id: str
     canonical_id: str
-    identity_key: bytes
+    identity_key: bytes | None
+    encrypted_identity_key: bytes | None = None
+    owner_key_version: int | None = None
+    device_type: int | None = None
     config_entry_id: str | None = None
 
 
@@ -4303,6 +4309,15 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         Assistant Device Registry identifier for each tracker.
         """
 
+        def _normalize_device_type(value: Any) -> int | None:
+            if isinstance(value, bool):
+                return None
+            if isinstance(value, int):
+                return value
+            if isinstance(value, str) and value.isdigit():
+                return int(value)
+            return None
+
         enabled_ids = set(self._enabled_poll_device_ids)
         ignored = self._get_ignored_set()
         device_ids = [dev_id for dev_id in enabled_ids if dev_id not in ignored]
@@ -4334,6 +4349,8 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 )
 
         data_identities: dict[str, bytes] = {}
+        data_encrypted: dict[str, tuple[bytes | None, int | None]] = {}
+        data_device_types: dict[str, int | None] = {}
         device_data = getattr(self, "data", None)
         if isinstance(device_data, Iterable):
             for raw in device_data:
@@ -4350,8 +4367,27 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 if parsed is not None:
                     data_identities[dev_id] = parsed
 
+                encrypted_identity = self._normalize_identity_key(
+                    raw.get("encrypted_identity_key")
+                    or raw.get("encryptedIdentityKey")
+                )
+                owner_key_version = raw.get("owner_key_version")
+                if isinstance(owner_key_version, str) and owner_key_version.isdigit():
+                    owner_key_version = int(owner_key_version)
+                elif not isinstance(owner_key_version, int):
+                    owner_key_version = None
+
+                if encrypted_identity is not None or owner_key_version is not None:
+                    data_encrypted[dev_id] = (encrypted_identity, owner_key_version)
+
+                device_type = _normalize_device_type(raw.get("device_type"))
+                if device_type is not None:
+                    data_device_types[dev_id] = device_type
+
         cache = getattr(self, "_device_location_data", None)
         cache_identities: dict[str, bytes] = {}
+        cache_encrypted: dict[str, tuple[bytes | None, int | None]] = {}
+        cache_device_types: dict[str, int | None] = {}
         if isinstance(cache, dict):
             for dev_id in device_ids:
                 payload = cache.get(dev_id)
@@ -4365,6 +4401,23 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 if parsed is not None:
                     cache_identities[dev_id] = parsed
 
+                encrypted_identity = self._normalize_identity_key(
+                    payload.get("encrypted_identity_key")
+                    or payload.get("encryptedIdentityKey")
+                )
+                owner_key_version = payload.get("owner_key_version")
+                if isinstance(owner_key_version, str) and owner_key_version.isdigit():
+                    owner_key_version = int(owner_key_version)
+                elif not isinstance(owner_key_version, int):
+                    owner_key_version = None
+
+                if encrypted_identity is not None or owner_key_version is not None:
+                    cache_encrypted[dev_id] = (encrypted_identity, owner_key_version)
+
+                device_type = _normalize_device_type(payload.get("device_type"))
+                if device_type is not None:
+                    cache_device_types[dev_id] = device_type
+
         identities: list[DeviceIdentity] = []
         for canonical_id in device_ids:
             registry_entry = registry_map.get(canonical_id)
@@ -4377,7 +4430,16 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 identity_key = data_identities.get(canonical_id)
             if identity_key is None:
                 identity_key = cache_identities.get(canonical_id)
-            if identity_key is None:
+
+            encrypted_identity_key, owner_key_version = data_encrypted.get(
+                canonical_id,
+                cache_encrypted.get(canonical_id, (None, None)),
+            )
+            device_type = data_device_types.get(
+                canonical_id, cache_device_types.get(canonical_id)
+            )
+
+            if identity_key is None and encrypted_identity_key is None:
                 continue
 
             identities.append(
@@ -4385,6 +4447,9 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     registry_id=registry_id,
                     canonical_id=canonical_id,
                     identity_key=identity_key,
+                    encrypted_identity_key=encrypted_identity_key,
+                    owner_key_version=owner_key_version,
+                    device_type=device_type,
                     config_entry_id=entry_id,
                 )
             )

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -12,9 +12,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
-from typing import NamedTuple, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, NamedTuple, Protocol, runtime_checkable
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
@@ -22,6 +22,20 @@ from homeassistant.helpers.event import async_call_later, async_track_time_inter
 from .const import DOMAIN
 from .coordinator import DeviceIdentity, GoogleFindMyCoordinator
 from .FMDNCrypto.eid_generator import ROTATION_PERIOD, generate_eid
+from .FMDNCrypto.mcu_utils import flip_bits, is_mcu_tracker
+from .KeyBackup.cloud_key_decryptor import decrypt_eik
+from .SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+    OwnerKeyInfo,
+    async_get_owner_key,
+)
+
+if TYPE_CHECKING:
+    from custom_components.googlefindmy.Auth.token_cache import TokenCache
+else:
+    try:
+        from custom_components.googlefindmy.Auth.token_cache import TokenCache
+    except Exception:  # pragma: no cover - optional type aid only
+        TokenCache = None
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,7 +127,7 @@ class GoogleFindMyEIDResolver:
     async def _refresh_cache(self) -> None:
         """Rebuild the EID lookup table for enabled, non-ignored devices."""
 
-        identities: list[DeviceIdentity] = self._collect_device_secrets()
+        identities: list[DeviceIdentity] = await self._collect_device_secrets()
         lookup: dict[bytes, EIDMatch] = {}
         now = int(time.time())
         rotation_start = now - (now % ROTATION_PERIOD)
@@ -124,7 +138,7 @@ class GoogleFindMyEIDResolver:
         )
 
         for identity in identities:
-            if not identity.config_entry_id:
+            if not identity.config_entry_id or identity.identity_key is None:
                 continue
             for timestamp in windows:
                 try:
@@ -151,7 +165,7 @@ class GoogleFindMyEIDResolver:
             len(lookup),
         )
 
-    def _collect_device_secrets(self) -> list[DeviceIdentity]:
+    async def _collect_device_secrets(self) -> list[DeviceIdentity]:
         """Retrieve active tracker identities from all loaded coordinators."""
 
         bucket = self.hass.data.get(DOMAIN)
@@ -178,9 +192,93 @@ class GoogleFindMyEIDResolver:
             if coordinator is None:
                 continue
 
-            identities.extend(coordinator.get_active_device_identities())
+            identities.extend(
+                await self._normalize_identities(
+                    coordinator.get_active_device_identities(),
+                    cache=getattr(coordinator, "cache", None),
+                )
+            )
 
         return identities
+
+    async def _normalize_identities(
+        self,
+        identities: list[DeviceIdentity],
+        *,
+        cache: TokenCache | None,
+    ) -> list[DeviceIdentity]:
+        """Ensure each device identity has a usable plaintext key."""
+
+        normalized: list[DeviceIdentity] = []
+        for identity in identities:
+            if identity.identity_key is None:
+                decrypted = await self._try_decrypt_identity_key(identity, cache=cache)
+                if decrypted is None:
+                    continue
+                normalized.append(replace(identity, identity_key=decrypted))
+                continue
+
+            normalized.append(identity)
+
+        return normalized
+
+    async def _try_decrypt_identity_key(
+        self,
+        identity: DeviceIdentity,
+        *,
+        cache: TokenCache | None,
+    ) -> bytes | None:
+        """Decrypt encrypted identity key when owner key information is available."""
+
+        if (
+            cache is None
+            or identity.encrypted_identity_key is None
+            or not isinstance(identity.encrypted_identity_key, (bytes, bytearray))
+        ):
+            return None
+
+        encrypted_identity_key = bytes(identity.encrypted_identity_key)
+        if is_mcu_tracker(device_type=identity.device_type):
+            encrypted_identity_key = flip_bits(encrypted_identity_key, True)
+
+        try:
+            owner_key_info: OwnerKeyInfo = await async_get_owner_key(cache=cache)
+        except Exception as err:  # noqa: BLE001 - defensive
+            _LOGGER.debug(
+                "Failed to retrieve owner key for %s: %s",
+                identity.canonical_id,
+                err,
+            )
+            return None
+
+        expected_version = identity.owner_key_version
+        cached_version = owner_key_info.version
+        if (
+            expected_version is not None
+            and cached_version is not None
+            and expected_version != cached_version
+        ):
+            _LOGGER.warning(
+                "Owner key version mismatch for %s: device=%s cache=%s",
+                identity.canonical_id,
+                expected_version,
+                cached_version,
+            )
+
+        try:
+            decrypted = await asyncio.to_thread(
+                decrypt_eik, owner_key_info.key, encrypted_identity_key
+            )
+        except Exception as err:  # noqa: BLE001 - defensive
+            _LOGGER.debug(
+                "Failed to decrypt identity key for %s (owner_key_version=%s): %s",
+                identity.canonical_id,
+                identity.owner_key_version,
+                err,
+            )
+            return None
+
+        return decrypted if isinstance(decrypted, (bytes, bytearray)) else None
 
     def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:
         """Resolve a scanned EID to a Home Assistant device registry ID.

--- a/tests/test_e2ee_token_cache_propagation.py
+++ b/tests/test_e2ee_token_cache_propagation.py
@@ -10,6 +10,9 @@ from types import SimpleNamespace
 import pytest
 
 from custom_components.googlefindmy.Auth.username_provider import username_string
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+    OwnerKeyInfo,
+)
 from tests.helpers import DummyCache
 
 
@@ -26,7 +29,7 @@ def test_async_retrieve_identity_key_threads_cache(
 
     async def fake_async_get_owner_key(*, cache, **kwargs):  # type: ignore[no-untyped-def]
         owner_calls["owner_cache"] = cache
-        return b"\x01" * 32
+        return OwnerKeyInfo(key=b"\x01" * 32, version=1)
 
     async def fake_async_get_eid_info(*, cache):  # type: ignore[no-untyped-def]
         owner_calls["eid_cache"] = cache
@@ -76,7 +79,7 @@ def test_async_retrieve_identity_key_error_uses_cache(
 
     async def fake_async_get_owner_key(*, cache, **kwargs):  # type: ignore[no-untyped-def]
         caches["owner_cache"] = cache
-        return b"\x01" * 32
+        return OwnerKeyInfo(key=b"\x01" * 32, version=1)
 
     async def fake_async_get_eid_info(*, cache):  # type: ignore[no-untyped-def]
         caches["eid_cache"] = cache
@@ -133,7 +136,7 @@ def test_async_retrieve_identity_key_retries_after_clearing_owner_key(
 
     async def fake_async_get_owner_key(*, cache, **kwargs):  # type: ignore[no-untyped-def]
         owner_calls.append(cache)
-        return b"\x01" * 32
+        return OwnerKeyInfo(key=b"\x01" * 32, version=1)
 
     async def fake_async_get_eid_info(*, cache):  # type: ignore[no-untyped-def]
         eid_calls.append(cache)


### PR DESCRIPTION
## Summary
- track owner key metadata with a new OwnerKeyInfo structure and normalize cached values
- expose encrypted identity key, owner key version, and device type from device payloads for reuse
- allow the EID resolver to decrypt stored encrypted identity keys using owner key versions

## Testing
- python -m ruff check --fix .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693897ca0a9483298395a15eb529c35d)