### PR TITLE
Cache decrypted identity key in decrypted payloads

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -591,6 +591,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "semantic_name": loc.name,
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
+                    "identity_key": identity_key,
                 }
                 # Internal hint helps the coordinator schedule throttling-aware cooldowns.
                 if report_hint:
@@ -642,6 +643,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "semantic_name": None,
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
+                    "identity_key": identity_key,
                 }
                 if report_hint:
                     payload["_report_hint"] = report_hint


### PR DESCRIPTION
## Summary
- store the decrypted identity key alongside encrypted values when building location payloads so the coordinator can use the fresh key

## Testing
- python -m ruff check --fix .
- python -m mypy --strict
- python -m pytest --cov


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af30595248329a25de00d5dec224e)