### PR TITLE
Fix proto ownerKeyVersion extraction

### DIFF
--- a/custom_components/googlefindmy/ProtoDecoders/AGENTS.md
+++ b/custom_components/googlefindmy/ProtoDecoders/AGENTS.md
@@ -21,3 +21,7 @@ Use the checked-in proto sources (`custom_components/googlefindmy/ProtoDecoders/
 3. Verify the generated `.pyi` stubs keep `Message = _message.Message` and subclass `Message` directly before committing changes.
 
 If the upstream proto schema changes, update the mirrored definitions under `custom_components/googlefindmy/ProtoDecoders/*.proto` first so regenerations remain reproducible from source control.
+
+## Proto3 scalar presence reminder
+
+Proto3 **non-optional scalar fields do not support `HasField`**. Access them directly and rely on their default values (for example, `0` for integers) instead of calling presence checks that raise `ValueError`.

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -668,8 +668,9 @@ def get_devices_with_location(
                     encrypted_user_secrets.encryptedIdentityKey.hex()
                 )
 
-            if encrypted_user_secrets.HasField("ownerKeyVersion"):
-                owner_key_version = encrypted_user_secrets.ownerKeyVersion
+            # NOTE: In Proto3, non-optional scalar fields (int32) do not support
+            # HasField(). Accessing them directly returns 0 if unset.
+            owner_key_version = encrypted_user_secrets.ownerKeyVersion
 
             if registration.HasField("deviceTypeInformation") and (
                 registration.deviceTypeInformation.HasField("deviceType")


### PR DESCRIPTION
## Summary
- access ownerKeyVersion directly on EncryptedUserSecrets to avoid ValueError from HasField on Proto3 scalars
- document Proto3 scalar HasField behavior in decoder
- add ProtoDecoders AGENT reminder about Proto3 scalar presence semantics to guide future contributors

## Testing
- python -m ruff check --fix .
- python -m mypy --strict .
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938a87afc80832980a44ddf1b220767)