### PR TITLE
Refine EID resolver time windows

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -61,7 +61,18 @@ MODERN_FRAME_TYPE = 0x41
 RAW_HEADER_LENGTH = 1
 SERVICE_DATA_OFFSET = 8
 AESGCM_NONCE_LENGTH = 12
-MIN_UNIX_WINDOW_SIZE = 128
+
+# Strategy Configuration
+# ENABLE_ABSOLUTE_UNIX_BASIS: If True, scans for EIDs based on absolute Unix time (Deep Scan).
+# Proven unreliable for standard trackers (Motorola/Pebblebee), so disabled by default.
+ENABLE_ABSOLUTE_UNIX_BASIS: bool = False
+
+# MIN_UNIX_WINDOW_SIZE: Safety net for absolute scans. 128 * 1024s ~= 36h.
+MIN_UNIX_WINDOW_SIZE: int = 128
+
+# MIN_RELATIVE_WINDOW_SIZE: Safety net for relative scans (pair_date).
+# 5 * 1024s ~= 85 mins. Essential to absorb 1h Daylight Saving Time (DST) shifts.
+MIN_RELATIVE_WINDOW_SIZE: int = 5
 
 EID_LENGTH = LEGACY_EID_LENGTH
 LOCK_TTL_SECONDS = 7 * 24 * 60 * 60
@@ -200,7 +211,7 @@ class EIDGenerationLock:
         )
 
 
-def _normalize_counter_candidate(candidate_value: int, *, basis: str) -> int | None:
+def _normalize_counter_candidate(candidate_value: object, *, basis: str) -> int | None:
     """Return a sane u32 counter candidate or ``None`` when unusable."""
 
     if not isinstance(candidate_value, int) or candidate_value < 0:
@@ -376,13 +387,6 @@ class GoogleFindMyEIDResolver:
         lookup: dict[bytes, EIDMatch] = {}
         lookup_metadata: dict[bytes, dict[str, Any]] = {}
 
-        counter_bases: tuple[tuple[str, str], ...] = (
-            ("secrets_creation_date", "secrets_creation_date"),
-            ("pair_date", "pair_date"),
-            ("entity_time", "entity_time"),
-            ("unix", "unix"),
-        )
-
         max_window = math.ceil((24 * 60 * 60) / ROTATION_PERIOD)
 
         for identity in identities:
@@ -467,45 +471,88 @@ class GoogleFindMyEIDResolver:
                     EidVariant.MODERN_P256_X20_TRUNC_LE,
                 )
 
+            # 1. Define explicit time bases to allow iteration over all strategies.
+            # - "unix": Absolute time (Strategy A)
+            # - "pair_date" / "secrets...": Relative time (Strategy B & C)
+            counter_bases: tuple[tuple[str, str], ...] = (
+                ("unix", "unix"),
+                ("pair_date", "pair_date"),
+                ("secrets_creation_date", "secrets_creation_date"),
+            )
+
+            # 2. Logic Restoration (v3.31): Smart Drift Calculation.
+            # We determine the device's "age" using the freshest available anchor
+            # to estimate the crystal drift (50ppm) more accurately.
+            anchor_candidates = []
+            if isinstance(identity.pair_date, int) and identity.pair_date > 0:
+                anchor_candidates.append(identity.pair_date)
+            if (
+                isinstance(identity.secrets_creation_date, int)
+                and identity.secrets_creation_date > 0
+            ):
+                anchor_candidates.append(identity.secrets_creation_date)
+
+            best_anchor = max(anchor_candidates) if anchor_candidates else 0
+            provisioning_counter = max(0, now_unix - best_anchor) if best_anchor > 0 else 0
+
+            # Calculate expected drift based on age (50ppm)
+            drift_seconds = provisioning_counter * 0.00005
+            drift_windows = math.ceil(drift_seconds / ROTATION_PERIOD)
+
             counter_windows: list[tuple[int, str]] = []
+
+            # 3. Execution Loop: Apply specific math per strategy
             for basis, label in counter_bases:
                 candidate_value: int | None = None
-                if basis == "unix":
-                    candidate_value = now_unix
-                elif basis == "pair_date":
-                    anchor_value = (
-                        _normalize_counter_candidate(identity.pair_date, basis=basis)
-                        if isinstance(identity.pair_date, int)
-                        else None
-                    )
-                    if isinstance(anchor_value, int):
-                        candidate_value = now_unix - anchor_value
-                elif basis == "entity_time":
-                    candidate_value = getattr(identity, "entity_time", None)
-                else:
-                    anchor_value = (
-                        _normalize_counter_candidate(
-                            identity.secrets_creation_date, basis=basis
-                        )
-                        if isinstance(identity.secrets_creation_date, int)
-                        else None
-                    )
-                    if isinstance(anchor_value, int):
-                        candidate_value = now_unix - anchor_value
+                total_window: int = 0
 
-                normalized = (
-                    _normalize_counter_candidate(candidate_value, basis=basis)
-                    if isinstance(candidate_value, int)
-                    else None
-                )
+                if basis == "unix":
+                    # STRATEGY A: Absolute Time (Fallback)
+                    # Targets devices with a Real-Time Clock (RTC).
+                    # Disabled by default as it causes false negatives on simple trackers.
+                    if not ENABLE_ABSOLUTE_UNIX_BASIS:
+                        continue
+
+                    candidate_value = now_unix
+
+                    # Calculate timezone offset to catch wall-clock synced devices
+                    try:
+                        tz_offset = dt_util.now().utcoffset()
+                        tz_windows = (
+                            int(math.ceil(abs(tz_offset.total_seconds()) / ROTATION_PERIOD))
+                            if tz_offset
+                            else 0
+                        )
+                    except Exception:
+                        tz_windows = 0
+
+                    # Use massive window (Deep Scan) + Drift + Timezone
+                    total_window = max(MIN_UNIX_WINDOW_SIZE, 3 + drift_windows + tz_windows)
+
+                else:
+                    # STRATEGY B & C: Relative Time (Primary)
+                    # Applies to "pair_date" and "secrets_creation_date".
+                    # Targets standard trackers counting seconds since boot/pairing.
+                    # MATH FIX: We calculate ELAPSED time (now - anchor) to match v3.31 logic.
+
+                    raw_anchor = getattr(identity, basis, None)
+                    anchor_value = _normalize_counter_candidate(raw_anchor, basis=basis)
+
+                    if anchor_value is None:
+                        continue
+
+                    # Critical: Relative calculation (now - anchor)
+                    candidate_value = now_unix - anchor_value
+
+                    # ROBUSTNESS: Add safety buffer for DST shifts.
+                    # If the server jumps 1h (DST), the relative diff changes by 3600s.
+                    # MIN_RELATIVE_WINDOW_SIZE (5) absorbs this jump.
+                    total_window = min(MIN_RELATIVE_WINDOW_SIZE + drift_windows, max_window)
+
+                # 4. Generate windows for the calculated candidate
+                normalized = _normalize_counter_candidate(candidate_value, basis=basis)
                 if normalized is None:
                     continue
-
-                if basis == "unix":
-                    smart_window = 3 + drift_windows + tz_windows
-                    total_window = max(MIN_UNIX_WINDOW_SIZE, smart_window)
-                else:
-                    total_window = min(3 + drift_windows, max_window)
 
                 for ts in iter_rotation_windows(
                     normalized,

--- a/tests/test_eid_provisioning_counter.py
+++ b/tests/test_eid_provisioning_counter.py
@@ -57,6 +57,10 @@ async def test_resolver_matches_unix_timebase(monkeypatch: pytest.MonkeyPatch) -
         return [identity]
 
     monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
+    monkeypatch.setattr(
         GoogleFindMyEIDResolver,
         "_collect_device_secrets",
         _collect,

--- a/tests/test_eid_resolver.py
+++ b/tests/test_eid_resolver.py
@@ -62,6 +62,10 @@ async def test_resolver_extracts_service_data_legacy(monkeypatch: pytest.MonkeyP
     async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
         return [identity]
 
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
     monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
     monkeypatch.setattr(
         GoogleFindMyEIDResolver,
@@ -118,6 +122,10 @@ async def test_resolver_saves_locks_via_store(monkeypatch: pytest.MonkeyPatch) -
     async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
         return [identity]
 
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
     monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
     monkeypatch.setattr(
         GoogleFindMyEIDResolver,
@@ -171,6 +179,10 @@ async def test_resolver_handles_raw_eid(monkeypatch: pytest.MonkeyPatch) -> None
     async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
         return [identity]
 
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
     monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
     monkeypatch.setattr(
         GoogleFindMyEIDResolver,

--- a/tests/test_eid_resolver_logic.py
+++ b/tests/test_eid_resolver_logic.py
@@ -1,0 +1,96 @@
+# tests/test_eid_resolver_logic.py
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import (
+    ROTATION_PERIOD,
+    GoogleFindMyEIDResolver,
+)
+
+
+@pytest.mark.asyncio
+async def test_relative_time_calculation_uses_elapsed_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure relative bases compute now - anchor (v3.31 behavior)."""
+
+    now_ts = 20_000
+    pair_ts = 18_000
+    expected_counter = now_ts - pair_ts
+    aligned_expected = expected_counter - (expected_counter % ROTATION_PERIOD)
+
+    identity = DeviceIdentity(
+        registry_id="test-device",
+        canonical_id="canonical",
+        identity_key=b"123",
+        config_entry_id="entry-id",
+        pair_date=pair_ts,
+    )
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = MagicMock()
+    resolver._locks = {}
+    resolver._ensure_cache_defaults()
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_generate_variant",
+        MagicMock(return_value=b"mocked_eid"),
+    )
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return [identity]
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+    monkeypatch.setattr(time, "time", lambda: float(now_ts))
+
+    await resolver._refresh_cache()
+
+    calls = [call.kwargs["time_counter"] for call in resolver._generate_variant.call_args_list]
+    assert aligned_expected in calls, f"Expected counter {aligned_expected} not found in {calls}"
+
+
+@pytest.mark.asyncio
+async def test_unix_basis_disabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify absolute unix scans are skipped when the flag is False."""
+
+    now_ts = 50_000
+    identity = DeviceIdentity(
+        registry_id="test-device",
+        canonical_id="canonical",
+        identity_key=b"123",
+        config_entry_id="entry-id",
+    )
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = MagicMock()
+    resolver._locks = {}
+    resolver._ensure_cache_defaults()
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_generate_variant", MagicMock())
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return [identity]
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+    monkeypatch.setattr(time, "time", lambda: float(now_ts))
+
+    await resolver._refresh_cache()
+
+    assert resolver._generate_variant.call_count == 0

--- a/tests/test_eid_resolver_variants.py
+++ b/tests/test_eid_resolver_variants.py
@@ -13,6 +13,7 @@ import pytest
 from custom_components.googlefindmy.coordinator import DeviceIdentity
 from custom_components.googlefindmy.eid_resolver import (
     LOCK_TTL_SECONDS,
+    MIN_RELATIVE_WINDOW_SIZE,
     EIDGenerationLock,
     GoogleFindMyEIDResolver,
     iter_rotation_windows,
@@ -135,7 +136,7 @@ async def test_refresh_cache_uses_relative_timebases(monkeypatch: pytest.MonkeyP
         drift_seconds = provisioning_counter * 0.00005
         drift_windows = math.ceil(drift_seconds / ROTATION_PERIOD)
         max_window = math.ceil((24 * 60 * 60) / ROTATION_PERIOD)
-        total_window = min(3 + drift_windows, max_window)
+        total_window = min(MIN_RELATIVE_WINDOW_SIZE + drift_windows, max_window)
         elapsed = base_now - anchor
         rotation_start = elapsed - (elapsed % ROTATION_PERIOD)
         window_delta = total_window * ROTATION_PERIOD
@@ -155,6 +156,10 @@ async def test_refresh_cache_populates_all_variants_and_bases(monkeypatch: pytes
     """Cache refresh should cover both curves, truncation, and byte-order options."""
 
     resolver = _build_resolver(monkeypatch)
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
     identity = DeviceIdentity(
         registry_id="registry-id",
         canonical_id="canonical-id",
@@ -294,6 +299,10 @@ async def test_resolve_eid_persists_variant_and_format(monkeypatch: pytest.Monke
     """Resolver hits should persist the chosen variant and advertisement format."""
 
     resolver = _build_resolver(monkeypatch)
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
     identity = DeviceIdentity(
         registry_id="registry-id",
         canonical_id="canonical-id",


### PR DESCRIPTION
## Summary
- add strategy flags for EID resolver time bases, restoring relative elapsed math with DST safety buffers and optional unix deep-scan fallback
- update resolver cache logic to size drift windows from the freshest anchor and apply DST-protected relative windowing
- extend resolver tests to cover the new strategy defaults and relative counter expectations

## Testing
- python -m ruff check --fix
- python -m mypy --strict --install-types --non-interactive
- python -m pytest --cov -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947347ccb8c8329b77b972ac9c7f1d6)