### PR TITLE
Persist anchor metadata and prioritize newer anchors

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -185,7 +185,10 @@ async def async_retrieve_identity_key(
             eik_bytes = await asyncio.to_thread(
                 decrypt_eik, owner_key_info.key, flipped_blob
             )
-            if not isinstance(eik_bytes, (bytes, bytearray)) or len(eik_bytes) != _EIK_LEN:
+            if (
+                not isinstance(eik_bytes, (bytes, bytearray))
+                or len(eik_bytes) != _EIK_LEN
+            ):
                 raise DecryptionError(
                     f"Ephemeral identity key invalid (expected {_EIK_LEN} bytes)."
                 )
@@ -244,7 +247,9 @@ async def async_retrieve_identity_key(
                 "Owner key version mismatch (tracker=%s, current=%s); %s and retrying once.",
                 old_ver,
                 current_owner_key_version,
-                "clearing cached owner key" if cache_key else "retrying with fresh owner key",
+                "clearing cached owner key"
+                if cache_key
+                else "retrying with fresh owner key",
             )
 
             if cache_key:
@@ -282,6 +287,7 @@ async def async_retrieve_identity_key(
         current_owner_key_version,
     )
     raise DecryptionError("Identity key decryption failed.") from last_exc
+
 
 def retrieve_identity_key(
     device_registration: DeviceRegistration,
@@ -494,13 +500,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             device_registration,
             type(encrypted_user_secrets),
             serialized_length if serialized_length is not None else "Unknown",
-            len(raw_encrypted_identity_key)
-            if raw_encrypted_identity_key
-            else "None",
+            len(raw_encrypted_identity_key) if raw_encrypted_identity_key else "None",
             type(raw_encrypted_identity_key),
-            raw_encrypted_identity_key.hex()
-            if raw_encrypted_identity_key
-            else "None",
+            raw_encrypted_identity_key.hex() if raw_encrypted_identity_key else "None",
         )
 
         if (
@@ -563,7 +565,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     )
     identity_key = identity_key_candidates[0] if identity_key_candidates else None
     identity_key_bytes = bytes(identity_key) if identity_key is not None else None
-    identity_key_candidate_bytes = [bytes(candidate) for candidate in identity_key_candidates]
+    identity_key_candidate_bytes = [
+        bytes(candidate) for candidate in identity_key_candidates
+    ]
 
     if identity_key is None:
         raise DecryptionError("Identity key derivation returned no candidates.")
@@ -575,6 +579,58 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         raise
 
     is_mcu = is_mcu_tracker(device_registration)
+
+    now_wall = time.time()
+
+    def _normalize_anchor_timestamp(raw: Any) -> int | None:
+        ts = _parse_epoch_seconds(raw, now_wall)
+        if ts is None:
+            return None
+        return int(ts)
+
+    metadata: dict[str, Any] = {}
+    device_registration_metadata: dict[str, Any] = {}
+    encrypted_user_secrets_metadata: dict[str, Any] = {}
+
+    pair_date = _normalize_anchor_timestamp(
+        getattr(device_registration, "pairDate", None)
+    )
+    if pair_date is not None:
+        metadata["pair_date"] = pair_date
+        metadata["pairDate"] = pair_date
+        device_registration_metadata["pairDate"] = pair_date
+
+    secrets_creation_date = _normalize_anchor_timestamp(
+        getattr(encrypted_user_secrets, "creationDate", None)
+    )
+    if secrets_creation_date is not None:
+        metadata["secrets_creation_date"] = secrets_creation_date
+        metadata["secretsCreationDate"] = secrets_creation_date
+        metadata["creationDate"] = secrets_creation_date
+        metadata["creation_date"] = secrets_creation_date
+        encrypted_user_secrets_metadata["creationDate"] = secrets_creation_date
+        encrypted_user_secrets_metadata["creation_date"] = secrets_creation_date
+
+    if device_registration_metadata:
+        metadata["device_registration"] = device_registration_metadata
+        metadata.setdefault("deviceRegistration", device_registration_metadata)
+
+    if encrypted_user_secrets_metadata:
+        metadata["encrypted_user_secrets"] = encrypted_user_secrets_metadata
+        metadata.setdefault("encryptedUserSecrets", encrypted_user_secrets_metadata)
+
+    if identity_key_bytes is not None:
+        metadata.setdefault("identity_key", identity_key_bytes)
+        metadata.setdefault("identityKey", identity_key_bytes)
+    if identity_key_candidate_bytes:
+        metadata.setdefault("identity_key_candidates", identity_key_candidate_bytes)
+        metadata.setdefault("identityKeyCandidates", identity_key_candidate_bytes)
+    if raw_encrypted_identity_key:
+        metadata.setdefault("encrypted_identity_key", raw_encrypted_identity_key)
+        metadata.setdefault("encryptedIdentityKey", raw_encrypted_identity_key)
+    if raw_owner_key_version is not None:
+        metadata.setdefault("owner_key_version", raw_owner_key_version)
+        metadata.setdefault("ownerKeyVersion", raw_owner_key_version)
 
     # Assemble reports (preserve semantics; own report is appended if present)
     recent_location = locations_proto.recentLocation
@@ -591,8 +647,6 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     if locations_proto.HasField("recentLocation"):
         network_locations.append(recent_location)
         network_locations_time.append(recent_location_time)
-
-    now_wall = time.time()
 
     # Optional hard cap (defense-in-depth against pathological inputs)
     if len(network_locations) > _MAX_REPORTS:
@@ -675,6 +729,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
 
     if not wrapped:
         _LOGGER.debug("[DecryptLocations] No locations found.")
+        if metadata:
+            metadata_only = dict(metadata)
+            metadata_only["metadata_only"] = True
+            return [metadata_only]
         return []
 
     # Convert to structured payloads for HA entities (with fail-fast validation)
@@ -755,6 +813,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 if report_hint:
                     payload["_report_hint"] = report_hint
 
+            if metadata:
+                payload.update(metadata)
+
             # Log with timezone-awareness if HA util is available (debug only)
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 try:
@@ -822,8 +883,6 @@ def decrypt_location_response_locations(
 if __name__ == "__main__":  # Developer self-check only; not used by Home Assistant
     res = parse_device_update_protobuf("")
     try:
-        decrypt_location_response_locations(
-            res, cache=cast("TokenCache", None)
-        )
+        decrypt_location_response_locations(res, cache=cast("TokenCache", None))
     except Exception as exc:
         print(f"Self-check encountered exception (expected outside HA runtime): {exc}")

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -5757,6 +5757,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                                 )
 
                         # Validate/normalize coordinates (and accuracy if present).
+                        self._persist_anchor_metadata(dev_id, location)
                         if not self._normalize_coords(location, device_label=dev_name):
                             if not location.get("semantic_name"):
                                 _LOGGER.debug(
@@ -6288,6 +6289,57 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
         if not history or last_seen > history[-1]:
             history.append(last_seen)
+
+    def _persist_anchor_metadata(
+        self, device_id: str, location: Mapping[str, Any] | None
+    ) -> None:
+        """Persist anchor metadata even when no coordinates are present."""
+
+        if not isinstance(location, Mapping):
+            return
+
+        anchor_payload: dict[str, Any] = {}
+        for key in ("pair_date", "secrets_creation_date", "time_anchors_debug"):
+            if key in location and location[key] is not None:
+                anchor_payload[key] = location[key]
+
+        for key, alt in (
+            ("device_registration", "deviceRegistration"),
+            ("encrypted_user_secrets", "encryptedUserSecrets"),
+        ):
+            nested = location.get(key) or location.get(alt)
+            if isinstance(nested, Mapping) and nested:
+                anchor_payload[key] = dict(nested)
+
+        for key, alt in (
+            ("identity_key", "identityKey"),
+            ("identity_key_candidates", "identityKeyCandidates"),
+            ("encrypted_identity_key", "encryptedIdentityKey"),
+        ):
+            if key in location and location[key] is not None:
+                anchor_payload[key] = location[key]
+            elif alt in location and location[alt] is not None:
+                anchor_payload[key] = location[alt]
+
+        if (
+            "owner_key_version" in location
+            and location["owner_key_version"] is not None
+        ):
+            anchor_payload["owner_key_version"] = location["owner_key_version"]
+
+        if not anchor_payload:
+            return
+
+        existing = self._device_location_data.get(device_id)
+        merged: dict[str, Any] = {}
+        if isinstance(existing, Mapping):
+            merged.update(existing)
+
+        merged.update(anchor_payload)
+        if location.get("metadata_only"):
+            merged["metadata_only"] = True
+
+        self._device_location_data[device_id] = merged
 
     def _get_predicted_poll_time(self) -> float | None:
         """Predict the earliest next update time based on device histories."""

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -271,20 +271,41 @@ def _compute_provisioning_counter(
     rollover behavior.
     """
 
-    anchor_candidates = [
-        ("pair_date", identity.pair_date),
-        ("secrets_creation_date", identity.secrets_creation_date),
-    ]
+    secrets_anchor = _coerce_int(identity.secrets_creation_date)
+    pair_anchor = _coerce_int(identity.pair_date)
 
-    for label, anchor in anchor_candidates:
-        anchor_value = _coerce_int(anchor)
-        if anchor_value is None:
-            continue
+    selected_label: str | None = None
+    selected_anchor: int | None = None
 
-        counter = _clamp_and_mask_u32(now - anchor_value)
-        return counter, label, anchor_value
+    if secrets_anchor is not None and (
+        pair_anchor is None or secrets_anchor >= pair_anchor
+    ):
+        selected_label = "secrets_creation_date"
+        selected_anchor = secrets_anchor
+    elif pair_anchor is not None:
+        selected_label = "pair_date"
+        selected_anchor = pair_anchor
 
-    return _mask_u32(now), None, None
+    if selected_label is not None and selected_anchor is not None:
+        counter = _clamp_and_mask_u32(now - selected_anchor)
+        _LOGGER.debug(
+            "Anchor Selected: Type=%s Value=%s Counter=%s (pair_date=%s secrets_creation_date=%s)",
+            selected_label,
+            selected_anchor,
+            counter,
+            pair_anchor,
+            secrets_anchor,
+        )
+        return counter, selected_label, selected_anchor
+
+    fallback_counter = _mask_u32(now)
+    _LOGGER.debug(
+        "Anchor Selected: Type=%s Value=%s Counter=%s",
+        "unix_time",
+        now,
+        fallback_counter,
+    )
+    return fallback_counter, None, None
 
 
 def _build_timebase_candidates(
@@ -561,8 +582,8 @@ class GoogleFindMyEIDResolver:
             registry_id = identity.registry_id
             identity_key_bytes = bytes(identity.identity_key)
 
-            provisioning_counter, anchor_label, anchor_epoch = _compute_provisioning_counter(
-                identity, now=now_unix
+            provisioning_counter, anchor_label, anchor_epoch = (
+                _compute_provisioning_counter(identity, now=now_unix)
             )
             base_counter = provisioning_counter & ~(ROTATION_PERIOD - 1)
             counter_label = f"counter:{anchor_label}" if anchor_label else "counter"
@@ -579,7 +600,10 @@ class GoogleFindMyEIDResolver:
             if anchor_label is None:
                 last_warn = self._provisioning_warn_at.get(identity.canonical_id)
                 now_ts = time.time()
-                if last_warn is None or now_ts - last_warn >= PROVISIONING_WARN_COOLDOWN:
+                if (
+                    last_warn is None
+                    or now_ts - last_warn >= PROVISIONING_WARN_COOLDOWN
+                ):
                     _LOGGER.debug(
                         "Cannot compute provisioning counter reliably for %s",
                         identity.canonical_id,
@@ -674,7 +698,9 @@ class GoogleFindMyEIDResolver:
                 else base_candidates
             )
 
-            requested_timebases.update(candidate.label for candidate in timebase_candidates)
+            requested_timebases.update(
+                candidate.label for candidate in timebase_candidates
+            )
 
             for candidate in timebase_candidates:
                 if candidate.label == TimebaseLabel.REL_PAIR:
@@ -707,7 +733,9 @@ class GoogleFindMyEIDResolver:
                         aligned_rotation = active_lock.rotation_timestamp + (
                             rotations_since_lock * ROTATION_PERIOD
                         )
-                        local_search_offset = aligned_rotation - candidate.reference_time
+                        local_search_offset = (
+                            aligned_rotation - candidate.reference_time
+                        )
 
                     target_time = (
                         candidate.reference_time + local_search_offset
@@ -715,9 +743,7 @@ class GoogleFindMyEIDResolver:
                         else candidate.reference_time
                     )
 
-                    is_reversed = (
-                        local_search_offset is not None and known_endianness
-                    )
+                    is_reversed = local_search_offset is not None and known_endianness
 
                     rotation_windows = iter_rotation_windows(
                         target_time,
@@ -754,7 +780,10 @@ class GoogleFindMyEIDResolver:
                                 "variant": eid_candidate.name,
                             }
 
-                            if should_log_debug_dump and device_debug_state["count"] < DEBUG_LOG_LIMIT:
+                            if (
+                                should_log_debug_dump
+                                and device_debug_state["count"] < DEBUG_LOG_LIMIT
+                            ):
                                 message_key = (
                                     candidate.label,
                                     eid_candidate.name,
@@ -803,9 +832,8 @@ class GoogleFindMyEIDResolver:
             ):
                 rel_candidate = next((candidate for candidate in rel_candidates), None)
                 if rel_candidate is not None:
-                    fallback_rotation = (
-                        rel_candidate.reference_time
-                        - (rel_candidate.reference_time % ROTATION_PERIOD)
+                    fallback_rotation = rel_candidate.reference_time - (
+                        rel_candidate.reference_time % ROTATION_PERIOD
                     )
                     try:
                         fallback_candidates = _cached_candidates(

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -99,7 +99,10 @@ def test_async_decrypt_location_response_locations_aligns_missing_network_timest
         return serialize_location(invalid_location)
 
     async def fake_offload_foreign(
-        _identity_key: bytes, encrypted_location: bytes, *_args: object, **_kwargs: object
+        _identity_key: bytes,
+        encrypted_location: bytes,
+        *_args: object,
+        **_kwargs: object,
     ) -> bytes:
         return await fake_offload_aes(_identity_key, encrypted_location)
 
@@ -115,9 +118,7 @@ def test_async_decrypt_location_response_locations_aligns_missing_network_timest
     update = DeviceUpdate_pb2.DeviceUpdate()
     update.deviceMetadata.information.deviceRegistration.SetInParent()
 
-    reports = (
-        update.deviceMetadata.information.locationInformation.reports.recentLocationAndNetworkLocations
-    )
+    reports = update.deviceMetadata.information.locationInformation.reports.recentLocationAndNetworkLocations
 
     network_location = reports.networkLocations.add()
     network_location.status = Common_pb2.Status.LAST_KNOWN
@@ -150,3 +151,84 @@ def test_async_decrypt_location_response_locations_aligns_missing_network_timest
     assert entry["latitude"] == pytest.approx(40.0)
     assert entry["longitude"] == pytest.approx(-74.0)
     assert entry["is_own_report"] is True
+
+
+def test_async_decrypt_location_response_locations_returns_metadata_when_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pairing and secrets anchors propagate even without reports."""
+
+    base_now = 1_700_100_000.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x41" * 32]
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.pairDate = int(base_now - 120)
+    registration.encryptedUserSecrets.creationDate.seconds = int(base_now - 60)
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x00" * 32
+
+    result = asyncio.run(
+        decrypt_locations.async_decrypt_location_response_locations(
+            update, cache=object()
+        )
+    )
+
+    assert len(result) == 1
+    entry = result[0]
+    assert entry.get("metadata_only") is True
+    assert entry["pair_date"] == int(base_now - 120)
+    assert entry["secrets_creation_date"] == int(base_now - 60)
+    registration_meta = entry.get("device_registration")
+    assert isinstance(registration_meta, dict)
+    assert registration_meta.get("pairDate") == int(base_now - 120)
+    secrets_meta = entry.get("encrypted_user_secrets")
+    assert isinstance(secrets_meta, dict)
+    assert secrets_meta.get("creationDate") == int(base_now - 60)
+
+
+def test_async_decrypt_location_response_locations_normalizes_anchor_units(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anchor extraction normalizes millisecond-like inputs and preserves keys."""
+
+    base_now = 1_700_200_000.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x51" * 32]
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.pairDate = int(base_now - 300)
+    registration.encryptedUserSecrets.creationDate.seconds = int(base_now - 150)
+    registration.encryptedUserSecrets.creationDate.nanos = 500_000_000
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x10" * 32
+
+    result = asyncio.run(
+        decrypt_locations.async_decrypt_location_response_locations(
+            update, cache=object()
+        )
+    )
+
+    assert len(result) == 1
+    entry = result[0]
+    assert entry.get("metadata_only") is True
+    assert entry["pair_date"] == int(base_now - 300)
+    assert entry["secrets_creation_date"] == int(base_now - 150)
+    assert entry["identity_key"] == b"\x51" * 32
+    assert entry["identity_key_candidates"] == [b"\x51" * 32]
+    assert entry["encrypted_identity_key"] == b"\x10" * 32
+    assert decrypt_locations._parse_epoch_seconds(  # type: ignore[attr-defined]
+        int((base_now - 75) * 1000), base_now
+    ) == pytest.approx(base_now - 75)

--- a/tests/test_eid_resolver.py
+++ b/tests/test_eid_resolver.py
@@ -319,6 +319,81 @@ def test_build_timebase_candidates_ignores_unparsed_anchor_list() -> None:
     assert labels == {TimebaseLabel.ABSOLUTE}
 
 
+def test_compute_provisioning_counter_uses_pair_date(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    now = ROTATION_PERIOD * 20
+    pair_date = now - 100
+    identity = DeviceIdentity(
+        registry_id="registry-pair-anchor",
+        canonical_id="device-pair-anchor",
+        identity_key=b"\x07",
+        pair_date=pair_date,
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        counter, anchor_label, anchor_epoch = (
+            resolver_module._compute_provisioning_counter(identity, now=now)
+        )
+
+    assert counter == (now - pair_date) & 0xFFFFFFFF
+    assert anchor_label == "pair_date"
+    assert anchor_epoch == pair_date
+    assert any("Type=pair_date" in record.message for record in caplog.records)
+
+
+def test_compute_provisioning_counter_prefers_secrets_creation_date(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    now = ROTATION_PERIOD * 30
+    pair_date = now - 400
+    secrets_creation_date = now - 10
+    identity = DeviceIdentity(
+        registry_id="registry-secrets-anchor",
+        canonical_id="device-secrets-anchor",
+        identity_key=b"\x08",
+        pair_date=pair_date,
+        secrets_creation_date=secrets_creation_date,
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        counter, anchor_label, anchor_epoch = (
+            resolver_module._compute_provisioning_counter(identity, now=now)
+        )
+
+    assert counter == (now - secrets_creation_date) & 0xFFFFFFFF
+    assert anchor_label == "secrets_creation_date"
+    assert anchor_epoch == secrets_creation_date
+    assert any(
+        "Type=secrets_creation_date" in record.message for record in caplog.records
+    )
+
+
+def test_compute_provisioning_counter_uses_newer_pair_date_when_secrets_stale(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    now = ROTATION_PERIOD * 31
+    pair_date = now - 25
+    secrets_creation_date = now - 100
+    identity = DeviceIdentity(
+        registry_id="registry-pair-newer",
+        canonical_id="device-pair-newer",
+        identity_key=b"\x09",
+        pair_date=pair_date,
+        secrets_creation_date=secrets_creation_date,
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        counter, anchor_label, anchor_epoch = (
+            resolver_module._compute_provisioning_counter(identity, now=now)
+        )
+
+    assert counter == (now - pair_date) & 0xFFFFFFFF
+    assert anchor_label == "pair_date"
+    assert anchor_epoch == pair_date
+    assert any("Type=pair_date" in record.message for record in caplog.records)
+
+
 @pytest.mark.asyncio
 async def test_active_device_identities_surface_cached_timestamps(
     monkeypatch: pytest.MonkeyPatch,
@@ -357,6 +432,38 @@ async def test_active_device_identities_surface_cached_timestamps(
     assert identity.pair_date == 10
     assert identity.secrets_creation_date == 20
     assert identity.time_anchors_debug == [1, 2, 3]
+
+
+def test_persist_anchor_metadata_records_metadata_only_payload() -> None:
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator._device_location_data = {}
+
+    payload = {
+        "pair_date": 100,
+        "secrets_creation_date": 200,
+        "metadata_only": True,
+        "device_registration": {"pairDate": 100},
+        "encrypted_user_secrets": {"creationDate": 200},
+        "identity_key": b"\x01" * 32,
+        "identity_key_candidates": [b"\x01" * 32],
+        "encrypted_identity_key": b"\x02" * 32,
+        "owner_key_version": 3,
+    }
+
+    coordinator._persist_anchor_metadata("dev-meta", payload)
+
+    stored = coordinator._device_location_data["dev-meta"]
+    assert stored["pair_date"] == 100
+    assert stored["secrets_creation_date"] == 200
+    assert stored.get("metadata_only") is True
+    assert stored["device_registration"] == {"pairDate": 100}
+    assert stored["encrypted_user_secrets"] == {"creationDate": 200}
+    assert stored["identity_key"] == b"\x01" * 32
+    assert stored["identity_key_candidates"] == [b"\x01" * 32]
+    assert stored["encrypted_identity_key"] == b"\x02" * 32
+    assert stored["owner_key_version"] == 3
 
 
 @pytest.mark.asyncio
@@ -954,7 +1061,9 @@ async def test_rel_pair_timebase_lock_reduces_scan_volume(
 
 
 @pytest.mark.asyncio
-async def test_debug_dump_logs_all_variants(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+async def test_debug_dump_logs_all_variants(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     base_time = ROTATION_PERIOD * 6
 
     def _fake_time() -> int:
@@ -994,7 +1103,9 @@ async def test_debug_dump_logs_all_variants(monkeypatch: pytest.MonkeyPatch, cap
     with caplog.at_level(logging.DEBUG):
         await resolver._refresh_cache()
 
-    debug_messages = [message for message in caplog.messages if message.startswith("DEBUG DUMP:")]
+    debug_messages = [
+        message for message in caplog.messages if message.startswith("DEBUG DUMP:")
+    ]
     assert len(debug_messages) >= 3
     assert any("Variant=legacy_secp160r1_rx20" in message for message in debug_messages)
     assert any("Variant=modern_p256_x32" in message for message in debug_messages)
@@ -1005,7 +1116,9 @@ async def test_debug_dump_logs_all_variants(monkeypatch: pytest.MonkeyPatch, cap
     assert all("EID_PREFIX=" in message for message in debug_messages)
 
 
-def test_generate_eid_accepts_negative_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_generate_eid_accepts_negative_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def _signed_generate(key: bytes, timestamp: int) -> bytes:
         ts_bytes = int(timestamp).to_bytes(8, "big", signed=True)
         return (ts_bytes + key).ljust(EID_LENGTH, b"\x00")[:EID_LENGTH]
@@ -1020,9 +1133,9 @@ def test_generate_eid_accepts_negative_timestamp(monkeypatch: pytest.MonkeyPatch
     key = b"\x02" * 32
     candidates = resolver_module._cached_candidates(key, -1)
 
-    expected = ((-1).to_bytes(8, "big", signed=True) + key).ljust(
-        EID_LENGTH, b"\x00"
-    )[:EID_LENGTH]
+    expected = ((-1).to_bytes(8, "big", signed=True) + key).ljust(EID_LENGTH, b"\x00")[
+        :EID_LENGTH
+    ]
     assert candidates[0].eid == expected
     assert candidates == resolver_module._cached_candidates(key, -1)
 


### PR DESCRIPTION
## Summary
- propagate pairing and secrets creation anchors (plus identity keys) from decrypted updates even when no locations are present
- persist anchor metadata in the coordinator cache so resolver inputs survive metadata-only responses
- prefer the newest provisioning anchor when computing provisioning counters and extend regression coverage for anchor precedence and metadata-only flows

## Testing
- `python -m ruff check --fix custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py custom_components/googlefindmy/coordinator.py custom_components/googlefindmy/eid_resolver.py tests/test_decrypt_locations.py tests/test_eid_resolver.py`
- `python -m ruff format custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py custom_components/googlefindmy/coordinator.py custom_components/googlefindmy/eid_resolver.py tests/test_decrypt_locations.py tests/test_eid_resolver.py`
- `python -m mypy --strict custom_components/googlefindmy tests`
- `python -m pytest -q --cov=custom_components/googlefindmy --cov-report=term-missing --cov-report=xml --cov-fail-under=90` *(fails: total coverage 72.77% < 90%)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f2ae0e06c8329b6855ff9df4f5692)