### PR TITLE
Add debug logging for EID precalculation

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -143,6 +143,8 @@ class GoogleFindMyEIDResolver:
         for identity in identities:
             if not identity.config_entry_id or identity.identity_key is None:
                 continue
+
+            mcu_tracker = is_mcu_tracker(device_type=identity.device_type)
             for timestamp in windows:
                 try:
                     eid = generate_eid(identity.identity_key, timestamp)
@@ -159,6 +161,12 @@ class GoogleFindMyEIDResolver:
                     device_id=identity.registry_id,
                     config_entry_id=identity.config_entry_id,
                     canonical_id=identity.canonical_id,
+                )
+                _LOGGER.debug(
+                    "Precalculated EID for %s (MCU=%s): %s",
+                    identity.registry_id,
+                    mcu_tracker,
+                    eid.hex(),
                 )
 
         self._lookup = lookup


### PR DESCRIPTION
# Summary
- Type: ☑ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: EID resolver logging
- Linked issues: n/a

## Motivation
Improve diagnostics when scanned EIDs fail to resolve.

---

## Change Log (human-readable)
### Added
- Debug logging in the EID resolver to emit precalculated EIDs per device including MCU status.

### Changed
- n/a

### Fixed
- n/a

### Removed
- n/a

### Performance
- n/a

### Security/Privacy
- n/a

### Compatibility
- n/a

---

## Evidence (optional but helpful)
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally (not run)
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - n/a

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): n/a
- Impact here: n/a

---

## Risk & Rollback
- Risk level: low
- Rollback plan: revert commit

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939451e863c8329aa801e9883869f2b)