### PR TITLE
Add little-endian truncated EID variant

### DIFF
--- a/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
+++ b/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
@@ -53,6 +53,7 @@ class EidVariant(str, Enum):
     MODERN_P256_X32_BE = "modern_p256_x32_be"
     MODERN_P256_X20_TRUNC_BE = "modern_p256_x20_trunc_be"
     MODERN_P256_X32_LE_SCALAR = "modern_p256_x32_le_scalar"
+    MODERN_P256_X20_TRUNC_LE = "modern_p256_x20_trunc_le"
 
 
 def _normalize_time_counter(time_counter_u32: int, *, strict: bool) -> int:
@@ -251,6 +252,16 @@ def generate_eid_variant(
             strict=strict,
         )
         return _serialize_p256_x(scalar)
+
+    if variant is EidVariant.MODERN_P256_X20_TRUNC_LE:
+        full = generate_eid_variant(
+            eik,
+            counter_u32,
+            EidVariant.MODERN_P256_X32_LE_SCALAR,
+            k=k,
+            strict=strict,
+        )
+        return full[:LEGACY_EID_LENGTH]
 
     raise ValueError(f"Unsupported EID variant: {variant}")
 

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -154,7 +154,9 @@ class EIDGenerationLock:
         if not variant:
             scalar_endianness = str(payload.get("scalar_endianness") or "big")
             length = int(payload["eid_length"])
-            if length == LEGACY_EID_LENGTH:
+            if length == LEGACY_EID_LENGTH and scalar_endianness == "little":
+                variant = EidVariant.MODERN_P256_X20_TRUNC_LE.value
+            elif length == LEGACY_EID_LENGTH:
                 variant = EidVariant.LEGACY_SECP160R1_X20_BE.value
             elif scalar_endianness == "little":
                 variant = EidVariant.MODERN_P256_X32_LE_SCALAR.value
@@ -403,6 +405,7 @@ class GoogleFindMyEIDResolver:
                     EidVariant.MODERN_P256_X32_BE,
                     EidVariant.MODERN_P256_X20_TRUNC_BE,
                     EidVariant.MODERN_P256_X32_LE_SCALAR,
+                    EidVariant.MODERN_P256_X20_TRUNC_LE,
                 )
 
             counters: dict[int, str] = {}

--- a/tests/test_eid_generator_variants.py
+++ b/tests/test_eid_generator_variants.py
@@ -36,6 +36,7 @@ GOLDEN_VECTORS: dict[EidVariant, str] = {
     EidVariant.MODERN_P256_X32_BE: "72d4e4be2c6f3c1c5328f10d884ab58e0a474b06584d9c893b1e099853289cd9",
     EidVariant.MODERN_P256_X20_TRUNC_BE: "72d4e4be2c6f3c1c5328f10d884ab58e0a474b06",
     EidVariant.MODERN_P256_X32_LE_SCALAR: "acc9009d7630b76c89cfb17f126fe640508ba7e184528341cbdb217053dd4050",
+    EidVariant.MODERN_P256_X20_TRUNC_LE: "acc9009d7630b76c89cfb17f126fe640508ba7e1",
 }
 
 
@@ -138,7 +139,7 @@ def test_generate_eid_variants_match_golden_vectors() -> None:
         eid = generate_eid_variant(SAMPLE_EIK, SAMPLE_COUNTER, variant)
         assert eid.hex() == expected_hex
 
-        if variant is EidVariant.LEGACY_SECP160R1_X20_BE or variant is EidVariant.MODERN_P256_X20_TRUNC_BE:
+        if variant in (EidVariant.LEGACY_SECP160R1_X20_BE, EidVariant.MODERN_P256_X20_TRUNC_BE, EidVariant.MODERN_P256_X20_TRUNC_LE):
             assert len(eid) == LEGACY_EID_LENGTH
         else:
             assert len(eid) == MODERN_EID_LENGTH

--- a/tests/test_eid_resolver_variants.py
+++ b/tests/test_eid_resolver_variants.py
@@ -117,6 +117,7 @@ async def test_refresh_cache_populates_all_variants_and_bases(monkeypatch: pytes
             EidVariant.MODERN_P256_X32_BE.value,
             EidVariant.MODERN_P256_X20_TRUNC_BE.value,
             EidVariant.MODERN_P256_X32_LE_SCALAR.value,
+            EidVariant.MODERN_P256_X20_TRUNC_LE.value,
         }
     )
 


### PR DESCRIPTION
## Summary
- add the MODERN_P256_X20_TRUNC_LE EID variant derived by truncating the little-endian scalar path
- include the new variant in resolver cache population and lock deserialization so Android beacons are handled
- refresh generator and resolver tests with a golden vector and variant coverage for the truncated little-endian output

## Testing
- python -m ruff check --fix .
- python -m mypy --strict --install-types --non-interactive
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69466acf6cbc8329b4b92838caba5df9)