### PR TITLE
Harden EID derivation and resolver window handling

### DIFF
--- a/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
+++ b/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
@@ -149,13 +149,27 @@ def _derive_scalar(  # noqa: PLR0913
     byteorder: Literal["big", "little"],
     curve_order: int,
     strict: bool,
+    include_zero_endpoint: bool = False,
 ) -> int:
-    """Derive a scalar in ``[1, curve_order - 1]`` from the Table 10 PRF output."""
+    """Derive a scalar from the Table 10 PRF output.
+
+    Modern P-256 trackers require an open interval ``[1, curve_order - 1]`` to
+    avoid the point at infinity, while legacy FHNA accessories project directly
+    into the closed interval ``[0, curve_order - 1]``. The `include_zero_endpoint`
+    toggle preserves the legacy modulo-n behavior (Table 10) instead of the
+    P-256-adjusted projection used by modern trackers.
+    """
 
     r_dash: bytes = _prf_table10(identity_key, time_counter_u32, k, strict=strict)
     r_dash_int: int = int.from_bytes(r_dash, byteorder=byteorder, signed=False)
-    scalar: int = (r_dash_int % (curve_order - 1)) + 1
-    return scalar
+    order: int = int(curve_order)
+
+    if include_zero_endpoint:
+        mod_n_scalar: int = r_dash_int % order
+        return mod_n_scalar
+
+    projected_scalar: int = (r_dash_int % (order - 1)) + 1
+    return projected_scalar
 
 
 def _serialize_legacy_x(scalar_r: int) -> bytes:
@@ -194,13 +208,15 @@ def generate_eid_variant(
     counter_u32 = _normalize_time_counter(time_counter_u32, strict=strict)
 
     if variant is EidVariant.LEGACY_SECP160R1_X20_BE:
+        curve_order: int = int(_CURVE.order)
         scalar = _derive_scalar(
             eik,
             counter_u32,
             k=k,
             byteorder="big",
-            curve_order=int(_CURVE.order),
+            curve_order=curve_order,
             strict=strict,
+            include_zero_endpoint=True,
         )
         return _serialize_legacy_x(scalar)
 

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.storage import Store
 from .const import DOMAIN
 from .coordinator import DeviceIdentity, GoogleFindMyCoordinator
 from .FMDNCrypto.eid_generator import (
+    FHNA_COUNTER_MASK,
     LEGACY_EID_LENGTH,
     MODERN_EID_LENGTH,
     ROTATION_PERIOD,
@@ -105,7 +106,12 @@ def iter_rotation_windows(
         if include_neighbors:
             previous_window = timestamp - rotation_period
             next_window = timestamp + rotation_period
-            windows.extend((timestamp, previous_window, next_window))
+            if timestamp >= 0:
+                windows.append(timestamp)
+            if previous_window >= 0:
+                windows.append(previous_window)
+            if next_window >= 0:
+                windows.append(next_window)
         else:
             windows.append(timestamp)
 
@@ -165,6 +171,28 @@ class EIDGenerationLock:
             time_basis=str(payload.get("time_basis") or "") or None,
             created_at=int(payload.get("created_at") or int(time.time())),
         )
+
+
+def _normalize_counter_candidate(candidate_value: int, *, basis: str) -> int | None:
+    """Return a sane u32 counter candidate or ``None`` when unusable."""
+
+    if not isinstance(candidate_value, int) or candidate_value < 0:
+        return None
+
+    if candidate_value <= FHNA_COUNTER_MASK:
+        return candidate_value
+
+    candidate_seconds = candidate_value // 1000
+    if 0 < candidate_seconds <= FHNA_COUNTER_MASK:
+        _LOGGER.debug(
+            "Converted %s basis %s from milliseconds to seconds: %s",
+            candidate_value,
+            basis,
+            candidate_seconds,
+        )
+        return candidate_seconds
+
+    return None
 
 
 @dataclass(slots=True)
@@ -300,7 +328,7 @@ class GoogleFindMyEIDResolver:
                 self._pending_refresh = False
                 await self._refresh_cache()
 
-    async def _refresh_cache(self) -> None:  # noqa: PLR0912
+    async def _refresh_cache(self) -> None:  # noqa: PLR0912, PLR0915
         """Rebuild the EID lookup table for all active devices."""
 
         self._ensure_cache_defaults()
@@ -319,6 +347,7 @@ class GoogleFindMyEIDResolver:
             ("unix", "unix"),
             ("pair_date", "pair_date"),
             ("secrets_creation_date", "secrets_creation_date"),
+            ("entity_time", "entity_time"),
         )
 
         for identity in identities:
@@ -383,22 +412,47 @@ class GoogleFindMyEIDResolver:
                     candidate_value = now_unix
                 elif basis == "pair_date":
                     candidate_value = identity.pair_date
+                elif basis == "entity_time":
+                    candidate_value = getattr(identity, "entity_time", None)
                 else:
                     candidate_value = identity.secrets_creation_date
 
-                if isinstance(candidate_value, int):
-                    rotation_start = candidate_value - (candidate_value % ROTATION_PERIOD)
-                    for offset in (-1, 0, 1):
-                        ts = rotation_start + (offset * ROTATION_PERIOD)
-                        counters.setdefault(ts, label)
+                normalized = (
+                    _normalize_counter_candidate(candidate_value, basis=basis)
+                    if isinstance(candidate_value, int)
+                    else None
+                )
+                if normalized is None:
+                    continue
+
+                for ts in iter_rotation_windows(
+                    normalized,
+                    rotation_period=ROTATION_PERIOD,
+                    window_range=(0,),
+                    include_neighbors=True,
+                ):
+                    if ts < 0 or ts > FHNA_COUNTER_MASK:
+                        continue
+                    counters.setdefault(ts, label)
 
             for window_ts, time_basis in counters.items():
                 for variant in variants:
-                    eid_bytes = self._generate_variant(
-                        key_bytes,
-                        time_counter=window_ts,
-                        variant=variant,
-                    )
+                    try:
+                        eid_bytes = self._generate_variant(
+                            key_bytes,
+                            time_counter=window_ts,
+                            variant=variant,
+                        )
+                    except Exception as exc:  # pragma: no cover - defensive guard
+                        _LOGGER.debug(
+                            "Skipping EID generation for registry_id=%s basis=%s window_ts=%s variant=%s: %s",
+                            identity.registry_id,
+                            time_basis,
+                            window_ts,
+                            variant.value,
+                            exc,
+                        )
+                        continue
                     _register_variant(
                         eid_bytes,
                         variant=variant,

--- a/tests/test_eid_generator_variants.py
+++ b/tests/test_eid_generator_variants.py
@@ -32,7 +32,7 @@ PRF_INPUT_HEX = "ffffffffffffffffffffff0a1234540000000000000000000000000a1234540
 PRF_OUTPUT_HEX = "52c746bf4ab7c7c35f0ddb3b2c8632d129f0a0453f76767a29f033d00dee96ba"
 
 GOLDEN_VECTORS: dict[EidVariant, str] = {
-    EidVariant.LEGACY_SECP160R1_X20_BE: "86add72d6e7dea8bbdecb5dc8a5c3fa90e3eb6cc",
+    EidVariant.LEGACY_SECP160R1_X20_BE: "7bf149821dafae98259bfe53a87283c41d7b1b1c",
     EidVariant.MODERN_P256_X32_BE: "72d4e4be2c6f3c1c5328f10d884ab58e0a474b06584d9c893b1e099853289cd9",
     EidVariant.MODERN_P256_X20_TRUNC_BE: "72d4e4be2c6f3c1c5328f10d884ab58e0a474b06",
     EidVariant.MODERN_P256_X32_LE_SCALAR: "acc9009d7630b76c89cfb17f126fe640508ba7e184528341cbdb217053dd4050",
@@ -80,18 +80,55 @@ def test_prf_is_deterministic_and_matches_golden_vector() -> None:
 
 
 def test_scalar_derivation_respects_curve_ranges() -> None:
-    """Derived scalars must remain within the open interval (0, order)."""
+    """Derived scalars must stay within each variant's expected interval."""
 
     prf_input = build_table10_prf_input(SAMPLE_COUNTER, k=FHNA_K)
     prf_output = prf_aes_256_ecb(SAMPLE_EIK, prf_input)
     prf_int = int.from_bytes(prf_output, "big", signed=False)
 
     legacy_curve = load_curve()
-    legacy_scalar = (prf_int % (int(legacy_curve.order) - 1)) + 1
-    assert 1 <= legacy_scalar < int(legacy_curve.order)
+    legacy_order: int = int(legacy_curve.order)
+    legacy_scalar = prf_int % legacy_order
+    assert 0 <= legacy_scalar < legacy_order
 
     modern_scalar = (prf_int % (P256_ORDER - 1)) + 1
     assert 1 <= modern_scalar < P256_ORDER
+    assert legacy_scalar != modern_scalar
+
+
+def test_legacy_scalar_reduction_rejects_p256_projection() -> None:
+    """Legacy EIDs must use modulo-n reduction, not the modern (n-1)+1 projection.
+
+    This regression test is intentionally verbose so a future AI-assisted edit
+    can diagnose the failure: if the assertion below flips, it means the legacy
+    branch started using the P-256 scalar projection, which shifts every
+    derived key by one and produces invalid EIDs for SECP160R1 accessories.
+    """
+
+    prf_input = build_table10_prf_input(SAMPLE_COUNTER, k=FHNA_K)
+    prf_output = prf_aes_256_ecb(SAMPLE_EIK, prf_input)
+    prf_int = int.from_bytes(prf_output, "big", signed=False)
+
+    legacy_curve = load_curve()
+    legacy_order: int = int(legacy_curve.order)
+    mod_n_scalar = prf_int % legacy_order
+    p256_projection_scalar = (prf_int % (legacy_order - 1)) + 1
+
+    mod_n_x_int = int((mod_n_scalar * legacy_curve.generator).x())
+    projected_x_int = int((p256_projection_scalar * legacy_curve.generator).x())
+
+    legacy_eid = generate_eid_variant(
+        SAMPLE_EIK,
+        SAMPLE_COUNTER,
+        EidVariant.LEGACY_SECP160R1_X20_BE,
+    )
+
+    assert legacy_eid == mod_n_x_int.to_bytes(LEGACY_EID_LENGTH, "big"), (
+        "Legacy EID derivation must keep the modulo-n scalar; using the P-256 "
+        "projection ((r % (n-1)) + 1) would shift the scalar and break the "
+        "derived SECP160R1 EIDs."
+    )
+    assert mod_n_x_int != projected_x_int
 
 
 def test_generate_eid_variants_match_golden_vectors() -> None:

--- a/tests/test_eid_resolver_variants.py
+++ b/tests/test_eid_resolver_variants.py
@@ -17,6 +17,7 @@ from custom_components.googlefindmy.eid_resolver import (
     iter_rotation_windows,
 )
 from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    FHNA_COUNTER_MASK,
     MODERN_EID_LENGTH,
     ROTATION_PERIOD,
     EidVariant,
@@ -70,6 +71,20 @@ def test_iter_rotation_windows_alignment_and_neighbors() -> None:
     assert with_neighbors == (2048, 1024, 3072)
 
 
+def test_iter_rotation_windows_skips_negative_neighbors() -> None:
+    """Neighbor expansion must never produce negative windows."""
+
+    windows = iter_rotation_windows(
+        target_time=0,
+        rotation_period=ROTATION_PERIOD,
+        window_range=(0,),
+        include_neighbors=True,
+    )
+    assert 0 in windows
+    assert ROTATION_PERIOD in windows
+    assert all(ts >= 0 for ts in windows)
+
+
 @pytest.mark.asyncio
 async def test_refresh_cache_populates_all_variants_and_bases(monkeypatch: pytest.MonkeyPatch) -> None:
     """Cache refresh should cover both curves, truncation, and byte-order options."""
@@ -107,6 +122,103 @@ async def test_refresh_cache_populates_all_variants_and_bases(monkeypatch: pytes
 
     bases = {meta["timestamp_basis"] for meta in resolver._lookup_metadata.values()}
     assert {"unix", "pair_date", "secrets_creation_date"}.issubset(bases)
+
+
+@pytest.mark.asyncio
+async def test_refresh_cache_skips_negative_neighbor_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero-valued candidates should not generate negative neighbor windows."""
+
+    resolver = _build_resolver(monkeypatch)
+    identity = DeviceIdentity(
+        registry_id="zeroed-id",
+        canonical_id="canonical-id",
+        identity_key=b"\x03" * 32,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-id",
+        fast_pair_model_id=None,
+        pair_date=0,
+        secrets_creation_date=0,
+    )
+
+    call_log: list[int] = []
+    original_generate = GoogleFindMyEIDResolver._generate_variant
+
+    def _guarded_generate(
+        self: GoogleFindMyEIDResolver,
+        key_bytes: bytes,
+        *,
+        time_counter: int,
+        variant: EidVariant,
+    ) -> bytes:
+        assert 0 <= time_counter <= FHNA_COUNTER_MASK
+        call_log.append(time_counter)
+        return original_generate(self, key_bytes, time_counter=time_counter, variant=variant)
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_generate_variant", _guarded_generate)
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return [identity]
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+    monkeypatch.setattr(time, "time", lambda: float(ROTATION_PERIOD))
+
+    await resolver._refresh_cache()
+
+    assert call_log
+    assert min(call_log) >= 0
+    assert all(ts <= FHNA_COUNTER_MASK for ts in call_log)
+
+
+@pytest.mark.asyncio
+async def test_refresh_cache_converts_millisecond_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Millisecond timestamps should normalize to seconds when plausible."""
+
+    resolver = _build_resolver(monkeypatch)
+    ms_candidate = 1_700_000_000_000
+    identity = DeviceIdentity(
+        registry_id="ms-id",
+        canonical_id="canonical-id",
+        identity_key=b"\x04" * 32,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-id",
+        fast_pair_model_id=None,
+        pair_date=None,
+        secrets_creation_date=ms_candidate,
+    )
+
+    call_log: list[int] = []
+    original_generate = GoogleFindMyEIDResolver._generate_variant
+
+    def _guarded_generate(
+        self: GoogleFindMyEIDResolver,
+        key_bytes: bytes,
+        *,
+        time_counter: int,
+        variant: EidVariant,
+    ) -> bytes:
+        assert 0 <= time_counter <= FHNA_COUNTER_MASK
+        call_log.append(time_counter)
+        return original_generate(self, key_bytes, time_counter=time_counter, variant=variant)
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_generate_variant", _guarded_generate)
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return [identity]
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+
+    await resolver._refresh_cache()
+
+    assert call_log
+    assert all(ts <= FHNA_COUNTER_MASK for ts in call_log)
+    assert any(
+        meta["timestamp_basis"] == "secrets_creation_date" and meta["rotation_timestamp"] <= FHNA_COUNTER_MASK
+        for meta in resolver._lookup_metadata.values()
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restore the legacy SECP160R1 scalar derivation to use modulo-n reduction and keep curve order typed
- refresh EID golden vector expectations to reflect the corrected legacy output
- add an explicit regression test that fails if the legacy branch reverts to the modern projection
- harden EID resolver window normalization to skip negative/overflow counters, convert plausible millisecond timestamps, and contain per-window failures with debug logging
- add regression coverage for zero/overflowing time bases and neighbor window generation

## Testing
- python -m ruff check --fix .
- python -m mypy --strict --install-types --non-interactive
- python -m pytest --cov -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d31b546c8329905d7c94de1f635c)