### PR TITLE
Implement FHNA-compliant EID derivation and resolver parsing

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -12,6 +12,10 @@ child directory overrides it.
 | Runtime lifecycle patterns, platform forwarding, and subentry helpers (**entity lifecycle requirements live here**) | [`agents/runtime_patterns/AGENTS.md`](agents/runtime_patterns/AGENTS.md) |
 | Typing reminders, stub imports, and strict mypy expectations | [`agents/typing_guidance/AGENTS.md`](agents/typing_guidance/AGENTS.md) |
 
+### FHNA frame slicing reminder
+
+BLE FHNA service data places the frame type at octet 7 (0x40 legacy / 0x41 modern) with the EID starting at octet 8. Resolver updates must keep these offsets authoritative and only fall back to the 1-byte header layout when the service-data pattern does not apply.
+
 ### SPOT/gRPC client reminder
 
 When reusing the shared grpclib transport (`SpotGrpcTransport`), keep SSL context creation lazy and ensure ALPN includes `h2`. The transport helper already sets the protocol list and should be closed on unload so new channels negotiate HTTP/2 cleanly.

--- a/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
+++ b/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Final, cast
+from typing import Final
 
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -16,10 +16,12 @@ from custom_components.googlefindmy.FMDNCrypto._ecdsa_shim import (
 )
 
 # Constants
-K: Final[int] = 10
-ROTATION_PERIOD: Final[int] = 1024
+FHNA_K: Final[int] = 10
+K: Final[int] = FHNA_K
+ROTATION_PERIOD: Final[int] = 1 << FHNA_K
 EIK_LENGTH: Final[int] = 32
 LEGACY_EID_LENGTH: Final[int] = 20
+FHNA_PRF_INPUT_LENGTH: Final[int] = 32
 _CURVE: CurveParametersProtocol = load_curve()
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,91 +35,129 @@ class EidCandidate:
     eid: bytes
 
 
-def build_table10_block(timestamp: int, k: int = K) -> bytes:
-    """Build the Table 10 AES-256-ECB input block for the masked timestamp.
+def fhna_build_prf_input(ts_u32: int) -> bytes:
+    """Return the FHNA Table 10 PRF input buffer for a masked timestamp.
 
-    FHN Accessory Specification v1.3 Table 10 defines the 32-byte buffer layout
-    for the pseudorandom seed: 11 bytes of 0xFF, the rotation exponent ``K``,
-    the masked timestamp, 11 bytes of 0x00, ``K`` again, and the same masked
-    timestamp. This helper materializes that structure for reuse in tests and
-    encryption routines.
+    FHN Accessory Specification v1.3 Table 10: Construction of a
+    pseudorandom number mandates a 32-byte buffer composed of fixed padding,
+    the rotation exponent (``K = 10``), and the rotation-aligned timestamp.
+    This helper aligns ``ts_u32`` to the current rotation boundary by clearing
+    the lowest ``FHNA_K`` bits and emits the exact byte layout required by the
+    AES-256-ECB pseudorandom function.
     """
 
-    ts_bytes = get_masked_timestamp(timestamp, k)
+    ts_mask: int = (1 << FHNA_K) - 1
+    ts_aligned: int = (ts_u32 & 0xFFFFFFFF) & ~ts_mask
+    ts_bytes = ts_aligned.to_bytes(4, byteorder="big", signed=False)
 
-    data = bytearray(32)
-    data[0:11] = b"\xff" * 11
-    data[11] = k
-    data[12:16] = ts_bytes
-    data[16:27] = b"\x00" * 11
-    data[27] = k
-    data[28:32] = ts_bytes
+    block = bytearray(FHNA_PRF_INPUT_LENGTH)
+    block[0:11] = b"\xff" * 11
+    block[11] = FHNA_K
+    block[12:16] = ts_bytes
+    block[16:27] = b"\x00" * 11
+    block[27] = FHNA_K
+    block[28:32] = ts_bytes
 
-    return bytes(data)
+    return bytes(block)
+
+
+def build_table10_block(timestamp: int, k: int = K) -> bytes:
+    """Legacy wrapper for FHNA Table 10 PRF input construction.
+
+    The ``k`` argument is retained for backward compatibility with older test
+    helpers but defaults to the FHNA rotation exponent. Inputs that request a
+    different ``k`` are rejected to avoid silently producing malformed PRF
+    buffers.
+    """
+
+    if k != FHNA_K:
+        raise ValueError(
+            f"Unsupported rotation exponent {k}; FHNA requires FHNA_K={FHNA_K}"
+        )
+
+    return fhna_build_prf_input(timestamp & 0xFFFFFFFF)
+
+
+def fhna_prf_aes_ecb_256(eik: bytes, prf_input: bytes) -> bytes:
+    """Encrypt the FHNA PRF input with AES-256-ECB.
+
+    Args:
+        eik: 32-byte Ephemeral Identity Key.
+        prf_input: 32-byte Table 10 buffer.
+
+    Raises:
+        ValueError: If either input is not exactly 32 bytes.
+    """
+
+    if len(eik) != EIK_LENGTH:
+        raise ValueError(f"Ephemeral Identity Key must be {EIK_LENGTH} bytes")
+    if len(prf_input) != FHNA_PRF_INPUT_LENGTH:
+        raise ValueError(f"PRF input must be {FHNA_PRF_INPUT_LENGTH} bytes")
+
+    cipher = Cipher(algorithms.AES(eik), modes.ECB())
+    encryptor = cipher.encryptor()
+    return encryptor.update(prf_input) + encryptor.finalize()
 
 
 def _prf_table10(identity_key: bytes, timestamp: int, k: int = K) -> bytes:
     """Derive the 32-byte Table 10 pseudorandom output from the masked timestamp."""
 
-    block = build_table10_block(timestamp, k)
-
-    cipher = Cipher(algorithms.AES(identity_key), modes.ECB())
-    encryptor = cipher.encryptor()
-    return encryptor.update(block) + encryptor.finalize()
+    return fhna_prf_aes_ecb_256(identity_key, build_table10_block(timestamp, k=k))
 
 
 def generate_eid(identity_key: bytes, timestamp: int) -> bytes:
-    """Generate the advertised EID per FHN Accessory Specification v1.3.
+    """Generate a legacy FHNA EID using secp160r1 semantics."""
 
-    The specification defines ``R = r * G`` (with ``r`` derived from the
-    pseudorandom construction in Table 10) as the public point; the beacon
-    advertises ``Rx`` as the ephemeral identifier for the current rotation
-    period. This helper preserves that flow: compute ``r``, multiply by the
-    curve generator, and emit the x coordinate.
-    """
-    # Calculate r
-    r = calculate_r(identity_key, timestamp)
-
-    # Compute R = r * G
-    curve = _CURVE
-    generator = curve.generator
-    R = r * generator
-
-    # Return the x coordinate of R as the EID
-    x_coord: bytes = cast(bytes, R.x().to_bytes(LEGACY_EID_LENGTH, "big"))
-    return x_coord
+    return generate_eid_fhna_secp160r1(identity_key, timestamp)
 
 
 def generate_eid_p256(identity_key: bytes, timestamp: int) -> bytes:
-    """Generate a modern (NIST P-256) EID using the Table 10 PRF.
+    """Generate a modern FHNA EID using secp256r1 semantics."""
 
-    Modern Find My Device Network trackers appear to reuse the FHN Accessory
-    Specification v1.3 Table 10 pseudorandom construction. This helper masks
-    the timestamp with ``K = 10`` (rotation period ``2^K``), encrypts the 32-byte
-    Table 10 buffer with AES-256-ECB, reduces the result modulo the P-256 order
-    (coerced into ``1..n-1``), multiplies by the curve generator, and returns the
-    32-byte X coordinate of the public point.
-    """
+    return generate_eid_fhna_secp256r1(identity_key, timestamp)
 
-    if len(identity_key) != EIK_LENGTH:
-        raise ValueError(
-            f"Ephemeral Identity Key must be {EIK_LENGTH} bytes; got {len(identity_key)}"
-        )
 
-    seed_bytes = _prf_table10(identity_key, timestamp)
+def generate_eid_fhna_secp160r1(identity_key: bytes, ts_u32: int) -> bytes:
+    """Generate a 20-byte FHNA EID on secp160r1 (Table 10 PRF)."""
+
+    ts_masked: int = ts_u32 & 0xFFFFFFFF
+    prf_input = fhna_build_prf_input(ts_masked)
+    r_bytes = fhna_prf_aes_ecb_256(identity_key, prf_input)
+    r_prime: int = int.from_bytes(r_bytes, byteorder="big", signed=False)
+
+    curve = _CURVE
+    curve_order: int = int(curve.order)
+    generator = curve.generator
+
+    # Project into 1..n-1 to avoid the point at infinity when r_prime % n == 0
+    r: int = (r_prime % (curve_order - 1)) + 1
+    R = r * generator
+
+    x_int: int = int(R.x())
+    x_bytes: bytes = x_int.to_bytes(LEGACY_EID_LENGTH, "big")
+    return x_bytes
+
+
+def generate_eid_fhna_secp256r1(identity_key: bytes, ts_u32: int) -> bytes:
+    """Generate a 32-byte FHNA EID on secp256r1 (Table 10 PRF)."""
+
+    ts_masked: int = ts_u32 & 0xFFFFFFFF
+    prf_input = fhna_build_prf_input(ts_masked)
+    r_bytes = fhna_prf_aes_ecb_256(identity_key, prf_input)
+    r_prime: int = int.from_bytes(r_bytes, byteorder="big", signed=False)
 
     n: int = (
         0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
     )
-    seed_int: int = int.from_bytes(seed_bytes, byteorder="big")
-    private_scalar: int = (seed_int % (n - 1)) + 1
+    # Project into 1..n-1 to avoid generating the point at infinity
+    r: int = (r_prime % (n - 1)) + 1
 
     curve = ec.SECP256R1()
-    private_key = ec.derive_private_key(private_scalar, curve)
-    public_key = private_key.public_key()
+    private_key = ec.derive_private_key(r, curve)
+    public_numbers = private_key.public_key().public_numbers()
 
-    public_numbers = public_key.public_numbers()
-    x_bytes = public_numbers.x.to_bytes(32, byteorder="big")
+    x_int: int = int(public_numbers.x)
+    x_bytes: bytes = x_int.to_bytes(32, byteorder="big")
     return x_bytes
 
 
@@ -129,14 +169,12 @@ def generate_eid_candidates(identity_key: bytes, timestamp: int) -> tuple[EidCan
             f"Ephemeral Identity Key must be {EIK_LENGTH} bytes; got {len(identity_key)}"
         )
 
-    legacy_eid = generate_eid(identity_key, timestamp)
-    modern_eid = generate_eid_p256(identity_key, timestamp)
-    modern_truncated = modern_eid[:LEGACY_EID_LENGTH]
+    legacy_eid = generate_eid_fhna_secp160r1(identity_key, timestamp)
+    modern_eid = generate_eid_fhna_secp256r1(identity_key, timestamp)
 
     return (
-        EidCandidate(name="legacy_secp160r1_rx20", eid=legacy_eid),
-        EidCandidate(name="modern_p256_x32", eid=modern_eid),
-        EidCandidate(name="modern_p256_trunc20", eid=modern_truncated),
+        EidCandidate(name="fhna_secp160r1_rx20", eid=legacy_eid),
+        EidCandidate(name="fhna_secp256r1_rx32", eid=modern_eid),
     )
 
 
@@ -159,8 +197,9 @@ def calculate_r(identity_key: bytes, timestamp: int) -> int:
     curve = _CURVE
     curve_order: int = int(curve.order)
 
-    # r' is now projected to the finite field Fp by calculating r = r' mod n
-    r_mod: int = r_dash_int % curve_order
+    # r' is now projected to the finite field Fp by calculating r = (r' mod (n-1)) + 1
+    # Keep the scalar in the valid range [1, n-1]
+    r_mod: int = (r_dash_int % (curve_order - 1)) + 1
     return r_mod
 
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -4,7 +4,7 @@
 #
 from __future__ import annotations
 
-# ruff: noqa: PLR0912, PLR0915
+# ruff: noqa: PLR0911, PLR0912, PLR0915
 import asyncio
 import datetime
 import hashlib
@@ -353,6 +353,59 @@ def _parse_epoch_seconds(value: Any, now_s: float) -> float | None:  # noqa: PLR
     return v
 
 
+def normalize_pair_date_value(raw: Any, *, now_wall: float) -> int | None:
+    """Normalize pairDate values that may include millisecond or microsecond units."""
+
+    if raw is None:
+        return None
+
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        if not math.isfinite(raw):
+            return None
+
+        value = float(raw)
+        if value > _MICROSECONDS_THRESHOLD:
+            value /= 1e6
+        elif value > _MILLISECONDS_THRESHOLD:
+            value /= 1e3
+
+        if value < _MIN_VALID_EPOCH_S:
+            return None
+        if value > (now_wall + MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S):
+            return None
+        return int(value)
+
+    ts = _parse_epoch_seconds(raw, now_wall)
+    if ts is None:
+        return None
+    return int(ts)
+
+
+def normalize_creation_timestamp_value(raw: Any, *, now_wall: float) -> int | None:
+    """Normalize encryptedUserSecrets.creationDate inputs."""
+
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        if not math.isfinite(raw):
+            return None
+
+        value = float(raw)
+        if value > _MICROSECONDS_THRESHOLD:
+            value /= 1e6
+        elif value > _MILLISECONDS_THRESHOLD:
+            value /= 1e3
+
+        if value < _MIN_VALID_EPOCH_S:
+            return None
+        if value > (now_wall + MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S):
+            return None
+        return int(value)
+
+    ts = _parse_epoch_seconds(raw, now_wall)
+    if ts is None:
+        return None
+    return int(ts)
+
+
 async def _offload_decrypt_aes(identity_key: bytes, encrypted_location: bytes) -> bytes:
     """Offload AES-GCM decryption; derive key hash cheaply on event loop."""
     identity_key_hash = hashlib.sha256(identity_key).digest()  # cheap hash → OK on loop
@@ -581,27 +634,20 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     is_mcu = is_mcu_tracker(device_registration)
 
     now_wall = time.time()
-
-    def _normalize_anchor_timestamp(raw: Any) -> int | None:
-        ts = _parse_epoch_seconds(raw, now_wall)
-        if ts is None:
-            return None
-        return int(ts)
-
     metadata: dict[str, Any] = {}
     device_registration_metadata: dict[str, Any] = {}
     encrypted_user_secrets_metadata: dict[str, Any] = {}
 
-    pair_date = _normalize_anchor_timestamp(
-        getattr(device_registration, "pairDate", None)
+    pair_date = normalize_pair_date_value(
+        getattr(device_registration, "pairDate", None), now_wall=now_wall
     )
     if pair_date is not None:
         metadata["pair_date"] = pair_date
         metadata["pairDate"] = pair_date
         device_registration_metadata["pairDate"] = pair_date
 
-    secrets_creation_date = _normalize_anchor_timestamp(
-        getattr(encrypted_user_secrets, "creationDate", None)
+    secrets_creation_date = normalize_creation_timestamp_value(
+        getattr(encrypted_user_secrets, "creationDate", None), now_wall=now_wall
     )
     if secrets_creation_date is not None:
         metadata["secrets_creation_date"] = secrets_creation_date

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -204,6 +204,21 @@ _ALTITUDE_SIGNIFICANT_DELTA_M = 1.0
 # Predictive polling buffer to avoid requesting data before it is available server-side.
 _PREDICTION_BUFFER_S = 45
 
+# Fields consumed by get_active_device_identities from cached payloads/anchors.
+_PERSISTED_METADATA_KEYS: tuple[str, ...] = (
+    "pair_date",
+    "secrets_creation_date",
+    "time_anchors_debug",
+    "metadata_only",
+    "device_registration",
+    "encrypted_user_secrets",
+    "identity_key",
+    "identity_key_candidates",
+    "encrypted_identity_key",
+    "encrypted_identity_key_candidates",
+    "owner_key_version",
+)
+
 
 def _clamp(value: float, lo: float, hi: float) -> float:
     """Clamp value between lo and hi (inclusive)."""
@@ -2693,8 +2708,46 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         """Return the registry entry for a tracker and migrate legacy unique IDs."""
 
         ent_reg = er.async_get(self.hass)
+        device_reg = dr.async_get(self.hass)
         entry_id = self._entry_id()
-        device_label = self.get_device_display_name(device_id) or device_id
+
+        registry_device = (
+            device_reg.async_get(device_id) if device_reg is not None else None
+        )
+        canonical_device_id = device_id
+        registry_identifier: str | None = None
+
+        if registry_device is not None:
+            registry_identifier = self._extract_our_identifier(registry_device)
+            registry_uuid = getattr(registry_device, "id", None)
+            if registry_uuid == device_id:
+                _LOGGER.debug(
+                    "Tracker entity lookup received registry UUID=%s; attempting canonical mapping",
+                    registry_uuid,
+                )
+            if registry_identifier:
+                canonical_device_id = registry_identifier
+                if canonical_device_id != device_id:
+                    _LOGGER.debug(
+                        "Tracker entity lookup remapped registry_id=%s to canonical_id=%s",
+                        device_id,
+                        canonical_device_id,
+                    )
+            else:
+                _LOGGER.debug(
+                    "Tracker entity lookup found device %s but no matching identifier in %s",
+                    device_id,
+                    registry_device.identifiers,
+                )
+        else:
+            _LOGGER.debug(
+                "Tracker entity lookup could not find device registry entry for id=%s",
+                device_id,
+            )
+
+        device_label = (
+            self.get_device_display_name(canonical_device_id) or canonical_device_id
+        )
 
         entities_container = getattr(ent_reg, "entities", None)
         ent_registry_values: Sequence[Any] = ()
@@ -2742,7 +2795,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 tracker_subentry_identifier = tracker_subentry_key
 
             parts: list[str] = []
-            for part in (entry_id, tracker_subentry_identifier, device_id):
+            for part in (entry_id, tracker_subentry_identifier, canonical_device_id):
                 if isinstance(part, str) and part:
                     stripped = part.strip()
                     if stripped:
@@ -2810,15 +2863,15 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if entry_id:
             if tracker_subentry_identifier:
                 candidate_unique_ids.append(
-                    f"{entry_id}:{tracker_subentry_identifier}:{device_id}"
+                    f"{entry_id}:{tracker_subentry_identifier}:{canonical_device_id}"
                 )
             if tracker_subentry_key:
                 candidate_unique_ids.append(
-                    f"{entry_id}:{tracker_subentry_key}:{device_id}"
+                    f"{entry_id}:{tracker_subentry_key}:{canonical_device_id}"
                 )
-            candidate_unique_ids.append(f"{entry_id}:{device_id}")
-            candidate_unique_ids.append(f"{DOMAIN}_{entry_id}_{device_id}")
-        candidate_unique_ids.append(f"{DOMAIN}_{device_id}")
+            candidate_unique_ids.append(f"{entry_id}:{canonical_device_id}")
+            candidate_unique_ids.append(f"{DOMAIN}_{entry_id}_{canonical_device_id}")
+        candidate_unique_ids.append(f"{DOMAIN}_{canonical_device_id}")
 
         for unique_id in candidate_unique_ids:
             entry = _get_entry_for_unique_id(unique_id)
@@ -2864,7 +2917,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             if entry.domain != DEVICE_TRACKER_DOMAIN or entry.platform != DOMAIN:
                 continue
             unique_id = getattr(entry, "unique_id", "")
-            if not isinstance(unique_id, str) or device_id not in unique_id:
+            if not isinstance(unique_id, str) or canonical_device_id not in unique_id:
                 continue
             if entry.config_entry_id and entry.config_entry_id != entry_id:
                 continue
@@ -2911,10 +2964,12 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             return entry
 
         _LOGGER.debug(
-            "No entity registry entry for device '%s'; checked unique_id formats %s (canonical=%s)",
+            "No entity registry entry for device '%s'; checked unique_id formats %s (canonical=%s registry_id=%s registry_identifier=%s)",
             device_label,
             candidate_unique_ids,
             canonical_unique_id,
+            device_id,
+            registry_identifier,
         )
         return None
 
@@ -5757,7 +5812,14 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                                 )
 
                         # Validate/normalize coordinates (and accuracy if present).
-                        self._persist_anchor_metadata(dev_id, location)
+                        clear_metadata_only = (
+                            (location.get("latitude") is not None
+                            or location.get("longitude") is not None)
+                            and location.get("metadata_only") is not True
+                        )
+                        self._persist_anchor_metadata(
+                            dev_id, location, clear_metadata_only=clear_metadata_only
+                        )
                         if not self._normalize_coords(location, device_label=dev_name):
                             if not location.get("semantic_name"):
                                 _LOGGER.debug(
@@ -5965,8 +6027,16 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if not cached:
             return False
 
-        entry.update(cached)
-        last_updated_ts = cached.get("last_updated", 0)
+        if isinstance(cached, Mapping):
+            entry.update(cached)
+        else:
+            entry.update({"status": "Anchor metadata cached"})
+
+        if entry.get("metadata_only"):
+            entry.setdefault("status", "Anchor metadata cached")
+            return True
+
+        last_updated_ts = cached.get("last_updated", 0) if isinstance(cached, Mapping) else 0
         age = max(0.0, wall_now - float(last_updated_ts))
         if age < self.location_poll_interval:
             entry["status"] = "Location data current"
@@ -6291,7 +6361,11 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             history.append(last_seen)
 
     def _persist_anchor_metadata(
-        self, device_id: str, location: Mapping[str, Any] | None
+        self,
+        device_id: str,
+        location: Mapping[str, Any] | None,
+        *,
+        clear_metadata_only: bool,
     ) -> None:
         """Persist anchor metadata even when no coordinates are present."""
 
@@ -6315,6 +6389,10 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             ("identity_key", "identityKey"),
             ("identity_key_candidates", "identityKeyCandidates"),
             ("encrypted_identity_key", "encryptedIdentityKey"),
+            (
+                "encrypted_identity_key_candidates",
+                "encryptedIdentityKeyCandidates",
+            ),
         ):
             if key in location and location[key] is not None:
                 anchor_payload[key] = location[key]
@@ -6335,8 +6413,11 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if isinstance(existing, Mapping):
             merged.update(existing)
 
+        if clear_metadata_only:
+            merged.pop("metadata_only", None)
+
         merged.update(anchor_payload)
-        if location.get("metadata_only"):
+        if location.get("metadata_only") and not clear_metadata_only:
             merged["metadata_only"] = True
 
         self._device_location_data[device_id] = merged
@@ -6397,9 +6478,41 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         # Shallow copy to avoid caller-side mutation
         slot = dict(location_data)
 
+        previous_cached = self._device_location_data.get(device_id)
+        if not isinstance(previous_cached, Mapping):
+            previous_cached = None
+        comparison_cached = previous_cached
+
+        if isinstance(previous_cached, Mapping):
+            for metadata_key in _PERSISTED_METADATA_KEYS:
+                cached_value = previous_cached.get(metadata_key)
+                incoming_value = slot.get(metadata_key)
+                if cached_value is None or incoming_value is not None:
+                    continue
+
+                if isinstance(cached_value, dict):
+                    slot[metadata_key] = dict(cached_value)
+                elif isinstance(cached_value, list):
+                    slot[metadata_key] = list(cached_value)
+                else:
+                    slot[metadata_key] = cached_value
+
+        incoming_metadata_only = location_data.get("metadata_only")
+        has_location_payload = (
+            slot.get("latitude") is not None or slot.get("longitude") is not None
+        )
+        if slot.get("metadata_only") and incoming_metadata_only is False:
+            slot.pop("metadata_only", None)
+        elif slot.get("metadata_only") and has_location_payload and incoming_metadata_only is not True:
+            slot.pop("metadata_only", None)
+
+        clear_metadata_only = has_location_payload and incoming_metadata_only is not True
+        self._persist_anchor_metadata(
+            device_id, slot, clear_metadata_only=clear_metadata_only
+        )
         self._record_semantic_label(slot, device_id=device_id)
 
-        cached_loc = self._device_location_data.get(device_id)
+        cached_loc = comparison_cached
         is_replay = False
         if isinstance(cached_loc, Mapping):
             new_ts = _normalize_epoch_seconds(slot.get("last_seen"))

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -62,8 +62,15 @@ _LOGGER = logging.getLogger(__name__)
 EID_LENGTH = LEGACY_EID_LENGTH
 RAW_HEADER_LENGTH = 1
 FMDN_FRAME_TYPE = 0x40
+FHNA_FRAME_TYPE_LEGACY = 0x40
+FHNA_FRAME_TYPE_MODERN = 0x41
 MODERN_EID_LENGTH = 32
-NARROW_SCAN_RANGE = range(-3, 4)
+FHNA_SERVICE_OFFSET = 8
+FHNA_LEGACY_SERVICE_TOTAL = FHNA_SERVICE_OFFSET + EID_LENGTH
+FHNA_MODERN_SERVICE_TOTAL = FHNA_SERVICE_OFFSET + MODERN_EID_LENGTH
+FHNA_BACKCOMP_LEGACY_TOTAL = RAW_HEADER_LENGTH + EID_LENGTH
+FHNA_BACKCOMP_MODERN_TOTAL = RAW_HEADER_LENGTH + MODERN_EID_LENGTH
+NARROW_SCAN_RANGE: tuple[int, ...] = (0, -1, 1, -2, 2, -3, 3)
 LOCK_CUSTOM_FIELD = "eid_timebase_lock"
 DEBUG_LOG_LIMIT = 50
 PROVISIONING_WARN_COOLDOWN = 3600
@@ -101,7 +108,7 @@ def iter_rotation_windows(
     target_time: int,
     *,
     rotation_period: int,
-    window_range: range,
+    window_range: Iterable[int],
     include_neighbors: bool,
     allow_negative: bool = False,
 ) -> tuple[int, ...]:
@@ -146,6 +153,23 @@ def _normalize_identity_key(identity_key: bytes) -> bytes:
 
 def _coerce_int(value: Any) -> int | None:
     """Return a best-effort integer conversion for optional payloads."""
+
+    if isinstance(value, Mapping):
+        seconds = value.get("seconds")
+        nanos = value.get("nanos", 0)
+        if seconds is not None:
+            try:
+                return int(seconds) + int(nanos) // 1_000_000_000
+            except (TypeError, ValueError):
+                return None
+
+    seconds_attr = getattr(value, "seconds", None)
+    if seconds_attr is not None:
+        try:
+            nanos_attr = getattr(value, "nanos", 0)
+            return int(seconds_attr) + int(nanos_attr) // 1_000_000_000
+        except (TypeError, ValueError):
+            return None
 
     try:
         return int(value)
@@ -246,7 +270,7 @@ def _iter_debug_timebases(anchors: Any, *, now: int) -> list[_TimebaseCandidate]
             offset_seconds = _coerce_int(offset_raw) or 0
 
             label = str(raw.get("label") or "REL_DEBUG")
-            reference_time = now - anchor_epoch + offset_seconds
+            reference_time = _mask_u32(now - anchor_epoch + offset_seconds)
             candidates.append(
                 _TimebaseCandidate(
                     label=label,
@@ -287,7 +311,7 @@ def _compute_provisioning_counter(
         selected_anchor = pair_anchor
 
     if selected_label is not None and selected_anchor is not None:
-        counter = _clamp_and_mask_u32(now - selected_anchor)
+        counter = now - selected_anchor
         _LOGGER.debug(
             "Anchor Selected: Type=%s Value=%s Counter=%s (pair_date=%s secrets_creation_date=%s)",
             selected_label,
@@ -298,7 +322,7 @@ def _compute_provisioning_counter(
         )
         return counter, selected_label, selected_anchor
 
-    fallback_counter = _mask_u32(now)
+    fallback_counter = now
     _LOGGER.debug(
         "Anchor Selected: Type=%s Value=%s Counter=%s",
         "unix_time",
@@ -313,50 +337,85 @@ def _build_timebase_candidates(
     *,
     now: int,
     provisioning_counter: int,
+    primary_anchor_label: str | None,
     primary_anchor_epoch: int | None,
 ) -> list[_TimebaseCandidate]:
     """Return candidate timebases derived from identity anchors."""
 
-    def _build_candidate(
-        label: str, anchor_value: int | None
+    candidates: list[_TimebaseCandidate] = []
+    reference_counter = provisioning_counter
+    anchor_epoch_value = _coerce_int(primary_anchor_epoch)
+    absolute_candidate = _TimebaseCandidate(
+        TimebaseLabel.ABSOLUTE,
+        reference_time=reference_counter,
+        anchor_epoch=anchor_epoch_value,
+    )
+
+    def _build_anchor_candidate(
+        label: str, anchor_epoch: int | None
     ) -> _TimebaseCandidate | None:
+        anchor_value = _coerce_int(anchor_epoch)
         if anchor_value is None:
             return None
 
-        reference = now - anchor_value
-        if reference < -FUTURE_ANCHOR_MAX_DRIFT:
+        anchor_age = now - anchor_value
+        if anchor_age < -FUTURE_ANCHOR_MAX_DRIFT:
             _LOGGER.debug(
                 "Skipping %s timebase for %s due to excessive future skew (%s)",
                 label,
                 identity.canonical_id,
-                reference,
+                anchor_age,
             )
             return None
 
         return _TimebaseCandidate(
             label=label,
-            reference_time=reference,
+            reference_time=anchor_age,
             anchor_epoch=anchor_value,
         )
 
-    candidates: list[_TimebaseCandidate] = []
-    candidates.append(
-        _TimebaseCandidate(
-            TimebaseLabel.ABSOLUTE,
-            reference_time=provisioning_counter,
-            anchor_epoch=primary_anchor_epoch,
+    primary_label: str | None = None
+    primary_anchor_value: int | None = None
+
+    if primary_anchor_label == "secrets_creation_date":
+        primary_label = TimebaseLabel.REL_SECRETS
+        primary_anchor_value = _coerce_int(identity.secrets_creation_date)
+    elif primary_anchor_label == "pair_date":
+        primary_label = TimebaseLabel.REL_PAIR
+        primary_anchor_value = _coerce_int(identity.pair_date)
+
+    if primary_label is not None and primary_anchor_value is not None:
+        primary_anchor_age = now - primary_anchor_value
+        if primary_anchor_age < -FUTURE_ANCHOR_MAX_DRIFT:
+            _LOGGER.debug(
+                "Skipping %s timebase for %s due to excessive future skew (%s)",
+                primary_label,
+                identity.canonical_id,
+                primary_anchor_age,
+            )
+        else:
+            candidates.append(
+                _TimebaseCandidate(
+                    primary_label,
+                    reference_time=reference_counter,
+                    anchor_epoch=primary_anchor_value,
+                )
+            )
+
+    candidates.append(absolute_candidate)
+
+    if primary_label is None or primary_anchor_value is None:
+        fallback_pair = _build_anchor_candidate(
+            TimebaseLabel.REL_PAIR, identity.pair_date
         )
-    )
+        if fallback_pair is not None:
+            candidates.append(fallback_pair)
 
-    pair_candidate = _build_candidate(TimebaseLabel.REL_PAIR, identity.pair_date)
-    if pair_candidate is not None:
-        candidates.append(pair_candidate)
-
-    secrets_candidate = _build_candidate(
-        TimebaseLabel.REL_SECRETS, identity.secrets_creation_date
-    )
-    if secrets_candidate is not None:
-        candidates.append(secrets_candidate)
+        fallback_secrets = _build_anchor_candidate(
+            TimebaseLabel.REL_SECRETS, identity.secrets_creation_date
+        )
+        if fallback_secrets is not None:
+            candidates.append(fallback_secrets)
 
     if identity.time_anchors_debug is not None:
         candidates.extend(_iter_debug_timebases(identity.time_anchors_debug, now=now))
@@ -376,23 +435,23 @@ def _cached_candidates(identity_key: bytes, timestamp: int) -> tuple[EidCandidat
     ``timestamp`` must be the provisioning counter (seconds since pairing), not
     Unix time, to mirror the tracker-side EID PRF input.
     """
+    normalized_key = _normalize_identity_key(identity_key)
 
-    legacy_eid = generate_eid(identity_key, timestamp)
+    try:
+        legacy_eid = generate_eid(identity_key, timestamp)
+    except ValueError:
+        legacy_eid = generate_eid(normalized_key, timestamp)
     candidates: list[EidCandidate] = [
-        EidCandidate(name="legacy_secp160r1_rx20", eid=legacy_eid)
+        EidCandidate(name="fhna_secp160r1_rx20", eid=legacy_eid)
     ]
 
-    if len(identity_key) == EIK_LENGTH:
-        normalized_key = _normalize_identity_key(identity_key)
-        modern_eid = generate_eid_p256(normalized_key, timestamp)
-        modern_truncated = modern_eid[:LEGACY_EID_LENGTH]
+    if len(normalized_key) == EIK_LENGTH:
+        try:
+            modern_eid = generate_eid_p256(identity_key, timestamp)
+        except ValueError:
+            modern_eid = generate_eid_p256(normalized_key, timestamp)
 
-        candidates.extend(
-            (
-                EidCandidate(name="modern_p256_x32", eid=modern_eid),
-                EidCandidate(name="modern_p256_truncated_rx20", eid=modern_truncated),
-            )
-        )
+        candidates.append(EidCandidate(name="fhna_secp256r1_rx32", eid=modern_eid))
 
     return tuple(candidates)
 
@@ -494,10 +553,14 @@ class GoogleFindMyEIDResolver:
             return
 
         async with self._refresh_lock:
+            pending_refresh = self._pending_refresh
+            self._pending_refresh = False
             await self._refresh_cache()
             while self._pending_refresh:
                 self._pending_refresh = False
                 await self._refresh_cache()
+            if pending_refresh:
+                self._pending_refresh = False
 
     async def _refresh_cache(self) -> None:  # noqa: PLR0912, PLR0915 - iterative window search
         """Rebuild the EID lookup table for enabled, non-ignored devices."""
@@ -585,7 +648,7 @@ class GoogleFindMyEIDResolver:
             provisioning_counter, anchor_label, anchor_epoch = (
                 _compute_provisioning_counter(identity, now=now_unix)
             )
-            base_counter = provisioning_counter & ~(ROTATION_PERIOD - 1)
+            base_counter = (provisioning_counter // ROTATION_PERIOD) * ROTATION_PERIOD
             counter_label = f"counter:{anchor_label}" if anchor_label else "counter"
 
             _LOGGER.debug(
@@ -663,10 +726,23 @@ class GoogleFindMyEIDResolver:
                 )
                 existing = lookup.get(eid_value)
                 existing_offset = existing.time_offset if existing is not None else None
-                should_force = (
-                    metadata_payload.get("timebase") == TimebaseLabel.REL_PAIR
-                    and TimebaseLabel.REL_PAIR not in recorded_timebases
-                )
+                timebase_label = metadata_payload.get("timebase")
+                should_force = timebase_label in {
+                    TimebaseLabel.REL_PAIR,
+                    TimebaseLabel.REL_SECRETS,
+                } and timebase_label not in recorded_timebases
+
+                existing_metadata = lookup_metadata.get(eid_value)
+                history: list[dict[str, Any]] = []
+                if isinstance(existing_metadata, dict):
+                    prior = existing_metadata.get("timebases")
+                    if isinstance(prior, list):
+                        history = list(prior)
+                    else:
+                        history = [existing_metadata]
+
+                if metadata_payload not in history:
+                    history.append(metadata_payload)
 
                 if (
                     should_force
@@ -678,14 +754,19 @@ class GoogleFindMyEIDResolver:
                     lookup_metadata[eid_value] = {
                         **metadata_payload,
                         "is_reversed": reversed_flag,
+                        "timebases": history,
                     }
                     recorded_timebases.add(str(metadata_payload.get("timebase")))
+                elif isinstance(existing_metadata, dict):
+                    existing_metadata["timebases"] = history
+                    lookup_metadata[eid_value] = existing_metadata
 
             base_candidates = _build_timebase_candidates(
                 identity,
                 now=now_unix,
                 provisioning_counter=provisioning_counter,
-                primary_anchor_epoch=anchor_epoch if anchor_label else None,
+                primary_anchor_label=anchor_label,
+                primary_anchor_epoch=anchor_epoch,
             )
 
             timebase_candidates = (
@@ -706,7 +787,7 @@ class GoogleFindMyEIDResolver:
                 if candidate.label == TimebaseLabel.REL_PAIR:
                     rel_candidates.append(candidate)
 
-                passes: list[tuple[range, bool]]
+                passes: list[tuple[Iterable[int], bool]]
                 if base_search_offset is not None:
                     passes = [(range(0, 1), True)]
                 else:
@@ -714,13 +795,41 @@ class GoogleFindMyEIDResolver:
                     if not skip_deep_scan:
                         passes.append((range(-90, 91), False))
 
-                allow_negative = candidate.label != TimebaseLabel.ABSOLUTE and (
-                    candidate.reference_time < 0
+                anchor_age: int | None = None
+                if candidate.anchor_epoch is not None:
+                    try:
+                        anchor_age = now_unix - int(candidate.anchor_epoch)
+                    except (TypeError, ValueError):
+                        anchor_age = None
+
+                reference_value = candidate.reference_time
+                offset_reference = anchor_age if anchor_age is not None else reference_value
+                allow_negative = bool(
+                    candidate.label != TimebaseLabel.ABSOLUTE
+                    and anchor_age is not None
+                    and anchor_age < 0
                 )
 
                 for window_range, include_neighbors in passes:
+                    local_window_range = window_range
+                    local_include_neighbors = include_neighbors
                     local_search_offset = base_search_offset
+                    base_target_time = offset_reference
+
                     if (
+                        active_lock is not None
+                        and active_lock.label == candidate.label
+                        and active_lock.rotation_timestamp is not None
+                    ):
+                        base_target_time = active_lock.rotation_timestamp
+                        offset_reference = active_lock.rotation_timestamp - (
+                            active_lock.offset or 0
+                        )
+                        local_search_offset = 0
+                        local_window_range = range(0, 3)
+                        local_include_neighbors = False
+
+                    elif (
                         local_search_offset is None
                         and active_lock is not None
                         and active_lock.rotation_timestamp is not None
@@ -738,9 +847,9 @@ class GoogleFindMyEIDResolver:
                         )
 
                     target_time = (
-                        candidate.reference_time + local_search_offset
+                        base_target_time + local_search_offset
                         if local_search_offset is not None
-                        else candidate.reference_time
+                        else base_target_time
                     )
 
                     is_reversed = local_search_offset is not None and known_endianness
@@ -748,17 +857,20 @@ class GoogleFindMyEIDResolver:
                     rotation_windows = iter_rotation_windows(
                         target_time,
                         rotation_period=ROTATION_PERIOD,
-                        window_range=window_range,
-                        include_neighbors=include_neighbors,
+                        window_range=local_window_range,
+                        include_neighbors=local_include_neighbors,
                         allow_negative=allow_negative,
                     )
 
                     for window_timestamp in rotation_windows:
-                        time_offset = window_timestamp - candidate.reference_time
+                        time_offset = window_timestamp - offset_reference
+
+                        masked_timestamp = _mask_u32(window_timestamp)
+                        rotation_timestamp = window_timestamp
 
                         try:
                             candidates = _cached_candidates(
-                                identity_key_bytes, window_timestamp
+                                identity_key_bytes, masked_timestamp
                             )
                         except Exception as err:  # noqa: BLE001 - defensive guard
                             _LOGGER.debug(
@@ -774,7 +886,8 @@ class GoogleFindMyEIDResolver:
                             metadata = {
                                 "timebase": candidate.label,
                                 "anchor_epoch": candidate.anchor_epoch,
-                                "rotation_timestamp": window_timestamp,
+                                "rotation_timestamp": rotation_timestamp,
+                                "masked_rotation_timestamp": masked_timestamp,
                                 "time_offset": time_offset,
                                 "timestamp_basis": counter_label,
                                 "variant": eid_candidate.name,
@@ -787,7 +900,7 @@ class GoogleFindMyEIDResolver:
                                 message_key = (
                                     candidate.label,
                                     eid_candidate.name,
-                                    window_timestamp,
+                                    masked_timestamp,
                                 )
                                 if message_key not in device_debug_state["seen"]:
                                     device_debug_state["seen"].add(message_key)
@@ -1224,15 +1337,16 @@ class GoogleFindMyEIDResolver:
             },
         )
 
-    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:  # noqa: PLR0912, PLR0915
+    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:  # noqa: PLR0911, PLR0912, PLR0915
         """Resolve a scanned EID to a Home Assistant device registry ID.
 
-        Only Find My Device Network (FMDN) advertising frames (Frame Type
-        ``0x40``) are considered when the payload includes framing/telemetry;
-        the resolver slices the header and trailing bytes to isolate the
-        20-byte EID before lookup. Legacy callers that already provide a
-        20-byte EID bypass the framing filter, while unexpected lengths are
-        rejected with a debug log to aid frame parsing investigations.
+        FHNA Find My Device Network frames encode the frame type at octet 7.
+        Legacy (``0x40``) frames carry a 20-byte EID at octets 8–27; modern
+        (``0x41``) frames carry a 32-byte EID at octets 8–39. Optional hashed
+        flags follow the EID and are ignored for lookup. Raw 20-byte and
+        32-byte payloads are accepted as-is, and a backward compatible slice
+        attempts to parse payloads that start with ``0x40``/``0x41`` when the
+        length matches the legacy one-byte header layout.
 
         Returns the matching :class:`EIDMatch` when the identifier was
         precomputed for a known tracker; otherwise returns ``None``. The
@@ -1247,37 +1361,93 @@ class GoogleFindMyEIDResolver:
         mismatches.
         """
 
-        lookup_key: bytes | None
         eid_length = len(eid_bytes)
+        lookup_candidates: list[bytes] = []
 
         if eid_length == EID_LENGTH:
-            lookup_key = eid_bytes
+            lookup_candidates.append(eid_bytes)
         elif eid_length == MODERN_EID_LENGTH:
-            lookup_key = eid_bytes
-        elif eid_length >= EID_LENGTH + 1:
-            if eid_bytes[0] != FMDN_FRAME_TYPE:
-                _LOGGER.debug(
-                    "RESOLVER PROBE: Unexpected frame type for %d-byte payload",
-                    eid_length,
-                )
-                return None
-            lookup_key = eid_bytes[1 : 1 + EID_LENGTH]
+            lookup_candidates.append(eid_bytes)
         else:
+            if eid_length >= FHNA_LEGACY_SERVICE_TOTAL and eid_bytes[7] == FHNA_FRAME_TYPE_LEGACY:
+                lookup_candidates.append(
+                    eid_bytes[FHNA_SERVICE_OFFSET:FHNA_LEGACY_SERVICE_TOTAL]
+                )
+            if eid_length >= FHNA_MODERN_SERVICE_TOTAL and eid_bytes[7] == FHNA_FRAME_TYPE_MODERN:
+                lookup_candidates.append(
+                    eid_bytes[FHNA_SERVICE_OFFSET:FHNA_MODERN_SERVICE_TOTAL]
+                )
+
+            if not lookup_candidates and eid_length >= RAW_HEADER_LENGTH:
+                frame_type = eid_bytes[0]
+                if frame_type == FHNA_FRAME_TYPE_LEGACY and eid_length >= FHNA_BACKCOMP_LEGACY_TOTAL:
+                    lookup_candidates.append(eid_bytes[RAW_HEADER_LENGTH:FHNA_BACKCOMP_LEGACY_TOTAL])
+                elif frame_type == FHNA_FRAME_TYPE_MODERN and eid_length >= FHNA_BACKCOMP_MODERN_TOTAL:
+                    lookup_candidates.append(eid_bytes[RAW_HEADER_LENGTH:FHNA_BACKCOMP_MODERN_TOTAL])
+
+        if not lookup_candidates:
             _LOGGER.debug(
                 "RESOLVER PROBE: Unexpected EID length received (length=%d)", eid_length
             )
             return None
 
-        eid_prefix = _eid_prefix(lookup_key)
+        if not lookup_candidates:
+            _LOGGER.debug(
+                "RESOLVER PROBE: No candidates produced for length=%d", eid_length
+            )
+            return None
+
+        eid_prefix = _eid_prefix(lookup_candidates[0])
         _LOGGER.debug(
             "RESOLVER PROBE: Checking Sliced EID prefix %s (Original Len: %d)",
             eid_prefix,
             len(eid_bytes),
         )
 
-        match = self._lookup.get(lookup_key)
-        if match is None:
-            match = self._lookup.get(lookup_key[::-1])
+        if not self._lookup:
+            is_locked = self._refresh_lock.locked()
+            if self._pending_refresh or is_locked:
+                _LOGGER.debug(
+                    "RESOLVER NOT READY: cache priming (pending=%s locked=%s prefix=%s)",
+                    self._pending_refresh,
+                    is_locked,
+                    eid_prefix,
+                )
+                return None
+
+            _LOGGER.debug(
+                "RESOLVER NOT READY: empty cache; scheduling refresh for prefix=%s",
+                eid_prefix,
+            )
+            refresh = getattr(self, "async_refresh", None)
+            create_task = getattr(self.hass, "async_create_task", None)
+            if callable(refresh) and callable(create_task):
+                self._pending_refresh = True
+                try:
+                    create_task(refresh())
+                except Exception:  # pragma: no cover - defensive
+                    self._pending_refresh = False
+                    _LOGGER.debug(
+                        "RESOLVER REFRESH SCHEDULING FAILED (prefix=%s)", eid_prefix
+                    )
+            return None
+
+        match: EIDMatch | None = None
+        metadata: dict[str, Any] | None = None
+
+        for lookup_key in lookup_candidates:
+            match = self._lookup.get(lookup_key)
+            if match is None:
+                match = self._lookup.get(lookup_key[::-1])
+            if match is None:
+                continue
+
+            lookup_metadata = getattr(self, "_lookup_metadata", None)
+            if isinstance(lookup_metadata, dict):
+                metadata = lookup_metadata.get(lookup_key) or lookup_metadata.get(
+                    lookup_key[::-1]
+                )
+            break
 
         if match is None:
             known_timebases = getattr(self, "_known_timebases", {})
@@ -1288,13 +1458,6 @@ class GoogleFindMyEIDResolver:
                 len(known_timebases),
             )
             return None
-
-        metadata: dict[str, Any] | None = None
-        lookup_metadata = getattr(self, "_lookup_metadata", None)
-        if isinstance(lookup_metadata, dict):
-            metadata = lookup_metadata.get(lookup_key)
-            if metadata is None:
-                metadata = lookup_metadata.get(lookup_key[::-1])
 
         previous_offset = self._known_offsets.get(match.device_id)
         previous_endianness = self._known_endianness.get(match.device_id)

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -232,3 +232,25 @@ def test_async_decrypt_location_response_locations_normalizes_anchor_units(
     assert decrypt_locations._parse_epoch_seconds(  # type: ignore[attr-defined]
         int((base_now - 75) * 1000), base_now
     ) == pytest.approx(base_now - 75)
+
+
+def test_pair_date_microseconds_normalization_and_future_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PairDate with microseconds normalizes while future drift is discarded."""
+
+    base_now = 1_700_300_000.0
+
+    normalized_pair_date = decrypt_locations.normalize_pair_date_value(
+        (base_now - 240) * 1_000_000,
+        now_wall=base_now,
+    )
+    assert normalized_pair_date == int(base_now - 240)
+
+    future_pair_date = decrypt_locations.normalize_pair_date_value(
+        (base_now + decrypt_locations.MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S + 50)
+        * 1_000_000,
+        now_wall=base_now,
+    )
+
+    assert future_pair_date is None

--- a/tests/test_eid_generator_p256.py
+++ b/tests/test_eid_generator_p256.py
@@ -1,5 +1,8 @@
 import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
 
+from custom_components.googlefindmy.FMDNCrypto import eid_generator
+from custom_components.googlefindmy.FMDNCrypto._ecdsa_shim import load_curve
 from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
     ROTATION_PERIOD,
     _prf_table10,
@@ -34,3 +37,37 @@ def test_generate_eid_p256_matches_known_x_coordinate() -> None:
 def test_generate_eid_p256_rejects_invalid_key_lengths() -> None:
     with pytest.raises(ValueError):
         generate_eid_p256(b"short", 0)
+
+
+def test_generate_eid_p256_avoids_zero_scalar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero PRF output should still yield the generator point (r=1)."""
+
+    identity_key = b"\xAA" * 32
+
+    monkeypatch.setattr(
+        eid_generator, "fhna_prf_aes_ecb_256", lambda *_args, **_kwargs: b"\x00" * 32
+    )
+
+    eid = generate_eid_p256(identity_key, 0)
+
+    generator_point = ec.derive_private_key(1, ec.SECP256R1()).public_key().public_numbers()
+    expected_x = int(generator_point.x).to_bytes(32, "big")
+
+    assert eid == expected_x
+
+
+def test_generate_eid_legacy_avoids_zero_scalar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy path maps zero PRF output to the curve generator (r=1)."""
+
+    identity_key = b"\xBB" * 32
+
+    monkeypatch.setattr(
+        eid_generator, "fhna_prf_aes_ecb_256", lambda *_args, **_kwargs: b"\x00" * 32
+    )
+
+    eid = eid_generator.generate_eid(identity_key, 0)
+
+    curve = load_curve()
+    expected_x = int(curve.generator.x()).to_bytes(20, "big")
+
+    assert eid == expected_x

--- a/tests/test_eid_resolver.py
+++ b/tests/test_eid_resolver.py
@@ -19,9 +19,12 @@ from custom_components.googlefindmy.eid_resolver import (
     _build_timebase_candidates,
 )
 from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    FHNA_K,
     ROTATION_PERIOD,
     EidCandidate,
     K,
+    build_table10_block,
+    fhna_build_prf_input,
     get_masked_timestamp,
 )
 
@@ -32,6 +35,14 @@ def _fixed_length_eid(key: bytes, timestamp: int) -> bytes:
     ts_bytes = timestamp.to_bytes(8, "big", signed=False)
     seed = key + ts_bytes
     return seed.ljust(EID_LENGTH, b"\x00")[:EID_LENGTH]
+
+
+def _fixed_length_p256_eid(key: bytes, timestamp: int) -> bytes:
+    ts_bytes = timestamp.to_bytes(8, "big", signed=False)
+    seed = b"p256" + key + ts_bytes + key
+    return seed.ljust(resolver_module.MODERN_EID_LENGTH, b"\x00")[
+        : resolver_module.MODERN_EID_LENGTH
+    ]
 
 
 def _build_resolver() -> GoogleFindMyEIDResolver:
@@ -49,6 +60,170 @@ def _build_resolver() -> GoogleFindMyEIDResolver:
     resolver._refresh_lock = asyncio.Lock()
     resolver._pending_refresh = False
     return resolver
+
+
+def test_fhna_prf_input_layout_matches_table_10() -> None:
+    ts_u32 = 0x1234_5678
+
+    prf_input = fhna_build_prf_input(ts_u32)
+
+    assert len(prf_input) == 32
+    assert prf_input[0:11] == b"\xff" * 11
+    assert prf_input[11] == FHNA_K
+    assert prf_input[16:27] == b"\x00" * 11
+    assert prf_input[27] == FHNA_K
+
+    aligned_ts = (ts_u32 & 0xFFFFFFFF) & ~((1 << FHNA_K) - 1)
+    assert prf_input[12:16] == aligned_ts.to_bytes(4, "big")
+    assert prf_input[28:32] == aligned_ts.to_bytes(4, "big")
+
+
+def test_fhna_prf_input_masks_low_bits() -> None:
+    base_ts = 0xABCDEF00
+    offset_ts = base_ts | ((1 << FHNA_K) - 1)
+
+    assert fhna_build_prf_input(base_ts) == fhna_build_prf_input(offset_ts)
+
+
+def test_build_table10_block_enforces_fhna_k() -> None:
+    ts_u32 = 0x12345678
+
+    assert build_table10_block(ts_u32, k=FHNA_K) == fhna_build_prf_input(ts_u32)
+    with pytest.raises(ValueError):
+        build_table10_block(ts_u32, k=FHNA_K + 1)
+
+
+@pytest.mark.asyncio
+async def test_refresh_cache_records_consistent_time_domains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rotation_timestamp and time_offset share the same domain."""
+
+    resolver = _build_resolver()
+    resolver.hass = SimpleNamespace()
+    resolver._refresh_lock = asyncio.Lock()
+
+    anchor_now = 2_000
+    monkeypatch.setattr(resolver_module.time, "time", lambda: anchor_now)
+
+    identity = DeviceIdentity(
+        registry_id="registry-time",  # type: ignore[arg-type]
+        canonical_id="canon-time",  # type: ignore[arg-type]
+        identity_key=b"\x11" * 20,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        config_entry_id="entry-time",  # type: ignore[arg-type]
+        pair_date=500,
+    )
+
+    async def _fake_collect(self: resolver_module.GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return [identity]
+
+    monkeypatch.setattr(
+        resolver_module.GoogleFindMyEIDResolver, "_collect_device_secrets", _fake_collect
+    )
+    monkeypatch.setattr(
+        resolver_module, "_cached_candidates", lambda *_args, **_kwargs: (
+            EidCandidate(name="fhna_secp160r1_rx20", eid=b"\xAA" * EID_LENGTH),
+        )
+    )
+    monkeypatch.setattr(
+        resolver_module.dr, "async_get", lambda _hass: SimpleNamespace(async_get=lambda _id: None)
+    )
+
+    await resolver._refresh_cache()
+
+    assert resolver._lookup_metadata
+    metadata = next(iter(resolver._lookup_metadata.values()))
+
+    expected_reference = anchor_now - identity.pair_date
+    assert metadata["rotation_timestamp"] - metadata["time_offset"] == expected_reference
+    assert metadata["masked_rotation_timestamp"] == resolver_module._mask_u32(
+        metadata["rotation_timestamp"]
+    )
+
+
+def test_coerce_int_accepts_timestamp_like_mapping() -> None:
+    timestamp_mapping = {"seconds": 1_000, "nanos": 500_000_000}
+    timestamp_object = SimpleNamespace(seconds=2_000, nanos=250_000_000)
+
+    assert resolver_module._coerce_int(timestamp_mapping) == 1_000
+    assert resolver_module._coerce_int(timestamp_object) == 2_000
+
+
+def test_timebase_candidates_include_absolute_and_relative_anchor() -> None:
+    now = 1_700_000_000
+    secrets_anchor = now - 86_400
+    identity = DeviceIdentity(
+        device_type="pixel",
+        registry_id="registry-anchor",
+        canonical_id="anchor-device",
+        identity_key=b"\x01" * EID_LENGTH,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        config_entry_id="entry-anchor",
+        pair_date=now - 200_000,
+        secrets_creation_date=secrets_anchor,
+        time_anchors_debug=None,
+    )
+
+    provisioning_counter, anchor_label, anchor_epoch = resolver_module._compute_provisioning_counter(  # type: ignore[attr-defined]
+        identity, now=now
+    )
+    candidates = _build_timebase_candidates(
+        identity,
+        now=now,
+        provisioning_counter=provisioning_counter,
+        primary_anchor_label=anchor_label,
+        primary_anchor_epoch=anchor_epoch,
+    )
+
+    absolute = next(
+        candidate for candidate in candidates if candidate.label == TimebaseLabel.ABSOLUTE
+    )
+    relative = next(
+        candidate
+        for candidate in candidates
+        if candidate.label in {TimebaseLabel.REL_SECRETS, TimebaseLabel.REL_PAIR}
+    )
+
+    assert absolute.reference_time == provisioning_counter
+    assert relative.reference_time == provisioning_counter
+
+
+def test_time_offset_alignment_uses_candidate_reference() -> None:
+    now = 2_000_000
+    anchor_epoch = now - 100
+    identity = DeviceIdentity(
+        device_type="pixel",
+        registry_id="registry-offset",
+        canonical_id="offset-device",
+        identity_key=b"\x02" * EID_LENGTH,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        config_entry_id="entry-offset",
+        pair_date=anchor_epoch,
+        secrets_creation_date=None,
+        time_anchors_debug=None,
+    )
+
+    provisioning_counter, anchor_label, anchor_epoch = resolver_module._compute_provisioning_counter(  # type: ignore[attr-defined]
+        identity, now=now
+    )
+    candidates = _build_timebase_candidates(
+        identity,
+        now=now,
+        provisioning_counter=provisioning_counter,
+        primary_anchor_label=anchor_label,
+        primary_anchor_epoch=anchor_epoch,
+    )
+
+    relative = next(candidate for candidate in candidates if candidate.label == TimebaseLabel.REL_PAIR)
+    rotation_timestamp = relative.reference_time - (relative.reference_time % ROTATION_PERIOD)
+    time_offset = rotation_timestamp - relative.reference_time
+
+    assert abs(time_offset) < ROTATION_PERIOD
+    assert relative.reference_time == provisioning_counter
 
 
 class _StubDevice:
@@ -265,6 +440,7 @@ def test_build_timebase_candidates_with_time_anchor_hints(
         identity,
         now=now,
         provisioning_counter=now,
+        primary_anchor_label=None,
         primary_anchor_epoch=None,
     )
 
@@ -291,12 +467,46 @@ def test_build_timebase_candidates_always_include_absolute_with_rel_anchor() -> 
         identity,
         now=now,
         provisioning_counter=now,
+        primary_anchor_label="pair_date",
         primary_anchor_epoch=pair_date,
     )
 
     labels = {candidate.label for candidate in candidates}
     assert TimebaseLabel.ABSOLUTE in labels
     assert TimebaseLabel.REL_PAIR in labels
+
+
+def test_build_timebase_candidates_use_provisioning_for_absolute() -> None:
+    now = 1_700_000_000
+    anchor_epoch = now - 100_000
+    provisioning_counter = 100_000
+    identity = DeviceIdentity(
+        registry_id="registry-absolute",
+        canonical_id="device-absolute",
+        identity_key=b"\x04",
+        secrets_creation_date=anchor_epoch,
+    )
+
+    candidates = _build_timebase_candidates(
+        identity,
+        now=now,
+        provisioning_counter=provisioning_counter,
+        primary_anchor_label="secrets_creation_date",
+        primary_anchor_epoch=anchor_epoch,
+    )
+
+    absolute_candidate = next(
+        candidate for candidate in candidates if candidate.label == TimebaseLabel.ABSOLUTE
+    )
+    relative_candidate = next(
+        candidate
+        for candidate in candidates
+        if candidate.label == TimebaseLabel.REL_SECRETS
+    )
+
+    assert absolute_candidate.reference_time == provisioning_counter
+    assert relative_candidate.reference_time == provisioning_counter
+    assert relative_candidate.anchor_epoch == anchor_epoch
 
 
 def test_build_timebase_candidates_ignores_unparsed_anchor_list() -> None:
@@ -312,6 +522,7 @@ def test_build_timebase_candidates_ignores_unparsed_anchor_list() -> None:
         identity,
         now=now,
         provisioning_counter=now,
+        primary_anchor_label=None,
         primary_anchor_epoch=None,
     )
 
@@ -452,7 +663,9 @@ def test_persist_anchor_metadata_records_metadata_only_payload() -> None:
         "owner_key_version": 3,
     }
 
-    coordinator._persist_anchor_metadata("dev-meta", payload)
+    coordinator._persist_anchor_metadata(
+        "dev-meta", payload, clear_metadata_only=False
+    )
 
     stored = coordinator._device_location_data["dev-meta"]
     assert stored["pair_date"] == 100
@@ -465,6 +678,266 @@ def test_persist_anchor_metadata_records_metadata_only_payload() -> None:
     assert stored["encrypted_identity_key"] == b"\x02" * 32
     assert stored["owner_key_version"] == 3
 
+
+def test_update_device_cache_preserves_anchor_metadata() -> None:
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator._device_location_data = {
+        "dev-meta": {
+            "pair_date": 100,
+            "secrets_creation_date": 200,
+            "metadata_only": True,
+            "last_seen": 1,
+            "source_rank": 1,
+            "status": "baseline",
+            "identity_key": b"\x03" * 32,
+            "identity_key_candidates": [b"\x03" * 32],
+            "encrypted_identity_key": b"\x04" * 32,
+            "encrypted_identity_key_candidates": [b"\x04" * 32],
+            "owner_key_version": 7,
+            "encrypted_user_secrets": {"creationDate": 111},
+            "device_registration": {"pairDate": 100},
+        }
+    }
+    coordinator._record_semantic_label = lambda *args, **kwargs: None
+    coordinator._apply_semantic_mapping = lambda *args, **kwargs: None
+    coordinator._apply_weighted_location_fusion = lambda *args, **kwargs: True
+    coordinator._apply_report_type_cooldown = lambda *args, **kwargs: None
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._is_significant_update = lambda *args, **kwargs: True
+    coordinator.increment_stat = lambda *args, **kwargs: None
+    coordinator._normalize_identity_key = lambda value: value
+    coordinator._ensure_device_name_cache = lambda: {}
+    coordinator._run_on_hass_loop = lambda *args, **kwargs: None
+
+    coordinator.update_device_cache(
+        "dev-meta",
+        {
+            "status": "updated",
+            "last_seen": 2,
+        },
+    )
+
+    updated = coordinator._device_location_data["dev-meta"]
+    assert updated["pair_date"] == 100
+    assert updated["secrets_creation_date"] == 200
+    assert updated["metadata_only"] is True
+    assert updated["identity_key"] == b"\x03" * 32
+    assert updated["identity_key_candidates"] == [b"\x03" * 32]
+    assert updated["encrypted_identity_key"] == b"\x04" * 32
+    assert updated["encrypted_identity_key_candidates"] == [b"\x04" * 32]
+    assert updated["owner_key_version"] == 7
+    assert updated["encrypted_user_secrets"] == {"creationDate": 111}
+    assert updated["device_registration"] == {"pairDate": 100}
+
+
+def test_update_device_cache_clears_metadata_only_when_locations_arrive() -> None:
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator._device_location_data = {
+        "dev-meta": {
+            "pair_date": 100,
+            "metadata_only": True,
+            "identity_key": b"\x05" * 32,
+        }
+    }
+    coordinator._record_semantic_label = lambda *args, **kwargs: None
+    coordinator._apply_semantic_mapping = lambda *args, **kwargs: None
+    coordinator._apply_weighted_location_fusion = lambda *args, **kwargs: True
+    coordinator._apply_report_type_cooldown = lambda *args, **kwargs: None
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._is_significant_update = lambda *args, **kwargs: True
+    coordinator.increment_stat = lambda *args, **kwargs: None
+    coordinator._normalize_identity_key = lambda value: value
+    coordinator._ensure_device_name_cache = lambda: {}
+    coordinator._run_on_hass_loop = lambda *args, **kwargs: None
+
+    coordinator.update_device_cache(
+        "dev-meta",
+        {
+            "latitude": 1.0,
+            "longitude": 2.0,
+            "status": "updated",
+        },
+    )
+
+    updated = coordinator._device_location_data["dev-meta"]
+    assert updated.get("metadata_only") is None
+    assert updated["pair_date"] == 100
+    assert updated["identity_key"] == b"\x05" * 32
+
+
+def test_metadata_only_snapshot_preserved() -> None:
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator._device_location_data = {
+        "dev-meta": {
+            "pair_date": 100,
+            "metadata_only": True,
+            "latitude": 12.0,
+            "longitude": 34.0,
+            "status": "Anchor metadata cached",
+        }
+    }
+    coordinator.location_poll_interval = 30.0
+
+    snapshot = coordinator._build_snapshot_from_cache(
+        [{"id": "dev-meta", "name": "Meta"}], wall_now=0
+    )
+
+    assert len(snapshot) == 1
+    entry = snapshot[0]
+    assert entry["metadata_only"] is True
+    assert entry["latitude"] == 12.0
+    assert entry["longitude"] == 34.0
+    assert entry["status"] == "Anchor metadata cached"
+
+
+@pytest.mark.asyncio
+async def test_resolve_eid_schedules_refresh_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolver = _build_resolver()
+    scheduled: list[asyncio.Task] = []
+    refresh_calls: list[int] = []
+
+    async def _fake_refresh(self: resolver_module.GoogleFindMyEIDResolver) -> None:
+        refresh_calls.append(1)
+        resolver._pending_refresh = False
+
+    def _fake_create_task(coro: asyncio.Future) -> asyncio.Task:
+        task = asyncio.create_task(coro)
+        scheduled.append(task)
+        return task
+
+    resolver.hass = SimpleNamespace(async_create_task=_fake_create_task)
+    monkeypatch.setattr(
+        resolver_module.GoogleFindMyEIDResolver, "async_refresh", _fake_refresh
+    )
+    resolver._lookup = {}
+
+    first = resolver.resolve_eid(b"\x00" * EID_LENGTH)
+    second = resolver.resolve_eid(b"\x01" * EID_LENGTH)
+
+    assert first is None
+    assert second is None
+    assert resolver._pending_refresh is True
+    assert len(scheduled) == 1
+
+    await asyncio.gather(*scheduled)
+    assert len(refresh_calls) == 1
+    assert resolver._pending_refresh is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_eid_parses_fhna_legacy_service_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolver = _build_resolver()
+    legacy_eid = b"L" * resolver_module.EID_LENGTH
+    modern_eid = b"M" * resolver_module.MODERN_EID_LENGTH
+
+    def _fake_cached_candidates(identity_key: bytes, timestamp: int) -> tuple[EidCandidate, ...]:
+        return (
+            EidCandidate(name="fhna_secp160r1_rx20", eid=legacy_eid),
+            EidCandidate(name="fhna_secp256r1_rx32", eid=modern_eid),
+        )
+
+    monkeypatch.setattr(resolver_module, "_cached_candidates", _fake_cached_candidates)
+
+    match = EIDMatch("device-legacy", "entry-legacy", "canonical-legacy", 0, False)
+    resolver._lookup[legacy_eid] = match
+
+    payload = bytearray(29)
+    payload[7] = 0x40
+    payload[8:28] = legacy_eid
+    payload[28] = 0xAA
+
+    assert resolver.resolve_eid(bytes(payload)) == match
+
+
+def test_resolve_eid_parses_fhna_modern_service_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolver = _build_resolver()
+    legacy_eid = b"L" * resolver_module.EID_LENGTH
+    modern_eid = b"M" * resolver_module.MODERN_EID_LENGTH
+
+    def _fake_cached_candidates(identity_key: bytes, timestamp: int) -> tuple[EidCandidate, ...]:
+        return (
+            EidCandidate(name="fhna_secp160r1_rx20", eid=legacy_eid),
+            EidCandidate(name="fhna_secp256r1_rx32", eid=modern_eid),
+        )
+
+    monkeypatch.setattr(resolver_module, "_cached_candidates", _fake_cached_candidates)
+
+    match = EIDMatch("device-modern", "entry-modern", "canonical-modern", 0, False)
+    resolver._lookup[modern_eid] = match
+
+    payload = bytearray(41)
+    payload[7] = 0x41
+    payload[8:40] = modern_eid
+    payload[40] = 0xBB
+
+    assert resolver.resolve_eid(bytes(payload)) == match
+
+
+@pytest.mark.asyncio
+async def test_provisioning_counters_used_for_timebases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_time = 10_000
+    recorded_timestamps: list[int] = []
+
+    def _fake_time() -> int:
+        return base_time
+
+    def _recording_generate_eid(key: bytes, timestamp: int) -> bytes:
+        recorded_timestamps.append(timestamp)
+        return _fixed_length_eid(key, timestamp)
+
+    def _recording_generate_eid_p256(key: bytes, timestamp: int) -> bytes:
+        recorded_timestamps.append(timestamp)
+        return _fixed_length_p256_eid(key, timestamp)
+
+    monkeypatch.setattr(resolver_module.time, "time", _fake_time)
+    monkeypatch.setattr(resolver_module, "generate_eid", _recording_generate_eid)
+    monkeypatch.setattr(
+        resolver_module, "generate_eid_p256", _recording_generate_eid_p256
+    )
+
+    identity = DeviceIdentity(
+        registry_id="registry-counter",
+        canonical_id="device-counter",
+        identity_key=b"\x0B" * resolver_module.EIK_LENGTH,
+        config_entry_id="entry-counter",
+        pair_date=base_time - 120,
+    )
+
+    coordinator = SimpleNamespace(
+        get_active_device_identities=lambda: [identity]
+    )
+    hass = _StubHass(
+        {
+            DOMAIN: {
+                "entries": {"entry-counter": SimpleNamespace(coordinator=coordinator)}
+            }
+        }
+    )
+
+    resolver = _build_resolver()
+    resolver.hass = hass
+    cache_clear = getattr(resolver_module._cached_candidates, "cache_clear", None)
+    if callable(cache_clear):
+        cache_clear()
+
+    await resolver._refresh_cache()
+
+    assert recorded_timestamps
+    assert all(ts < 5_000_000 for ts in recorded_timestamps)
 
 @pytest.mark.asyncio
 async def test_resolver_refreshes_all_rotation_windows(
@@ -523,6 +996,52 @@ async def test_resolver_refreshes_all_rotation_windows(
 
 
 @pytest.mark.asyncio
+async def test_time_offset_uses_candidate_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_time = 1_700_000_000
+    anchor_epoch = base_time - 86400
+
+    monkeypatch.setattr(resolver_module.time, "time", lambda: base_time)
+    monkeypatch.setattr(
+        resolver_module,
+        "_cached_candidates",
+        lambda key, timestamp: (
+            EidCandidate(name="test", eid=_fixed_length_eid(key, timestamp)),
+        ),
+    )
+
+    identity = DeviceIdentity(
+        registry_id="registry-offset",
+        canonical_id="device-offset",
+        identity_key=b"\x0b",
+        config_entry_id="entry-offset",
+        secrets_creation_date=anchor_epoch,
+    )
+
+    coordinator = SimpleNamespace(get_active_device_identities=lambda: [identity])
+    hass = _StubHass(
+        {DOMAIN: {"entries": {"entry-offset": SimpleNamespace(coordinator=coordinator)}}}
+    )
+
+    resolver = _build_resolver()
+    resolver.hass = hass
+
+    await resolver._refresh_cache()
+
+    offsets_by_label: dict[str, list[int]] = {}
+    for metadata in resolver._lookup_metadata.values():
+        history = metadata.get("timebases", [metadata])
+        for entry in history:
+            label = str(entry.get("timebase"))
+            offsets_by_label.setdefault(label, []).append(entry.get("time_offset", 0))
+
+    assert TimebaseLabel.ABSOLUTE in offsets_by_label
+    assert TimebaseLabel.REL_SECRETS in offsets_by_label
+
+    for label, offsets in offsets_by_label.items():
+        assert any(abs(offset) < ROTATION_PERIOD for offset in offsets), label
+
+
+@pytest.mark.asyncio
 async def test_negative_windows_processed_when_allowed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -559,7 +1078,7 @@ async def test_negative_windows_processed_when_allowed(
 
     await resolver._refresh_cache()
 
-    assert any(timestamp < 0 for timestamp in recorded_timestamps)
+    assert any(timestamp > 2**31 for timestamp in recorded_timestamps)
 
 
 @pytest.mark.asyncio
@@ -786,7 +1305,7 @@ async def test_resolver_learns_offsets_and_endianness(
         max(0, target_rotation - ROTATION_PERIOD),
         target_rotation + ROTATION_PERIOD,
     }
-    assert len(resolver._lookup) == 3
+    assert len(resolver._lookup) == 6
     assert all(match.is_reversed for match in resolver._lookup.values())
 
 
@@ -836,14 +1355,10 @@ async def test_resolver_populates_modern_and_legacy_eids(
     rotation_start = base_time - (base_time % ROTATION_PERIOD)
     legacy_eid = _fake_generate_eid(identity.identity_key, rotation_start)
     modern_eid_full = _fake_generate_eid_p256(identity.identity_key, rotation_start)
-    modern_eid_truncated = modern_eid_full[: resolver_module.EID_LENGTH]
 
-    assert len(resolver._lookup) == 9
+    assert len(resolver._lookup) == 6
     assert resolver.resolve_eid(legacy_eid).device_id == identity.registry_id
     assert resolver.resolve_eid(modern_eid_full).device_id == identity.registry_id
-    match = resolver.resolve_eid(modern_eid_truncated)
-    assert match is not None
-    assert match.device_id == identity.registry_id
 
 
 def test_resolve_eid_slices_fmdn_frame() -> None:
@@ -860,11 +1375,49 @@ def test_resolve_eid_slices_fmdn_frame() -> None:
     assert result == match
 
 
+def test_resolve_eid_handles_fhna_service_data_frames() -> None:
+    resolver = _build_resolver()
+
+    legacy_eid = b"L" * EID_LENGTH
+    modern_eid = b"M" * resolver_module.MODERN_EID_LENGTH
+
+    legacy_match = EIDMatch("dev-legacy", "entry-legacy", "canon-legacy", 0, False)
+    modern_match = EIDMatch("dev-modern", "entry-modern", "canon-modern", 0, False)
+    resolver._lookup[legacy_eid] = legacy_match
+    resolver._lookup[modern_eid] = modern_match
+
+    legacy_payload = bytearray(29)
+    legacy_payload[7] = resolver_module.FHNA_FRAME_TYPE_LEGACY
+    legacy_payload[8:28] = legacy_eid
+    legacy_payload[28] = 0xAA
+
+    modern_payload = bytearray(45)
+    modern_payload[7] = resolver_module.FHNA_FRAME_TYPE_MODERN
+    modern_payload[8:40] = modern_eid
+    modern_payload[40] = 0xBB
+    modern_payload[44] = 0xCC
+
+    assert resolver.resolve_eid(bytes(legacy_payload)) == legacy_match
+    assert resolver.resolve_eid(bytes(modern_payload)) == modern_match
+
+
 def test_resolve_eid_accepts_raw_20_byte_payloads() -> None:
     resolver = _build_resolver()
 
     expected_eid = b"\x02" * EID_LENGTH
     match = EIDMatch("device-2", "entry-2", "canonical-2", 0, False)
+    resolver._lookup[expected_eid] = match
+
+    result = resolver.resolve_eid(expected_eid)
+
+    assert result == match
+
+
+def test_resolve_eid_accepts_raw_32_byte_payloads() -> None:
+    resolver = _build_resolver()
+
+    expected_eid = b"\x03" * resolver_module.MODERN_EID_LENGTH
+    match = EIDMatch("device-3", "entry-3", "canonical-3", 0, False)
     resolver._lookup[expected_eid] = match
 
     result = resolver.resolve_eid(expected_eid)
@@ -1038,13 +1591,18 @@ async def test_rel_pair_timebase_lock_reduces_scan_volume(
     ]
     assert counter_eids
 
-    match = resolver.resolve_eid(counter_eids[0][0])
+    best_eid, best_meta = min(
+        counter_eids,
+        key=lambda item: abs(int(item[1].get("time_offset", 0))),
+    )
+
+    match = resolver.resolve_eid(best_eid)
     assert match is not None
     lock = resolver._known_timebases.get(identity.registry_id)
     assert lock is not None
-    assert lock.label == str(counter_eids[0][1].get("timebase"))
+    assert lock.label == str(best_meta.get("timebase"))
     assert lock.anchor_epoch == pair_date
-    assert lock.offset < 0
+    assert abs(lock.offset) < ROTATION_PERIOD
 
     recorded_timestamps.clear()
     current_time = base_time + ROTATION_PERIOD
@@ -1053,9 +1611,8 @@ async def test_rel_pair_timebase_lock_reduces_scan_volume(
 
     lock_rotation = resolver._known_timebases[identity.registry_id].rotation_timestamp
     expected_neighbors = {
-        lock_rotation - ROTATION_PERIOD,
-        lock_rotation,
-        lock_rotation + ROTATION_PERIOD,
+        resolver_module._mask_u32(lock_rotation + (offset * ROTATION_PERIOD))
+        for offset in range(0, 3)
     }
     assert set(recorded_timestamps) <= expected_neighbors
 
@@ -1107,11 +1664,8 @@ async def test_debug_dump_logs_all_variants(
         message for message in caplog.messages if message.startswith("DEBUG DUMP:")
     ]
     assert len(debug_messages) >= 3
-    assert any("Variant=legacy_secp160r1_rx20" in message for message in debug_messages)
-    assert any("Variant=modern_p256_x32" in message for message in debug_messages)
-    assert any(
-        "Variant=modern_p256_truncated_rx20" in message for message in debug_messages
-    )
+    assert any("Variant=fhna_secp160r1_rx20" in message for message in debug_messages)
+    assert any("Variant=fhna_secp256r1_rx32" in message for message in debug_messages)
     assert any("Timebase=REL_PAIR" in message for message in debug_messages)
     assert all("EID_PREFIX=" in message for message in debug_messages)
 

--- a/tests/test_eid_time_bases.py
+++ b/tests/test_eid_time_bases.py
@@ -11,6 +11,7 @@ from custom_components.googlefindmy.eid_resolver import (
     TimebaseLabel,
     _build_timebase_candidates,
     _clamp_and_mask_u32,
+    _compute_provisioning_counter,
 )
 
 
@@ -70,9 +71,53 @@ def test_future_anchor_candidates_are_skipped() -> None:
         identity,
         now=now,
         provisioning_counter=now,
+        primary_anchor_label=None,
         primary_anchor_epoch=None,
     )
 
     labels = {candidate.label for candidate in candidates}
     assert TimebaseLabel.ABSOLUTE in labels
     assert TimebaseLabel.REL_PAIR not in labels
+
+
+def test_selected_anchor_drives_relative_candidate() -> None:
+    """Chosen anchor should seed the relative timebase candidate."""
+
+    now = 200 * 86_400
+    secrets_creation_date = now - 86_400
+    pair_date = now - 15_552_000
+    identity = DeviceIdentity(
+        registry_id="registry-anchor",
+        canonical_id="can-anchor",
+        identity_key=b"\x01" * 2,
+        config_entry_id="entry-anchor",
+        pair_date=pair_date,
+        secrets_creation_date=secrets_creation_date,
+    )
+
+    provisioning_counter, anchor_label, anchor_epoch = _compute_provisioning_counter(
+        identity, now=now
+    )
+
+    assert anchor_label == "secrets_creation_date"
+    assert provisioning_counter == 86_400
+
+    candidates = _build_timebase_candidates(
+        identity,
+        now=now,
+        provisioning_counter=provisioning_counter,
+        primary_anchor_label=anchor_label,
+        primary_anchor_epoch=anchor_epoch,
+    )
+
+    labels = {candidate.label for candidate in candidates}
+    assert TimebaseLabel.REL_SECRETS in labels
+    assert TimebaseLabel.REL_PAIR not in labels
+
+    rel_candidate = next(
+        candidate
+        for candidate in candidates
+        if candidate.label == TimebaseLabel.REL_SECRETS
+    )
+    assert rel_candidate.reference_time == provisioning_counter
+    assert rel_candidate.anchor_epoch == secrets_creation_date

--- a/tests/test_hybrid_eid_candidates.py
+++ b/tests/test_hybrid_eid_candidates.py
@@ -51,16 +51,19 @@ def test_generate_eid_candidates_expected_variants() -> None:
     variant_map = {candidate.name: candidate.eid for candidate in candidates}
 
     assert set(variant_map) == {
-        "legacy_secp160r1_rx20",
-        "modern_p256_x32",
-        "modern_p256_trunc20",
+        "fhna_secp160r1_rx20",
+        "fhna_secp256r1_rx32",
     }
-    assert len(variant_map["legacy_secp160r1_rx20"]) == LEGACY_EID_LENGTH
-    assert variant_map["legacy_secp160r1_rx20"].hex() == "1783ab2c308fd47caa8ec4274373322e51ed5031"
-    assert len(variant_map["modern_p256_x32"]) == 32
-    assert variant_map["modern_p256_x32"].hex() == "f5a2f55527688d26c47043bde3f8888274a4eb9fcd6ff5fad3302f12dd47bf5e"
-    assert variant_map["modern_p256_trunc20"] == variant_map["modern_p256_x32"][:LEGACY_EID_LENGTH]
-    assert variant_map["modern_p256_trunc20"].hex() == "f5a2f55527688d26c47043bde3f8888274a4eb9f"
+    assert len(variant_map["fhna_secp160r1_rx20"]) == LEGACY_EID_LENGTH
+    assert (
+        variant_map["fhna_secp160r1_rx20"].hex()
+        == "bccc42845790b5a2d9376edd6d66f8d15a6c7877"
+    )
+    assert len(variant_map["fhna_secp256r1_rx32"]) == 32
+    assert (
+        variant_map["fhna_secp256r1_rx32"].hex()
+        == "f5a2f55527688d26c47043bde3f8888274a4eb9fcd6ff5fad3302f12dd47bf5e"
+    )
 
 
 def test_iter_rotation_windows_alignment_and_neighbors() -> None:


### PR DESCRIPTION
## Summary
- enforce FHNA scalar range handling and rotation-exponent validation in the EID generator while keeping PRF inputs aligned to the spec
- normalize anchor timestamp parsing and cache metadata persistence so metadata-only payloads are preserved yet cleared once real locations arrive
- keep resolver timebase metadata consistent with rotation offsets and refresh FHNA frame-slicing tests to cover metadata and window handling

## Testing
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f42e5fb4c8329b0493a181527213e)