### PR TITLE
Fix per-device timestamp lookup for identities

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -4648,8 +4648,8 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                         )
 
                     anchors_debug = _extract_time_anchors_debug(custom_fields)
-                    if anchors_debug is not None:
-                        registry_time_anchors_debug[canonical_id] = anchors_debug
+                if anchors_debug is not None:
+                    registry_time_anchors_debug[canonical_id] = anchors_debug
 
         last_device_list = getattr(self, "_last_device_list", None)
         last_identities: dict[str, bytes] = {}
@@ -4911,25 +4911,27 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 last_fast_pair_model_ids,
             )
 
-            pair_date = normalize_epoch_seconds(
-                _lookup_prio(
-                    lookup_id,
-                    registry_pair_dates,
-                    cache_pair_dates,
-                    data_pair_dates,
-                    last_pair_dates,
-                )
+            pair_date = _lookup_prio(
+                lookup_id,
+                cache_pair_dates,
+                data_pair_dates,
+                last_pair_dates,
             )
+            if pair_date is None:
+                pair_date = _lookup_prio(lookup_id, registry_pair_dates)
+            pair_date = normalize_epoch_seconds(pair_date)
 
-            secrets_creation_date = normalize_epoch_seconds(
-                _lookup_prio(
-                    lookup_id,
-                    registry_secrets_creation_dates,
-                    cache_secrets_creation_dates,
-                    data_secrets_creation_dates,
-                    last_secrets_creation_dates,
-                )
+            secrets_creation_date = _lookup_prio(
+                lookup_id,
+                cache_secrets_creation_dates,
+                data_secrets_creation_dates,
+                last_secrets_creation_dates,
             )
+            if secrets_creation_date is None:
+                secrets_creation_date = _lookup_prio(
+                    lookup_id, registry_secrets_creation_dates
+                )
+            secrets_creation_date = normalize_epoch_seconds(secrets_creation_date)
 
             anchors_debug = _lookup_prio(
                 lookup_id,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -471,3 +471,49 @@ def test_coordinator_yields_identities_without_pair_date(
     identity = identities[0]
     assert identity.identity_key == identity_only_payload["identity_key"]
     assert identity.pair_date is None
+
+
+def test_active_device_identities_assigns_correct_timestamps_per_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each device should retain its own timestamps from the last device list."""
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._is_on_hass_loop = lambda: True
+    coordinator._run_on_hass_loop = lambda *args, **kwargs: None
+    coordinator.stats = {}
+    coordinator._device_location_data = {}
+    coordinator._device_update_history = {}
+    coordinator._enabled_poll_device_ids = {"device-1", "device-2"}
+    coordinator._last_device_list = [
+        {"id": "device-1", "identity_key": b"\x01", "pair_date": 100},
+        {"id": "device-2", "identity_key": b"\x02", "pair_date": 200},
+    ]
+    coordinator.data = []
+    coordinator.config_entry = SimpleNamespace(entry_id="entry-id", options={})
+    coordinator.hass = SimpleNamespace(data={})
+    coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
+        "canonical_id"
+    )
+
+    registry = SimpleNamespace()
+    registry_devices = [
+        SimpleNamespace(
+            id="registry-1", disabled_by=None, custom_fields={"canonical_id": "device-1"}
+        ),
+        SimpleNamespace(
+            id="registry-2", disabled_by=None, custom_fields={"canonical_id": "device-2"}
+        ),
+    ]
+
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda hass: registry)
+    monkeypatch.setattr(
+        coordinator_module.dr,
+        "async_entries_for_config_entry",
+        lambda _registry, _entry_id: registry_devices,
+    )
+
+    identities = coordinator.get_active_device_identities()
+
+    pair_dates = {identity.canonical_id: identity.pair_date for identity in identities}
+    assert pair_dates == {"device-1": 100, "device-2": 200}


### PR DESCRIPTION
## Summary
- ensure pair and secret creation timestamps are resolved per device using cache/data/last priority with registry fallback
- preserve registry time anchor handling and add a regression test covering per-device pair dates

## Testing
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407ea858fc83299cc396f02042fca4)