### PR TITLE
Add multi-candidate identity key handling for EID resolution

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -4,9 +4,11 @@
 #
 from __future__ import annotations
 
+# ruff: noqa: PLR0912, PLR0915
 import asyncio
 import datetime
 import hashlib
+import inspect
 import logging
 import math
 import time
@@ -143,13 +145,13 @@ async def async_retrieve_identity_key(
     *,
     cache: TokenCache,
     _retry: bool = True,
-) -> bytes:
+) -> list[bytes]:  # noqa: PLR0912, PLR0915
     """Retrieve the device Ephemeral Identity Key (EIK) asynchronously.
 
     Flow (async-first, HA-friendly):
-    - Apply MCU bit-flip quirk to the encrypted EIK blob.
+    - Try both MCU bit-flip states to derive candidate keys.
     - Obtain owner key (async).
-    - Decrypt EIK (CPU-bound → offload to thread).
+    - Decrypt each candidate EIK (CPU-bound → offload to thread).
     - Strictly validate length to avoid silent misuse downstream.
 
     Args:
@@ -162,13 +164,9 @@ async def async_retrieve_identity_key(
         SpotApiEmptyResponseError: propagated if EID info trailers-only response indicates auth/session issue.
         RuntimeError: if the TokenCache is missing (multi-account safety guard).
     """
-    is_mcu = is_mcu_tracker(device_registration)
     encrypted_user_secrets = device_registration.encryptedUserSecrets
 
-    encrypted_identity_key = flip_bits(
-        encrypted_user_secrets.encryptedIdentityKey,
-        is_mcu,
-    )
+    raw_encrypted_identity_key = encrypted_user_secrets.encryptedIdentityKey
 
     if cache is None:
         raise RuntimeError(
@@ -176,106 +174,119 @@ async def async_retrieve_identity_key(
         )
 
     owner_key_info: OwnerKeyInfo = await async_get_owner_key(cache=cache)
+    candidates: list[bytes] = []
+    decrypt_errors: list[Exception] = []
 
-    try:
-        # CPU-heavy → do not block the event loop
-        eik_bytes = await asyncio.to_thread(
-            decrypt_eik, owner_key_info.key, encrypted_identity_key
-        )
-        # Strict sanity: EIK must be exactly 32 bytes
-        if not isinstance(eik_bytes, (bytes, bytearray)) or len(eik_bytes) != _EIK_LEN:
-            raise DecryptionError(
-                f"Ephemeral identity key invalid (expected {_EIK_LEN} bytes)."
-            )
-        return bytes(eik_bytes)
-    except Exception as e:
-        current_owner_key_version = None
+    for do_flip in (False, True):
+        flipped_blob = flip_bits(raw_encrypted_identity_key, do_flip)
         try:
-            e2ee_data = await async_get_eid_info(cache=cache)
-            current_owner_key_version = (
-                e2ee_data.encryptedOwnerKeyAndMetadata.ownerKeyVersion
+            # CPU-heavy → do not block the event loop
+            eik_bytes = await asyncio.to_thread(
+                decrypt_eik, owner_key_info.key, flipped_blob
             )
-            _LOGGER.debug(
-                "E2EE metadata: current ownerKeyVersion=%s", current_owner_key_version
-            )
-        except SpotApiEmptyResponseError:
-            _LOGGER.error(
-                "Failed to decrypt identity key due to empty trailers-only EID info response "
-                "(authentication/session). Please re-authenticate and retry."
-            )
-            raise
-        except Exception as meta_exc:  # best-effort diagnostics
-            _LOGGER.warning(
-                "Failed to retrieve E2EE metadata for diagnostics: %s", meta_exc
-            )
-
-        old_ver = getattr(encrypted_user_secrets, "ownerKeyVersion", None)
-        if (
-            current_owner_key_version is not None
-            and old_ver is not None
-            and old_ver < current_owner_key_version
-        ):
-            if _retry:
-                username = None
-                cache_key = None
-                try:
-                    username = await cache.get(username_string)
-                except Exception as cache_exc:
-                    _LOGGER.debug(
-                        "Failed to resolve username from cache before clearing owner key: %s",
-                        cache_exc,
-                    )
-
-                if isinstance(username, str) and username:
-                    cache_key = f"owner_key_{username}"
-
-                _LOGGER.info(
-                    "Owner key version mismatch (tracker=%s, current=%s); %s and retrying once.",
-                    old_ver,
-                    current_owner_key_version,
-                    "clearing cached owner key" if cache_key else "retrying with fresh owner key",
+            if not isinstance(eik_bytes, (bytes, bytearray)) or len(eik_bytes) != _EIK_LEN:
+                raise DecryptionError(
+                    f"Ephemeral identity key invalid (expected {_EIK_LEN} bytes)."
                 )
 
-                if cache_key:
-                    try:
-                        await cache.set(cache_key, None)
-                    except Exception as cache_exc:
-                        _LOGGER.warning(
-                            "Failed to clear cached owner key '%s': %s", cache_key, cache_exc
-                        )
+            key_bytes = bytes(eik_bytes)
+            if key_bytes not in candidates:
+                candidates.append(key_bytes)
+        except Exception as exc:  # Capture and continue to try the other flip state
+            decrypt_errors.append(exc)
 
-                return await async_retrieve_identity_key(
-                    device_registration,
-                    cache=cache,
-                    _retry=False,
+    if candidates:
+        return candidates
+
+    current_owner_key_version = None
+    try:
+        e2ee_data = await async_get_eid_info(cache=cache)
+        current_owner_key_version = (
+            e2ee_data.encryptedOwnerKeyAndMetadata.ownerKeyVersion
+        )
+        _LOGGER.debug(
+            "E2EE metadata: current ownerKeyVersion=%s", current_owner_key_version
+        )
+    except SpotApiEmptyResponseError:
+        _LOGGER.error(
+            "Failed to decrypt identity key due to empty trailers-only EID info response "
+            "(authentication/session). Please re-authenticate and retry."
+        )
+        raise
+    except Exception as meta_exc:  # best-effort diagnostics
+        _LOGGER.warning(
+            "Failed to retrieve E2EE metadata for diagnostics: %s", meta_exc
+        )
+
+    old_ver = getattr(encrypted_user_secrets, "ownerKeyVersion", None)
+    last_exc = decrypt_errors[-1] if decrypt_errors else None
+    if (
+        current_owner_key_version is not None
+        and old_ver is not None
+        and old_ver < current_owner_key_version
+    ):
+        if _retry:
+            username = None
+            cache_key = None
+            try:
+                username = await cache.get(username_string)
+            except Exception as cache_exc:
+                _LOGGER.debug(
+                    "Failed to resolve username from cache before clearing owner key: %s",
+                    cache_exc,
                 )
 
-            _LOGGER.error(
-                "Owner key version mismatch: tracker=%s, current=%s. "
-                "This typically occurs after resetting E2EE data. "
-                "The tracker cannot be decrypted anymore; remove it in the Find My Device app.",
+            if isinstance(username, str) and username:
+                cache_key = f"owner_key_{username}"
+
+            _LOGGER.info(
+                "Owner key version mismatch (tracker=%s, current=%s); %s and retrying once.",
                 old_ver,
                 current_owner_key_version,
+                "clearing cached owner key" if cache_key else "retrying with fresh owner key",
             )
-            raise StaleOwnerKeyError(
-                "Tracker was encrypted with a stale owner key version."
-            ) from e
+
+            if cache_key:
+                try:
+                    delete_method = getattr(cache, "delete", None)
+                    if callable(delete_method):
+                        result = delete_method(cache_key)
+                        if inspect.isawaitable(result):
+                            await result
+                except Exception as cache_exc:
+                    _LOGGER.debug("Failed to clear cached owner key: %s", cache_exc)
+
+            return await async_retrieve_identity_key(
+                device_registration,
+                cache=cache,
+                _retry=False,
+            )
 
         _LOGGER.error(
-            "Failed to decrypt identity key (owner key version %s vs. current %s). "
-            "If you recently reset E2EE data, re-authenticate or recreate keys. "
-            "If the issue persists, clear the integration secrets to force a fresh key derivation.",
+            "Owner key version mismatch: tracker=%s, current=%s. "
+            "This typically occurs after resetting E2EE data. "
+            "The tracker cannot be decrypted anymore; remove it in the Find My Device app.",
             old_ver,
             current_owner_key_version,
         )
-        raise DecryptionError("Identity key decryption failed.") from e
+        raise StaleOwnerKeyError(
+            "Tracker was encrypted with a stale owner key version."
+        ) from last_exc
 
+    _LOGGER.error(
+        "Failed to decrypt identity key (owner key version %s vs. current %s). "
+        "If you recently reset E2EE data, re-authenticate or recreate keys. "
+        "If the issue persists, clear the integration secrets to force a fresh key derivation.",
+        old_ver,
+        current_owner_key_version,
+    )
+    raise DecryptionError("Identity key decryption failed.") from last_exc
 
 def retrieve_identity_key(
     device_registration: DeviceRegistration,
     *,
     cache: TokenCache | None = None,
-) -> bytes:
+) -> list[bytes]:
     """Legacy synchronous facade removed in favor of the async API."""
 
     raise RuntimeError(
@@ -461,8 +472,15 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     )
     raw_owner_key_version = getattr(encrypted_user_secrets, "ownerKeyVersion", None)
 
-    identity_key = await async_retrieve_identity_key(device_registration, cache=cache)
+    identity_key_candidates = await async_retrieve_identity_key(
+        device_registration, cache=cache
+    )
+    identity_key = identity_key_candidates[0] if identity_key_candidates else None
     identity_key_bytes = bytes(identity_key) if identity_key is not None else None
+    identity_key_candidate_bytes = [bytes(candidate) for candidate in identity_key_candidates]
+
+    if identity_key is None:
+        raise DecryptionError("Identity key derivation returned no candidates.")
 
     try:
         locations_proto = device_update_protobuf.deviceMetadata.information.locationInformation.reports.recentLocationAndNetworkLocations
@@ -593,6 +611,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
                     "identity_key": identity_key_bytes,
+                    "identity_key_candidates": identity_key_candidate_bytes,
                 }
                 # Internal hint helps the coordinator schedule throttling-aware cooldowns.
                 if report_hint:
@@ -645,6 +664,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
                     "identity_key": identity_key_bytes,
+                    "identity_key_candidates": identity_key_candidate_bytes,
                 }
                 if report_hint:
                     payload["_report_hint"] = report_hint

--- a/custom_components/googlefindmy/SpotApi/UploadPrecomputedPublicKeyIds/upload_precomputed_public_key_ids.py
+++ b/custom_components/googlefindmy/SpotApi/UploadPrecomputedPublicKeyIds/upload_precomputed_public_key_ids.py
@@ -44,7 +44,7 @@ def refresh_custom_trackers(device_list: DevicesList) -> None:
             )
 
             try:
-                identity_key = retrieve_identity_key(
+                identity_keys = retrieve_identity_key(
                     device.information.deviceRegistration
                 )
             except RuntimeError as exc:
@@ -54,10 +54,16 @@ def refresh_custom_trackers(device_list: DevicesList) -> None:
                     f"{exc}"
                 )
                 return
+            if not identity_keys:
+                print(
+                    "[UploadPrecomputedPublicKeyIds] No identity key candidates derived; "
+                    "skipping upload."
+                )
+                continue
             start_timestamp = int(time.time() - hours_to_seconds(3))
 
             next_eids = get_next_eids(
-                identity_key,
+                identity_keys[0],
                 new_truncated_ids.pairDate,
                 start_timestamp,
                 duration_seconds=max_truncated_eid_seconds_server,

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -4283,6 +4283,24 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 return None
         return None
 
+    @staticmethod
+    def _normalize_identity_key_candidates(raw: object) -> list[bytes]:
+        """Normalize collections of candidate identity keys."""
+
+        if raw is None:
+            return []
+        if isinstance(raw, (bytes, bytearray, str)):
+            one = GoogleFindMyCoordinator._normalize_identity_key(raw)
+            return [one] if one is not None else []
+        if isinstance(raw, Iterable) and not isinstance(raw, (str, bytes, bytearray)):
+            out: list[bytes] = []
+            for item in raw:
+                key = GoogleFindMyCoordinator._normalize_identity_key(item)
+                if key is not None and key not in out:
+                    out.append(key)
+            return out
+        return []
+
     def _schedule_eid_resolver_refresh(self) -> None:
         """Refresh the global EID resolver when active device sets change."""
 
@@ -4391,6 +4409,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         last_device_types: dict[str, int | None] = {}
         last_fast_pair_model_ids: dict[str, str | None] = {}
         last_raw_keys: dict[str, list[str]] = {}
+        last_identity_candidates: dict[str, list[bytes]] = {}
         if isinstance(last_device_list, Iterable):
             for raw in last_device_list:
                 if not isinstance(raw, dict):
@@ -4407,6 +4426,13 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 )
                 if parsed is not None:
                     last_identities[dev_id] = parsed
+
+                candidate_list = self._normalize_identity_key_candidates(
+                    raw.get("identity_key_candidates")
+                    or raw.get("identityKeyCandidates")
+                )
+                if candidate_list:
+                    last_identity_candidates[dev_id] = candidate_list
 
                 encrypted_identity = self._normalize_identity_key(
                     raw.get("encrypted_identity_key")
@@ -4436,6 +4462,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         data_device_types: dict[str, int | None] = {}
         data_fast_pair_model_ids: dict[str, str | None] = {}
         raw_data_keys: dict[str, list[str]] = {}
+        data_identity_candidates: dict[str, list[bytes]] = {}
         device_data = getattr(self, "data", None)
         if isinstance(device_data, Iterable):
             for raw in device_data:
@@ -4452,6 +4479,13 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 )
                 if parsed is not None:
                     data_identities[dev_id] = parsed
+
+                candidate_list = self._normalize_identity_key_candidates(
+                    raw.get("identity_key_candidates")
+                    or raw.get("identityKeyCandidates")
+                )
+                if candidate_list:
+                    data_identity_candidates[dev_id] = candidate_list
 
                 encrypted_identity = self._normalize_identity_key(
                     raw.get("encrypted_identity_key")
@@ -4482,6 +4516,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         cache_device_types: dict[str, int | None] = {}
         cache_fast_pair_model_ids: dict[str, str | None] = {}
         cache_data_keys: dict[str, list[str]] = {}
+        cache_identity_candidates: dict[str, list[bytes]] = {}
         if isinstance(cache, dict):
             for dev_id in allowed_raw_ids:
                 payload = cache.get(dev_id)
@@ -4495,6 +4530,13 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 )
                 if parsed is not None:
                     cache_identities[dev_id] = parsed
+
+                candidate_list = self._normalize_identity_key_candidates(
+                    payload.get("identity_key_candidates")
+                    or payload.get("identityKeyCandidates")
+                )
+                if candidate_list:
+                    cache_identity_candidates[dev_id] = candidate_list
 
                 encrypted_identity = self._normalize_identity_key(
                     payload.get("encrypted_identity_key")
@@ -4535,6 +4577,15 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             if identity_key is None:
                 identity_key = registry_key
 
+            identity_candidates = _lookup_prio(
+                lookup_id,
+                cache_identity_candidates,
+                data_identity_candidates,
+                last_identity_candidates,
+            )
+            if identity_candidates is None:
+                identity_candidates = []
+
             encrypted_identity_tuple = _lookup_prio(
                 lookup_id, cache_encrypted, data_encrypted, last_encrypted
             )
@@ -4553,7 +4604,18 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 last_fast_pair_model_ids,
             )
 
-            if identity_key is None and encrypted_identity_key is None:
+            if not identity_candidates and identity_key is not None:
+                identity_candidates = [identity_key]
+            elif not identity_candidates and registry_key is not None:
+                identity_candidates = [registry_key]
+
+            normalized_candidates: list[bytes] = []
+            for candidate in identity_candidates:
+                normalized = self._normalize_identity_key(candidate)
+                if normalized is not None and normalized not in normalized_candidates:
+                    normalized_candidates.append(normalized)
+
+            if not normalized_candidates and encrypted_identity_key is None:
                 _LOGGER.debug(
                     "Device %s skipped: No identity key found (Data: %s)",
                     canonical_id,
@@ -4564,18 +4626,33 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 )
                 continue
 
-            identities.append(
-                DeviceIdentity(
-                    registry_id=registry_id,
-                    canonical_id=canonical_id,
-                    identity_key=identity_key,
-                    encrypted_identity_key=encrypted_identity_key,
-                    owner_key_version=owner_key_version,
-                    device_type=device_type,
-                    config_entry_id=entry_id,
-                    fast_pair_model_id=fast_pair_model_id,
+            if normalized_candidates:
+                for candidate in normalized_candidates:
+                    identities.append(
+                        DeviceIdentity(
+                            registry_id=registry_id,
+                            canonical_id=canonical_id,
+                            identity_key=candidate,
+                            encrypted_identity_key=encrypted_identity_key,
+                            owner_key_version=owner_key_version,
+                            device_type=device_type,
+                            config_entry_id=entry_id,
+                            fast_pair_model_id=fast_pair_model_id,
+                        )
+                    )
+            else:
+                identities.append(
+                    DeviceIdentity(
+                        registry_id=registry_id,
+                        canonical_id=canonical_id,
+                        identity_key=None,
+                        encrypted_identity_key=encrypted_identity_key,
+                        owner_key_version=owner_key_version,
+                        device_type=device_type,
+                        config_entry_id=entry_id,
+                        fast_pair_model_id=fast_pair_model_id,
+                    )
                 )
-            )
 
         _LOGGER.debug("Returning %d identities to resolver", len(identities))
         return identities

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -30,8 +30,8 @@ def test_async_decrypt_location_response_locations_allows_future_owner_timestamp
     location_proto.altitude = 1337
     location_bytes = location_proto.SerializeToString()
 
-    async def fake_identity_key(*_args, **_kwargs) -> bytes:
-        return b"\x42" * 32
+    async def fake_identity_key(*_args, **_kwargs) -> list[bytes]:
+        return [b"\x42" * 32]
 
     async def fake_offload(*_args, **_kwargs) -> bytes:
         return location_bytes
@@ -88,8 +88,8 @@ def test_async_decrypt_location_response_locations_aligns_missing_network_timest
     def serialize_location(loc: DeviceUpdate_pb2.Location) -> bytes:
         return loc.SerializeToString()
 
-    async def fake_identity_key(*_args, **_kwargs) -> bytes:
-        return b"\x01" * 32
+    async def fake_identity_key(*_args, **_kwargs) -> list[bytes]:
+        return [b"\x01" * 32]
 
     async def fake_offload_aes(
         _identity_key: bytes, encrypted_location: bytes

--- a/tests/test_dual_key_strategy.py
+++ b/tests/test_dual_key_strategy.py
@@ -1,0 +1,70 @@
+"""Ensure multiple identity key candidates are indexed for a single device."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import custom_components.googlefindmy.coordinator as coordinator_module
+
+
+class _StubDevice:
+    def __init__(self, identifier: str, registry_id: str | None = None) -> None:
+        self.identifier = identifier
+        self.id = registry_id or identifier
+        self.custom_fields: dict[str, object] = {}
+        self.disabled_by: str | None = None
+
+
+class _StubDeviceRegistry:
+    def __init__(self, devices: list[_StubDevice]) -> None:
+        self._devices = devices
+
+    def async_entries_for_config_entry(self, _entry_id: str) -> list[_StubDevice]:
+        return list(self._devices)
+
+
+class _StubHass:
+    def __init__(self) -> None:
+        self.data: dict[str, object] = {}
+
+    def async_create_task(self, coro):
+        return coro
+
+
+def _build_coordinator(monkeypatch):
+    registry = _StubDeviceRegistry([_StubDevice("device-1", registry_id="registry-1")])
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator.hass = _StubHass()
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
+    coordinator._enabled_poll_device_ids = {"device-1"}
+    coordinator._get_ignored_set = lambda: set()
+    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator.data = []
+    coordinator._last_device_list = []
+    coordinator._device_location_data = {}
+    return coordinator
+
+
+def test_multiple_candidates_expand_identities(monkeypatch):
+    coordinator = _build_coordinator(monkeypatch)
+    coordinator._device_location_data = {
+        "device-1": {
+            "identity_key_candidates": [b"a" * 32, b"b" * 32],
+            "encrypted_identity_key": b"enc",
+            "owner_key_version": 7,
+        }
+    }
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 2
+    keys = {identity.identity_key for identity in identities}
+    assert keys == {b"a" * 32, b"b" * 32}
+    for identity in identities:
+        assert identity.canonical_id == "device-1"
+        assert identity.encrypted_identity_key == b"enc"
+        assert identity.owner_key_version == 7

--- a/tests/test_e2ee_token_cache_propagation.py
+++ b/tests/test_e2ee_token_cache_propagation.py
@@ -60,7 +60,7 @@ def test_async_retrieve_identity_key_threads_cache(
         decrypt_locations.async_retrieve_identity_key(DummyRegistration(), cache=cache)
     )
 
-    assert result == b"\x02" * 32
+    assert result == [b"\x02" * 32]
     assert owner_calls["owner_cache"] is cache
     # Success path does not consult async_get_eid_info; ensure no unexpected call
     assert "eid_cache" not in owner_calls
@@ -181,7 +181,7 @@ def test_async_retrieve_identity_key_retries_after_clearing_owner_key(
         decrypt_locations.async_retrieve_identity_key(DummyRegistration(), cache=cache)
     )
 
-    assert result == b"\xAA" * 32
+    assert result == [b"\xAA" * 32]
     assert cache.values.get("owner_key_user@example.com") is None
     assert owner_calls == [cache, cache]
     assert eid_calls == [cache]

--- a/tests/test_key_propagation_flow.py
+++ b/tests/test_key_propagation_flow.py
@@ -89,8 +89,8 @@ async def test_decrypted_key_reaches_coordinator_cache(
     common_stub = SimpleNamespace(Status=_StatusEnum)
     device_update_stub = SimpleNamespace(Location=lambda: SimpleNamespace(ParseFromString=lambda *_a, **_kw: None))
 
-    async def _stub_async_retrieve_identity_key(*_args: Any, **_kwargs: Any) -> bytes:
-        return identity_key
+    async def _stub_async_retrieve_identity_key(*_args: Any, **_kwargs: Any) -> list[bytes]:
+        return [identity_key]
 
     monkeypatch.setattr(decrypt_module, "_get_common_pb2", lambda: common_stub)
     monkeypatch.setattr(decrypt_module, "_get_device_update_pb2", lambda: device_update_stub)


### PR DESCRIPTION
## Summary
- derive both flipped and unflipped identity key candidates during decryption and include them in payloads
- propagate candidate lists into coordinator device identities so the resolver indexes all possible keys
- update and add tests to cover the dual-key strategy and type changes

## Testing
- make test-stubs
- python -m ruff check --fix .
- python -m mypy --strict .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b47a075e08329b8ff627e94338b5c)