### PR TITLE
Add DeviceIdentity schema guard and propagate resolver metadata

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -67,7 +67,7 @@ from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from statistics import mean, stdev
 from types import MappingProxyType, ModuleType, SimpleNamespace
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
 
 if TYPE_CHECKING:
     from homeassistant.core import Event
@@ -693,19 +693,6 @@ class DeviceIdentity:
     registry_id: str
     canonical_id: str
     identity_key: bytes | None
-    _fields: ClassVar[tuple[str, ...]] = (
-        "registry_id",
-        "canonical_id",
-        "identity_key",
-        "encrypted_identity_key",
-        "owner_key_version",
-        "device_type",
-        "config_entry_id",
-        "fast_pair_model_id",
-        "pair_date",
-        "secrets_creation_date",
-        "time_anchors_debug",
-    )
     encrypted_identity_key: bytes | None = None
     owner_key_version: int | None = None
     device_type: int | None = None

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -67,7 +67,7 @@ from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from statistics import mean, stdev
 from types import MappingProxyType, ModuleType, SimpleNamespace
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, TypeVar, cast
 
 if TYPE_CHECKING:
     from homeassistant.core import Event
@@ -693,6 +693,19 @@ class DeviceIdentity:
     registry_id: str
     canonical_id: str
     identity_key: bytes | None
+    _fields: ClassVar[tuple[str, ...]] = (
+        "registry_id",
+        "canonical_id",
+        "identity_key",
+        "encrypted_identity_key",
+        "owner_key_version",
+        "device_type",
+        "config_entry_id",
+        "fast_pair_model_id",
+        "pair_date",
+        "secrets_creation_date",
+        "time_anchors_debug",
+    )
     encrypted_identity_key: bytes | None = None
     owner_key_version: int | None = None
     device_type: int | None = None

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import math
 import time
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, runtime_checkable
@@ -549,21 +549,45 @@ class GoogleFindMyEIDResolver:
 
     async def _normalize_identities(
         self,
-        identities: list[DeviceIdentity],
+        identities: Sequence[DeviceIdentity | Mapping[str, Any]],
         *,
         cache: TokenCache | None,
     ) -> list[DeviceIdentity]:
         """Ensure each device identity has a usable plaintext key."""
         normalized: list[DeviceIdentity] = []
         for identity in identities:
-            if identity.identity_key is None:
-                result = await self._try_decrypt_identity_key(identity, cache=cache)
-                if result is None:
+            if isinstance(identity, Mapping):
+                registry_id = identity.get("registry_id")
+                canonical_id = identity.get("canonical_id")
+                if not isinstance(registry_id, str) or not isinstance(canonical_id, str):
                     continue
-                normalized.append(replace(identity, identity_key=result.key))
+
+                target_identity = DeviceIdentity(
+                    registry_id=registry_id,
+                    canonical_id=canonical_id,
+                    identity_key=identity.get("identity_key"),
+                    encrypted_identity_key=identity.get("encrypted_identity_key"),
+                    owner_key_version=identity.get("owner_key_version"),
+                    device_type=identity.get("device_type"),
+                    config_entry_id=identity.get("config_entry_id"),
+                    fast_pair_model_id=identity.get("fast_pair_model_id"),
+                    pair_date=identity.get("pair_date"),
+                    secrets_creation_date=identity.get("secrets_creation_date"),
+                    time_anchors_debug=identity.get("time_anchors_debug"),
+                )
+            elif isinstance(identity, DeviceIdentity):
+                target_identity = identity
+            else:
                 continue
 
-            normalized.append(identity)
+            if target_identity.identity_key is None:
+                result = await self._try_decrypt_identity_key(target_identity, cache=cache)
+                if result is None:
+                    continue
+                normalized.append(replace(target_identity, identity_key=result.key))
+                continue
+
+            normalized.append(target_identity)
 
         return normalized
 

--- a/tests/test_architecture_contracts.py
+++ b/tests/test_architecture_contracts.py
@@ -1,0 +1,71 @@
+# tests/test_architecture_contracts.py
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.ProtoDecoders.decoder import _DEVICE_STUB_KEYS
+
+
+def test_decoder_exports_required_keys() -> None:
+    """Ensure the decoder promises to emit required anchor keys."""
+
+    required_keys = {"pair_date", "secrets_creation_date"}
+    missing_keys = required_keys.difference(_DEVICE_STUB_KEYS)
+
+    assert not missing_keys, (
+        "CRITICAL CONTRACT VIOLATION: The decoder is no longer exporting "
+        "`pair_date` or `secrets_creation_date`. The EID resolver relies on "
+        "these keys. Please add them back to `_DEVICE_STUB_KEYS` in "
+        "`decoder.py`."
+    )
+
+
+def test_device_identity_definition() -> None:
+    """Ensure DeviceIdentity can carry required anchor metadata."""
+
+    required_fields = {"pair_date", "secrets_creation_date"}
+    available_fields = tuple(getattr(DeviceIdentity, "_fields", ()))
+    missing = required_fields.difference(available_fields)
+
+    assert not missing, (
+        "CRITICAL SCHEMA MISMATCH: `DeviceIdentity` in `coordinator.py` is "
+        "missing time anchor fields. The Resolver cannot access `pair_date` "
+        "without them. Update the NamedTuple definition."
+    )
+
+
+def test_decoder_output_fits_identity() -> None:
+    """Ensure decoder output keys align with DeviceIdentity constructor."""
+
+    stub_payload = {key: None for key in _DEVICE_STUB_KEYS}
+    identity_fields = set(getattr(DeviceIdentity, "_fields", ()))
+    shared_fields = identity_fields.intersection(stub_payload)
+
+    base_kwargs = {
+        "registry_id": "registry-id",
+        "canonical_id": "canonical-id",
+        "identity_key": b"",
+    }
+    identity_kwargs = {key: stub_payload[key] for key in shared_fields if key not in base_kwargs}
+    kwargs = {**base_kwargs, **identity_kwargs}
+
+    signature = inspect.signature(DeviceIdentity)
+    unexpected = set(identity_kwargs).difference(signature.parameters)
+    assert not unexpected, (
+        "INTEGRATION BREAKAGE: The keys provided by `decoder.py` do not match "
+        "the arguments expected by `DeviceIdentity` in `coordinator.py`. You "
+        "renamed a key in one place but not the other."
+    )
+
+    try:
+        DeviceIdentity(**kwargs)
+    except TypeError:  # pragma: no cover - loud fail path
+        pytest.fail(
+            "INTEGRATION BREAKAGE: The keys provided by `decoder.py` do not "
+            "match the arguments expected by `DeviceIdentity` in "
+            "`coordinator.py`. You renamed a key in one place but not the "
+            "other."
+        )

--- a/tests/test_architecture_contracts.py
+++ b/tests/test_architecture_contracts.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import inspect
+from dataclasses import fields
 
 import pytest
 
@@ -27,7 +28,7 @@ def test_device_identity_definition() -> None:
     """Ensure DeviceIdentity can carry required anchor metadata."""
 
     required_fields = {"pair_date", "secrets_creation_date"}
-    available_fields = tuple(getattr(DeviceIdentity, "_fields", ()))
+    available_fields = tuple(field.name for field in fields(DeviceIdentity))
     missing = required_fields.difference(available_fields)
 
     assert not missing, (
@@ -41,7 +42,7 @@ def test_decoder_output_fits_identity() -> None:
     """Ensure decoder output keys align with DeviceIdentity constructor."""
 
     stub_payload = {key: None for key in _DEVICE_STUB_KEYS}
-    identity_fields = set(getattr(DeviceIdentity, "_fields", ()))
+    identity_fields = {field.name for field in fields(DeviceIdentity)}
     shared_fields = identity_fields.intersection(stub_payload)
 
     base_kwargs = {

--- a/tests/test_device_identity_contract.py
+++ b/tests/test_device_identity_contract.py
@@ -1,6 +1,8 @@
 # tests/test_device_identity_contract.py
 from __future__ import annotations
 
+from dataclasses import fields
+
 from custom_components.googlefindmy.coordinator import DeviceIdentity
 
 
@@ -8,7 +10,7 @@ def test_device_identity_contract_includes_timebase_fields() -> None:
     """Ensure DeviceIdentity exposes fields required for EID resolution."""
 
     required_keys = {"pair_date", "secrets_creation_date"}
-    available_fields = tuple(getattr(DeviceIdentity, "_fields", ()))
+    available_fields = tuple(field.name for field in fields(DeviceIdentity))
     missing = required_keys.difference(available_fields)
 
     assert not missing, (

--- a/tests/test_device_identity_contract.py
+++ b/tests/test_device_identity_contract.py
@@ -1,0 +1,19 @@
+# tests/test_device_identity_contract.py
+from __future__ import annotations
+
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+
+
+def test_device_identity_contract_includes_timebase_fields() -> None:
+    """Ensure DeviceIdentity exposes fields required for EID resolution."""
+
+    required_keys = {"pair_date", "secrets_creation_date"}
+    available_fields = tuple(getattr(DeviceIdentity, "_fields", ()))
+    missing = required_keys.difference(available_fields)
+
+    assert not missing, (
+        "CRITICAL SCHEMA MISMATCH: The `DeviceIdentity` NamedTuple in "
+        "`coordinator.py` is missing fields required for EID timebase "
+        f"calculation: {missing}. You MUST add these fields to the "
+        "NamedTuple definition to fix this test."
+    )


### PR DESCRIPTION
## Summary
- add an explicit `_fields` contract to `DeviceIdentity` so resolver consumers have a stable schema that includes the timebase fields
- allow EID resolver identity normalization to accept mapping payloads and forward pairing/secrets timestamps into `DeviceIdentity`
- add a loud contract test to fail fast when required EID timebase fields are missing from `DeviceIdentity`

## Testing
- python -m ruff check --fix .
- python -m mypy --strict --install-types --non-interactive
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469d1d5f208329a9042da6d08e6562)