### PR TITLE
Improve resolver diagnostics and offset reset handling

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -4286,7 +4286,8 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
     def _schedule_eid_resolver_refresh(self) -> None:
         """Refresh the global EID resolver when active device sets change."""
 
-        hass_data = getattr(self.hass, "data", None)
+        hass = getattr(self, "hass", None)
+        hass_data = getattr(hass, "data", None)
         if not isinstance(hass_data, dict):
             return
 
@@ -6085,7 +6086,25 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self.increment_stat("background_updates")
 
         if resolver_refresh_needed:
+            self._reset_resolver_offset(device_id)
             self._schedule_eid_resolver_refresh()
+
+    def _reset_resolver_offset(self, device_id: str) -> None:
+        """Clear resolver offsets when identity keys rotate."""
+
+        hass = getattr(self, "hass", None)
+        hass_data = getattr(hass, "data", None)
+        if not isinstance(hass_data, dict):
+            return
+
+        bucket = hass_data.get(DOMAIN)
+        if not isinstance(bucket, dict):
+            return
+
+        resolver = bucket.get(DATA_EID_RESOLVER)
+        reset = getattr(resolver, "reset_device_offset", None)
+        if callable(reset):
+            reset(device_id)
 
     def _is_significant_update(self, device_id: str, new_data: dict[str, Any]) -> bool:
         """Validate temporal ordering before committing cache updates.

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -132,7 +132,7 @@ class GoogleFindMyEIDResolver:
                 self._pending_refresh = False
                 await self._refresh_cache()
 
-    async def _refresh_cache(self) -> None:
+    async def _refresh_cache(self) -> None:  # noqa: PLR0912 - iterative window search
         """Rebuild the EID lookup table for enabled, non-ignored devices."""
 
         identities: list[DeviceIdentity] = await self._collect_device_secrets()
@@ -142,15 +142,25 @@ class GoogleFindMyEIDResolver:
         lookup: dict[bytes, EIDMatch] = {}
         now = int(time.time())
 
+        first_identity_id: str | None = None
+
         for identity in identities:
             if not identity.config_entry_id or identity.identity_key is None:
                 continue
+
+            if first_identity_id is None:
+                first_identity_id = identity.canonical_id
 
             known_offset = self._known_offsets.get(identity.registry_id)
             known_endianness = self._known_endianness.get(identity.registry_id, False)
             target_time = now if known_offset is None else now + known_offset
             rotation_start = target_time - (target_time % ROTATION_PERIOD)
             window_range: range
+            should_log_debug_dump = identity.canonical_id.endswith("d329") or (
+                first_identity_id is not None
+                and identity.canonical_id == first_identity_id
+            )
+            debug_dump_logged = False
 
             if known_offset is None:
                 window_range = range(-90, 91)
@@ -209,6 +219,17 @@ class GoogleFindMyEIDResolver:
                             time_offset=time_offset,
                             is_reversed=is_reversed,
                         )
+
+                    if should_log_debug_dump and not debug_dump_logged:
+                        key_snippet = identity.identity_key.hex()[:6]
+                        _LOGGER.info(
+                            "DEBUG DUMP: Device=%s KeyStart=%s... TS=%s GeneratedEID=%s",
+                            identity.canonical_id,
+                            key_snippet,
+                            window_timestamp,
+                            eid.hex(),
+                        )
+                        debug_dump_logged = True
 
         self._lookup = lookup
         _LOGGER.debug(
@@ -387,9 +408,9 @@ class GoogleFindMyEIDResolver:
         prefer a ``device_id`` string or ``None``.
 
         EIDs are not logged to avoid leaking hardware identifiers in debug
-        output during normal operation. A temporary warning-level probe log at
-        the start of this method prints the scanned EID for troubleshooting
-        cache mismatches. Incoming BLE payloads may include framing bytes and
+        output during normal operation. A debug-level probe log at the start of
+        this method prints the scanned EID for troubleshooting cache
+        mismatches. Incoming BLE payloads may include framing bytes and
         telemetry appended to the 20-byte EID; the resolver normalizes the
         payload before checking the lookup table.
         """
@@ -442,6 +463,12 @@ class GoogleFindMyEIDResolver:
         self._known_endianness[match.device_id] = match.is_reversed
         _LOGGER.debug("Resolved EID to device %s", match.device_id)
         return match
+
+    def reset_device_offset(self, device_id: str) -> None:
+        """Clear cached time offset and endianness for a device."""
+
+        self._known_offsets.pop(device_id, None)
+        self._known_endianness.pop(device_id, None)
 
     def get_resolved_eid(self, eid_bytes: bytes) -> str | None:
         """Backward compatible convenience wrapper for resolve_eid.

--- a/tests/test_eid_diagnostics.py
+++ b/tests/test_eid_diagnostics.py
@@ -1,0 +1,100 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+import custom_components.googlefindmy.eid_resolver as resolver_module
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import (
+    EID_LENGTH,
+    EIDMatch,
+    GoogleFindMyEIDResolver,
+)
+
+
+def _build_resolver() -> GoogleFindMyEIDResolver:
+    class _Resolver(resolver_module.GoogleFindMyEIDResolver):
+        def _start_alignment_timer(self) -> None:
+            return None
+
+    instance = _Resolver(hass=object())
+    instance._lookup = {}
+    instance._known_offsets = {}
+    instance._known_endianness = {}
+    instance._unsub_interval = None
+    instance._unsub_alignment = None
+    instance._refresh_lock = asyncio.Lock()
+    instance._pending_refresh = False
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_refresh_cache_logs_debug_dump(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    identity = DeviceIdentity(
+        registry_id="registry-dump",
+        canonical_id="device-d329",
+        identity_key=b"\x01" * EID_LENGTH,
+        config_entry_id="entry-dump",
+    )
+    resolver = _build_resolver()
+
+    base_time = 4096
+    monkeypatch.setattr(resolver_module.time, "time", lambda: base_time)
+
+    def _fake_generate_eid(key: bytes, timestamp: int) -> bytes:
+        return (key + timestamp.to_bytes(8, "big"))[:EID_LENGTH]
+
+    monkeypatch.setattr(resolver_module, "generate_eid", _fake_generate_eid)
+    monkeypatch.setattr(
+        resolver_module.GoogleFindMyEIDResolver,
+        "_collect_device_secrets",
+        AsyncMock(return_value=[identity]),
+    )
+
+    caplog.set_level(logging.INFO)
+
+    await resolver._refresh_cache()
+
+    assert any(
+        record.levelno == logging.INFO
+        and "DEBUG DUMP: Device=device-d329" in record.message
+        and "GeneratedEID" in record.message
+        for record in caplog.records
+    )
+
+
+def test_resolve_eid_logs_match_found(caplog: pytest.LogCaptureFixture) -> None:
+    resolver = _build_resolver()
+    lookup_key = b"\x02" * EID_LENGTH
+    match = EIDMatch(
+        device_id="device-logs",
+        config_entry_id="entry-logs",
+        canonical_id="canonical-logs",
+        time_offset=0,
+        is_reversed=False,
+    )
+    resolver._lookup = {lookup_key: match}
+
+    caplog.set_level(logging.INFO)
+
+    assert resolver.resolve_eid(lookup_key) is match
+    assert any(
+        record.levelno == logging.INFO
+        and "MATCH FOUND: EID" in record.message
+        and "device-logs" in record.message
+        for record in caplog.records
+    )
+
+
+def test_reset_device_offset_clears_cache() -> None:
+    resolver = _build_resolver()
+    resolver._known_offsets = {"device-clear": 10}
+    resolver._known_endianness = {"device-clear": True}
+
+    resolver.reset_device_offset("device-clear")
+
+    assert resolver._known_offsets == {}
+    assert resolver._known_endianness == {}


### PR DESCRIPTION
## Summary
- log focused EID generation diagnostics for targeted devices with clearer key snippets
- add a resolver offset reset helper and invoke it when identity keys change
- extend diagnostics tests to cover debug dump output and offset reset behavior

## Testing
- python -m ruff check --fix .
- python -m mypy --strict
- python -m pytest --cov


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b1fe0e0388329a65c82628a6716b4)