### PR TITLE
Prioritize decrypted identity keys and filter FMDN frames

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -462,6 +462,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     raw_owner_key_version = getattr(encrypted_user_secrets, "ownerKeyVersion", None)
 
     identity_key = await async_retrieve_identity_key(device_registration, cache=cache)
+    identity_key_bytes = bytes(identity_key) if identity_key is not None else None
 
     try:
         locations_proto = device_update_protobuf.deviceMetadata.information.locationInformation.reports.recentLocationAndNetworkLocations
@@ -591,7 +592,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "semantic_name": loc.name,
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
-                    "identity_key": identity_key,
+                    "identity_key": identity_key_bytes,
                 }
                 # Internal hint helps the coordinator schedule throttling-aware cooldowns.
                 if report_hint:
@@ -643,7 +644,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "semantic_name": None,
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
-                    "identity_key": identity_key,
+                    "identity_key": identity_key_bytes,
                 }
                 if report_hint:
                     payload["_report_hint"] = report_hint

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -4335,7 +4335,9 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
         T = TypeVar("T")
 
-        def _lookup(key: str, *sources: Mapping[str, T]) -> T | None:
+        def _lookup_prio(key: str, *sources: Mapping[str, T]) -> T | None:
+            """Return the first matching value across ordered sources."""
+
             for source in sources:
                 if key in source:
                     return source[key]
@@ -4526,28 +4528,29 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 continue
 
             registry_id, registry_key = registry_entry
-            identity_key = _lookup(lookup_id, cache_identities, last_identities)
+
+            identity_key = _lookup_prio(
+                lookup_id, cache_identities, data_identities, last_identities
+            )
             if identity_key is None:
                 identity_key = registry_key
-            if identity_key is None:
-                identity_key = _lookup(lookup_id, data_identities)
 
-            encrypted_identity_tuple = _lookup(
-                lookup_id, cache_encrypted, last_encrypted, data_encrypted
+            encrypted_identity_tuple = _lookup_prio(
+                lookup_id, cache_encrypted, data_encrypted, last_encrypted
             )
             encrypted_identity_key, owner_key_version = encrypted_identity_tuple or (
                 None,
                 None,
             )
-            device_type = _lookup(
-                lookup_id, cache_device_types, last_device_types, data_device_types
+            device_type = _lookup_prio(
+                lookup_id, cache_device_types, data_device_types, last_device_types
             )
 
-            fast_pair_model_id = _lookup(
+            fast_pair_model_id = _lookup_prio(
                 lookup_id,
                 cache_fast_pair_model_ids,
-                last_fast_pair_model_ids,
                 data_fast_pair_model_ids,
+                last_fast_pair_model_ids,
             )
 
             if identity_key is None and encrypted_identity_key is None:
@@ -6044,29 +6047,53 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             return
 
         resolver_refresh_needed = False
-        incoming_eik = slot.get("encrypted_identity_key")
+
+        cached_identity_key = None
+        if isinstance(cached_loc, Mapping):
+            cached_identity_key = self._normalize_identity_key(
+                cached_loc.get("identity_key")
+            )
+
+        incoming_identity_key = self._normalize_identity_key(slot.get("identity_key"))
+        if incoming_identity_key is not None:
+            slot["identity_key"] = incoming_identity_key
+
+        incoming_eik = self._normalize_identity_key(slot.get("encrypted_identity_key"))
+        if incoming_eik is not None:
+            slot["encrypted_identity_key"] = incoming_eik
+
         incoming_owner_key_version = slot.get("owner_key_version")
 
-        if incoming_eik is not None or incoming_owner_key_version is not None:
-            cached_eik = None
-            cached_owner_key_version = None
-            if isinstance(cached_loc, Mapping):
-                cached_eik = cached_loc.get("encrypted_identity_key")
-                cached_owner_key_version = cached_loc.get("owner_key_version")
+        identity_changed = (
+            incoming_identity_key is not None
+            and incoming_identity_key != cached_identity_key
+        )
 
-            if (
-                cached_eik != incoming_eik
-                or cached_owner_key_version != incoming_owner_key_version
-            ):
-                resolver_refresh_needed = True
-                _LOGGER.info(
-                    (
-                        "Identity key update detected for %s (ownerKeyVersion=%s); "
-                        "scheduling EID resolver refresh."
-                    ),
-                    device_id,
-                    incoming_owner_key_version,
-                )
+        cached_eik = None
+        cached_owner_key_version = None
+        if isinstance(cached_loc, Mapping):
+            cached_eik = self._normalize_identity_key(
+                cached_loc.get("encrypted_identity_key")
+            )
+            cached_owner_key_version = cached_loc.get("owner_key_version")
+
+        encrypted_changed = False
+        if incoming_eik is not None or incoming_owner_key_version is not None:
+            encrypted_changed = (
+                incoming_eik != cached_eik
+                or incoming_owner_key_version != cached_owner_key_version
+            )
+
+        if identity_changed or encrypted_changed:
+            resolver_refresh_needed = True
+            _LOGGER.info(
+                (
+                    "Identity key update detected for %s "
+                    "(ownerKeyVersion=%s); scheduling EID resolver refresh."
+                ),
+                device_id,
+                incoming_owner_key_version,
+            )
 
         # Ensure last_updated is present
         slot.setdefault("last_updated", time.time())
@@ -6090,9 +6117,32 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             self._schedule_eid_resolver_refresh()
 
     def _reset_resolver_offset(self, device_id: str) -> None:
-        """Clear resolver offsets when identity keys rotate."""
+        """Clear resolver offsets using registry IDs when identity keys rotate."""
 
         hass = getattr(self, "hass", None)
+        if hass is None:
+            return
+
+        registry_id: str | None = None
+        entry_id = self._entry_id()
+
+        dev_reg = dr.async_get(hass)
+        if entry_id and dev_reg:
+            identifiers = {
+                (DOMAIN, f"{entry_id}:{device_id}"),
+                (DOMAIN, device_id),
+            }
+            device = dev_reg.async_get_device(identifiers=identifiers)
+            if device:
+                registry_id = device.id
+
+        if not registry_id:
+            _LOGGER.debug(
+                "Could not resolve Registry ID for canonical %s; skipping offset reset.",
+                device_id,
+            )
+            return
+
         hass_data = getattr(hass, "data", None)
         if not isinstance(hass_data, dict):
             return
@@ -6102,9 +6152,17 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             return
 
         resolver = bucket.get(DATA_EID_RESOLVER)
+        if resolver is None:
+            return
+
         reset = getattr(resolver, "reset_device_offset", None)
         if callable(reset):
-            reset(device_id)
+            _LOGGER.debug(
+                "Triggering resolver offset reset for %s (Registry ID: %s)",
+                device_id,
+                registry_id,
+            )
+            reset(registry_id)
 
     def _is_significant_update(self, device_id: str, new_data: dict[str, Any]) -> bool:
         """Validate temporal ordering before committing cache updates.

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -42,6 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 
 EID_LENGTH = 20
 RAW_HEADER_LENGTH = 1
+FMDN_FRAME_TYPE = 0x40
 
 
 class EIDMatch(NamedTuple):
@@ -400,6 +401,12 @@ class GoogleFindMyEIDResolver:
     def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:
         """Resolve a scanned EID to a Home Assistant device registry ID.
 
+        Only Find My Device Network (FMDN) advertising frames (Frame Type
+        ``0x40``) are considered when the payload includes framing/telemetry;
+        the resolver slices the header and trailing bytes to isolate the
+        20-byte EID before lookup. Legacy callers that already provide a
+        20-byte EID bypass the framing filter.
+
         Returns the matching :class:`EIDMatch` when the identifier was
         precomputed for a known tracker; otherwise returns ``None``. The
         ``device_id`` in the returned mapping corresponds to the Home
@@ -409,21 +416,23 @@ class GoogleFindMyEIDResolver:
 
         EIDs are not logged to avoid leaking hardware identifiers in debug
         output during normal operation. A debug-level probe log at the start of
-        this method prints the scanned EID for troubleshooting cache
-        mismatches. Incoming BLE payloads may include framing bytes and
-        telemetry appended to the 20-byte EID; the resolver normalizes the
-        payload before checking the lookup table.
+        this method prints the sliced EID for troubleshooting cache
+        mismatches.
         """
 
-        if len(eid_bytes) < EID_LENGTH:
+        lookup_key: bytes | None
+
+        if len(eid_bytes) == EID_LENGTH:
+            lookup_key = eid_bytes
+        elif len(eid_bytes) > EID_LENGTH:
+            if eid_bytes[0] != FMDN_FRAME_TYPE:
+                return None
+            lookup_key = eid_bytes[1 : 1 + EID_LENGTH]
+        else:
             return None
 
-        if len(eid_bytes) > EID_LENGTH:
-            lookup_key = eid_bytes[
-                RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + EID_LENGTH
-            ]
-        else:
-            lookup_key = eid_bytes
+        if len(lookup_key) != EID_LENGTH:
+            return None
 
         _LOGGER.debug(
             "RESOLVER PROBE: Checking Sliced EID %s (Original Len: %d)",

--- a/tests/test_coordinator_priority.py
+++ b/tests/test_coordinator_priority.py
@@ -1,0 +1,128 @@
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import custom_components.googlefindmy.coordinator as coordinator_module
+
+
+class _StubDevice:
+    def __init__(self, identifier: str, registry_id: str | None = None) -> None:
+        self.identifier = identifier
+        self.id = registry_id or identifier
+        self.custom_fields: dict[str, object] = {}
+        self.disabled_by: str | None = None
+
+
+class _StubDeviceRegistry:
+    def __init__(self, devices: list[_StubDevice]) -> None:
+        self._devices = devices
+
+    def async_entries_for_config_entry(self, _entry_id: str) -> list[_StubDevice]:
+        return list(self._devices)
+
+
+class _StubHass:
+    def __init__(self) -> None:
+        self.data: dict[str, object] = {}
+
+    def async_create_task(self, coro: Any):
+        return coro
+
+
+def _build_coordinator(monkeypatch: pytest.MonkeyPatch) -> coordinator_module.GoogleFindMyCoordinator:
+    registry = _StubDeviceRegistry([_StubDevice("device-1", registry_id="registry-1")])
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator.hass = _StubHass()
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator._enabled_poll_device_ids = {"device-1"}
+    coordinator._get_ignored_set = lambda: set()
+    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator.data = []
+    coordinator._device_location_data = {}
+    return coordinator
+
+
+def test_decrypted_cache_identity_overrides_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    coordinator = _build_coordinator(monkeypatch)
+    coordinator._last_device_list = [
+        {
+            "id": "device-1",
+            "encryptedIdentityKey": "aaaa",
+            "owner_key_version": 1,
+        }
+    ]
+    coordinator._device_location_data = {
+        "device-1": {
+            "identity_key": b"\x01\x02",
+            "encryptedIdentityKey": "bbbb",
+            "owner_key_version": 2,
+        }
+    }
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.identity_key == b"\x01\x02"
+    assert identity.encrypted_identity_key == bytes.fromhex("bbbb")
+    assert identity.owner_key_version == 2
+
+
+def test_poll_identity_used_when_cache_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    coordinator = _build_coordinator(monkeypatch)
+    coordinator._last_device_list = [
+        {
+            "id": "device-1",
+            "identityKey": "0c0d",
+            "encryptedIdentityKey": "cccc",
+            "owner_key_version": 4,
+        }
+    ]
+    coordinator._device_location_data = {
+        "device-1": {
+            "encryptedIdentityKey": "aaaa",
+            "owner_key_version": 4,
+        }
+    }
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.identity_key == bytes.fromhex("0c0d")
+    assert identity.encrypted_identity_key == bytes.fromhex("aaaa")
+    assert identity.owner_key_version == 4
+
+
+def test_cache_update_triggers_resolver_reset(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    coordinator = _build_coordinator(monkeypatch)
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._run_on_hass_loop = lambda *_args, **_kwargs: None
+    coordinator._record_semantic_label = lambda *_args, **_kwargs: None
+    coordinator._apply_semantic_mapping = lambda *_args, **_kwargs: None
+    coordinator._apply_weighted_location_fusion = lambda *_args, **_kwargs: True
+    coordinator._apply_report_type_cooldown = lambda *_args, **_kwargs: None
+    coordinator.increment_stat = lambda *_args, **_kwargs: None
+    coordinator._merge_with_existing_cache_row = lambda _dev_id, slot: slot
+    coordinator._is_significant_update = lambda *_args, **_kwargs: True
+    coordinator._ensure_device_name_cache = lambda: {}
+    coordinator._device_location_data = {"device-1": {"identity_key": b"\x00\x00"}}
+
+    reset_calls: list[str] = []
+    refresh_calls: list[bool] = []
+    coordinator._reset_resolver_offset = lambda dev_id: reset_calls.append(dev_id)
+    coordinator._schedule_eid_resolver_refresh = lambda: refresh_calls.append(True)
+
+    caplog.set_level(logging.INFO)
+    coordinator.update_device_cache("device-1", {"identity_key": b"\x00\x01"})
+
+    assert reset_calls == ["device-1"]
+    assert refresh_calls == [True]
+    assert any("Identity key update detected" in record.message for record in caplog.records)
+

--- a/tests/test_eid_resolver_logging.py
+++ b/tests/test_eid_resolver_logging.py
@@ -56,7 +56,7 @@ def test_non_match_does_not_log_info(
 def test_probe_logs_sliced_key(
     resolver: GoogleFindMyEIDResolver, caplog: pytest.LogCaptureFixture
 ) -> None:
-    raw_payload = b"\x00" + (b"\x03" * EID_LENGTH) + b"\xFF"
+    raw_payload = b"\x40" + (b"\x03" * EID_LENGTH) + b"\xFF"
     expected_lookup = raw_payload[RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + EID_LENGTH]
     resolver._lookup = {}
 

--- a/tests/test_fmdn_frame_filter.py
+++ b/tests/test_fmdn_frame_filter.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+from custom_components.googlefindmy.eid_resolver import (
+    EIDMatch,
+    GoogleFindMyEIDResolver,
+)
+
+
+def _build_resolver(lookup_key: bytes, match: EIDMatch) -> GoogleFindMyEIDResolver:
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = SimpleNamespace()
+    resolver._lookup = {lookup_key: match}
+    resolver._known_offsets = {}
+    resolver._known_endianness = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    return resolver
+
+
+def test_fmdn_frame_required_for_extended_payload() -> None:
+    eid = bytes.fromhex("00112233445566778899aabbccddeeff00112233")
+    match = EIDMatch(
+        device_id="device-fmdn",
+        config_entry_id="entry-fmdn",
+        canonical_id="canonical-fmdn",
+        time_offset=0,
+        is_reversed=False,
+    )
+    resolver = _build_resolver(eid, match)
+
+    payload = b"\x40" + eid + b"\x00\x01"
+    resolved = resolver.resolve_eid(payload)
+
+    assert resolved == match
+
+    non_fmdn_payload = b"\x41" + eid + b"\x00\x01"
+    assert resolver.resolve_eid(non_fmdn_payload) is None
+
+
+def test_exact_length_payloads_bypass_frame_filter() -> None:
+    eid = bytes.fromhex("abcdefabcdefabcdefabcdefabcdefabcdefabcd")
+    match = EIDMatch(
+        device_id="device-legacy",
+        config_entry_id="entry-legacy",
+        canonical_id="canonical-legacy",
+        time_offset=4,
+        is_reversed=True,
+    )
+    resolver = _build_resolver(eid, match)
+
+    assert resolver.resolve_eid(eid) == match

--- a/tests/test_key_propagation_flow.py
+++ b/tests/test_key_propagation_flow.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import custom_components.googlefindmy.coordinator as coordinator_module
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    decrypt_locations as decrypt_module,
+)
+
+
+class _StatusEnum:
+    SEMANTIC = 1
+
+    @staticmethod
+    def Name(code: int) -> str:
+        return "SEMANTIC" if code == _StatusEnum.SEMANTIC else str(code)
+
+
+class _LocationContainer:
+    def __init__(self, location: Any, timestamp: int) -> None:
+        self.networkLocations = [location]
+        self.networkLocationTimestamps = [timestamp]
+        self.recentLocation = location
+        self.recentLocationTimestamp = timestamp
+
+    def HasField(self, _name: str) -> bool:  # noqa: N802
+        return False
+
+
+def _build_coordinator(monkeypatch: pytest.MonkeyPatch) -> coordinator_module.GoogleFindMyCoordinator:
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator.hass = SimpleNamespace(async_create_task=lambda coro: coro, data={})
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator._enabled_poll_device_ids = set()
+    coordinator._get_ignored_set = lambda: set()
+    coordinator.data = []
+    coordinator._device_location_data = {}
+    coordinator._record_semantic_label = lambda *_args, **_kwargs: None
+    coordinator._apply_semantic_mapping = lambda *_args, **_kwargs: None
+    coordinator._apply_weighted_location_fusion = lambda *_args, **_kwargs: True
+    coordinator._apply_report_type_cooldown = lambda *_args, **_kwargs: None
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._run_on_hass_loop = lambda *_args, **_kwargs: None
+    coordinator._track_device_interval = lambda *_args, **_kwargs: None
+    coordinator._is_significant_update = lambda *_args, **_kwargs: True
+    coordinator._merge_with_existing_cache_row = lambda _dev_id, slot: slot
+    coordinator.increment_stat = lambda *_args, **_kwargs: None
+    coordinator._ensure_device_name_cache = lambda: {}
+    coordinator._reset_resolver_offset = lambda *_args, **_kwargs: None
+    coordinator._schedule_eid_resolver_refresh = lambda *_args, **_kwargs: None
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_decrypted_key_reaches_coordinator_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity_key = b"new_decrypted_bytes_source_of_truth"
+    timestamp = int(time.time())
+
+    semantic_location = SimpleNamespace(
+        status=_StatusEnum.SEMANTIC,
+        semanticLocation=SimpleNamespace(locationName="Semantic"),
+    )
+    locations = _LocationContainer(semantic_location, timestamp)
+
+    device_update_protobuf = SimpleNamespace(
+        deviceMetadata=SimpleNamespace(
+            information=SimpleNamespace(
+                deviceRegistration=SimpleNamespace(
+                    encryptedUserSecrets=SimpleNamespace(
+                        encryptedIdentityKey=b"enc_bytes",
+                        ownerKeyVersion=1,
+                    )
+                ),
+                locationInformation=SimpleNamespace(
+                    reports=SimpleNamespace(recentLocationAndNetworkLocations=locations)
+                ),
+            )
+        )
+    )
+
+    common_stub = SimpleNamespace(Status=_StatusEnum)
+    device_update_stub = SimpleNamespace(Location=lambda: SimpleNamespace(ParseFromString=lambda *_a, **_kw: None))
+
+    async def _stub_async_retrieve_identity_key(*_args: Any, **_kwargs: Any) -> bytes:
+        return identity_key
+
+    monkeypatch.setattr(decrypt_module, "_get_common_pb2", lambda: common_stub)
+    monkeypatch.setattr(decrypt_module, "_get_device_update_pb2", lambda: device_update_stub)
+    monkeypatch.setattr(
+        decrypt_module,
+        "async_retrieve_identity_key",
+        _stub_async_retrieve_identity_key,
+    )
+    monkeypatch.setattr(decrypt_module, "is_mcu_tracker", lambda *_args: False)
+
+    decrypted_payloads = await decrypt_module.async_decrypt_location_response_locations(
+        device_update_protobuf, cache=SimpleNamespace()
+    )
+
+    assert decrypted_payloads
+    payload = decrypted_payloads[0]
+    assert payload["identity_key"] == identity_key
+
+    coordinator = _build_coordinator(monkeypatch)
+    coordinator.update_device_cache("device-1", payload)
+
+    stored_data = coordinator.get_device_location_data("device-1")
+    assert stored_data is not None
+    assert stored_data["identity_key"] == identity_key


### PR DESCRIPTION
# Summary
- add an integration test that exercises the decrypt_locations payload contract and ensures decrypted identity keys reach the coordinator cache

# Testing
- python -m ruff check --fix .
- python -m mypy --strict
- python -m pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2b957aac8329b3a8c55e53c16f25)