### PR TITLE
Prioritize cached identity data over poll results

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -67,7 +67,7 @@ from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from statistics import mean, stdev
 from types import MappingProxyType, ModuleType, SimpleNamespace
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
 
 if TYPE_CHECKING:
     from homeassistant.core import Event
@@ -4332,6 +4332,14 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 return decoded or None
             return None
 
+        T = TypeVar("T")
+
+        def _lookup(key: str, *sources: Mapping[str, T]) -> T | None:
+            for source in sources:
+                if key in source:
+                    return source[key]
+            return None
+
         enabled_ids = set(self._enabled_poll_device_ids)
         _LOGGER.debug(
             "Collecting EID identities for %d polling-enabled devices...",
@@ -4517,30 +4525,28 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 continue
 
             registry_id, registry_key = registry_entry
-            identity_key = last_identities.get(lookup_id)
+            identity_key = _lookup(lookup_id, cache_identities, last_identities)
             if identity_key is None:
                 identity_key = registry_key
             if identity_key is None:
-                identity_key = data_identities.get(lookup_id)
-            if identity_key is None:
-                identity_key = cache_identities.get(lookup_id)
+                identity_key = _lookup(lookup_id, data_identities)
 
-            encrypted_identity_key, owner_key_version = last_encrypted.get(
-                lookup_id,
-                data_encrypted.get(
-                    lookup_id, cache_encrypted.get(lookup_id, (None, None))
-                ),
+            encrypted_identity_tuple = _lookup(
+                lookup_id, cache_encrypted, last_encrypted, data_encrypted
             )
-            device_type = last_device_types.get(
-                lookup_id,
-                data_device_types.get(lookup_id, cache_device_types.get(lookup_id)),
+            encrypted_identity_key, owner_key_version = encrypted_identity_tuple or (
+                None,
+                None,
+            )
+            device_type = _lookup(
+                lookup_id, cache_device_types, last_device_types, data_device_types
             )
 
-            fast_pair_model_id = last_fast_pair_model_ids.get(
+            fast_pair_model_id = _lookup(
                 lookup_id,
-                data_fast_pair_model_ids.get(
-                    lookup_id, cache_fast_pair_model_ids.get(lookup_id)
-                ),
+                cache_fast_pair_model_ids,
+                last_fast_pair_model_ids,
+                data_fast_pair_model_ids,
             )
 
             if identity_key is None and encrypted_identity_key is None:

--- a/tests/test_coordinator_key_priority.py
+++ b/tests/test_coordinator_key_priority.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+import pytest
+
+import custom_components.googlefindmy.coordinator as coordinator_module
+
+
+class _StubDevice:
+    def __init__(self, identifier: str, registry_id: str | None = None) -> None:
+        self.identifier = identifier
+        self.id = registry_id or identifier
+        self.custom_fields: dict[str, object] = {}
+        self.disabled_by: str | None = None
+
+
+class _StubDeviceRegistry:
+    def __init__(self, devices: list[_StubDevice]) -> None:
+        self._devices = devices
+
+    def async_entries_for_config_entry(self, _entry_id: str) -> list[_StubDevice]:
+        return list(self._devices)
+
+
+class _StubHass:
+    def __init__(self) -> None:
+        self.data: dict[str, object] = {}
+
+    def async_create_task(self, coro):
+        return coro
+
+
+def _build_coordinator(monkeypatch: pytest.MonkeyPatch) -> coordinator_module.GoogleFindMyCoordinator:
+    registry = _StubDeviceRegistry([_StubDevice("device-1", registry_id="registry-1")])
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator.hass = _StubHass()
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator._enabled_poll_device_ids = {"device-1"}
+    coordinator._get_ignored_set = lambda: set()
+    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator.data = []
+    return coordinator
+
+
+def test_cache_prioritized_over_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    coordinator = _build_coordinator(monkeypatch)
+    coordinator._last_device_list = [
+        {
+            "id": "device-1",
+            "encryptedIdentityKey": "aaaa",
+            "owner_key_version": 1,
+            "device_type": 1,
+            "fastPairModelId": "poll-model",
+        }
+    ]
+    coordinator._device_location_data = {
+        "device-1": {
+            "encryptedIdentityKey": "bbbb",
+            "owner_key_version": 2,
+            "device_type": 3,
+            "fast_pair_model_id": "push-model",
+        }
+    }
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.encrypted_identity_key == bytes.fromhex("bbbb")
+    assert identity.owner_key_version == 2
+    assert identity.device_type == 3
+    assert identity.fast_pair_model_id == "push-model"
+
+
+def test_poll_used_when_cache_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    coordinator = _build_coordinator(monkeypatch)
+    coordinator._last_device_list = [
+        {
+            "id": "device-1",
+            "encryptedIdentityKey": "cccc",
+            "owner_key_version": 4,
+            "device_type": 9,
+            "fastPairModelId": "poll-fallback",
+        }
+    ]
+    coordinator._device_location_data = {}
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.encrypted_identity_key == bytes.fromhex("cccc")
+    assert identity.owner_key_version == 4
+    assert identity.device_type == 9
+    assert identity.fast_pair_model_id == "poll-fallback"


### PR DESCRIPTION
## Summary
- prioritize cached identity and metadata fields in the coordinator so push-updated cache entries override stale poll responses
- refactor identity aggregation to use a shared lookup helper and keep device type/fast pair data aligned with cache-first priority
- add regression coverage that ensures cached keys win over polled keys while still falling back to poll data when the cache is empty

## Testing
- python -m ruff check --fix .
- python -m mypy --strict
- python -m pytest --cov=custom_components.googlefindmy.coordinator tests/test_coordinator_key_priority.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a957664888329b10484b674cd99aa)