### PR TITLE
Preserve anchor metadata in decoder

### DIFF
--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -236,6 +236,19 @@ def get_canonic_ids(
 # Tunables to keep behavior explicit and easily auditable
 _NEAR_TS_TOLERANCE_S: float = 5.0  # semantic merge tolerance (seconds)
 
+_ANCHOR_METADATA_KEYS: tuple[str, ...] = (
+    "pair_date",
+    "secrets_creation_date",
+    "device_registration",
+    "device_type_information",
+    "encrypted_user_secrets",
+    "identity_key",
+    "identity_key_candidates",
+    "encrypted_identity_key_candidates",
+    "time_anchors_debug",
+    "metadata_only",
+)
+
 _DEVICE_STUB_KEYS: tuple[str, ...] = (
     "name",
     "id",
@@ -255,6 +268,7 @@ _DEVICE_STUB_KEYS: tuple[str, ...] = (
     "is_own_report",
     "semantic_name",
     "battery_level",
+    *_ANCHOR_METADATA_KEYS,
 )
 
 
@@ -283,6 +297,16 @@ def _build_device_stub(device_name: str, canonic_id: str) -> dict[str, Any]:
         "is_own_report": None,
         "semantic_name": None,
         "battery_level": None,
+        "pair_date": None,
+        "secrets_creation_date": None,
+        "device_registration": None,
+        "device_type_information": None,
+        "encrypted_user_secrets": None,
+        "identity_key": None,
+        "identity_key_candidates": None,
+        "encrypted_identity_key_candidates": None,
+        "time_anchors_debug": None,
+        "metadata_only": None,
     }
 
 

--- a/tests/test_decoder_location_ranking.py
+++ b/tests/test_decoder_location_ranking.py
@@ -144,6 +144,55 @@ def test_decoder_logs_decryption_failures(caplog: pytest.LogCaptureFixture) -> N
     )
 
 
+def test_device_list_preserves_anchor_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Metadata from decrypted device list payloads must survive filtering."""
+
+    devices_list = DeviceUpdate_pb2.DevicesList()
+    device = devices_list.deviceMetadata.add()
+    device.userDefinedDeviceName = "Tracker"
+    canonic = device.identifierInformation.canonicIds.canonicId.add()
+    canonic.id = "device-anchor"
+
+    reports = device.information.locationInformation.reports
+    reports.recentLocationAndNetworkLocations.recentLocation.semanticLocation.locationName = (
+        "seed"
+    )
+
+    anchor_payload = {
+        "pair_date": 1_700_000_100,
+        "secrets_creation_date": 1_700_000_200,
+        "identity_key": b"\xaa" * 32,
+        "identity_key_candidates": [b"\xaa" * 32, b"\xbb" * 32],
+        "encrypted_identity_key_candidates": [b"\x01\x02"],
+        "device_registration": {"pairDate": 1_700_000_300},
+        "encrypted_user_secrets": {"creationDate": 1_700_000_400},
+        "time_anchors_debug": {"source": "device_list"},
+        "metadata_only": True,
+    }
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations.decrypt_location_response_locations",
+        lambda *args, **kwargs: [anchor_payload],
+    )
+
+    rows = get_devices_with_location(devices_list, cache=cast("TokenCache", object()))
+
+    assert len(rows) == 1
+    row = rows[0]
+
+    assert row["pair_date"] == anchor_payload["pair_date"]
+    assert row["secrets_creation_date"] == anchor_payload["secrets_creation_date"]
+    assert row["identity_key"] == anchor_payload["identity_key"]
+    assert row["identity_key_candidates"] == anchor_payload["identity_key_candidates"]
+    assert row["encrypted_identity_key_candidates"] == anchor_payload[
+        "encrypted_identity_key_candidates"
+    ]
+    assert row["device_registration"] == anchor_payload["device_registration"]
+    assert row["encrypted_user_secrets"] == anchor_payload["encrypted_user_secrets"]
+    assert row["time_anchors_debug"] == anchor_payload["time_anchors_debug"]
+    assert row["metadata_only"] is True
+
+
 def test_semantic_report_outranks_older_coordinate_candidate() -> None:
     """A fresher semantic report without coords takes selection precedence."""
 


### PR DESCRIPTION
## Summary
- retain decrypted anchor metadata (pair dates, secrets creation, identity candidates) when building device list rows so relative EIDs keep their timebase
- initialize device stubs with anchor fields to avoid dropping values during normalization
- add regression coverage to ensure decrypted device-list metadata survives filtering

## Testing
- python -m ruff check --fix
- python -m mypy --strict --install-types --non-interactive
- python -m pytest --cov -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943382d3a1483299283222dc1da3f96)