### PR TITLE
Implement robust slicing in resolve_eid

### DIFF
--- a/custom_components/googlefindmy/constraints-test-stubs.txt
+++ b/custom_components/googlefindmy/constraints-test-stubs.txt
@@ -1,3 +1,4 @@
 # Pinned Home Assistant stub packages to speed up make test-stubs runs
 homeassistant==2025.12.1
 pytest-homeassistant-custom-component==0.13.299
+pycares<5

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -40,6 +40,9 @@ else:
 
 _LOGGER = logging.getLogger(__name__)
 
+EID_LENGTH = 20
+RAW_HEADER_LENGTH = 1
+
 
 class EIDMatch(NamedTuple):
     """Resolved mapping between an EID and a Home Assistant device.
@@ -398,7 +401,9 @@ class GoogleFindMyEIDResolver:
         EIDs are not logged to avoid leaking hardware identifiers in debug
         output during normal operation. A temporary warning-level probe log at
         the start of this method prints the scanned EID for troubleshooting
-        cache mismatches.
+        cache mismatches. Incoming BLE payloads may include framing bytes and
+        telemetry appended to the 20-byte EID; the resolver normalizes the
+        payload before checking the lookup table.
         """
 
         _LOGGER.warning(
@@ -407,9 +412,24 @@ class GoogleFindMyEIDResolver:
             len(eid_bytes),
         )
 
-        match = self._lookup.get(eid_bytes)
+        if len(eid_bytes) < EID_LENGTH:
+            return None
+
+        if len(eid_bytes) > EID_LENGTH:
+            lookup_key = eid_bytes[
+                RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + EID_LENGTH
+            ]
+            _LOGGER.debug(
+                "Sliced raw payload %s to EID candidate %s",
+                eid_bytes.hex(),
+                lookup_key.hex(),
+            )
+        else:
+            lookup_key = eid_bytes
+
+        match = self._lookup.get(lookup_key)
         if match is None:
-            match = self._lookup.get(eid_bytes[::-1])
+            match = self._lookup.get(lookup_key[::-1])
 
         if match is None:
             return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1388,7 +1388,7 @@ def _stub_homeassistant() -> None:
 
     event_module = ModuleType("homeassistant.helpers.event")
 
-    async def _async_call_later(
+    def _async_call_later(
         *_args, **_kwargs
     ):  # pragma: no cover - stubbed behaviour
         return None

--- a/tests/test_eid_resolver.py
+++ b/tests/test_eid_resolver.py
@@ -7,8 +7,19 @@ import custom_components.googlefindmy.coordinator as coordinator_module
 import custom_components.googlefindmy.eid_resolver as resolver_module
 from custom_components.googlefindmy.const import DOMAIN
 from custom_components.googlefindmy.coordinator import DeviceIdentity
-from custom_components.googlefindmy.eid_resolver import GoogleFindMyEIDResolver
+from custom_components.googlefindmy.eid_resolver import (
+    EID_LENGTH,
+    GoogleFindMyEIDResolver,
+)
 from custom_components.googlefindmy.FMDNCrypto.eid_generator import ROTATION_PERIOD
+
+
+def _fixed_length_eid(key: bytes, timestamp: int) -> bytes:
+    """Generate a deterministic 20-byte EID for test fixtures."""
+
+    ts_bytes = timestamp.to_bytes(8, "big", signed=False)
+    seed = key + ts_bytes
+    return seed.ljust(EID_LENGTH, b"\x00")[:EID_LENGTH]
 
 
 class _StubDevice:
@@ -135,7 +146,7 @@ async def test_resolver_refreshes_all_rotation_windows(monkeypatch: pytest.Monke
 
     def _fake_generate_eid(key: bytes, timestamp: int) -> bytes:
         recorded_timestamps.append(timestamp)
-        return f"{key.hex()}-{timestamp}".encode()
+        return _fixed_length_eid(key, timestamp)
 
     monkeypatch.setattr(resolver_module.time, "time", _fake_time)
     monkeypatch.setattr(resolver_module, "generate_eid", _fake_generate_eid)
@@ -168,7 +179,7 @@ async def test_resolver_refreshes_all_rotation_windows(monkeypatch: pytest.Monke
     expected_windows = ((latest_timestamp - earliest_timestamp) // ROTATION_PERIOD) + 1
     assert len(recorded_timestamps) == expected_windows
 
-    expected_eid = f"{identity.identity_key.hex()}-{rotation_start}".encode()
+    expected_eid = _fixed_length_eid(identity.identity_key, rotation_start)
     match = resolver.resolve_eid(expected_eid)
     assert match is not None
     assert match.device_id == "registry-4"
@@ -188,7 +199,7 @@ async def test_resolver_aggregates_multiple_entries(monkeypatch: pytest.MonkeyPa
         return base_time
 
     def _fake_generate_eid(key: bytes, timestamp: int) -> bytes:
-        return f"{key.hex()}-{timestamp}".encode()
+        return _fixed_length_eid(key, timestamp)
 
     monkeypatch.setattr(resolver_module.time, "time", _fake_time)
     monkeypatch.setattr(resolver_module, "generate_eid", _fake_generate_eid)
@@ -232,8 +243,8 @@ async def test_resolver_aggregates_multiple_entries(monkeypatch: pytest.MonkeyPa
     await resolver._refresh_cache()
 
     rotation_start = base_time - (base_time % ROTATION_PERIOD)
-    eid_one = f"{identity_one.identity_key.hex()}-{rotation_start}".encode()
-    eid_two = f"{identity_two.identity_key.hex()}-{rotation_start}".encode()
+    eid_one = _fixed_length_eid(identity_one.identity_key, rotation_start)
+    eid_two = _fixed_length_eid(identity_two.identity_key, rotation_start)
 
     assert resolver.resolve_eid(eid_one).config_entry_id == "entry-a"
     assert resolver.resolve_eid(eid_two).config_entry_id == "entry-b"
@@ -288,7 +299,7 @@ async def test_concurrent_refresh_requests_are_serialized(monkeypatch: pytest.Mo
         await asyncio.sleep(0)
 
     def _fake_generate_eid(key: bytes, timestamp: int) -> bytes:
-        return f"{key.hex()}-{timestamp}".encode()
+        return _fixed_length_eid(key, timestamp)
 
     monkeypatch.setattr(resolver_module.time, "time", _fake_time)
     monkeypatch.setattr(resolver_module, "generate_eid", _fake_generate_eid)
@@ -320,7 +331,7 @@ async def test_concurrent_refresh_requests_are_serialized(monkeypatch: pytest.Mo
     await asyncio.gather(resolver.async_refresh(), resolver.async_refresh(), resolver.async_refresh())
 
     rotation_start = base_time - (base_time % ROTATION_PERIOD)
-    expected_eid = f"{identity.identity_key.hex()}-{rotation_start}".encode()
+    expected_eid = _fixed_length_eid(identity.identity_key, rotation_start)
     assert expected_eid in resolver._lookup
 
 
@@ -335,7 +346,7 @@ async def test_resolver_learns_offsets_and_endianness(monkeypatch: pytest.Monkey
 
     def _fake_generate_eid(key: bytes, timestamp: int) -> bytes:
         generated.append(timestamp)
-        return f"{key.hex()}-{timestamp}".encode()
+        return _fixed_length_eid(key, timestamp)
 
     monkeypatch.setattr(resolver_module.time, "time", _fake_time)
     monkeypatch.setattr(resolver_module, "generate_eid", _fake_generate_eid)
@@ -365,7 +376,7 @@ async def test_resolver_learns_offsets_and_endianness(monkeypatch: pytest.Monkey
     rotation_start = base_time - (base_time % ROTATION_PERIOD)
     assert len(generated) == 181
     target_timestamp = rotation_start + (ROTATION_PERIOD * 2)
-    expected_eid = f"{identity.identity_key.hex()}-{target_timestamp}".encode()
+    expected_eid = _fixed_length_eid(identity.identity_key, target_timestamp)
     assert expected_eid in resolver._lookup
 
     match = resolver.resolve_eid(expected_eid[::-1])

--- a/tests/test_eid_resolver_slicing.py
+++ b/tests/test_eid_resolver_slicing.py
@@ -1,0 +1,81 @@
+"""Tests for normalizing raw BLE payloads before EID resolution."""
+
+from types import SimpleNamespace
+
+from custom_components.googlefindmy.eid_resolver import (
+    EIDMatch,
+    GoogleFindMyEIDResolver,
+)
+
+
+def _build_resolver(lookup_key: bytes, match: EIDMatch) -> GoogleFindMyEIDResolver:
+    """Construct a resolver instance with a single lookup entry."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = SimpleNamespace()
+    resolver._lookup = {lookup_key: match}
+    resolver._known_offsets = {}
+    resolver._known_endianness = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    return resolver
+
+
+def test_resolve_eid_slices_raw_payload() -> None:
+    """Raw service data should skip the header and slice the EID portion."""
+
+    eid = bytes.fromhex("0102030405060708090a0b0c0d0e0f1011121314")
+    match = EIDMatch(
+        device_id="device-raw",
+        config_entry_id="entry-raw",
+        canonical_id="canonical-raw",
+        time_offset=0,
+        is_reversed=False,
+    )
+    resolver = _build_resolver(eid, match)
+    payload = b"\x40" + eid + b"\x30"
+
+    resolved = resolver.resolve_eid(payload)
+
+    assert resolved == match
+    assert resolver._known_offsets.get("device-raw") == 0
+    assert resolver._known_endianness.get("device-raw") is False
+
+
+def test_resolve_eid_accepts_pure_eid() -> None:
+    """Exact-length payloads should resolve without slicing."""
+
+    eid = bytes.fromhex("ffffffffffffffffffffffffffffffffffffffff")
+    match = EIDMatch(
+        device_id="device-pure",
+        config_entry_id="entry-pure",
+        canonical_id="canonical-pure",
+        time_offset=5,
+        is_reversed=True,
+    )
+    resolver = _build_resolver(eid, match)
+
+    resolved = resolver.resolve_eid(eid)
+
+    assert resolved == match
+    assert resolver._known_offsets.get("device-pure") == 5
+    assert resolver._known_endianness.get("device-pure") is True
+
+
+def test_resolve_eid_rejects_short_payload() -> None:
+    """Payloads shorter than the 20-byte EID should return ``None``."""
+
+    resolver = _build_resolver(
+        b"\x00" * 20,
+        EIDMatch(
+            device_id="device-short",
+            config_entry_id="entry-short",
+            canonical_id="canonical-short",
+            time_offset=3,
+            is_reversed=False,
+        ),
+    )
+
+    assert resolver.resolve_eid(b"\x01" * 19) is None
+    assert resolver._known_offsets == {}
+    assert resolver._known_endianness == {}


### PR DESCRIPTION
# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☑ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: test stubs
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

Pin pycares below version 5 in the stub constraint list so `make test-stubs` avoids the pytest plugin import error seen during stub installation.

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Changed
- Normalized resolve_eid to slice header bytes from raw BLE payloads, reject undersized frames, and log the derived EID before dictionary lookups so cached 20-byte keys resolve correctly.
- Added resolver regression tests covering raw service data, pure EID inputs, and short payload rejection using a lightweight stubbed resolver builder.
- Constrain `pycares<5` in `constraints-test-stubs.txt` to keep stub installs compatible with the bundled pytest plugins.

---

## Tests (MUST)
- ☑ `python -m ruff check --fix .`
- ☑ `python -m mypy --strict custom_components/googlefindmy tests`
- ☑ `python -m pytest -q tests/test_eid_resolver_slicing.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab6e6bc148329a885737597baee4c)