### PR TITLE
Persist anchor metadata to device registry for restart durability

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -102,6 +102,40 @@ class StaleOwnerKeyError(DecryptionError):
     """Raised when the tracker was encrypted with an older owner key version."""
 
 
+async def _unwrap_encrypted_identity_key(
+    identity_key: bytes, *, cache: TokenCache
+) -> bytes | None:
+    """Unwrap a 60-byte encrypted identity key into a 32-byte EIK if possible."""
+
+    if len(identity_key) != EIK_GCM_TOTAL_LEN:
+        return None
+
+    try:
+        owner_key_info = await async_get_owner_key(cache=cache)
+    except Exception as exc:  # pragma: no cover - defensive diagnostic path
+        _LOGGER.debug("[DECRYPT] Owner key lookup failed while unwrapping EIK: %s", exc)
+        return None
+
+    try:
+        decrypted_eik = await asyncio.to_thread(
+            decrypt_eik, owner_key_info.key, identity_key
+        )
+    except Exception as exc:  # pragma: no cover - defensive diagnostic path
+        _LOGGER.debug("[DECRYPT] EIK unwrap failed in thread: %s", exc)
+        return None
+
+    if len(decrypted_eik) != _EIK_LEN:
+        _LOGGER.debug(
+            "[DECRYPT] Unwrapped EIK length %s does not match expected %s bytes",
+            len(decrypted_eik),
+            _EIK_LEN,
+        )
+        return None
+
+    _LOGGER.debug("[DECRYPT] Successfully unwrapped 60-byte EIK to 32 bytes (early path).")
+    return bytes(decrypted_eik)
+
+
 def _status_name_safe(code: Any) -> str:
     """Safely get the string representation of an enum, with a robust fallback."""
     try:
@@ -528,6 +562,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         raise
 
     encrypted_user_secrets = device_registration.encryptedUserSecrets
+    raw_encrypted_identity_key: bytes = b""
+    early_unwrapped_identity_key: bytes | None = None
     try:
         raw_encrypted_identity_key = getattr(
             encrypted_user_secrets, "encryptedIdentityKey", b""
@@ -541,6 +577,11 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             _LOGGER.debug(
                 "Failed to serialize encryptedUserSecrets for length check: %s",
                 serialize_exc,
+            )
+
+        if raw_encrypted_identity_key and len(raw_encrypted_identity_key) == EIK_GCM_TOTAL_LEN:
+            early_unwrapped_identity_key = await _unwrap_encrypted_identity_key(
+                raw_encrypted_identity_key, cache=cache
             )
 
         _LOGGER.warning(
@@ -566,11 +607,15 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             _LOGGER.warning(
                 "[DIAG-ALERT] encryptedUserSecrets serialized length is %d bytes (> %d)."
                 " This suggests a wrapped/structured payload instead of a raw key.",
-                serialized_length,
-                _SECRETS_STRUCT_LEN_THRESHOLD,
-            )
+            serialized_length,
+            _SECRETS_STRUCT_LEN_THRESHOLD,
+        )
 
-        if raw_encrypted_identity_key and len(raw_encrypted_identity_key) != _EIK_LEN:
+        if (
+            early_unwrapped_identity_key is None
+            and raw_encrypted_identity_key
+            and len(raw_encrypted_identity_key) != _EIK_LEN
+        ):
             _LOGGER.warning(
                 "[DIAG-ALERT] Key length is %d (expected %d for raw EIK)."
                 " This suggests wrapping/encryption!",
@@ -578,7 +623,11 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 _EIK_LEN,
             )
 
-        if raw_encrypted_identity_key and len(raw_encrypted_identity_key) > _EIK_LEN:
+        if (
+            early_unwrapped_identity_key is None
+            and raw_encrypted_identity_key
+            and len(raw_encrypted_identity_key) > _EIK_LEN
+        ):
             _LOGGER.warning(
                 "[DIAG-ALERT] Key length %d bytes exceeds expected raw EIK length (%d)."
                 " Probable wrapped key container or HKDF-required envelope.",
@@ -614,8 +663,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     raw_encrypted_identity_key = bytes(raw_encrypted_identity_key)
     raw_owner_key_version = getattr(encrypted_user_secrets, "ownerKeyVersion", None)
 
-    identity_key_candidates = await async_retrieve_identity_key(
-        device_registration, cache=cache
+    identity_key_candidates = (
+        [early_unwrapped_identity_key]
+        if early_unwrapped_identity_key is not None
+        else await async_retrieve_identity_key(device_registration, cache=cache)
     )
     identity_key = identity_key_candidates[0] if identity_key_candidates else None
     identity_key_bytes = bytes(identity_key) if identity_key is not None else None
@@ -625,26 +676,13 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
 
     # Handle Moto Tag / Chipolo-style 60-byte EIK wrappers by unwrapping to 32 bytes.
     if identity_key_bytes is not None and len(identity_key_bytes) == EIK_GCM_TOTAL_LEN:
-        try:
-            owner_key_info = await async_get_owner_key(cache=cache)
-            decrypted_eik = await asyncio.to_thread(
-                decrypt_eik, owner_key_info.key, identity_key_bytes
-            )
-
-            if len(decrypted_eik) == _EIK_LEN:
-                identity_key_bytes = bytes(decrypted_eik)
-                identity_key_candidate_bytes = [identity_key_bytes]
-                identity_key = identity_key_bytes
-                _LOGGER.debug(
-                    "[DECRYPT-FIX] Successfully unwrapped 60-byte EIK to 32 bytes."
-                )
-            else:
-                _LOGGER.debug(
-                    "[DECRYPT-FIX] Unwrapped 60-byte EIK to unexpected length %s bytes",
-                    len(decrypted_eik),
-                )
-        except Exception as exc:  # pragma: no cover - defensive diagnostic path
-            _LOGGER.warning("[DECRYPT-FIX] Failed to unwrap 60-byte EIK: %s", exc)
+        unwrapped_identity_key = await _unwrap_encrypted_identity_key(
+            identity_key_bytes, cache=cache
+        )
+        if unwrapped_identity_key:
+            identity_key_bytes = unwrapped_identity_key
+            identity_key_candidate_bytes = [identity_key_bytes]
+            identity_key = identity_key_bytes
 
     if identity_key is None:
         raise DecryptionError("Identity key derivation returned no candidates.")
@@ -659,6 +697,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
 
     now_wall = time.time()
     metadata: dict[str, Any] = {}
+    metadata_update: dict[str, Any] = {}
     device_registration_metadata: dict[str, Any] = {}
     encrypted_user_secrets_metadata: dict[str, Any] = {}
     device_type_information_metadata: dict[str, Any] = {}
@@ -678,8 +717,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             break
 
     if pair_date is not None:
-        metadata["pair_date"] = pair_date
-        metadata["pairDate"] = pair_date
+        metadata_update["pair_date"] = pair_date
+        metadata_update["pairDate"] = pair_date
         device_registration_metadata["pairDate"] = pair_date
         if device_type_information is not None:
             device_type_information_metadata["pairDate"] = pair_date
@@ -703,10 +742,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             break
 
     if secrets_creation_date is not None:
-        metadata["secrets_creation_date"] = secrets_creation_date
-        metadata["secretsCreationDate"] = secrets_creation_date
-        metadata["creationDate"] = secrets_creation_date
-        metadata["creation_date"] = secrets_creation_date
+        metadata_update["secrets_creation_date"] = secrets_creation_date
+        metadata_update["secretsCreationDate"] = secrets_creation_date
+        metadata_update["creationDate"] = secrets_creation_date
+        metadata_update["creation_date"] = secrets_creation_date
         encrypted_user_secrets_metadata["creationDate"] = secrets_creation_date
         encrypted_user_secrets_metadata["creation_date"] = secrets_creation_date
         if device_type_information is not None:
@@ -724,18 +763,21 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         metadata["device_type_information"] = device_type_information_metadata
         metadata.setdefault("deviceTypeInformation", device_type_information_metadata)
 
-    if identity_key_bytes is not None:
-        metadata.setdefault("identity_key", identity_key_bytes)
-        metadata.setdefault("identityKey", identity_key_bytes)
+    if identity_key_bytes is not None and len(identity_key_bytes) == _EIK_LEN:
+        metadata_update["identity_key"] = identity_key_bytes
+        metadata_update["identityKey"] = identity_key_bytes
     if identity_key_candidate_bytes:
         metadata.setdefault("identity_key_candidates", identity_key_candidate_bytes)
         metadata.setdefault("identityKeyCandidates", identity_key_candidate_bytes)
     if raw_encrypted_identity_key:
-        metadata.setdefault("encrypted_identity_key", raw_encrypted_identity_key)
-        metadata.setdefault("encryptedIdentityKey", raw_encrypted_identity_key)
+        metadata_update.setdefault("encrypted_identity_key", raw_encrypted_identity_key)
+        metadata_update.setdefault("encryptedIdentityKey", raw_encrypted_identity_key)
     if raw_owner_key_version is not None:
         metadata.setdefault("owner_key_version", raw_owner_key_version)
         metadata.setdefault("ownerKeyVersion", raw_owner_key_version)
+
+    if metadata_update:
+        metadata.update(metadata_update)
 
     # Assemble reports (preserve semantics; own report is appended if present)
     recent_location = locations_proto.recentLocation

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -6559,6 +6559,72 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if not isinstance(location, Mapping):
             return
 
+        def _persist_registry_anchor_metadata(anchor_payload: Mapping[str, Any]) -> None:
+            hass_obj = getattr(self, "hass", None)
+            if hass_obj is None:
+                return
+
+            try:
+                dev_reg = dr.async_get(hass_obj)
+            except Exception as err:  # pragma: no cover - defensive fallback
+                _LOGGER.debug(
+                    "Unable to load device registry for %s: %s", device_id, err
+                )
+                return
+
+            device_entry = dev_reg.async_get_device(identifiers={(DOMAIN, device_id)})
+            if device_entry is None:
+                return
+
+            custom_fields: Mapping[str, Any] | None = getattr(
+                device_entry, "custom_fields", None
+            )
+            new_custom_fields: dict[str, Any] = (
+                dict(custom_fields) if isinstance(custom_fields, Mapping) else {}
+            )
+            changed = False
+
+            for key in ("pair_date", "secrets_creation_date"):
+                if key not in anchor_payload:
+                    continue
+                candidate_value = anchor_payload[key]
+                if candidate_value != new_custom_fields.get(key):
+                    new_custom_fields[key] = candidate_value
+                    changed = True
+
+            if "identity_key" in anchor_payload:
+                raw_key = anchor_payload["identity_key"]
+                key_hex = raw_key.hex() if isinstance(raw_key, (bytes, bytearray)) else raw_key
+                if key_hex != new_custom_fields.get("identity_key"):
+                    new_custom_fields["identity_key"] = key_hex
+                    changed = True
+                    _LOGGER.info(
+                        "Persisting updated identity key for %s to device registry",
+                        device_id,
+                    )
+
+            if not changed:
+                return
+
+            try:
+                self._call_device_registry_api(
+                    dev_reg.async_update_device,
+                    base_kwargs={
+                        "device_id": device_entry.id,
+                        "custom_fields": new_custom_fields,
+                    },
+                )
+            except Exception as err:  # pragma: no cover - defensive fallback
+                _LOGGER.warning(
+                    "Failed to persist anchors to device registry for %s: %s",
+                    device_id,
+                    err,
+                )
+            else:
+                _LOGGER.debug(
+                    "Persisted anchor metadata to device registry for %s", device_id
+                )
+
         def _normalize_anchor_value(value: Any) -> int | Any:
             normalized = normalize_epoch_seconds(value)
             if normalized is not None:
@@ -6632,6 +6698,8 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
         if not anchor_payload:
             return
+
+        _persist_registry_anchor_metadata(anchor_payload)
 
         existing = self._device_location_data.get(device_id)
         merged: dict[str, Any] = {}

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 
@@ -197,12 +198,14 @@ def test_async_decrypt_location_response_locations_returns_metadata_when_empty(
 
 
 def test_async_decrypt_location_response_unwraps_60_byte_eik(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Regression Test: Unwrap 60-byte EIKs so HKDF/location decryption never sees "Key length 60"."""
 
     base_now = 1_700_100_000.0
     monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+
+    caplog.set_level(logging.WARNING)
 
     encrypted_eik = b"\x99" * decrypt_locations.EIK_GCM_TOTAL_LEN
     # Moto Tag/Chipolo responses wrap the 32-byte identity key inside a 60-byte envelope.
@@ -214,7 +217,10 @@ def test_async_decrypt_location_response_unwraps_60_byte_eik(
     location_proto.altitude = ALTITUDE_METERS
     location_bytes = location_proto.SerializeToString()
 
+    identity_key_calls = {"count": 0}
+
     async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        identity_key_calls["count"] += 1
         return [encrypted_eik]
 
     unwrap_calls: dict[str, object] = {}
@@ -277,6 +283,8 @@ def test_async_decrypt_location_response_unwraps_60_byte_eik(
     assert entry["identity_key"] == unwrapped_eik
     assert entry["identity_key_candidates"] == [unwrapped_eik]
     assert entry["encrypted_identity_key"] == encrypted_eik
+    assert entry["pair_date"] == int(base_now - 30)
+    assert entry["secrets_creation_date"] == int(base_now - 15)
     assert entry["accuracy"] == ACCURACY_METERS
     assert entry["altitude"] == ALTITUDE_METERS
     assert offload_calls["identity_key"] == unwrapped_eik
@@ -285,6 +293,8 @@ def test_async_decrypt_location_response_unwraps_60_byte_eik(
     assert unwrap_calls["cache"] is cache
     assert unwrap_calls["owner_key"] == b"\xAA" * 32
     assert unwrap_calls["encrypted"] == encrypted_eik
+    assert identity_key_calls["count"] == 0
+    assert "[DIAG-ALERT] Key length" not in caplog.text
 
 
 def test_async_decrypt_location_response_locations_normalizes_anchor_units(

--- a/tests/test_eid_resolver.py
+++ b/tests/test_eid_resolver.py
@@ -512,11 +512,13 @@ class _StubDevice:
         registry_id: str | None = None,
         custom_fields: dict | None = None,
         disabled: bool = False,
+        identifiers: set[tuple[str, str]] | None = None,
     ) -> None:
         self.identifier = identifier
         self.id = registry_id or identifier
         self.custom_fields = custom_fields
         self.disabled_by = "user" if disabled else None
+        self.identifiers = identifiers or {(DOMAIN, identifier)}
 
 
 class _StubDeviceRegistry:
@@ -530,6 +532,23 @@ class _StubDeviceRegistry:
         return next(
             (device for device in self._devices if device.id == device_id), None
         )
+
+    def async_get_device(
+        self,
+        *,
+        identifiers: set[tuple[str, str]] | None = None,
+        device_id: str | None = None,
+    ) -> _StubDevice | None:
+        if device_id:
+            return self.async_get(device_id)
+
+        if identifiers:
+            for device in self._devices:
+                device_identifiers = getattr(device, "identifiers", None)
+                if device_identifiers and set(device_identifiers) & identifiers:
+                    return device
+
+        return None
 
     def async_update_device(
         self, device_id: str, *, custom_fields: dict | None = None
@@ -1036,6 +1055,47 @@ def test_persist_anchor_metadata_records_metadata_only_payload() -> None:
     assert stored["identity_key_candidates"] == [b"\x01" * 32]
     assert stored["encrypted_identity_key"] == b"\x02" * 32
     assert stored["owner_key_version"] == 3
+
+
+def test_persist_anchor_metadata_updates_device_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = _StubDeviceRegistry(
+        [
+            _StubDevice(
+                "dev-anchor",
+                registry_id="registry-anchor",
+                custom_fields={"pair_date": 1, "identity_key": "00"},
+            )
+        ]
+    )
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator.hass = _StubHass()
+    coordinator._device_location_data = {}
+
+    monkeypatch.setattr(coordinator_module.dr, "async_get", lambda _hass: registry)
+
+    payload = {
+        "pair_date": 2,
+        "secrets_creation_date": 3,
+        "identity_key": b"\x01" * 32,
+    }
+
+    coordinator._persist_anchor_metadata(
+        "dev-anchor", payload, clear_metadata_only=False
+    )
+
+    updated_device = registry.async_get_device(
+        identifiers={(DOMAIN, "dev-anchor")}
+    )
+    assert updated_device is not None
+    assert updated_device.custom_fields == {
+        "pair_date": 2,
+        "secrets_creation_date": 3,
+        "identity_key": (b"\x01" * 32).hex(),
+    }
 
 
 def test_persist_anchor_metadata_ignores_nanos_only_payload() -> None:


### PR DESCRIPTION
## Summary
- write updated pair dates, creation dates, and decrypted identity keys into the Home Assistant device registry when anchor metadata changes so new crypto material survives restarts
- extend the anchor metadata persistence tests and stubs to cover registry lookups and updates for decrypted identity keys

## Testing
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest tests/test_eid_resolver.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941ead00e488329bb880e8a3e6d532c)