### PR TITLE
Fix resolver metadata propagation

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -4849,8 +4849,16 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     cache_time_anchors_debug[dev_id] = anchors_debug
 
         identities: list[DeviceIdentity] = []
+        cache_lookup: dict[str, Any] | None = cache if isinstance(cache, dict) else None
         for canonical_id in device_ids:
             lookup_id = canonical_id.split(":")[-1]
+            device_data = None
+            if cache_lookup is not None:
+                device_data = cache_lookup.get(canonical_id) or cache_lookup.get(lookup_id)
+            _LOGGER.debug(
+                "Building Identity for %s: cached_data=%s", canonical_id, device_data
+            )
+
             registry_entry = registry_map.get(canonical_id)
             if registry_entry is None:
                 continue
@@ -4931,6 +4939,18 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     and normalized_key not in normalized_candidates
                 ):
                     normalized_candidates.append(normalized_key)
+
+            effective_identity_for_log = identity_key
+            if effective_identity_for_log is None and normalized_candidates:
+                effective_identity_for_log = normalized_candidates[0]
+            if identity_key is None or pair_date is None:
+                _LOGGER.warning(
+                    "Missing crypto material for %s: key=%s, pair=%s. Skipping resolution.",
+                    canonical_id,
+                    effective_identity_for_log,
+                    pair_date,
+                )
+                continue
 
             if not normalized_candidates and encrypted_identity_key is None:
                 _LOGGER.debug(
@@ -6373,37 +6393,31 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             return
 
         anchor_payload: dict[str, Any] = {}
-        for key in ("pair_date", "secrets_creation_date", "time_anchors_debug"):
-            if key in location and location[key] is not None:
-                anchor_payload[key] = location[key]
+        alt_keys = {
+            "pair_date": ("pairDate",),
+            "secrets_creation_date": ("secretsCreationDate",),
+            "device_registration": ("deviceRegistration",),
+            "encrypted_user_secrets": ("encryptedUserSecrets",),
+            "time_anchors_debug": ("timeAnchorsDebug", "timeAnchors"),
+        }
 
-        for key, alt in (
-            ("device_registration", "deviceRegistration"),
-            ("encrypted_user_secrets", "encryptedUserSecrets"),
-        ):
-            nested = location.get(key) or location.get(alt)
-            if isinstance(nested, Mapping) and nested:
-                anchor_payload[key] = dict(nested)
+        for key in _PERSISTED_METADATA_KEYS:
+            value = location.get(key)
+            if value is None:
+                for alt in alt_keys.get(key, ()):  # Prefer snake_case when present
+                    if alt in location:
+                        value = location.get(alt)
+                        break
 
-        for key, alt in (
-            ("identity_key", "identityKey"),
-            ("identity_key_candidates", "identityKeyCandidates"),
-            ("encrypted_identity_key", "encryptedIdentityKey"),
-            (
-                "encrypted_identity_key_candidates",
-                "encryptedIdentityKeyCandidates",
-            ),
-        ):
-            if key in location and location[key] is not None:
-                anchor_payload[key] = location[key]
-            elif alt in location and location[alt] is not None:
-                anchor_payload[key] = location[alt]
+            if value is None:
+                continue
 
-        if (
-            "owner_key_version" in location
-            and location["owner_key_version"] is not None
-        ):
-            anchor_payload["owner_key_version"] = location["owner_key_version"]
+            if isinstance(value, list) and value:
+                anchor_payload[key] = list(value)
+            elif isinstance(value, Mapping) and value:
+                anchor_payload[key] = dict(value)
+            else:
+                anchor_payload[key] = value
 
         if not anchor_payload:
             return

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from custom_components.googlefindmy import coordinator as coordinator_module
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 
 
@@ -228,6 +230,9 @@ def test_device_registry_wrapper_retries_with_legacy_config_subentry_kwarg(
     ]
 
 
+# fmt: off
+
+
 def test_device_registry_wrapper_retries_with_legacy_remove_config_subentry_kwarg() -> None:
     """The wrapper retries without ``remove_config_subentry_id`` on legacy cores."""
 
@@ -257,3 +262,55 @@ def test_device_registry_wrapper_retries_with_legacy_remove_config_subentry_kwar
             "remove_config_entry_id": "entry-id",
         },
     ]
+
+# fmt: on
+
+
+def test_coordinator_propagates_timestamps_to_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metadata-only updates should populate resolver identities with timestamps."""
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._run_on_hass_loop = lambda *args, **kwargs: None
+    coordinator.stats = {}
+    coordinator._device_location_data = {}
+    coordinator._device_update_history = {}
+    coordinator._enabled_poll_device_ids = {"device-1"}
+    coordinator._last_device_list = []
+    coordinator.data = []
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.hass = SimpleNamespace(data={})
+    coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
+        "canonical_id"
+    )
+
+    metadata_only_payload = {
+        "identity_key": b"\x01\x02\x03\x04",
+        "pair_date": 1_700_000_000,
+        "metadata_only": True,
+    }
+
+    coordinator.update_device_cache("device-1", metadata_only_payload)
+
+    registry = SimpleNamespace()
+    registry_device = SimpleNamespace(
+        id="registry-id",
+        disabled_by=None,
+        custom_fields={"canonical_id": "device-1"},
+    )
+
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+    monkeypatch.setattr(
+        coordinator_module.dr,
+        "async_entries_for_config_entry",
+        lambda _registry, _entry_id: [registry_device],
+    )
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.pair_date == metadata_only_payload["pair_date"]
+    assert identity.identity_key == metadata_only_payload["identity_key"]


### PR DESCRIPTION
## Summary
- ensure cached device metadata uses both snake_case and camelCase fields and add diagnostics when building resolver identities
- guard resolver identity creation when pairing data is missing and retain anchor metadata from metadata-only updates
- add regression coverage to confirm metadata-only updates propagate pairing timestamps into DeviceIdentity

## Testing
- python -m ruff check --fix
- python -m mypy --strict

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940294229c48329a4d3c766d534fea5)