### PR TITLE
Implement dual timebase strategy and fix metadata keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,6 +294,7 @@ Prefer the executable name when it is available; fall back to the module form wh
 ### Shared pip cache for stub installs
 
 * Export `PIP_CACHE_DIR=/workspace/.cache/pip` (or reuse the default `~/.cache/pip`) before invoking `make test-stubs` so wheel downloads persist across sessions. Reusing the same cache keeps the Home Assistant and pytest stub installs fast and avoids repeated dependency fetches in fresh shells.
+* If you routinely rebuild the stub environment, keep a reusable virtualenv or wheelhouse around to sidestep the lengthy `make test-stubs` bootstrap. For example, cache a pre-populated `.venv` or store `pip download` artifacts in a shared directory that `PIP_FIND_LINKS` or `pip --no-index --find-links` can consume on the next run.
 
 ---
 

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -208,8 +208,6 @@ _PREDICTION_BUFFER_S = 45
 _PERSISTED_METADATA_KEYS: tuple[str, ...] = (
     "pair_date",
     "secrets_creation_date",
-    "time_anchors_debug",
-    "metadata_only",
     "device_registration",
     "encrypted_user_secrets",
     "identity_key",
@@ -217,6 +215,7 @@ _PERSISTED_METADATA_KEYS: tuple[str, ...] = (
     "encrypted_identity_key",
     "encrypted_identity_key_candidates",
     "owner_key_version",
+    "time_anchors_debug",
 )
 
 
@@ -4783,6 +4782,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     data_time_anchors_debug[dev_id] = anchors_debug
 
         cache = getattr(self, "_device_location_data", None)
+        internal_cache: dict[str, Any] = cache if isinstance(cache, dict) else {}
         cache_identities: dict[str, bytes] = {}
         cache_encrypted: dict[str, tuple[bytes | None, int | None]] = {}
         cache_device_types: dict[str, int | None] = {}
@@ -4792,9 +4792,9 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         cache_pair_dates: dict[str, int] = {}
         cache_secrets_creation_dates: dict[str, int] = {}
         cache_time_anchors_debug: dict[str, Any] = {}
-        if isinstance(cache, dict):
+        if internal_cache:
             for dev_id in allowed_raw_ids:
-                payload = cache.get(dev_id)
+                payload = internal_cache.get(dev_id)
                 if not isinstance(payload, dict):
                     continue
                 cache_data_keys[dev_id] = list(payload.keys())
@@ -4851,6 +4851,26 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         identities: list[DeviceIdentity] = []
         for canonical_id in device_ids:
             lookup_id = canonical_id.split(":")[-1]
+            device_data = None
+            cache_lookup: Mapping[str, Any] | None = (
+                cache if isinstance(cache, Mapping) else None
+            )
+            if cache_lookup is not None:
+                device_data = cache_lookup.get(canonical_id) or cache_lookup.get(lookup_id)
+            fallback_device_data = internal_cache.get(canonical_id) or internal_cache.get(
+                lookup_id
+            )
+            merged_device_data: dict[str, Any] = {}
+            if isinstance(fallback_device_data, Mapping):
+                merged_device_data.update(fallback_device_data)
+            if isinstance(device_data, Mapping):
+                merged_device_data.update(device_data)
+            if merged_device_data:
+                device_data = merged_device_data
+            _LOGGER.debug(
+                "Building Identity for %s: cached_data=%s", canonical_id, device_data
+            )
+
             registry_entry = registry_map.get(canonical_id)
             if registry_entry is None:
                 continue
@@ -4931,6 +4951,19 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     and normalized_key not in normalized_candidates
                 ):
                     normalized_candidates.append(normalized_key)
+
+            effective_identity_for_log = identity_key
+            if effective_identity_for_log is None and normalized_candidates:
+                effective_identity_for_log = normalized_candidates[0]
+            has_key = identity_key is not None or encrypted_identity_key is not None
+            if not has_key:
+                _LOGGER.warning(
+                    "Missing crypto material for %s: key=%s (pair=%s). Skipping resolution.",
+                    canonical_id,
+                    effective_identity_for_log,
+                    pair_date,
+                )
+                continue
 
             if not normalized_candidates and encrypted_identity_key is None:
                 _LOGGER.debug(
@@ -6373,37 +6406,38 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             return
 
         anchor_payload: dict[str, Any] = {}
-        for key in ("pair_date", "secrets_creation_date", "time_anchors_debug"):
-            if key in location and location[key] is not None:
-                anchor_payload[key] = location[key]
-
-        for key, alt in (
-            ("device_registration", "deviceRegistration"),
-            ("encrypted_user_secrets", "encryptedUserSecrets"),
-        ):
-            nested = location.get(key) or location.get(alt)
-            if isinstance(nested, Mapping) and nested:
-                anchor_payload[key] = dict(nested)
-
-        for key, alt in (
-            ("identity_key", "identityKey"),
-            ("identity_key_candidates", "identityKeyCandidates"),
-            ("encrypted_identity_key", "encryptedIdentityKey"),
-            (
-                "encrypted_identity_key_candidates",
+        alt_keys = {
+            "pair_date": ("pairDate",),
+            "secrets_creation_date": ("secretsCreationDate",),
+            "device_registration": ("deviceRegistration",),
+            "encrypted_user_secrets": ("encryptedUserSecrets",),
+            "identity_key": ("identityKey",),
+            "identity_key_candidates": ("identityKeyCandidates",),
+            "encrypted_identity_key": ("encryptedIdentityKey",),
+            "encrypted_identity_key_candidates": (
                 "encryptedIdentityKeyCandidates",
             ),
-        ):
-            if key in location and location[key] is not None:
-                anchor_payload[key] = location[key]
-            elif alt in location and location[alt] is not None:
-                anchor_payload[key] = location[alt]
+            "owner_key_version": ("ownerKeyVersion",),
+            "time_anchors_debug": ("timeAnchorsDebug", "timeAnchors"),
+        }
 
-        if (
-            "owner_key_version" in location
-            and location["owner_key_version"] is not None
-        ):
-            anchor_payload["owner_key_version"] = location["owner_key_version"]
+        for key in _PERSISTED_METADATA_KEYS:
+            value = location.get(key)
+            if value is None:
+                for alt in alt_keys.get(key, ()):  # Prefer snake_case when present
+                    if alt in location:
+                        value = location.get(alt)
+                        break
+
+            if value is None:
+                continue
+
+            if isinstance(value, list) and value:
+                anchor_payload[key] = list(value)
+            elif isinstance(value, Mapping) and value:
+                anchor_payload[key] = dict(value)
+            else:
+                anchor_payload[key] = value
 
         if not anchor_payload:
             return

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -336,7 +336,6 @@ def _build_timebase_candidates(
     identity: DeviceIdentity,
     *,
     now_unix: int,
-    provisioning_counter: int,
 ) -> list[_TimebaseCandidate]:
     """Return candidate timebases derived from identity anchors."""
 
@@ -372,17 +371,17 @@ def _build_timebase_candidates(
 
     candidates.append(absolute_candidate)
 
-    pair_candidate = _build_anchor_candidate(
-        TimebaseLabel.REL_PAIR, identity.pair_date
-    )
-    if pair_candidate is not None:
-        candidates.append(pair_candidate)
-
     secrets_candidate = _build_anchor_candidate(
         TimebaseLabel.REL_SECRETS, identity.secrets_creation_date
     )
     if secrets_candidate is not None:
         candidates.append(secrets_candidate)
+
+    pair_candidate = _build_anchor_candidate(
+        TimebaseLabel.REL_PAIR, identity.pair_date
+    )
+    if pair_candidate is not None:
+        candidates.append(pair_candidate)
 
     if identity.time_anchors_debug is not None:
         candidates.extend(
@@ -614,34 +613,6 @@ class GoogleFindMyEIDResolver:
             registry_id = identity.registry_id
             identity_key_bytes = bytes(identity.identity_key)
 
-            provisioning_counter, anchor_label, anchor_epoch = (
-                _compute_provisioning_counter(identity, now=now_unix)
-            )
-            base_counter = (provisioning_counter // ROTATION_PERIOD) * ROTATION_PERIOD
-            counter_label = f"counter:{anchor_label}" if anchor_label else "counter"
-
-            _LOGGER.debug(
-                "EID cache anchor: device=%s key_len=%d anchor=%s counter=%d base_counter=%d",
-                identity.canonical_id,
-                len(identity_key_bytes),
-                anchor_label or "unknown",
-                provisioning_counter,
-                base_counter,
-            )
-
-            if anchor_label is None:
-                last_warn = self._provisioning_warn_at.get(identity.canonical_id)
-                now_ts = time.time()
-                if (
-                    last_warn is None
-                    or now_ts - last_warn >= PROVISIONING_WARN_COOLDOWN
-                ):
-                    _LOGGER.debug(
-                        "Cannot compute provisioning counter reliably for %s",
-                        identity.canonical_id,
-                    )
-                    self._provisioning_warn_at[identity.canonical_id] = now_ts
-
             active_lock: _TimebaseLock | None = self._known_timebases.get(registry_id)
             known_offset = (
                 active_lock.offset
@@ -649,21 +620,6 @@ class GoogleFindMyEIDResolver:
                 else self._known_offsets.get(registry_id)
             )
             known_endianness = self._known_endianness.get(registry_id, False)
-            base_search_offset = known_offset
-            if (
-                base_search_offset is None
-                and active_lock is not None
-                and active_lock.rotation_timestamp is not None
-            ):
-                rotations_since_lock = round(
-                    (provisioning_counter - active_lock.rotation_timestamp)
-                    / ROTATION_PERIOD
-                )
-                aligned_rotation = active_lock.rotation_timestamp + (
-                    rotations_since_lock * ROTATION_PERIOD
-                )
-                base_search_offset = aligned_rotation - provisioning_counter
-
             requested_timebases: set[str] = set()
             recorded_timebases: set[str] = set()
             rel_candidates: list[_TimebaseCandidate] = []
@@ -737,7 +693,6 @@ class GoogleFindMyEIDResolver:
             base_candidates = _build_timebase_candidates(
                 identity,
                 now_unix=now_unix,
-                provisioning_counter=provisioning_counter,
             )
 
             timebase_candidates = (
@@ -758,8 +713,24 @@ class GoogleFindMyEIDResolver:
                 if candidate.label == TimebaseLabel.REL_PAIR:
                     rel_candidates.append(candidate)
 
+                local_search_offset = known_offset
+                if (
+                    local_search_offset is None
+                    and active_lock is not None
+                    and active_lock.rotation_timestamp is not None
+                    and active_lock.label == candidate.label
+                ):
+                    rotations_since_lock = round(
+                        (candidate.reference_time - active_lock.rotation_timestamp)
+                        / ROTATION_PERIOD
+                    )
+                    aligned_rotation = active_lock.rotation_timestamp + (
+                        rotations_since_lock * ROTATION_PERIOD
+                    )
+                    local_search_offset = aligned_rotation - candidate.reference_time
+
                 passes: list[tuple[Iterable[int], bool]]
-                if base_search_offset is not None:
+                if local_search_offset is not None:
                     passes = [(range(0, 1), True)]
                 else:
                     passes = [(NARROW_SCAN_RANGE, False)]
@@ -789,8 +760,13 @@ class GoogleFindMyEIDResolver:
                 for window_range, include_neighbors in passes:
                     local_window_range = window_range
                     local_include_neighbors = include_neighbors
-                    local_search_offset = base_search_offset
                     base_target_time = offset_reference
+
+                    counter_label = (
+                        f"counter:{candidate.label}"
+                        if candidate.label != TimebaseLabel.ABSOLUTE
+                        else "counter"
+                    )
 
                     if (
                         active_lock is not None
@@ -940,9 +916,9 @@ class GoogleFindMyEIDResolver:
                                 "timebase": TimebaseLabel.REL_PAIR,
                                 "anchor_epoch": rel_candidate.anchor_epoch,
                                 "rotation_timestamp": fallback_rotation,
-                                "time_offset": fallback_rotation - base_counter,
-                                "timestamp_basis": anchor_label
-                                and f"counter:{anchor_label}",
+                                "time_offset": fallback_rotation
+                                - rel_candidate.reference_time,
+                                "timestamp_basis": "counter:REL_PAIR",
                                 "variant": eid_candidate.name,
                             }
                             _register_with_metadata(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from custom_components.googlefindmy import coordinator as coordinator_module
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 
 
@@ -228,6 +230,9 @@ def test_device_registry_wrapper_retries_with_legacy_config_subentry_kwarg(
     ]
 
 
+# fmt: off
+
+
 def test_device_registry_wrapper_retries_with_legacy_remove_config_subentry_kwarg() -> None:
     """The wrapper retries without ``remove_config_subentry_id`` on legacy cores."""
 
@@ -257,3 +262,212 @@ def test_device_registry_wrapper_retries_with_legacy_remove_config_subentry_kwar
             "remove_config_entry_id": "entry-id",
         },
     ]
+
+# fmt: on
+
+
+def test_coordinator_propagates_timestamps_to_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metadata-only updates should populate resolver identities with timestamps."""
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._run_on_hass_loop = lambda *args, **kwargs: None
+    coordinator.stats = {}
+    coordinator._device_location_data = {}
+    coordinator._device_update_history = {}
+    coordinator._enabled_poll_device_ids = {"device-1"}
+    coordinator._last_device_list = []
+    coordinator.data = []
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.hass = SimpleNamespace(data={})
+    coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
+        "canonical_id"
+    )
+
+    metadata_only_payload = {
+        "identity_key": b"\x01\x02\x03\x04",
+        "pair_date": 1_700_000_000,
+        "metadata_only": True,
+    }
+
+    coordinator.update_device_cache("device-1", metadata_only_payload)
+
+    registry = SimpleNamespace()
+    registry_device = SimpleNamespace(
+        id="registry-id",
+        disabled_by=None,
+        custom_fields={"canonical_id": "device-1"},
+    )
+
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+    monkeypatch.setattr(
+        coordinator_module.dr,
+        "async_entries_for_config_entry",
+        lambda _registry, _entry_id: [registry_device],
+    )
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.pair_date == metadata_only_payload["pair_date"]
+    assert identity.identity_key == metadata_only_payload["identity_key"]
+
+
+def test_coordinator_persists_camelCase_identity_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CamelCase identity metadata should persist and feed resolver identities."""
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._run_on_hass_loop = lambda *args, **kwargs: None
+    coordinator.stats = {}
+    coordinator._device_location_data = {}
+    coordinator._device_update_history = {}
+    coordinator._enabled_poll_device_ids = {"device-1"}
+    coordinator._last_device_list = []
+    coordinator.data = []
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.hass = SimpleNamespace(data={})
+    coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
+        "canonical_id"
+    )
+
+    camel_payload = {
+        "identityKey": b"\x05\x06\x07\x08",
+        "pairDate": 1_800_000_000,
+        "metadata_only": True,
+    }
+
+    coordinator.update_device_cache("device-1", camel_payload)
+
+    assert (
+        coordinator._device_location_data["device-1"]["identity_key"]
+        == (camel_payload["identityKey"])
+    )
+    assert (
+        coordinator._device_location_data["device-1"]["pair_date"]
+        == camel_payload["pairDate"]
+    )
+
+    registry = SimpleNamespace()
+    registry_device = SimpleNamespace(
+        id="registry-id",
+        disabled_by=None,
+        custom_fields={"canonical_id": "device-1"},
+    )
+
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+    monkeypatch.setattr(
+        coordinator_module.dr,
+        "async_entries_for_config_entry",
+        lambda _registry, _entry_id: [registry_device],
+    )
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.pair_date == camel_payload["pairDate"]
+    assert identity.identity_key == camel_payload["identityKey"]
+
+
+def test_coordinator_yields_encrypted_only_identities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allow encrypted identity keys to flow to the resolver."""
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._run_on_hass_loop = lambda *args, **kwargs: None
+    coordinator.stats = {}
+    coordinator._device_location_data = {}
+    coordinator._device_update_history = {}
+    coordinator._enabled_poll_device_ids = {"device-1"}
+    coordinator._last_device_list = []
+    coordinator.data = []
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.hass = SimpleNamespace(data={})
+    coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
+        "canonical_id"
+    )
+
+    encrypted_payload = {
+        "pair_date": 1_700_000_000,
+        "encrypted_identity_key": b"\x01\x02\x03\x04",
+    }
+
+    coordinator.update_device_cache("device-1", encrypted_payload)
+
+    registry = SimpleNamespace()
+    registry_device = SimpleNamespace(
+        id="registry-id",
+        disabled_by=None,
+        custom_fields={"canonical_id": "device-1"},
+    )
+
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+    monkeypatch.setattr(
+        coordinator_module.dr,
+        "async_entries_for_config_entry",
+        lambda _registry, _entry_id: [registry_device],
+    )
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.identity_key is None
+    assert identity.encrypted_identity_key == encrypted_payload["encrypted_identity_key"]
+    assert identity.pair_date == encrypted_payload["pair_date"]
+
+
+def test_coordinator_yields_identities_without_pair_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Permit identities without pairing timestamps to reach the resolver."""
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._run_on_hass_loop = lambda *args, **kwargs: None
+    coordinator.stats = {}
+    coordinator._device_location_data = {}
+    coordinator._device_update_history = {}
+    coordinator._enabled_poll_device_ids = {"device-1"}
+    coordinator._last_device_list = []
+    coordinator.data = []
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.hass = SimpleNamespace(data={})
+    coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
+        "canonical_id"
+    )
+
+    identity_only_payload = {
+        "identity_key": b"\x09\x0A\x0B\x0C",
+    }
+
+    coordinator.update_device_cache("device-1", identity_only_payload)
+
+    registry = SimpleNamespace()
+    registry_device = SimpleNamespace(
+        id="registry-id",
+        disabled_by=None,
+        custom_fields={"canonical_id": "device-1"},
+    )
+
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+    monkeypatch.setattr(
+        coordinator_module.dr,
+        "async_entries_for_config_entry",
+        lambda _registry, _entry_id: [registry_device],
+    )
+
+    identities = coordinator.get_active_device_identities()
+
+    assert len(identities) == 1
+    identity = identities[0]
+    assert identity.identity_key == identity_only_payload["identity_key"]
+    assert identity.pair_date is None

--- a/tests/test_coordinator_key_priority.py
+++ b/tests/test_coordinator_key_priority.py
@@ -29,7 +29,9 @@ class _StubHass:
         return coro
 
 
-def _build_coordinator(monkeypatch: pytest.MonkeyPatch) -> coordinator_module.GoogleFindMyCoordinator:
+def _build_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> coordinator_module.GoogleFindMyCoordinator:
     registry = _StubDeviceRegistry([_StubDevice("device-1", registry_id="registry-1")])
     monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
 
@@ -40,7 +42,9 @@ def _build_coordinator(monkeypatch: pytest.MonkeyPatch) -> coordinator_module.Go
     coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._get_ignored_set = lambda: set()
-    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator._extract_our_identifier = lambda device: getattr(
+        device, "identifier", None
+    )
     coordinator.data = []
     return coordinator
 
@@ -50,18 +54,22 @@ def test_cache_prioritized_over_poll(monkeypatch: pytest.MonkeyPatch) -> None:
     coordinator._last_device_list = [
         {
             "id": "device-1",
+            "identityKey": "1111",
             "encryptedIdentityKey": "aaaa",
             "owner_key_version": 1,
             "device_type": 1,
             "fastPairModelId": "poll-model",
+            "pairDate": 1_700_000_001,
         }
     ]
     coordinator._device_location_data = {
         "device-1": {
+            "identity_key": b"\x11\x11",
             "encryptedIdentityKey": "bbbb",
             "owner_key_version": 2,
             "device_type": 3,
             "fast_pair_model_id": "push-model",
+            "pair_date": 1_700_000_001,
         }
     }
 
@@ -84,9 +92,13 @@ def test_poll_used_when_cache_missing(monkeypatch: pytest.MonkeyPatch) -> None:
             "owner_key_version": 4,
             "device_type": 9,
             "fastPairModelId": "poll-fallback",
+            "pairDate": 1_700_000_002,
+            "identityKey": "dddd",
         }
     ]
-    coordinator._device_location_data = {}
+    coordinator._device_location_data = {
+        "device-1": {"pair_date": 1_700_000_002, "identity_key": b"\xdd\xdd"}
+    }
 
     identities = coordinator.get_active_device_identities()
 

--- a/tests/test_coordinator_priority.py
+++ b/tests/test_coordinator_priority.py
@@ -31,7 +31,9 @@ class _StubHass:
         return coro
 
 
-def _build_coordinator(monkeypatch: pytest.MonkeyPatch) -> coordinator_module.GoogleFindMyCoordinator:
+def _build_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> coordinator_module.GoogleFindMyCoordinator:
     registry = _StubDeviceRegistry([_StubDevice("device-1", registry_id="registry-1")])
     monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
 
@@ -42,19 +44,24 @@ def _build_coordinator(monkeypatch: pytest.MonkeyPatch) -> coordinator_module.Go
     coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._get_ignored_set = lambda: set()
-    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator._extract_our_identifier = lambda device: getattr(
+        device, "identifier", None
+    )
     coordinator.data = []
     coordinator._device_location_data = {}
     return coordinator
 
 
-def test_decrypted_cache_identity_overrides_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_decrypted_cache_identity_overrides_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     coordinator = _build_coordinator(monkeypatch)
     coordinator._last_device_list = [
         {
             "id": "device-1",
             "encryptedIdentityKey": "aaaa",
             "owner_key_version": 1,
+            "pairDate": 1_700_000_003,
         }
     ]
     coordinator._device_location_data = {
@@ -62,6 +69,7 @@ def test_decrypted_cache_identity_overrides_poll(monkeypatch: pytest.MonkeyPatch
             "identity_key": b"\x01\x02",
             "encryptedIdentityKey": "bbbb",
             "owner_key_version": 2,
+            "pair_date": 1_700_000_003,
         }
     }
 
@@ -82,12 +90,14 @@ def test_poll_identity_used_when_cache_missing(monkeypatch: pytest.MonkeyPatch) 
             "identityKey": "0c0d",
             "encryptedIdentityKey": "cccc",
             "owner_key_version": 4,
+            "pairDate": 1_700_000_004,
         }
     ]
     coordinator._device_location_data = {
         "device-1": {
             "encryptedIdentityKey": "aaaa",
             "owner_key_version": 4,
+            "pair_date": 1_700_000_004,
         }
     }
 
@@ -100,7 +110,9 @@ def test_poll_identity_used_when_cache_missing(monkeypatch: pytest.MonkeyPatch) 
     assert identity.owner_key_version == 4
 
 
-def test_cache_update_triggers_resolver_reset(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_cache_update_triggers_resolver_reset(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     coordinator = _build_coordinator(monkeypatch)
     coordinator._is_on_hass_loop = lambda: True
     coordinator._run_on_hass_loop = lambda *_args, **_kwargs: None
@@ -124,5 +136,6 @@ def test_cache_update_triggers_resolver_reset(monkeypatch: pytest.MonkeyPatch, c
 
     assert reset_calls == ["device-1"]
     assert refresh_calls == [True]
-    assert any("Identity key update detected" in record.message for record in caplog.records)
-
+    assert any(
+        "Identity key update detected" in record.message for record in caplog.records
+    )

--- a/tests/test_dual_key_strategy.py
+++ b/tests/test_dual_key_strategy.py
@@ -42,7 +42,9 @@ def _build_coordinator(monkeypatch):
     coordinator.config_entry = SimpleNamespace(entry_id="entry-1")
     coordinator._enabled_poll_device_ids = {"device-1"}
     coordinator._get_ignored_set = lambda: set()
-    coordinator._extract_our_identifier = lambda device: getattr(device, "identifier", None)
+    coordinator._extract_our_identifier = lambda device: getattr(
+        device, "identifier", None
+    )
     coordinator.data = []
     coordinator._last_device_list = []
     coordinator._device_location_data = {}
@@ -56,6 +58,8 @@ def test_multiple_candidates_expand_identities(monkeypatch):
             "identity_key_candidates": [b"a" * 32, b"b" * 32],
             "encrypted_identity_key": b"enc",
             "owner_key_version": 7,
+            "pair_date": 1_700_000_005,
+            "identity_key": b"a" * 32,
         }
     }
 

--- a/tests/test_eid_provisioning_counter.py
+++ b/tests/test_eid_provisioning_counter.py
@@ -85,5 +85,5 @@ async def test_resolver_matches_counter_timebase(
     assert match.time_offset == 0
     metadata = resolver._lookup_metadata.get(eid)
     assert metadata is not None
-    assert metadata.get("timestamp_basis") == "counter:pair_date"
+    assert metadata.get("timestamp_basis") == "counter:REL_PAIR"
     assert metadata.get("anchor_epoch") == pair_date

--- a/tests/test_eid_resolver.py
+++ b/tests/test_eid_resolver.py
@@ -183,13 +183,9 @@ def test_timebase_candidates_include_absolute_and_relative_anchor() -> None:
         time_anchors_debug=None,
     )
 
-    provisioning_counter, _, _ = resolver_module._compute_provisioning_counter(  # type: ignore[attr-defined]
-        identity, now=now
-    )
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=provisioning_counter,
     )
 
     absolute = next(
@@ -198,7 +194,9 @@ def test_timebase_candidates_include_absolute_and_relative_anchor() -> None:
         if candidate.label == TimebaseLabel.ABSOLUTE
     )
     rel_pair = next(
-        candidate for candidate in candidates if candidate.label == TimebaseLabel.REL_PAIR
+        candidate
+        for candidate in candidates
+        if candidate.label == TimebaseLabel.REL_PAIR
     )
     rel_secrets = next(
         candidate
@@ -207,7 +205,7 @@ def test_timebase_candidates_include_absolute_and_relative_anchor() -> None:
     )
 
     assert absolute.reference_time == resolver_module._mask_u32(now)  # type: ignore[attr-defined]
-    assert rel_secrets.reference_time == provisioning_counter
+    assert rel_secrets.reference_time == now - secrets_anchor
     assert rel_pair.reference_time == now - pair_anchor
 
 
@@ -229,13 +227,9 @@ def test_timebase_domain_separation() -> None:
         time_anchors_debug=None,
     )
 
-    provisioning_counter, _, _ = resolver_module._compute_provisioning_counter(  # type: ignore[attr-defined]
-        identity, now=now
-    )
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=provisioning_counter,
     )
 
     absolute = next(
@@ -250,7 +244,7 @@ def test_timebase_domain_separation() -> None:
     )
 
     assert absolute.reference_time == resolver_module._mask_u32(now)  # type: ignore[attr-defined]
-    assert rel_pair.reference_time == provisioning_counter
+    assert rel_pair.reference_time == now - pair_date
     assert absolute.reference_time > 1_000_000_000
     assert rel_pair.reference_time < 1_000_000_000
 
@@ -272,13 +266,9 @@ def test_candidates_include_both_anchors_when_present() -> None:
         time_anchors_debug=None,
     )
 
-    provisioning_counter, _, _ = resolver_module._compute_provisioning_counter(  # type: ignore[attr-defined]
-        identity, now=now
-    )
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=provisioning_counter,
     )
 
     labels = {candidate.label for candidate in candidates}
@@ -289,7 +279,9 @@ def test_candidates_include_both_anchors_when_present() -> None:
     }.issubset(labels)
 
     rel_pair = next(
-        candidate for candidate in candidates if candidate.label == TimebaseLabel.REL_PAIR
+        candidate
+        for candidate in candidates
+        if candidate.label == TimebaseLabel.REL_PAIR
     )
     rel_secrets = next(
         candidate
@@ -318,13 +310,9 @@ def test_time_offset_alignment_uses_candidate_reference() -> None:
         time_anchors_debug=None,
     )
 
-    provisioning_counter, _, _ = resolver_module._compute_provisioning_counter(  # type: ignore[attr-defined]
-        identity, now=now
-    )
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=provisioning_counter,
     )
 
     relative = next(
@@ -338,7 +326,7 @@ def test_time_offset_alignment_uses_candidate_reference() -> None:
     time_offset = rotation_timestamp - relative.reference_time
 
     assert abs(time_offset) < ROTATION_PERIOD
-    assert relative.reference_time == provisioning_counter
+    assert relative.reference_time == now - anchor_epoch
 
 
 class _StubDevice:
@@ -398,7 +386,7 @@ async def test_active_device_identities_prefer_registry_custom_fields(
             _StubDevice(
                 "dev-1",
                 registry_id="registry-1",
-                custom_fields={"identity_key": "0f0e0d"},
+                custom_fields={"identity_key": "0f0e0d", "pairDate": 1_700_000_006},
             )
         ]
     )
@@ -447,7 +435,9 @@ async def test_active_device_identities_fall_back_to_location_cache(
         device, "identifier", None
     )
     coordinator.data = []
-    coordinator._device_location_data = {"dev-2": {"identityKey": "abcd"}}
+    coordinator._device_location_data = {
+        "dev-2": {"identityKey": "abcd", "pair_date": 1_700_000_007}
+    }
 
     identities = coordinator.get_active_device_identities()
 
@@ -536,9 +526,7 @@ async def test_active_device_identities_surface_registry_timestamps(
     assert identity.time_anchors_debug == {"hint": "anchor"}
 
 
-def test_build_timebase_candidates_with_time_anchor_hints(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_build_timebase_candidates_with_time_anchor_hints() -> None:
     now = ROTATION_PERIOD * 8
     identity = DeviceIdentity(
         registry_id="registry-anchor",
@@ -554,7 +542,6 @@ def test_build_timebase_candidates_with_time_anchor_hints(
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=now,
     )
 
     labels = {candidate.label for candidate in candidates}
@@ -579,7 +566,6 @@ def test_build_timebase_candidates_always_include_absolute_with_rel_anchor() -> 
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=now,
     )
 
     labels = {candidate.label for candidate in candidates}
@@ -590,7 +576,6 @@ def test_build_timebase_candidates_always_include_absolute_with_rel_anchor() -> 
 def test_build_timebase_candidates_use_provisioning_for_absolute() -> None:
     now = 1_700_000_000
     anchor_epoch = now - 100_000
-    provisioning_counter = 100_000
     identity = DeviceIdentity(
         registry_id="registry-absolute",
         canonical_id="device-absolute",
@@ -601,7 +586,6 @@ def test_build_timebase_candidates_use_provisioning_for_absolute() -> None:
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=provisioning_counter,
     )
 
     absolute_candidate = next(
@@ -616,7 +600,7 @@ def test_build_timebase_candidates_use_provisioning_for_absolute() -> None:
     )
 
     assert absolute_candidate.reference_time == resolver_module._mask_u32(now)  # type: ignore[attr-defined]
-    assert relative_candidate.reference_time == provisioning_counter
+    assert relative_candidate.reference_time == now - anchor_epoch
     assert relative_candidate.anchor_epoch == anchor_epoch
 
 
@@ -632,7 +616,6 @@ def test_build_timebase_candidates_ignores_unparsed_anchor_list() -> None:
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=now,
     )
 
     labels = {candidate.label for candidate in candidates}

--- a/tests/test_eid_time_bases.py
+++ b/tests/test_eid_time_bases.py
@@ -11,7 +11,6 @@ from custom_components.googlefindmy.eid_resolver import (
     TimebaseLabel,
     _build_timebase_candidates,
     _clamp_and_mask_u32,
-    _compute_provisioning_counter,
 )
 
 
@@ -70,7 +69,6 @@ def test_future_anchor_candidates_are_skipped() -> None:
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=now,
     )
 
     labels = {candidate.label for candidate in candidates}
@@ -93,17 +91,9 @@ def test_selected_anchor_drives_relative_candidate() -> None:
         secrets_creation_date=secrets_creation_date,
     )
 
-    provisioning_counter, anchor_label, anchor_epoch = _compute_provisioning_counter(
-        identity, now=now
-    )
-
-    assert anchor_label == "secrets_creation_date"
-    assert provisioning_counter == 86_400
-
     candidates = _build_timebase_candidates(
         identity,
         now_unix=now,
-        provisioning_counter=provisioning_counter,
     )
 
     labels = {candidate.label for candidate in candidates}
@@ -119,7 +109,7 @@ def test_selected_anchor_drives_relative_candidate() -> None:
         for candidate in candidates
         if candidate.label == TimebaseLabel.REL_PAIR
     )
-    assert rel_secrets_candidate.reference_time == provisioning_counter
+    assert rel_secrets_candidate.reference_time == now - secrets_creation_date
     assert rel_secrets_candidate.anchor_epoch == secrets_creation_date
     assert rel_pair_candidate.reference_time == now - pair_date
     assert rel_pair_candidate.anchor_epoch == pair_date


### PR DESCRIPTION
## Summary
- define the persisted metadata key whitelist used when merging cached device secrets
- generate resolver timebase candidates for both pair and secrets anchors instead of choosing a single primary anchor
- update resolver tests for the new additive strategy and timestamp basis expectations

## Testing
- python -m ruff check --fix
- python -m mypy --strict --explicit-package-bases custom_components/googlefindmy tests
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940294229c48329a4d3c766d534fea5)