### PR TITLE
Improve EID resolver logging and add tests

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -146,10 +146,6 @@ class GoogleFindMyEIDResolver:
             if not identity.config_entry_id or identity.identity_key is None:
                 continue
 
-            mcu_tracker = is_mcu_tracker(
-                device_type=identity.device_type,
-                fast_pair_model_id=identity.fast_pair_model_id,
-            )
             known_offset = self._known_offsets.get(identity.registry_id)
             known_endianness = self._known_endianness.get(identity.registry_id, False)
             target_time = now if known_offset is None else now + known_offset
@@ -213,14 +209,6 @@ class GoogleFindMyEIDResolver:
                             time_offset=time_offset,
                             is_reversed=is_reversed,
                         )
-
-                    _LOGGER.debug(
-                        "Precalculated EID for %s (MCU=%s, ModelID=%s): %s",
-                        identity.registry_id,
-                        mcu_tracker,
-                        identity.fast_pair_model_id,
-                        eid.hex(),
-                    )
 
         self._lookup = lookup
         _LOGGER.debug(
@@ -406,12 +394,6 @@ class GoogleFindMyEIDResolver:
         payload before checking the lookup table.
         """
 
-        _LOGGER.warning(
-            "RESOLVER PROBE: Checking EID %s (Len: %d)",
-            eid_bytes.hex(),
-            len(eid_bytes),
-        )
-
         if len(eid_bytes) < EID_LENGTH:
             return None
 
@@ -419,13 +401,14 @@ class GoogleFindMyEIDResolver:
             lookup_key = eid_bytes[
                 RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + EID_LENGTH
             ]
-            _LOGGER.debug(
-                "Sliced raw payload %s to EID candidate %s",
-                eid_bytes.hex(),
-                lookup_key.hex(),
-            )
         else:
             lookup_key = eid_bytes
+
+        _LOGGER.debug(
+            "RESOLVER PROBE: Checking Sliced EID %s (Original Len: %d)",
+            lookup_key.hex(),
+            len(eid_bytes),
+        )
 
         match = self._lookup.get(lookup_key)
         if match is None:
@@ -447,6 +430,13 @@ class GoogleFindMyEIDResolver:
                 match.time_offset,
                 match.is_reversed,
             )
+
+        _LOGGER.info(
+            "MATCH FOUND: EID %s belongs to device %s (Time Offset: %s)",
+            lookup_key.hex(),
+            match.device_id,
+            match.time_offset,
+        )
 
         self._known_offsets[match.device_id] = match.time_offset
         self._known_endianness[match.device_id] = match.is_reversed

--- a/tests/test_eid_resolver_logging.py
+++ b/tests/test_eid_resolver_logging.py
@@ -1,0 +1,68 @@
+import logging
+
+import pytest
+
+from custom_components.googlefindmy.eid_resolver import (
+    EID_LENGTH,
+    RAW_HEADER_LENGTH,
+    EIDMatch,
+    GoogleFindMyEIDResolver,
+)
+
+
+@pytest.fixture
+def resolver(monkeypatch: pytest.MonkeyPatch) -> GoogleFindMyEIDResolver:
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver, "_start_alignment_timer", lambda self: None
+    )
+    return GoogleFindMyEIDResolver(hass=object())
+
+
+def _probe_message(records: list[logging.LogRecord]) -> list[str]:
+    return [record.message for record in records if record.levelno == logging.DEBUG]
+
+
+def test_match_triggers_info_log(
+    resolver: GoogleFindMyEIDResolver, caplog: pytest.LogCaptureFixture
+) -> None:
+    lookup_key = b"\x01" * EID_LENGTH
+    match = EIDMatch(
+        device_id="device-1",
+        config_entry_id="entry-1",
+        canonical_id="canonical-1",
+        time_offset=0,
+        is_reversed=False,
+    )
+    resolver._lookup = {lookup_key: match}
+
+    caplog.set_level(logging.DEBUG)
+
+    assert resolver.resolve_eid(lookup_key) is match
+    assert any(
+        "MATCH FOUND: EID" in record.message and record.levelno == logging.INFO
+        for record in caplog.records
+    )
+
+
+def test_non_match_does_not_log_info(
+    resolver: GoogleFindMyEIDResolver, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    assert resolver.resolve_eid(b"\x02" * EID_LENGTH) is None
+    assert not any(record.levelno == logging.INFO for record in caplog.records)
+
+
+def test_probe_logs_sliced_key(
+    resolver: GoogleFindMyEIDResolver, caplog: pytest.LogCaptureFixture
+) -> None:
+    raw_payload = b"\x00" + (b"\x03" * EID_LENGTH) + b"\xFF"
+    expected_lookup = raw_payload[RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + EID_LENGTH]
+    resolver._lookup = {}
+
+    caplog.set_level(logging.DEBUG)
+
+    resolver.resolve_eid(raw_payload)
+
+    probe_messages = _probe_message(caplog.records)
+    assert any(expected_lookup.hex() in message for message in probe_messages)


### PR DESCRIPTION
## Summary
- refine eid resolver probe logging to focus on sliced keys and log matches at info level while quieting precalculation noise
- add coverage to verify resolver logging behavior for matches, misses, and sliced payloads

## Testing
- python -m ruff check --fix .
- python -m mypy --strict
- python -m pytest tests/test_eid_resolver_logging.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0b21934c8329809a27380ee220ce)