### PR TITLE
Expand EID resolver rotation window

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -431,8 +431,8 @@ class GoogleFindMyEIDResolver:
                 for ts in iter_rotation_windows(
                     normalized,
                     rotation_period=ROTATION_PERIOD,
-                    window_range=(0,),
-                    include_neighbors=True,
+                    window_range=range(-3, 4),
+                    include_neighbors=False,
                 ):
                     if ts < 0 or ts > FHNA_COUNTER_MASK:
                         continue


### PR DESCRIPTION
## Summary
- widen EID cache generation to cover +/- three rotation periods to reduce resolver misses from clock drift

## Testing
- python -m ruff check --fix .
- python -m mypy --strict --install-types --non-interactive .
- python -m pytest --cov -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69467db4e3dc832992f8c47429d0ccc9)