### PR TITLE
Improve EID windowing for timezone drift

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -23,6 +23,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import DeviceIdentity, GoogleFindMyCoordinator
@@ -60,6 +61,7 @@ MODERN_FRAME_TYPE = 0x41
 RAW_HEADER_LENGTH = 1
 SERVICE_DATA_OFFSET = 8
 AESGCM_NONCE_LENGTH = 12
+MIN_UNIX_WINDOW_SIZE = 128
 
 EID_LENGTH = LEGACY_EID_LENGTH
 LOCK_TTL_SECONDS = 7 * 24 * 60 * 60
@@ -398,7 +400,12 @@ class GoogleFindMyEIDResolver:
                 provisioning_counter = max(0, now_unix - identity.pair_date)
             drift_seconds = provisioning_counter * 0.00005
             drift_windows = math.ceil(drift_seconds / ROTATION_PERIOD)
-            total_window = min(3 + drift_windows, max_window)
+            tz_offset = dt_util.now().utcoffset()
+            tz_windows = (
+                math.ceil(abs(tz_offset.total_seconds()) / ROTATION_PERIOD)
+                if tz_offset
+                else 0
+            )
 
             def _register_variant(
                 eid_bytes: bytes,
@@ -464,6 +471,12 @@ class GoogleFindMyEIDResolver:
                 )
                 if normalized is None:
                     continue
+
+                if basis == "unix":
+                    smart_window = 3 + drift_windows + tz_windows
+                    total_window = max(MIN_UNIX_WINDOW_SIZE, smart_window)
+                else:
+                    total_window = min(3 + drift_windows, max_window)
 
                 for ts in iter_rotation_windows(
                     normalized,

--- a/tests/test_architecture_contracts.py
+++ b/tests/test_architecture_contracts.py
@@ -6,6 +6,7 @@ from dataclasses import fields
 
 import pytest
 
+from custom_components.googlefindmy import eid_resolver
 from custom_components.googlefindmy.coordinator import DeviceIdentity
 from custom_components.googlefindmy.ProtoDecoders.decoder import _DEVICE_STUB_KEYS
 
@@ -86,3 +87,13 @@ def test_decoder_output_fits_identity() -> None:
             "`coordinator.py`. You renamed a key in one place but not the "
             "other."
         )
+
+
+def test_resolver_safety_constants_exist() -> None:
+    """Ensure Deep Scan safety constants remain present and conservative."""
+
+    value = getattr(eid_resolver, "MIN_UNIX_WINDOW_SIZE", None)
+    assert isinstance(value, int) and value >= 128, (
+        "CRITICAL SAFETY: The Deep Scan constant `MIN_UNIX_WINDOW_SIZE` is "
+        "missing or dangerously small."
+    )


### PR DESCRIPTION
## Summary
- add timezone-aware window calculation for unix-based EID windows and enforce a minimum search window
- introduce timezone offset handling and constant for unix window sizing
- add architecture contract test to guard the MIN_UNIX_WINDOW_SIZE safety constant

## Testing
- python -m ruff check custom_components/googlefindmy/eid_resolver.py
- python -m ruff check tests/test_architecture_contracts.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694717e966808329b7530ae320f6dd12)