### PR TITLE
Refine cache merge quality guard

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -6081,11 +6081,51 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if not existing:
             return incoming
 
-        merged = dict(existing)
-        merged.update(incoming)
-
         existing_seen = _normalize_epoch_seconds(existing.get("last_seen"))
         incoming_seen = _normalize_epoch_seconds(incoming.get("last_seen"))
+        existing_rank = existing.get("source_rank")
+        incoming_rank = incoming.get("source_rank")
+
+        location_fields = {
+            "latitude",
+            "longitude",
+            "accuracy",
+            "altitude",
+            "status",
+            "source_label",
+            "source_rank",
+            "is_own_report",
+            "last_seen",
+            "last_seen_utc",
+        }
+
+        allow_location_update = True
+        if existing_seen is not None and incoming_seen is not None:
+            if incoming_seen < existing_seen:
+                allow_location_update = False
+            elif incoming_seen == existing_seen and (
+                existing_rank is not None
+                and (
+                    incoming_rank is None
+                    or existing_rank > incoming_rank
+                )
+            ):
+                allow_location_update = False
+        elif existing_seen is not None and incoming_seen is None:
+            allow_location_update = False
+        elif existing_seen is None and incoming_seen is None and (
+            existing_rank is not None
+            and (incoming_rank is None or existing_rank > incoming_rank)
+        ):
+            allow_location_update = False
+
+        merged = dict(existing)
+        if allow_location_update:
+            merged.update(incoming)
+        else:
+            merged.update({
+                key: value for key, value in incoming.items() if key not in location_fields
+            })
 
         # Keep monotonic last_seen timestamps when payloads arrive without a newer value.
         if existing_seen is not None and (


### PR DESCRIPTION
## Summary
- tighten the cache merge guard to block location downgrades when incoming updates lack timestamps or carry lower-quality ranks
- continue preserving cached coordinates and monotonic timestamps unless a clearly better report arrives

## Testing
- python -m ruff check --fix .
- python -m mypy --strict .
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391f09f9d08329baf3573adfe41923)