### PR TITLE
Handle reverse byte order EID lookups

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -359,7 +359,17 @@ class GoogleFindMyEIDResolver:
             # Intentionally avoid logging raw EID bytes for privacy; only the
             # registry device identifier is included.
             _LOGGER.debug("Resolved EID to device %s", match.device_id)
-        return match
+            return match
+
+        match_reverse = self._lookup.get(eid_bytes[::-1])
+        if match_reverse is not None:
+            _LOGGER.debug(
+                "Resolved EID (Reverse Byte Order) to device %s",
+                match_reverse.device_id,
+            )
+            return match_reverse
+
+        return None
 
     def get_resolved_eid(self, eid_bytes: bytes) -> str | None:
         """Backward compatible convenience wrapper for resolve_eid.


### PR DESCRIPTION
## Summary
- add reverse byte order lookup when resolving EIDs
- log when reverse byte order resolution succeeds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69395e0347dc8329aa08b7e9fd751cdd)