### PR TITLE
Implement self-learning EID resolver

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -52,6 +52,8 @@ class EIDMatch(NamedTuple):
     device_id: str
     config_entry_id: str
     canonical_id: str
+    time_offset: int
+    is_reversed: bool
 
 
 @dataclass(slots=True)
@@ -69,6 +71,8 @@ class GoogleFindMyEIDResolver:
 
     hass: HomeAssistant
     _lookup: dict[bytes, EIDMatch] = field(init=False, default_factory=dict)
+    _known_offsets: dict[str, int] = field(default_factory=dict)
+    _known_endianness: dict[str, bool] = field(default_factory=dict)
     _unsub_interval: CALLBACK_TYPE | None = field(init=False, default=None)
     _unsub_alignment: CALLBACK_TYPE | None = field(init=False, default=None)
     _refresh_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
@@ -134,12 +138,6 @@ class GoogleFindMyEIDResolver:
         )
         lookup: dict[bytes, EIDMatch] = {}
         now = int(time.time())
-        rotation_start = now - (now % ROTATION_PERIOD)
-        windows = (
-            rotation_start,
-            max(0, rotation_start - ROTATION_PERIOD),
-            rotation_start + ROTATION_PERIOD,
-        )
 
         for identity in identities:
             if not identity.config_entry_id or identity.identity_key is None:
@@ -149,30 +147,77 @@ class GoogleFindMyEIDResolver:
                 device_type=identity.device_type,
                 fast_pair_model_id=identity.fast_pair_model_id,
             )
-            for timestamp in windows:
-                try:
-                    eid = generate_eid(identity.identity_key, timestamp)
-                except Exception as err:  # noqa: BLE001 - defensive guard
-                    _LOGGER.debug(
-                        "Failed to generate EID for %s at %s: %s",
-                        identity.canonical_id,
-                        timestamp,
-                        err,
-                    )
+            known_offset = self._known_offsets.get(identity.registry_id)
+            known_endianness = self._known_endianness.get(identity.registry_id, False)
+            target_time = now if known_offset is None else now + known_offset
+            rotation_start = target_time - (target_time % ROTATION_PERIOD)
+            window_range: range
+
+            if known_offset is None:
+                window_range = range(-90, 91)
+            else:
+                window_range = range(0, 1)
+
+            for offset in window_range:
+                timestamp = rotation_start + (offset * ROTATION_PERIOD)
+                if timestamp < 0:
                     continue
 
-                lookup[eid] = EIDMatch(
-                    device_id=identity.registry_id,
-                    config_entry_id=identity.config_entry_id,
-                    canonical_id=identity.canonical_id,
-                )
-                _LOGGER.debug(
-                    "Precalculated EID for %s (MCU=%s, ModelID=%s): %s",
-                    identity.registry_id,
-                    mcu_tracker,
-                    identity.fast_pair_model_id,
-                    eid.hex(),
-                )
+                if known_offset is not None:
+                    windows: tuple[int, ...] = (
+                        timestamp,
+                        max(0, timestamp - ROTATION_PERIOD),
+                        timestamp + ROTATION_PERIOD,
+                    )
+                else:
+                    windows = (timestamp,)
+
+                for window_timestamp in windows:
+                    try:
+                        eid = generate_eid(identity.identity_key, window_timestamp)
+                    except Exception as err:  # noqa: BLE001 - defensive guard
+                        _LOGGER.debug(
+                            "Failed to generate EID for %s at %s: %s",
+                            identity.canonical_id,
+                            window_timestamp,
+                            err,
+                        )
+                        continue
+
+                    time_offset = window_timestamp - now
+                    is_reversed = known_offset is not None and known_endianness
+                    if known_offset is None:
+                        lookup[eid] = EIDMatch(
+                            device_id=identity.registry_id,
+                            config_entry_id=identity.config_entry_id,
+                            canonical_id=identity.canonical_id,
+                            time_offset=time_offset,
+                            is_reversed=False,
+                        )
+                        lookup[eid[::-1]] = EIDMatch(
+                            device_id=identity.registry_id,
+                            config_entry_id=identity.config_entry_id,
+                            canonical_id=identity.canonical_id,
+                            time_offset=time_offset,
+                            is_reversed=True,
+                        )
+                    else:
+                        eid_bytes = eid[::-1] if is_reversed else eid
+                        lookup[eid_bytes] = EIDMatch(
+                            device_id=identity.registry_id,
+                            config_entry_id=identity.config_entry_id,
+                            canonical_id=identity.canonical_id,
+                            time_offset=time_offset,
+                            is_reversed=is_reversed,
+                        )
+
+                    _LOGGER.debug(
+                        "Precalculated EID for %s (MCU=%s, ModelID=%s): %s",
+                        identity.registry_id,
+                        mcu_tracker,
+                        identity.fast_pair_model_id,
+                        eid.hex(),
+                    )
 
         self._lookup = lookup
         _LOGGER.debug(
@@ -355,21 +400,30 @@ class GoogleFindMyEIDResolver:
         """
 
         match = self._lookup.get(eid_bytes)
-        if match is not None:
-            # Intentionally avoid logging raw EID bytes for privacy; only the
-            # registry device identifier is included.
-            _LOGGER.debug("Resolved EID to device %s", match.device_id)
-            return match
+        if match is None:
+            match = self._lookup.get(eid_bytes[::-1])
 
-        match_reverse = self._lookup.get(eid_bytes[::-1])
-        if match_reverse is not None:
-            _LOGGER.debug(
-                "Resolved EID (Reverse Byte Order) to device %s",
-                match_reverse.device_id,
+        if match is None:
+            return None
+
+        previous_offset = self._known_offsets.get(match.device_id)
+        previous_endianness = self._known_endianness.get(match.device_id)
+
+        if (
+            previous_offset != match.time_offset
+            or previous_endianness != match.is_reversed
+        ):
+            _LOGGER.info(
+                "Locked on to device %s! Applying Time Offset: %ss, Reverse: %s",
+                match.device_id,
+                match.time_offset,
+                match.is_reversed,
             )
-            return match_reverse
 
-        return None
+        self._known_offsets[match.device_id] = match.time_offset
+        self._known_endianness[match.device_id] = match.is_reversed
+        _LOGGER.debug("Resolved EID to device %s", match.device_id)
+        return match
 
     def get_resolved_eid(self, eid_bytes: bytes) -> str | None:
         """Backward compatible convenience wrapper for resolve_eid.

--- a/tests/test_eid_resolver.py
+++ b/tests/test_eid_resolver.py
@@ -153,23 +153,28 @@ async def test_resolver_refreshes_all_rotation_windows(monkeypatch: pytest.Monke
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = hass
     resolver._lookup = {}
+    resolver._known_offsets = {}
+    resolver._known_endianness = {}
     resolver._unsub_interval = None
     resolver._unsub_alignment = None
 
     await resolver._refresh_cache()
 
     rotation_start = base_time - (base_time % ROTATION_PERIOD)
-    assert set(recorded_timestamps) == {
-        rotation_start,
-        max(0, rotation_start - ROTATION_PERIOD),
-        rotation_start + ROTATION_PERIOD,
-    }
+    earliest_timestamp = max(0, rotation_start - (ROTATION_PERIOD * 90))
+    latest_timestamp = rotation_start + (ROTATION_PERIOD * 90)
+    assert min(recorded_timestamps) == earliest_timestamp
+    assert max(recorded_timestamps) == latest_timestamp
+    expected_windows = ((latest_timestamp - earliest_timestamp) // ROTATION_PERIOD) + 1
+    assert len(recorded_timestamps) == expected_windows
 
     expected_eid = f"{identity.identity_key.hex()}-{rotation_start}".encode()
     match = resolver.resolve_eid(expected_eid)
     assert match is not None
     assert match.device_id == "registry-4"
     assert match.canonical_id == "device-1"
+    assert expected_eid[::-1] in resolver._lookup
+    assert len(resolver._lookup) == len(recorded_timestamps) * 2
     assert resolver.get_resolved_eid(expected_eid) == "registry-4"
     assert resolver.resolve_eid(b"unknown") is None
     assert resolver.get_resolved_eid(b"unknown") is None
@@ -217,6 +222,8 @@ async def test_resolver_aggregates_multiple_entries(monkeypatch: pytest.MonkeyPa
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = hass
     resolver._lookup = {}
+    resolver._known_offsets = {}
+    resolver._known_endianness = {}
     resolver._unsub_interval = None
     resolver._unsub_alignment = None
     resolver._refresh_lock = asyncio.Lock()
@@ -258,6 +265,8 @@ async def test_resolver_excludes_disabled_or_ignored_devices(monkeypatch: pytest
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = hass
     resolver._lookup = {}
+    resolver._known_offsets = {}
+    resolver._known_endianness = {}
     resolver._unsub_interval = None
     resolver._unsub_alignment = None
     resolver._refresh_lock = asyncio.Lock()
@@ -301,6 +310,8 @@ async def test_concurrent_refresh_requests_are_serialized(monkeypatch: pytest.Mo
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = hass
     resolver._lookup = {}
+    resolver._known_offsets = {}
+    resolver._known_endianness = {}
     resolver._unsub_interval = None
     resolver._unsub_alignment = None
     resolver._refresh_lock = asyncio.Lock()
@@ -311,4 +322,71 @@ async def test_concurrent_refresh_requests_are_serialized(monkeypatch: pytest.Mo
     rotation_start = base_time - (base_time % ROTATION_PERIOD)
     expected_eid = f"{identity.identity_key.hex()}-{rotation_start}".encode()
     assert expected_eid in resolver._lookup
+
+
+@pytest.mark.asyncio
+async def test_resolver_learns_offsets_and_endianness(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_time = ROTATION_PERIOD * 200
+    current_time = base_time
+    generated: list[int] = []
+
+    def _fake_time() -> int:
+        return current_time
+
+    def _fake_generate_eid(key: bytes, timestamp: int) -> bytes:
+        generated.append(timestamp)
+        return f"{key.hex()}-{timestamp}".encode()
+
+    monkeypatch.setattr(resolver_module.time, "time", _fake_time)
+    monkeypatch.setattr(resolver_module, "generate_eid", _fake_generate_eid)
+
+    identity = DeviceIdentity(
+        registry_id="registry-learn",
+        canonical_id="canonical-learn",
+        identity_key=b"\x0b",
+        config_entry_id="entry-learn",
+    )
+
+    coordinator = SimpleNamespace(get_active_device_identities=lambda: [identity])
+    hass = _StubHass({DOMAIN: {"entries": {"entry-learn": SimpleNamespace(coordinator=coordinator)}}})
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = hass
+    resolver._lookup = {}
+    resolver._known_offsets = {}
+    resolver._known_endianness = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+
+    await resolver._refresh_cache()
+
+    rotation_start = base_time - (base_time % ROTATION_PERIOD)
+    assert len(generated) == 181
+    target_timestamp = rotation_start + (ROTATION_PERIOD * 2)
+    expected_eid = f"{identity.identity_key.hex()}-{target_timestamp}".encode()
+    assert expected_eid in resolver._lookup
+
+    match = resolver.resolve_eid(expected_eid[::-1])
+    assert match is not None
+    assert match.is_reversed is True
+    assert resolver._known_endianness[identity.registry_id] is True
+    assert resolver._known_offsets[identity.registry_id] == target_timestamp - base_time
+
+    generated.clear()
+    resolver._lookup = {}
+    current_time = base_time + ROTATION_PERIOD
+
+    await resolver._refresh_cache()
+
+    target_rotation = current_time + resolver._known_offsets[identity.registry_id]
+    target_rotation -= target_rotation % ROTATION_PERIOD
+    assert set(generated) == {
+        target_rotation,
+        max(0, target_rotation - ROTATION_PERIOD),
+        target_rotation + ROTATION_PERIOD,
+    }
+    assert len(resolver._lookup) == 3
+    assert all(match.is_reversed for match in resolver._lookup.values())
 


### PR DESCRIPTION
## Summary
- add tracking for per-device time offsets and endianness in the EID resolver so subsequent refreshes use optimized windows
- expand the initial forensic window generation and store match metadata to learn orientation and offset
- update resolver tests to cover the self-learning flow and revised window expectations

## Testing
- python -m ruff check --fix .
- python -m mypy --strict
- python -m pytest --cov


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396823b28483299438a1a0b4fc5fa3)