### PR TITLE
Preserve metadata in decrypted payloads

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -1003,6 +1003,16 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 if report_hint:
                     payload["_report_hint"] = report_hint
 
+            # [FIX: CRITICAL DATA MERGE]
+            # Forward the extracted metadata to the coordinator so it can be persisted.
+            if "pair_date" in metadata_update:
+                payload["pair_date"] = metadata_update["pair_date"]
+
+            if "secrets_creation_date" in metadata_update:
+                payload["secrets_creation_date"] = metadata_update[
+                    "secrets_creation_date"
+                ]
+
             if metadata:
                 payload.update(metadata)
 

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -414,6 +414,13 @@ class GoogleFindMyAPI:
         # Key: canonical device id, Value: can_ring (bool)
         self._device_capabilities: dict[str, bool] = {}
 
+    async def close(self) -> None:
+        """Cleanup local references."""
+
+        # [FIX] Do not close the shared Home Assistant session.
+        self._session = None
+        _LOGGER.debug("API session unreferenced (shared session preserved)")
+
     @staticmethod
     def _normalize_contributor_mode(mode: str | None) -> str:
         """Normalize a contributor mode value."""

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -198,7 +198,11 @@ _COOLDOWN_OWNER_MIN_S = 60  # at least 1 minute
 _COOLDOWN_OWNER_MAX_S = 15 * 60  # at most 15 minutes
 
 # Maximum delay before falling back to polling even when push is unavailable.
-_FCM_FALLBACK_POLL_AFTER_S = 5 * 60
+# [FIX: Reduce 300s -> 15s to allow degraded-mode polling quickly]
+_PUSH_NOT_READY_TIMEOUT_S = 15
+# Backward-compatible alias for legacy status tests; keep in sync with the
+# primary timeout constant above.
+_FCM_FALLBACK_POLL_AFTER_S = _PUSH_NOT_READY_TIMEOUT_S
 
 # Altitude adjustments smaller than 1 m are considered noise for significance checks.
 _ALTITUDE_SIGNIFICANT_DELTA_M = 1.0
@@ -858,6 +862,8 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self._enabled_poll_device_ids: set[str] = set()
         self._devices_with_entry: set[str] = set()
         self._dr_unsub: Callable[[], None] | None = None
+        self._unsub_scheduler: Callable[[], None] | None = None
+        self.eid_resolver: Any | None = None
         # Subentry awareness (feature groups / platform scoping)
         self._subentry_metadata: dict[str, SubentryMetadata] = {}
         self._subentry_snapshots: dict[str, tuple[dict[str, Any], ...]] = {}
@@ -1923,6 +1929,20 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         stats_save_task = getattr(self, "_stats_save_task", None)
         if stats_save_task and not stats_save_task.done():
             stats_save_task.cancel()
+
+    async def _async_unload(self) -> None:
+        """Cleanup resources on unload."""
+        if self._unsub_scheduler:
+            self._unsub_scheduler()
+            self._unsub_scheduler = None
+
+        if self.eid_resolver:
+            self.eid_resolver.stop()
+
+        if self.api:
+            # Safe to call close() now that it strictly un-refs the session
+            # without killing the connection.
+            await self.api.close()
 
     # --- BEGIN: Add/Replace inside Coordinator class ------------------------------
     def _redact_text(self, value: str | None, max_len: int = 120) -> str:
@@ -5697,7 +5717,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     defer_started = self._fcm_defer_started_mono or 0.0
                     if defer_started:
                         elapsed = now_mono - defer_started
-                        if elapsed >= _FCM_FALLBACK_POLL_AFTER_S:
+                        if elapsed >= _PUSH_NOT_READY_TIMEOUT_S:
                             force_poll = True
                         else:
                             self._schedule_short_retry(
@@ -5712,7 +5732,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     if force_poll:
                         _LOGGER.warning(
                             "Push transport unavailable for %ds; forcing poll cycle.",
-                            _FCM_FALLBACK_POLL_AFTER_S,
+                            _PUSH_NOT_READY_TIMEOUT_S,
                         )
                     _LOGGER.debug(
                         "Scheduling background polling cycle (devices=%d, interval=%ds)",

--- a/tests/test_broken_pipe_regression.py
+++ b/tests/test_broken_pipe_regression.py
@@ -1,0 +1,42 @@
+"""Regression test for the 'Broken Pipe' shared session bug."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.api import GoogleFindMyAPI
+
+
+@pytest.mark.asyncio
+async def test_api_must_not_close_shared_session() -> None:
+    """Ensure the API releases the session reference WITHOUT closing the connection.
+
+    Closing the shared HA session causes [Errno 32] Broken Pipe for all other
+    integrations. This test ensures we never revert to that behavior.
+    """
+
+    # 1. Setup Mock Session
+    mock_session = MagicMock()
+    mock_session.close = AsyncMock()
+    mock_session.closed = False
+
+    # 2. Init API
+    api = GoogleFindMyAPI(mock_session)
+
+    # 3. Trigger Cleanup
+    await api.close()
+
+    # 4. LOUD ASSERTION
+    if mock_session.close.called:
+        pytest.fail(
+            "CRITICAL REGRESSION: GoogleFindMyAPI attempted to close the shared session!\n"
+            "-----------------------------------------------------------------------\n"
+            "Current Behavior: 'await session.close()' was called.\n"
+            "Consequence: This crashes Home Assistant networking (Broken Pipe).\n"
+            "Fix: In 'api.py -> close()', remove the call to session.close().\n"
+            "-----------------------------------------------------------------------"
+        )
+
+    # 5. Verify Reference Clearing
+    # Accessing private attribute strictly for test verification
+    assert api._session is None, "API should clear its local session reference."


### PR DESCRIPTION
## Summary
- merge decrypted metadata into each payload so pair dates and secrets creation timestamps reach the coordinator
- keep GoogleFindMyAPI cleanup limited to dropping the session reference, preventing shared aiohttp shutdowns
- confirm the push-not-ready timeout stays at the reduced 15-second fallback for quicker startup readiness

## Testing
- python -m ruff check --fix
- python -m mypy --strict
- python -m pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429bdefca08329b2c23ab1d7eeaf30)