### PR TITLE
Add probe logging for EID resolution

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -396,8 +396,16 @@ class GoogleFindMyEIDResolver:
         prefer a ``device_id`` string or ``None``.
 
         EIDs are not logged to avoid leaking hardware identifiers in debug
-        output.
+        output during normal operation. A temporary warning-level probe log at
+        the start of this method prints the scanned EID for troubleshooting
+        cache mismatches.
         """
+
+        _LOGGER.warning(
+            "RESOLVER PROBE: Checking EID %s (Len: %d)",
+            eid_bytes.hex(),
+            len(eid_bytes),
+        )
 
         match = self._lookup.get(eid_bytes)
         if match is None:


### PR DESCRIPTION
## Summary
- add a warning-level probe log at the start of EID resolution to record scanned identifiers and lengths for debugging
- clarify the resolver docstring to explain the temporary probe logging during troubleshooting

## Testing
- python -m ruff check --fix custom_components/googlefindmy/eid_resolver.py
- python -m pip install --dry-run --no-deps pip

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939fb3c540483299e5726189848801d)