### PR TITLE
Preload SSL context for SPOT requests

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -12,6 +12,10 @@ child directory overrides it.
 | Runtime lifecycle patterns, platform forwarding, and subentry helpers (**entity lifecycle requirements live here**) | [`agents/runtime_patterns/AGENTS.md`](agents/runtime_patterns/AGENTS.md) |
 | Typing reminders, stub imports, and strict mypy expectations | [`agents/typing_guidance/AGENTS.md`](agents/typing_guidance/AGENTS.md) |
 
+### SPOT/gRPC client reminder
+
+When reusing a shared `httpx` SSL context for SPOT/gRPC traffic, **enable HTTP/2 on the context** so ALPN advertises `h2` and gRPC requests avoid HTTP/1.1 downgrades.
+
 ## Cross-reference index
 
 * [`tests/AGENTS.md`](../../tests/AGENTS.md) — Discovery and reconfigure test stubs, including the lightweight `ConfigEntry` doubles referenced across the topical guides above.

--- a/custom_components/googlefindmy/SpotApi/spot_request.py
+++ b/custom_components/googlefindmy/SpotApi/spot_request.py
@@ -74,8 +74,11 @@ _SPOT_MAX_RETRY_AFTER_S = 60.0
 
 # Preload the SSL context at import time so certifi's CA bundle is loaded outside the
 # event loop. httpx will reuse this context for every async client, avoiding blocking
-# `load_verify_locations` calls once Home Assistant has started.
-_SPOT_SSL_CONTEXT = httpx.create_ssl_context(http2=True)
+# `load_verify_locations` calls once Home Assistant has started. Manually enable
+# HTTP/2 ALPN to keep SPOT gRPC traffic on h2 without relying on the optional
+# `http2` parameter (missing from the current type stubs).
+_SPOT_SSL_CONTEXT = httpx.create_ssl_context()
+_SPOT_SSL_CONTEXT.set_alpn_protocols(["h2", "http/1.1"])
 _SPOT_SSL_CONTEXT.options |= ssl.OP_NO_COMPRESSION
 
 

--- a/custom_components/googlefindmy/SpotApi/spot_request.py
+++ b/custom_components/googlefindmy/SpotApi/spot_request.py
@@ -9,6 +9,7 @@ import asyncio
 import datetime
 import logging
 import random
+import ssl
 from email.utils import parsedate_to_datetime
 from typing import cast
 
@@ -69,6 +70,13 @@ _SPOT_MAX_RETRIES = 3
 _SPOT_INITIAL_BACKOFF_S = 1.0
 _SPOT_BACKOFF_FACTOR = 2.0
 _SPOT_MAX_RETRY_AFTER_S = 60.0
+
+
+# Preload the SSL context at import time so certifi's CA bundle is loaded outside the
+# event loop. httpx will reuse this context for every async client, avoiding blocking
+# `load_verify_locations` calls once Home Assistant has started.
+_SPOT_SSL_CONTEXT = httpx.create_ssl_context(http2=True)
+_SPOT_SSL_CONTEXT.options |= ssl.OP_NO_COMPRESSION
 
 
 def _compute_delay(attempt: int, retry_after: str | None) -> float:
@@ -241,7 +249,9 @@ async def async_spot_request(
     retries_used = 0
     aas_reset_once = False
 
-    async with httpx.AsyncClient(http2=True, timeout=30.0) as client:
+    async with httpx.AsyncClient(
+        http2=True, timeout=30.0, verify=_SPOT_SSL_CONTEXT
+    ) as client:
         while True:
             attempt = retries_used + 1
             prefer_adm = (


### PR DESCRIPTION
## Summary
- preload a shared SSL context so certifi certificates load before the event loop starts
- reuse the prepared context for all SPOT httpx clients to prevent blocking warnings
- create the shared SSL context with HTTP/2 enabled so ALPN negotiation supports gRPC
- document enabling HTTP/2 on shared SPOT SSL contexts to avoid gRPC downgrades

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b54325cb48329ad5615c5f5b390b4)