### PR TITLE
Add diagnostics for missing identity keys

### DIFF
--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -220,6 +220,11 @@ def get_canonic_ids(
         for canonic_id in canonic_ids:
             cid = getattr(canonic_id, "id", None)
             if isinstance(cid, str) and cid:
+                _LOGGER.warning(
+                    "DEBUG ID extraction: Found ID '%s' for device '%s'",
+                    cid,
+                    device_name,
+                )
                 result.append((device_name, cid))
     return result
 
@@ -686,6 +691,38 @@ def get_devices_with_location(
                     fast_pair_model_id = raw_fast_pair_model_id.decode() or None
                 except UnicodeDecodeError:
                     fast_pair_model_id = raw_fast_pair_model_id.hex()
+
+        # --- DIAGNOSTIC: FIND HIDDEN KEYS ---
+        if not encrypted_identity_key:
+            ids_str = ", ".join(
+                [str(getattr(canonic_id, "id", "")) for canonic_id in canonic_ids]
+            )
+            _LOGGER.warning(
+                "DEBUG STRUCTURE: Missing Key for '%s' (IDs: %s)", device_name, ids_str
+            )
+
+            # Level 1
+            fields = [f.name for f, _ in device.ListFields()]
+            _LOGGER.warning(" -> Device fields: %s", fields)
+
+            if device.HasField("information"):
+                info = device.information
+                _LOGGER.warning(" -> Info fields: %s", [f.name for f, _ in info.ListFields()])
+
+                if info.HasField("deviceRegistration"):
+                    reg = info.deviceRegistration
+                    _LOGGER.warning(
+                        " -> Registration fields: %s",
+                        [f.name for f, _ in reg.ListFields()],
+                    )
+
+                    if reg.HasField("encryptedUserSecrets"):
+                        sec = reg.encryptedUserSecrets
+                        _LOGGER.warning(
+                            " -> Secrets fields: %s",
+                            [f.name for f, _ in sec.ListFields()],
+                        )
+        # ------------------------------------
 
         # If decryption yielded results, select the best one and keep normalized list.
         if location_candidates:


### PR DESCRIPTION
## Summary
- log each canonical ID discovered during decoder processing for easier correlation with registry entries
- expand missing-key diagnostics to include the device's canonical IDs alongside the protobuf field structure

## Testing
- python -m pip install --dry-run --no-deps pip


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939868e2a488329b3c8e37e05ba522f)