### PR TITLE
Handle EID decryption with trial-and-error fallback

### DIFF
--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -238,6 +238,7 @@ _DEVICE_STUB_KEYS: tuple[str, ...] = (
     "encrypted_identity_key",
     "owner_key_version",
     "device_type",
+    "fast_pair_model_id",
     "latitude",
     "longitude",
     "altitude",
@@ -265,6 +266,7 @@ def _build_device_stub(device_name: str, canonic_id: str) -> dict[str, Any]:
         "encrypted_identity_key": None,
         "owner_key_version": None,
         "device_type": None,
+        "fast_pair_model_id": None,
         "latitude": None,
         "longitude": None,
         "altitude": None,
@@ -619,6 +621,7 @@ def get_devices_with_location(
         encrypted_identity_key = None
         owner_key_version = None
         device_type = None
+        fast_pair_model_id: str | None = None
         if decrypt_location_response_locations is not None and cache is not None:
             try:
                 if device.HasField("information") and device.information.HasField(
@@ -675,6 +678,15 @@ def get_devices_with_location(
             if registration.HasField("deviceTypeInformation"):
                 device_type = registration.deviceTypeInformation.deviceType
 
+            raw_fast_pair_model_id = getattr(registration, "fastPairModelId", None)
+            if isinstance(raw_fast_pair_model_id, str):
+                fast_pair_model_id = raw_fast_pair_model_id or None
+            elif isinstance(raw_fast_pair_model_id, (bytes, bytearray)):
+                try:
+                    fast_pair_model_id = raw_fast_pair_model_id.decode() or None
+                except UnicodeDecodeError:
+                    fast_pair_model_id = raw_fast_pair_model_id.hex()
+
         # If decryption yielded results, select the best one and keep normalized list.
         if location_candidates:
             best, normed = _select_best_location(location_candidates)
@@ -693,6 +705,7 @@ def get_devices_with_location(
             row["encrypted_identity_key"] = encrypted_identity_key
             row["owner_key_version"] = owner_key_version
             row["device_type"] = device_type
+            row["fast_pair_model_id"] = fast_pair_model_id
 
             if best:
                 # best already normalized by selection; merge only known keys

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -639,6 +639,7 @@ class DeviceIdentity:
         owner_key_version: Version of the owner key used to encrypt the EIK.
         device_type: SpotDeviceType enum value reported by the tracker, when known.
         config_entry_id: Parent config entry ID that owns the tracker.
+        fast_pair_model_id: Fast Pair model identifier advertised by the tracker.
     """
 
     registry_id: str
@@ -648,6 +649,7 @@ class DeviceIdentity:
     owner_key_version: int | None = None
     device_type: int | None = None
     config_entry_id: str | None = None
+    fast_pair_model_id: str | None = None
 
 
 class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
@@ -4318,6 +4320,18 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 return int(value)
             return None
 
+        def _normalize_fast_pair_model_id(value: Any) -> str | None:
+            if isinstance(value, str):
+                trimmed = value.strip()
+                return trimmed or None
+            if isinstance(value, (bytes, bytearray)):
+                try:
+                    decoded = value.decode().strip()
+                except UnicodeDecodeError:
+                    decoded = value.hex()
+                return decoded or None
+            return None
+
         enabled_ids = set(self._enabled_poll_device_ids)
         _LOGGER.debug(
             "Collecting EID identities for %d polling-enabled devices...",
@@ -4362,6 +4376,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         last_identities: dict[str, bytes] = {}
         last_encrypted: dict[str, tuple[bytes | None, int | None]] = {}
         last_device_types: dict[str, int | None] = {}
+        last_fast_pair_model_ids: dict[str, str | None] = {}
         last_raw_keys: dict[str, list[str]] = {}
         if isinstance(last_device_list, Iterable):
             for raw in last_device_list:
@@ -4397,9 +4412,16 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 if device_type is not None:
                     last_device_types[dev_id] = device_type
 
+                fast_pair_model_id = _normalize_fast_pair_model_id(
+                    raw.get("fast_pair_model_id") or raw.get("fastPairModelId")
+                )
+                if fast_pair_model_id is not None:
+                    last_fast_pair_model_ids[dev_id] = fast_pair_model_id
+
         data_identities: dict[str, bytes] = {}
         data_encrypted: dict[str, tuple[bytes | None, int | None]] = {}
         data_device_types: dict[str, int | None] = {}
+        data_fast_pair_model_ids: dict[str, str | None] = {}
         raw_data_keys: dict[str, list[str]] = {}
         device_data = getattr(self, "data", None)
         if isinstance(device_data, Iterable):
@@ -4435,10 +4457,17 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 if device_type is not None:
                     data_device_types[dev_id] = device_type
 
+                fast_pair_model_id = _normalize_fast_pair_model_id(
+                    raw.get("fast_pair_model_id") or raw.get("fastPairModelId")
+                )
+                if fast_pair_model_id is not None:
+                    data_fast_pair_model_ids[dev_id] = fast_pair_model_id
+
         cache = getattr(self, "_device_location_data", None)
         cache_identities: dict[str, bytes] = {}
         cache_encrypted: dict[str, tuple[bytes | None, int | None]] = {}
         cache_device_types: dict[str, int | None] = {}
+        cache_fast_pair_model_ids: dict[str, str | None] = {}
         cache_data_keys: dict[str, list[str]] = {}
         if isinstance(cache, dict):
             for dev_id in device_ids:
@@ -4471,6 +4500,13 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 if device_type is not None:
                     cache_device_types[dev_id] = device_type
 
+                fast_pair_model_id = _normalize_fast_pair_model_id(
+                    payload.get("fast_pair_model_id")
+                    or payload.get("fastPairModelId")
+                )
+                if fast_pair_model_id is not None:
+                    cache_fast_pair_model_ids[dev_id] = fast_pair_model_id
+
         identities: list[DeviceIdentity] = []
         for canonical_id in device_ids:
             registry_entry = registry_map.get(canonical_id)
@@ -4499,6 +4535,13 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 ),
             )
 
+            fast_pair_model_id = last_fast_pair_model_ids.get(
+                canonical_id,
+                data_fast_pair_model_ids.get(
+                    canonical_id, cache_fast_pair_model_ids.get(canonical_id)
+                ),
+            )
+
             if identity_key is None and encrypted_identity_key is None:
                 _LOGGER.debug(
                     "Device %s skipped: No identity key found (Data: %s)",
@@ -4519,6 +4562,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     owner_key_version=owner_key_version,
                     device_type=device_type,
                     config_entry_id=entry_id,
+                    fast_pair_model_id=fast_pair_model_id,
                 )
             )
 

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, NamedTuple, Protocol, runtime_checkable
 
+from cryptography.exceptions import InvalidTag
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 
@@ -144,7 +145,10 @@ class GoogleFindMyEIDResolver:
             if not identity.config_entry_id or identity.identity_key is None:
                 continue
 
-            mcu_tracker = is_mcu_tracker(device_type=identity.device_type)
+            mcu_tracker = is_mcu_tracker(
+                device_type=identity.device_type,
+                fast_pair_model_id=identity.fast_pair_model_id,
+            )
             for timestamp in windows:
                 try:
                     eid = generate_eid(identity.identity_key, timestamp)
@@ -163,9 +167,10 @@ class GoogleFindMyEIDResolver:
                     canonical_id=identity.canonical_id,
                 )
                 _LOGGER.debug(
-                    "Precalculated EID for %s (MCU=%s): %s",
+                    "Precalculated EID for %s (MCU=%s, ModelID=%s): %s",
                     identity.registry_id,
                     mcu_tracker,
+                    identity.fast_pair_model_id,
                     eid.hex(),
                 )
 
@@ -257,10 +262,6 @@ class GoogleFindMyEIDResolver:
         ):
             return None
 
-        encrypted_identity_key = bytes(identity.encrypted_identity_key)
-        if is_mcu_tracker(device_type=identity.device_type):
-            encrypted_identity_key = flip_bits(encrypted_identity_key, True)
-
         try:
             owner_key_info: OwnerKeyInfo = await async_get_owner_key(cache=cache)
         except Exception as err:  # noqa: BLE001 - defensive
@@ -293,20 +294,51 @@ class GoogleFindMyEIDResolver:
                     err,
                 )
 
-        try:
-            decrypted = await asyncio.to_thread(
-                decrypt_eik, owner_key_info.key, encrypted_identity_key
-            )
-        except Exception as err:  # noqa: BLE001 - defensive
-            _LOGGER.debug(
-                "Failed to decrypt identity key for %s (owner_key_version=%s): %s",
-                identity.canonical_id,
-                identity.owner_key_version,
-                err,
-            )
-            return None
+        encrypted_identity_key = bytes(identity.encrypted_identity_key)
 
-        return decrypted if isinstance(decrypted, (bytes, bytearray)) else None
+        suggested_mcu = is_mcu_tracker(
+            device_type=identity.device_type,
+            fast_pair_model_id=identity.fast_pair_model_id,
+        )
+        candidates = [suggested_mcu, not suggested_mcu]
+
+        for flip_mcu in candidates:
+            candidate_key = (
+                flip_bits(encrypted_identity_key, True) if flip_mcu else encrypted_identity_key
+            )
+
+            try:
+                decrypted = await asyncio.to_thread(
+                    decrypt_eik, owner_key_info.key, candidate_key
+                )
+            except InvalidTag as err:
+                _LOGGER.debug(
+                    "Identity key decrypt failed for %s with flip=%s: %s",
+                    identity.canonical_id,
+                    flip_mcu,
+                    err,
+                )
+                continue
+            except Exception as err:  # noqa: BLE001 - defensive
+                _LOGGER.debug(
+                    "Failed to decrypt identity key for %s (owner_key_version=%s, flip=%s): %s",
+                    identity.canonical_id,
+                    identity.owner_key_version,
+                    flip_mcu,
+                    err,
+                )
+                continue
+
+            if isinstance(decrypted, (bytes, bytearray)):
+                return bytes(decrypted)
+
+            _LOGGER.debug(
+                "Decryption returned non-bytes result for %s (flip=%s)",
+                identity.canonical_id,
+                flip_mcu,
+            )
+
+        return None
 
     def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:
         """Resolve a scanned EID to a Home Assistant device registry ID.


### PR DESCRIPTION
## Summary
- try both flipped and unflipped identity keys during decryption, prioritizing the MCU heuristic but falling back automatically
- log per-attempt decryption failures to aid diagnosing incorrect bit-flip assumptions

## Testing
- python -m ruff check --fix .
- mypy --strict
- pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69394b7c0eec832985d6cdfec3288736)