### PR TITLE
Optimize EID resolver time basis handling

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -348,6 +348,23 @@ class GoogleFindMyEIDResolver:
 
         await self._store.async_save([lock.to_dict() for lock in self._locks.values()])
 
+    def _schedule_lock_save(self) -> None:
+        """Schedule persistence of EID locks."""
+
+        try:
+            if hasattr(self.hass, "async_create_background_task"):
+                self.hass.async_create_background_task(
+                    self._async_save_locks(),
+                    name="googlefindmy_eid_resolver_save",
+                )
+            else:
+                self.hass.async_create_task(
+                    self._async_save_locks(),
+                    name="googlefindmy_eid_resolver_save",
+                )
+        except Exception as err:  # pragma: no cover - defensive log
+            _LOGGER.error("Failed to schedule EID lock persistence: %s", err)
+
     def _purge_stale_locks(self, *, now: int) -> None:
         """Drop expired generation locks to keep cache fresh."""
 
@@ -397,6 +414,7 @@ class GoogleFindMyEIDResolver:
         max_window = math.ceil((24 * 60 * 60) / ROTATION_PERIOD)
 
         for identity in identities:
+            basis_hint = self._known_timebases.get(identity.registry_id)
             if (
                 not identity.config_entry_id
                 or identity.identity_key is None
@@ -410,6 +428,7 @@ class GoogleFindMyEIDResolver:
 
             key_bytes = bytes(identity.identity_key)
             lock = self._locks.get(identity.registry_id)
+            locked_variant: EidVariant | None = None
 
             rotation_ts: int | None = None
             if lock is not None:
@@ -420,7 +439,16 @@ class GoogleFindMyEIDResolver:
                     and not isinstance(raw_rotation_ts, bool)
                     else None
                 )
+                lock_time_basis = _normalize_optional_string(lock.time_basis)
+                if lock_time_basis:
+                    basis_hint = lock_time_basis
+                    self._known_timebases[identity.registry_id] = lock_time_basis
+
                 is_legacy = rotation_ts is None
+                try:
+                    locked_variant = EidVariant(lock.variant)
+                except ValueError:
+                    locked_variant = EidVariant.MODERN_P256_X32_BE
 
                 if is_legacy:
                     _LOGGER.warning(
@@ -439,27 +467,18 @@ class GoogleFindMyEIDResolver:
                         clean_canonical_id,
                     )
                     lock.canonical_id = clean_canonical_id
-                    save_task = getattr(self.hass, "async_create_task", None)
-                    if callable(save_task) and hasattr(self, "_async_save_locks"):
-                        try:
-                            save_coro = self._async_save_locks()
-                            scheduled = save_task(save_coro)
-                            if scheduled is None:
-                                save_coro.close()
-                            elif asyncio.iscoroutine(scheduled):
-                                asyncio.create_task(scheduled)
-                        except Exception:  # pragma: no cover
-                            pass
+                    self._schedule_lock_save()
 
-            def _register_variant(
+            def _register_variant(  # noqa: PLR0913
                 eid_bytes: bytes,
                 *,
                 variant: EidVariant,
                 ts: int,
                 time_basis: str,
                 reversed_flag: bool,
+                computed_offset_seconds: int,
             ) -> None:
-                offset = int(ts - now_unix)
+                offset = computed_offset_seconds
                 match = EIDMatch(
                     device_id=identity.registry_id,
                     config_entry_id=str(identity.config_entry_id),
@@ -496,11 +515,7 @@ class GoogleFindMyEIDResolver:
                 }
 
             variants: tuple[EidVariant, ...]
-            if lock is not None:
-                try:
-                    locked_variant = EidVariant(lock.variant)
-                except ValueError:
-                    locked_variant = EidVariant.MODERN_P256_X32_BE
+            if locked_variant is not None:
                 variants = (locked_variant,)
             else:
                 variants = (
@@ -514,7 +529,7 @@ class GoogleFindMyEIDResolver:
             # 1. Define explicit time bases to allow iteration over all strategies.
             # - "unix": Absolute time (Strategy A)
             # - "pair_date" / "secrets...": Relative time (Strategy B & C)
-            counter_windows: list[tuple[int, str]] = []
+            counter_windows: list[tuple[int, str, int]] = []
 
             if rotation_ts is not None and lock is not None:
                 time_since_lock = max(0, now_unix - lock.created_at)
@@ -524,7 +539,8 @@ class GoogleFindMyEIDResolver:
                     window_ts = rotation_ts + (offset_periods * ROTATION_PERIOD)
                     if window_ts < 0:
                         continue
-                    counter_windows.append((window_ts, "lock_tracking"))
+                    semantic_offset = window_ts - now_unix
+                    counter_windows.append((window_ts, "lock_tracking", semantic_offset))
             else:
                 counter_bases: tuple[tuple[str, str], ...] = (
                     ("unix", "unix"),
@@ -554,7 +570,14 @@ class GoogleFindMyEIDResolver:
                 drift_windows = math.ceil(drift_seconds / ROTATION_PERIOD)
 
                 # 3. Execution Loop: Apply specific math per strategy
-                for basis, label in counter_bases:
+                known_basis = basis_hint
+                filtered_bases = (
+                    tuple((basis, label) for basis, label in counter_bases if basis == known_basis)
+                    if known_basis
+                    else counter_bases
+                )
+
+                for basis, label in filtered_bases:
                     candidate_value: int | None = None
                     total_window: int = 0
 
@@ -626,9 +649,10 @@ class GoogleFindMyEIDResolver:
                     ):
                         if ts < 0:
                             continue
-                        counter_windows.append((ts, label))
+                        semantic_offset = ts - normalized
+                        counter_windows.append((ts, label, semantic_offset))
 
-            for window_ts, time_basis in counter_windows:
+            for window_ts, time_basis, semantic_offset in counter_windows:
                 for variant in variants:
                     try:
                         eid_bytes = self._generate_variant(
@@ -652,6 +676,7 @@ class GoogleFindMyEIDResolver:
                         ts=window_ts,
                         time_basis=time_basis,
                         reversed_flag=False,
+                        computed_offset_seconds=semantic_offset,
                     )
                     _register_variant(
                         eid_bytes[::-1],
@@ -659,6 +684,7 @@ class GoogleFindMyEIDResolver:
                         ts=window_ts,
                         time_basis=time_basis,
                         reversed_flag=True,
+                        computed_offset_seconds=semantic_offset,
                     )
 
         self._lookup = lookup
@@ -1015,20 +1041,7 @@ class GoogleFindMyEIDResolver:
                 self._locks[match.device_id] = lock
                 self._persisted_locks[match.device_id] = lock
                 self._last_lock_confirmation[match.device_id] = int(time.time())
-                save_task = getattr(self.hass, "async_create_task", None)
-                if callable(save_task) and hasattr(self, "_store"):
-                    try:
-                        save_coro = self._async_save_locks()
-                        scheduled = save_task(save_coro)
-                        if scheduled is None:
-                            save_coro.close()
-                        elif asyncio.iscoroutine(scheduled):
-                            asyncio.create_task(scheduled)
-                    except Exception:  # pragma: no cover - defensive
-                        _LOGGER.debug(
-                            "Failed to schedule lock persistence for %s",
-                            match.device_id,
-                        )
+                self._schedule_lock_save()
 
             self._known_offsets[match.device_id] = match.time_offset
             self._known_advertisement_reversed[match.device_id] = match.is_reversed
@@ -1052,7 +1065,9 @@ class GoogleFindMyEIDResolver:
         )
         return None
 
-    def _extract_candidates(self, payload: bytes) -> tuple[list[bytes], int | None]:
+    def _extract_candidates(  # noqa: PLR0912
+        self, payload: bytes
+    ) -> tuple[list[bytes], int | None]:
         """Extract possible EID slices from a BLE payload."""
 
         length = len(payload)
@@ -1087,24 +1102,38 @@ class GoogleFindMyEIDResolver:
             frame_type = payload[0]
             if frame_type in (FMDN_FRAME_TYPE, MODERN_FRAME_TYPE):
                 observed_frame = frame_type
-                expected_len = (
-                    LEGACY_EID_LENGTH
-                    if frame_type == FMDN_FRAME_TYPE
-                    else MODERN_EID_LENGTH
-                )
-                if length >= RAW_HEADER_LENGTH + expected_len:
+                modern_required_length = RAW_HEADER_LENGTH + MODERN_EID_LENGTH
+
+                def _legacy_payload_start() -> int:
+                    """Return the starting index for a legacy-length payload slice."""
+
+                    if (
+                        length == RAW_HEADER_LENGTH + LEGACY_EID_LENGTH + 1
+                        and payload[RAW_HEADER_LENGTH] == 0
+                        and payload[-1] != 0
+                    ):
+                        return RAW_HEADER_LENGTH + 1
+                    return RAW_HEADER_LENGTH
+
+                if frame_type == FMDN_FRAME_TYPE and length >= RAW_HEADER_LENGTH + LEGACY_EID_LENGTH:
+                    payload_start = _legacy_payload_start()
                     candidates.append(
-                        payload[RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + expected_len]
+                        payload[payload_start : payload_start + LEGACY_EID_LENGTH]
                     )
+                elif frame_type == MODERN_FRAME_TYPE:
+                    if length >= modern_required_length:
+                        candidates.append(
+                            payload[RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + MODERN_EID_LENGTH]
+                        )
+                    elif RAW_HEADER_LENGTH + LEGACY_EID_LENGTH <= length <= RAW_HEADER_LENGTH + LEGACY_EID_LENGTH + 1:
+                        payload_start = _legacy_payload_start()
+                        candidates.append(
+                            payload[payload_start : payload_start + LEGACY_EID_LENGTH]
+                        )
+                    else:
+                        return candidates, observed_frame
 
         if not candidates and length > LEGACY_EID_LENGTH:
-            if (
-                length > RAW_HEADER_LENGTH
-                and payload[0] == MODERN_FRAME_TYPE
-                and length < RAW_HEADER_LENGTH + MODERN_EID_LENGTH
-            ):
-                return candidates, observed_frame
-
             window = min(length - LEGACY_EID_LENGTH + 1, 64)
             for i in range(window):
                 slice_20 = payload[i : i + LEGACY_EID_LENGTH]

--- a/tests/test_eid_resolver_extraction.py
+++ b/tests/test_eid_resolver_extraction.py
@@ -1,0 +1,46 @@
+# tests/test_eid_resolver_extraction.py
+"""EID extraction edge cases, including truncated modern frames."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.googlefindmy.eid_resolver import (
+    LEGACY_EID_LENGTH,
+    MODERN_FRAME_TYPE,
+    GoogleFindMyEIDResolver,
+)
+
+
+def test_extract_truncated_modern_frame() -> None:
+    """Modern frame header with legacy-length payload should still yield a candidate."""
+
+    hass = MagicMock()
+    resolver = GoogleFindMyEIDResolver(hass)
+
+    header = bytes([MODERN_FRAME_TYPE, 0x00])
+    fake_eid_data = b"\xAA" * LEGACY_EID_LENGTH
+    payload = header + fake_eid_data
+
+    candidates, frame_type = resolver._extract_candidates(payload)
+
+    assert frame_type == MODERN_FRAME_TYPE
+    assert len(candidates) == 1
+    assert candidates[0] == fake_eid_data
+    assert len(candidates[0]) == LEGACY_EID_LENGTH
+
+
+def test_extract_standard_legacy_frame() -> None:
+    """Legacy frame extraction should remain unaffected."""
+
+    hass = MagicMock()
+    resolver = GoogleFindMyEIDResolver(hass)
+
+    payload = bytes([0x40, 0x00]) + (b"\xBB" * LEGACY_EID_LENGTH)
+
+    candidates, frame_type = resolver._extract_candidates(payload)
+
+    assert frame_type == 0x40
+    assert len(candidates) == 1
+    assert candidates[0] == b"\xBB" * LEGACY_EID_LENGTH
+    assert len(candidates[0]) == LEGACY_EID_LENGTH

--- a/tests/test_eid_resolver_offset_semantics.py
+++ b/tests/test_eid_resolver_offset_semantics.py
@@ -1,0 +1,127 @@
+# tests/test_eid_resolver_offset_semantics.py
+"""Semantic offset handling for EID resolver timestamp bases."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+import custom_components.googlefindmy.eid_resolver as resolver_module
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import GoogleFindMyEIDResolver
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    LEGACY_EID_LENGTH,
+    ROTATION_PERIOD,
+    EidVariant,
+)
+
+
+@pytest.mark.asyncio
+async def test_pair_date_offset_beats_drifted_unix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure a perfect relative offset survives a later unix drift collision."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = SimpleNamespace(
+        async_create_task=lambda coro: asyncio.create_task(coro),
+        data={},
+    )
+    async def _async_noop(_payload=None):
+        return None
+
+    resolver._store = SimpleNamespace(async_load=lambda: None, async_save=_async_noop)
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._known_offsets = {}
+    resolver._known_advertisement_reversed = {}
+    resolver._known_timebases = {}
+    resolver._persisted_locks = {}
+    resolver._decryption_status = {}
+    resolver._last_lock_confirmation = {}
+    resolver._provisioning_warn_at = {}
+    resolver._locks = {}
+    resolver._lock_miss_counts = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+
+    base_now = ROTATION_PERIOD * 2
+    pair_target = base_now - ROTATION_PERIOD
+    unix_target = base_now
+    pair_collision_ts = pair_target
+    unix_collision_ts = unix_target + ROTATION_PERIOD
+    collision_eid = b"\xAB" * LEGACY_EID_LENGTH
+
+    identity = DeviceIdentity(
+        registry_id="device-id",
+        canonical_id="canonical-id",
+        identity_key=b"\x01" * 32,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-id",
+        fast_pair_model_id=None,
+        pair_date=base_now - pair_target,
+    )
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return [identity]
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_normalize_identities",
+        lambda self, identities, cache=None: identities,
+    )
+    monkeypatch.setattr(time, "time", lambda: float(base_now))
+    monkeypatch.setattr(resolver_module, "ENABLE_ABSOLUTE_UNIX_BASIS", True)
+
+    def _iter_rotation_windows(
+        target_time: int,
+        *,
+        rotation_period: int,
+        window_range,
+        include_neighbors: bool,
+    ) -> tuple[int, ...]:
+        _ = (rotation_period, window_range, include_neighbors)
+        if target_time == unix_target:
+            return (unix_collision_ts,)
+        if target_time == pair_target:
+            return (pair_collision_ts,)
+        return ()
+
+    collision_pairs = {
+        (EidVariant.LEGACY_SECP160R1_X20_BE, pair_collision_ts),
+        (EidVariant.LEGACY_SECP160R1_X20_BE, unix_collision_ts),
+    }
+
+    def _generate_variant(
+        self: GoogleFindMyEIDResolver,
+        _key_bytes: bytes,
+        *,
+        time_counter: int,
+        variant: EidVariant,
+    ) -> bytes:
+        if (variant, time_counter) in collision_pairs:
+            return collision_eid
+        return time_counter.to_bytes(LEGACY_EID_LENGTH, byteorder="big", signed=False)
+
+    monkeypatch.setattr(resolver_module, "iter_rotation_windows", _iter_rotation_windows)
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_generate_variant", _generate_variant)
+
+    await resolver._refresh_cache()
+
+    assert collision_eid in resolver._lookup
+    match = resolver._lookup[collision_eid]
+    metadata = resolver._lookup_metadata[collision_eid]
+
+    assert match.time_offset == 0
+    assert metadata["time_offset"] == 0
+    assert metadata["timestamp_basis"] == "pair_date"
+    assert {"pair_date", "unix"}.issubset(metadata["timestamp_bases"])

--- a/tests/test_eid_resolver_optimization.py
+++ b/tests/test_eid_resolver_optimization.py
@@ -1,0 +1,128 @@
+# tests/test_eid_resolver_optimization.py
+"""Optimization coverage for known time-basis pruning."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import custom_components.googlefindmy.eid_resolver as resolver_module
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import (
+    EIDGenerationLock,
+    GoogleFindMyEIDResolver,
+)
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    LEGACY_EID_LENGTH,
+    EidVariant,
+)
+
+
+@pytest.mark.asyncio
+async def test_known_time_basis_skips_alternate_strategies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the time basis is known, skip alternate counter strategies."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = SimpleNamespace(
+        async_create_task=lambda coro: asyncio.create_task(coro),
+        data={},
+    )
+    resolver._store = SimpleNamespace(
+        async_load=AsyncMock(return_value=None),
+        async_save=AsyncMock(),
+    )
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._known_offsets = {}
+    resolver._known_advertisement_reversed = {}
+    resolver._known_timebases = {}
+    resolver._persisted_locks = {}
+    resolver._decryption_status = {}
+    resolver._last_lock_confirmation = {}
+    resolver._provisioning_warn_at = {}
+    resolver._locks = {}
+    resolver._lock_miss_counts = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+
+    now_unix = 1000
+    pair_target = 100
+    secrets_target = 200
+
+    resolver._locks["tracker-1"] = EIDGenerationLock(
+        device_id="tracker-1",
+        canonical_id="can-1",
+        variant=EidVariant.LEGACY_SECP160R1_X20_BE.value,
+        advertisement_reversed=False,
+        eid_length=LEGACY_EID_LENGTH,
+        rotation_timestamp=None,
+        time_basis="pair_date",
+    )
+
+    identity = DeviceIdentity(
+        registry_id="tracker-1",
+        canonical_id="can-1",
+        identity_key=b"\x01" * 32,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-1",
+        fast_pair_model_id=None,
+        pair_date=now_unix - pair_target,
+        secrets_creation_date=now_unix - secrets_target,
+    )
+
+    monkeypatch.setattr(time, "time", lambda: float(now_unix))
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_collect_device_secrets",
+        AsyncMock(return_value=[identity]),
+    )
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_normalize_identities",
+        lambda self, identities, cache=None: identities,
+    )
+
+    seen_windows: list[int] = []
+
+    def _iter_rotation_windows(
+        target_time: int,
+        *,
+        rotation_period: int,
+        window_range,
+        include_neighbors: bool,
+    ) -> tuple[int, ...]:
+        _ = (rotation_period, window_range, include_neighbors)
+        seen_windows.append(target_time)
+        return (target_time + 1,)
+
+    monkeypatch.setattr(resolver_module, "iter_rotation_windows", _iter_rotation_windows)
+
+    seen_counters: list[int] = []
+
+    def _generate_variant(
+        _self: GoogleFindMyEIDResolver,
+        _key_bytes: bytes,
+        *,
+        time_counter: int,
+        variant: EidVariant,
+    ) -> bytes:
+        _ = variant
+        seen_counters.append(time_counter)
+        return b"\x11" * LEGACY_EID_LENGTH
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_generate_variant", _generate_variant)
+
+    await resolver._refresh_cache()
+
+    assert resolver._known_timebases["tracker-1"] == "pair_date"
+    assert seen_windows == [pair_target]
+    assert seen_counters == [pair_target + 1]

--- a/tests/test_eid_resolver_persistence.py
+++ b/tests/test_eid_resolver_persistence.py
@@ -1,0 +1,80 @@
+# tests/test_eid_resolver_persistence.py
+"""Persistence scheduling for EID resolver state."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import (
+    EIDGenerationLock,
+    GoogleFindMyEIDResolver,
+)
+
+
+@pytest.mark.asyncio
+async def test_refresh_triggers_persistence_on_id_update(hass) -> None:
+    """Canonical ID updates should schedule lock persistence."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = hass
+    resolver._store = MagicMock()
+    resolver._store.async_load = AsyncMock(return_value=None)
+    resolver._store.async_save = AsyncMock()
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._known_offsets = {}
+    resolver._known_advertisement_reversed = {}
+    resolver._known_timebases = {}
+    resolver._persisted_locks = {}
+    resolver._decryption_status = {}
+    resolver._last_lock_confirmation = {}
+    resolver._provisioning_warn_at = {}
+    resolver._locks = {}
+    resolver._lock_miss_counts = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+
+    resolver._locks["dev_1"] = EIDGenerationLock(
+        device_id="dev_1",
+        canonical_id="OLD_UUID",
+        variant="legacy",
+        advertisement_reversed=False,
+        eid_length=20,
+        rotation_timestamp=1000,
+    )
+
+    identity = DeviceIdentity(
+        registry_id="dev_1",
+        canonical_id="account:NEW_UUID",
+        identity_key=b"\x00" * 32,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry_1",
+        fast_pair_model_id=None,
+    )
+
+    hass.async_create_background_task = MagicMock()
+    hass.async_create_task = MagicMock()
+
+    with patch.object(
+        GoogleFindMyEIDResolver, "_collect_device_secrets", AsyncMock(return_value=[identity])
+    ), patch.object(
+        GoogleFindMyEIDResolver, "_generate_variant", return_value=b"\x01" * 20
+    ):
+        await resolver._refresh_cache()
+
+    assert resolver._locks["dev_1"].canonical_id == "NEW_UUID"
+    assert hass.async_create_background_task.called
+    hass.async_create_task.assert_not_called()
+    scheduled_coro = hass.async_create_background_task.call_args.args[0]
+    assert inspect.iscoroutine(scheduled_coro)
+    assert scheduled_coro.cr_code.co_name == resolver._async_save_locks.__name__


### PR DESCRIPTION
## Summary
- reuse stored time-basis hints and locked variants when rebuilding the EID cache to avoid unnecessary strategy scans
- ensure canonical ID updates persist locks using Home Assistant's background task helper
- add regression coverage around persistence scheduling and time-basis pruning

## Testing
- .venv/bin/python -m ruff check custom_components/googlefindmy/eid_resolver.py tests/test_eid_resolver_persistence.py tests/test_eid_resolver_optimization.py
- .venv/bin/python -m mypy --strict --install-types --non-interactive custom_components/googlefindmy/eid_resolver.py tests/test_eid_resolver_persistence.py tests/test_eid_resolver_extraction.py tests/test_eid_resolver_offset_semantics.py tests/test_eid_resolver_optimization.py --disable-error-code import-not-found
- .venv/bin/python -m pytest tests/test_eid_resolver_persistence.py tests/test_eid_resolver_optimization.py -q --no-cov --disable-warnings --maxfail=1

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949227c25948329b67a0e7484226d99)