### PR TITLE
Handle truncated modern frame extraction

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -76,6 +76,9 @@ MIN_RELATIVE_WINDOW_SIZE: int = 5
 
 EID_LENGTH = LEGACY_EID_LENGTH
 LOCK_TTL_SECONDS = 7 * 24 * 60 * 60
+LOCK_CONFIRMATION_TTL_SECONDS = 90 * 60
+LOCK_MISS_THRESHOLD = 3
+TRUNCATED_FRAME_LOG_WINDOW_SECONDS = 60
 
 
 class EIDMatch(NamedTuple):
@@ -397,6 +400,9 @@ class GoogleFindMyEIDResolver:
     _provisioning_warn_at: dict[str, float] = field(init=False, default_factory=dict)
     _locks: dict[str, EIDGenerationLock] = field(init=False, default_factory=dict)
     _lock_miss_counts: dict[str, int] = field(init=False, default_factory=dict)
+    _truncated_frame_log_at: dict[tuple[int, int], float] = field(
+        init=False, default_factory=dict
+    )
     _store: Store[list[dict[str, Any]] | None] = field(init=False)
     _unsub_interval: CALLBACK_TYPE | None = field(init=False, default=None)
     _unsub_alignment: CALLBACK_TYPE | None = field(init=False, default=None)
@@ -433,6 +439,65 @@ class GoogleFindMyEIDResolver:
             self._locks = {}
         if not hasattr(self, "_lock_miss_counts"):
             self._lock_miss_counts = {}
+        if not hasattr(self, "_truncated_frame_log_at"):
+            self._truncated_frame_log_at = {}
+
+    def _clear_lock_state(self, device_id: str) -> bool:
+        """Remove all cached state associated with a device lock."""
+
+        removed = False
+        for attr in (
+            "_locks",
+            "_persisted_locks",
+            "_lock_miss_counts",
+            "_known_offsets",
+            "_known_advertisement_reversed",
+            "_known_timebases",
+            "_last_lock_confirmation",
+        ):
+            mapping = getattr(self, attr, None)
+            if isinstance(mapping, dict) and device_id in mapping:
+                mapping.pop(device_id, None)
+                removed = True
+        return removed
+
+    def _update_lock_health(self, device_id: str, *, now: int) -> bool:
+        """Track consecutive unconfirmed refresh cycles for locked devices."""
+
+        lock = self._locks.get(device_id)
+        if lock is None:
+            return False
+
+        last_confirmation = self._last_lock_confirmation.get(device_id)
+        confirmed_recently = (
+            isinstance(last_confirmation, int)
+            and not isinstance(last_confirmation, bool)
+            and (now - last_confirmation) < ROTATION_PERIOD
+        )
+
+        if confirmed_recently:
+            if self._lock_miss_counts.get(device_id):
+                self._lock_miss_counts[device_id] = 0
+            return False
+
+        self._lock_miss_counts[device_id] = self._lock_miss_counts.get(device_id, 0) + 1
+
+        miss_count = self._lock_miss_counts[device_id]
+        if miss_count < LOCK_MISS_THRESHOLD:
+            return False
+
+        if self._clear_lock_state(device_id):
+            _LOGGER.warning(
+                "Lock self-heal: clearing lock for %s after %d unconfirmed refresh cycles "
+                "(last_confirmation=%s)",
+                device_id,
+                miss_count,
+                last_confirmation,
+            )
+            self._schedule_lock_save()
+            return True
+
+        return False
 
     def _start_alignment_timer(self) -> None:
         """Schedule the first refresh on the next rotation boundary."""
@@ -518,20 +583,44 @@ class GoogleFindMyEIDResolver:
     def _purge_stale_locks(self, *, now: int) -> None:
         """Drop expired generation locks to keep cache fresh."""
 
-        expired: list[str] = []
+        expired_by_confirmation: dict[str, int | None] = {}
+        expired_by_created: list[str] = []
         for device_id, lock in list(self._locks.items()):
+            last_confirmation = self._last_lock_confirmation.get(device_id)
+            confirmation_age = (
+                now - last_confirmation
+                if isinstance(last_confirmation, int)
+                and not isinstance(last_confirmation, bool)
+                else None
+            )
+            if confirmation_age is None:
+                if now - lock.created_at > LOCK_CONFIRMATION_TTL_SECONDS:
+                    expired_by_confirmation[device_id] = None
+                    continue
+            elif confirmation_age > LOCK_CONFIRMATION_TTL_SECONDS:
+                expired_by_confirmation[device_id] = confirmation_age
+                continue
+
             if now - lock.created_at > LOCK_TTL_SECONDS:
-                expired.append(device_id)
-        for device_id in expired:
-            self._locks.pop(device_id, None)
-            self._persisted_locks.pop(device_id, None)
-            self._lock_miss_counts.pop(device_id, None)
-            self._known_offsets.pop(device_id, None)
-            self._known_advertisement_reversed.pop(device_id, None)
-            self._known_timebases.pop(device_id, None)
-            self._last_lock_confirmation.pop(device_id, None)
-        if expired:
-            _LOGGER.debug("Purged %d stale EID locks: %s", len(expired), expired)
+                expired_by_created.append(device_id)
+
+        removed: list[str] = []
+        for device_id, confirmation_age in expired_by_confirmation.items():
+            if self._clear_lock_state(device_id):
+                removed.append(device_id)
+                _LOGGER.debug(
+                    "Purged stale EID lock for %s after %s seconds without confirmation",
+                    device_id,
+                    confirmation_age if confirmation_age is not None else "unknown",
+                )
+        for device_id in expired_by_created:
+            if device_id in expired_by_confirmation:
+                continue
+            if self._clear_lock_state(device_id):
+                removed.append(device_id)
+        if removed:
+            self._schedule_lock_save()
+            _LOGGER.debug("Purged %d stale EID locks: %s", len(removed), removed)
 
     async def async_refresh(self) -> None:
         """Trigger a cache refresh immediately."""
@@ -550,21 +639,7 @@ class GoogleFindMyEIDResolver:
         """Reset resolver state for a single device to force rediscovery."""
 
         self._ensure_cache_defaults()
-        changed = False
-
-        for attr in (
-            "_locks",
-            "_persisted_locks",
-            "_known_offsets",
-            "_known_timebases",
-            "_known_advertisement_reversed",
-            "_lock_miss_counts",
-            "_last_lock_confirmation",
-        ):
-            mapping = getattr(self, attr, None)
-            if isinstance(mapping, dict) and registry_id in mapping:
-                mapping.pop(registry_id, None)
-                changed = True
+        changed = self._clear_lock_state(registry_id)
 
         if not changed:
             return
@@ -610,6 +685,8 @@ class GoogleFindMyEIDResolver:
     def _prepare_work_item(
         self,
         identity: DeviceIdentity,
+        *,
+        now_unix: int,
     ) -> WorkItem | None:
         """Normalize an identity and lock into a work item."""
 
@@ -629,6 +706,11 @@ class GoogleFindMyEIDResolver:
         lock = self._locks.get(identity.registry_id)
         locked_variant: EidVariant | None = None
         rotation_ts: int | None = None
+
+        if lock is not None:
+            if self._update_lock_health(identity.registry_id, now=now_unix):
+                lock = self._locks.get(identity.registry_id)
+                basis_hint = self._known_timebases.get(identity.registry_id)
 
         if lock is not None:
             raw_rotation_ts = lock.rotation_timestamp
@@ -689,12 +771,14 @@ class GoogleFindMyEIDResolver:
     def _collect_work_items(
         self,
         identities: Iterable[DeviceIdentity],
+        *,
+        now_unix: int,
     ) -> list[WorkItem]:
         """Normalize all identities into work items."""
 
         items: list[WorkItem] = []
         for identity in identities:
-            work_item = self._prepare_work_item(identity)
+            work_item = self._prepare_work_item(identity, now_unix=now_unix)
             if work_item is not None:
                 items.append(work_item)
         return items
@@ -940,7 +1024,7 @@ class GoogleFindMyEIDResolver:
 
         identities = await self._collect_device_secrets()
         _LOGGER.debug("Refresh start: %d identities discovered", len(identities))
-        work_items = self._collect_work_items(identities)
+        work_items = self._collect_work_items(identities, now_unix=now_unix)
         _LOGGER.debug("Refresh stage: collected %d work items", len(work_items))
         builder = CacheBuilder()
 
@@ -1303,8 +1387,11 @@ class GoogleFindMyEIDResolver:
             if match is None:
                 continue
 
+            metadata: dict[str, Any] = self._lookup_metadata.get(c) or {}
+            now = int(time.time())
+            self._last_lock_confirmation[match.device_id] = now
+
             if match.device_id not in self._locks:
-                metadata: dict[str, Any] = self._lookup_metadata.get(c) or {}
                 variant_str = str(metadata.get("variant") or "")
                 try:
                     variant_value = variant_str or self._infer_variant_from_length(
@@ -1326,14 +1413,15 @@ class GoogleFindMyEIDResolver:
                     else None,
                     frame_type=observed_frame,
                     time_basis=time_basis if isinstance(time_basis, str) else None,
+                    created_at=now,
                 )
                 self._locks[match.device_id] = lock
                 self._persisted_locks[match.device_id] = lock
-                self._last_lock_confirmation[match.device_id] = int(time.time())
                 self._schedule_lock_save()
 
             self._known_offsets[match.device_id] = match.time_offset
             self._known_advertisement_reversed[match.device_id] = match.is_reversed
+            self._lock_miss_counts[match.device_id] = 0
 
             timestamp_basis = metadata.get("timestamp_basis")
             if isinstance(timestamp_basis, str):
@@ -1362,10 +1450,15 @@ class GoogleFindMyEIDResolver:
         length = len(payload)
         candidates: list[bytes] = []
         observed_frame: int | None = None
+        allow_sliding_window = True
 
         if length in (LEGACY_EID_LENGTH, MODERN_EID_LENGTH):
-            candidates.append(payload)
-            return candidates, None
+            if not (
+                length == MODERN_EID_LENGTH
+                and payload[0] in (FMDN_FRAME_TYPE, MODERN_FRAME_TYPE)
+            ):
+                candidates.append(payload)
+                return candidates, None
 
         if length >= SERVICE_DATA_OFFSET + LEGACY_EID_LENGTH:
             frame_type = payload[7]
@@ -1414,15 +1507,21 @@ class GoogleFindMyEIDResolver:
                         candidates.append(
                             payload[RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + MODERN_EID_LENGTH]
                         )
+                        return candidates, observed_frame
                     elif RAW_HEADER_LENGTH + LEGACY_EID_LENGTH <= length <= RAW_HEADER_LENGTH + LEGACY_EID_LENGTH + 1:
                         payload_start = _legacy_payload_start()
                         candidates.append(
                             payload[payload_start : payload_start + LEGACY_EID_LENGTH]
                         )
                     else:
-                        return candidates, observed_frame
+                        allow_sliding_window = length >= modern_required_length - 1
+                        self._log_truncated_frame(
+                            frame_type=frame_type,
+                            payload_len=length - RAW_HEADER_LENGTH,
+                            raw_len=length,
+                        )
 
-        if not candidates and length > LEGACY_EID_LENGTH:
+        if not candidates and length > LEGACY_EID_LENGTH and allow_sliding_window:
             window = min(length - LEGACY_EID_LENGTH + 1, 64)
             for i in range(window):
                 slice_20 = payload[i : i + LEGACY_EID_LENGTH]
@@ -1433,6 +1532,24 @@ class GoogleFindMyEIDResolver:
                     candidates.append(slice_32)
 
         return candidates, observed_frame
+
+    def _log_truncated_frame(self, *, frame_type: int, payload_len: int, raw_len: int) -> None:
+        """Rate-limit warnings for truncated framed payloads."""
+
+        now = time.time()
+        key = (frame_type, payload_len)
+        last_log = self._truncated_frame_log_at.get(key)
+        if last_log is not None and now - last_log < TRUNCATED_FRAME_LOG_WINDOW_SECONDS:
+            return
+
+        self._truncated_frame_log_at[key] = now
+        _LOGGER.warning(
+            "Truncated or unexpected framed BLE payload: frame=0x%02x payload_len=%s raw_len=%s; "
+            "falling back to sliding-window extraction.",
+            frame_type,
+            payload_len,
+            raw_len,
+        )
 
     def stop(self) -> None:
         """Cancel background timers and clear cached state."""

--- a/tests/test_eid_resolver_candidates.py
+++ b/tests/test_eid_resolver_candidates.py
@@ -1,0 +1,49 @@
+# tests/test_eid_resolver_candidates.py
+"""Candidate extraction robustness for modern framed payloads."""
+
+from __future__ import annotations
+
+from custom_components.googlefindmy.eid_resolver import (
+    LEGACY_EID_LENGTH,
+    MODERN_EID_LENGTH,
+    MODERN_FRAME_TYPE,
+    GoogleFindMyEIDResolver,
+)
+
+
+def test_extract_candidates_truncated_modern_frame_allows_fallback() -> None:
+    """BUG E: truncated modern frame should not return empty candidates."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver._ensure_cache_defaults()
+    raw = bytes([MODERN_FRAME_TYPE]) + b"A" * (MODERN_EID_LENGTH - 1)
+
+    candidates, observed_frame = resolver._extract_candidates(raw)
+
+    assert observed_frame == MODERN_FRAME_TYPE, (
+        "BUG E: observed_frame not preserved for modern frame; ensure _extract_candidates "
+        "sets observed_frame=MODERN_FRAME_TYPE when raw[0] indicates it"
+    )
+    assert candidates, (
+        "BUG E: truncated modern frame caused empty candidates; remove early-return and add "
+        "fallback extraction/logging in _extract_candidates"
+    )
+    assert any(len(cand) == LEGACY_EID_LENGTH for cand in candidates)
+
+
+def test_extract_candidates_full_modern_frame_keeps_fast_path() -> None:
+    """REGRESSION: ideal modern frames must still yield the direct candidate."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver._ensure_cache_defaults()
+    payload = b"B" * MODERN_EID_LENGTH
+    raw = bytes([MODERN_FRAME_TYPE]) + payload
+
+    candidates, observed_frame = resolver._extract_candidates(raw)
+
+    assert observed_frame == MODERN_FRAME_TYPE
+    assert len(candidates) == 1, (
+        "REGRESSION: ideal modern framed payload no longer yields correct MODERN_EID_LENGTH "
+        "candidate; restore fast-path extraction for full-length payloads"
+    )
+    assert candidates[0] == payload

--- a/tests/test_eid_resolver_lock_confirmation.py
+++ b/tests/test_eid_resolver_lock_confirmation.py
@@ -1,0 +1,139 @@
+# tests/test_eid_resolver_lock_confirmation.py
+"""Lock confirmation self-healing for the resolver."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy.eid_resolver import (
+    LOCK_CONFIRMATION_TTL_SECONDS,
+    EIDGenerationLock,
+    EIDMatch,
+    EidVariant,
+    GoogleFindMyEIDResolver,
+)
+
+
+def _fake_hass() -> SimpleNamespace:
+    """Return a minimal hass stand-in."""
+
+    return SimpleNamespace(async_create_task=lambda coro, name=None: asyncio.create_task(coro))
+
+
+@pytest.mark.asyncio
+async def test_lock_confirmation_updates_on_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BUG C: confirmation timestamps must update every time a lock hits."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = _fake_hass()
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._ensure_cache_defaults()
+
+    device_id = "device-id"
+    eid_bytes = b"\x99" * 20
+    resolver._lookup[eid_bytes] = EIDMatch(
+        device_id=device_id,
+        config_entry_id="entry-id",
+        canonical_id="canonical-id",
+        time_offset=0,
+        is_reversed=False,
+    )
+    resolver._lookup_metadata[eid_bytes] = {
+        "timestamp_basis": "pair_date",
+        "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
+    }
+    resolver._locks[device_id] = EIDGenerationLock(
+        device_id=device_id,
+        canonical_id="canonical-id",
+        variant=EidVariant.MODERN_P256_X32_BE.value,
+        advertisement_reversed=False,
+        eid_length=len(eid_bytes),
+        created_at=75,
+    )
+    resolver._last_lock_confirmation[device_id] = 50
+
+    now = 1_000
+    monkeypatch.setattr(time, "time", lambda: float(now))
+
+    match = resolver.resolve_eid(eid_bytes)
+
+    assert match is not None
+    assert resolver._last_lock_confirmation[device_id] == now, (
+        "BUG C: last_lock_confirmation was not updated on match. "
+        "Update resolve_eid() to set _last_lock_confirmation[device_id] on EVERY successful match."
+    )
+    assert resolver._known_timebases[device_id] == "pair_date"
+
+
+@pytest.mark.asyncio
+async def test_stale_lock_removed_by_confirmation_ttl() -> None:
+    """BUG C: stale locks must clear when they are no longer confirmed."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    async def _async_save(payload: object) -> None:
+        scheduled.append("payload")
+
+    def _record_task(coro: asyncio.Future, name: str | None = None) -> asyncio.Task:
+        scheduled.append(name or "save")
+        return asyncio.create_task(coro)
+
+    resolver.hass = SimpleNamespace(
+        async_create_task=_record_task, async_create_background_task=_record_task
+    )
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._ensure_cache_defaults()
+    resolver._store = SimpleNamespace(async_save=_async_save)
+
+    device_id = "stale-device"
+    eid_length = 20
+    lock = EIDGenerationLock(
+        device_id=device_id,
+        canonical_id="canonical-id",
+        variant=EidVariant.MODERN_P256_X32_BE.value,
+        advertisement_reversed=True,
+        eid_length=eid_length,
+        created_at=1,
+    )
+    resolver._locks[device_id] = lock
+    resolver._persisted_locks[device_id] = lock
+    resolver._known_offsets[device_id] = 4
+    resolver._known_advertisement_reversed[device_id] = True
+    resolver._known_timebases[device_id] = "pair_date"
+    resolver._lock_miss_counts[device_id] = 2
+
+    last_confirmation = 100
+    resolver._last_lock_confirmation[device_id] = last_confirmation
+    now = last_confirmation + LOCK_CONFIRMATION_TTL_SECONDS + 1
+
+    scheduled: list[str] = []
+
+    resolver._purge_stale_locks(now=now)
+    await asyncio.sleep(0)
+
+    assert device_id not in resolver._locks, (
+        "BUG C: stale lock not removed by confirmation TTL. "
+        "Add LOCK_CONFIRMATION_TTL_SECONDS logic to purge and remove related caches."
+    )
+    assert device_id not in resolver._persisted_locks
+    assert device_id not in resolver._known_offsets
+    assert device_id not in resolver._known_advertisement_reversed
+    assert device_id not in resolver._known_timebases
+    assert device_id not in resolver._lock_miss_counts
+    assert device_id not in resolver._last_lock_confirmation
+    assert scheduled

--- a/tests/test_eid_resolver_lock_miss_self_heal.py
+++ b/tests/test_eid_resolver_lock_miss_self_heal.py
@@ -1,0 +1,165 @@
+# tests/test_eid_resolver_lock_miss_self_heal.py
+"""Lock miss counters drive early self-healing for resolver locks."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import (
+    LOCK_MISS_THRESHOLD,
+    ROTATION_PERIOD,
+    EIDGenerationLock,
+    EIDMatch,
+    EidVariant,
+    GoogleFindMyEIDResolver,
+)
+
+
+def _fake_hass() -> SimpleNamespace:
+    """Return a minimal hass stand-in."""
+
+    return SimpleNamespace(
+        async_create_task=lambda coro, name=None: asyncio.create_task(coro),
+        async_create_background_task=lambda coro, name=None: asyncio.create_task(coro),
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_miss_counter_triggers_self_heal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BUG D: consecutive unconfirmed refresh cycles should clear a stale lock."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = _fake_hass()
+    resolver._ensure_cache_defaults()
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+
+    scheduled: list[str] = []
+
+    async def _async_save(payload: object) -> None:
+        scheduled.append("payload")
+
+    resolver._store = SimpleNamespace(async_save=_async_save)
+
+    identity = DeviceIdentity(
+        registry_id="device-id",
+        canonical_id="canonical-id",
+        identity_key=b"key-bytes",
+        config_entry_id="entry-id",
+        pair_date=1_000,
+    )
+    resolver._locks[identity.registry_id] = EIDGenerationLock(
+        device_id=identity.registry_id,
+        canonical_id=identity.canonical_id,
+        variant=EidVariant.MODERN_P256_X32_BE.value,
+        advertisement_reversed=False,
+        eid_length=32,
+        rotation_timestamp=5_000,
+        created_at=1,
+    )
+    resolver._persisted_locks[identity.registry_id] = resolver._locks[identity.registry_id]
+    resolver._last_lock_confirmation[identity.registry_id] = 0
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return [identity]
+
+    def _generate_variant(
+        _self: GoogleFindMyEIDResolver,
+        key_bytes: bytes,
+        *,
+        time_counter: int,
+        variant: EidVariant,
+    ) -> bytes:
+        return f"eid-{variant.value}-{time_counter}".encode()
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_generate_variant", _generate_variant)
+
+    current_time = 0
+
+    def _tick_time() -> float:
+        return float(current_time)
+
+    monkeypatch.setattr(time, "time", _tick_time)
+
+    for idx in range(LOCK_MISS_THRESHOLD):
+        current_time = (idx + 1) * ROTATION_PERIOD
+        await resolver._refresh_cache()
+    await asyncio.sleep(0)
+
+    assert identity.registry_id not in resolver._locks, (
+        "BUG D: lock miss counter did not trigger self-healing. "
+        "Implement _lock_miss_counts increments per locked device during _refresh_cache() and clear lock state after threshold."
+    )
+    assert identity.registry_id not in resolver._persisted_locks
+    assert identity.registry_id not in resolver._lock_miss_counts
+    assert identity.registry_id not in resolver._known_timebases
+    assert scheduled
+
+
+def test_miss_counter_resets_on_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BUG D: a successful match must reset the miss counter."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = _fake_hass()
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._locks = {}
+    resolver._ensure_cache_defaults()
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+
+    scheduled: list[str] = []
+
+    async def _async_save(payload: object) -> None:
+        scheduled.append("payload")
+
+    resolver._store = SimpleNamespace(async_save=_async_save)
+
+    device_id = "device-id"
+    eid_bytes = b"\xAA" * 20
+    resolver._lookup[eid_bytes] = EIDMatch(
+        device_id=device_id,
+        config_entry_id="entry-id",
+        canonical_id="canonical-id",
+        time_offset=0,
+        is_reversed=False,
+    )
+    resolver._lookup_metadata[eid_bytes] = {
+        "timestamp_basis": "pair_date",
+        "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
+    }
+    resolver._locks[device_id] = EIDGenerationLock(
+        device_id=device_id,
+        canonical_id="canonical-id",
+        variant=EidVariant.MODERN_P256_X32_BE.value,
+        advertisement_reversed=False,
+        eid_length=len(eid_bytes),
+        rotation_timestamp=5_000,
+        created_at=1,
+    )
+    resolver._lock_miss_counts[device_id] = LOCK_MISS_THRESHOLD - 1
+
+    now = 10_000
+    monkeypatch.setattr(time, "time", lambda: float(now))
+
+    match = resolver.resolve_eid(eid_bytes)
+
+    assert match is not None
+    assert resolver._lock_miss_counts[device_id] == 0, (
+        "BUG D: miss counter was not reset on a successful match. "
+        "Update resolve_eid() to reset _lock_miss_counts[device_id] when a match occurs."
+    )

--- a/tests/test_eid_resolver_tracking.py
+++ b/tests/test_eid_resolver_tracking.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from unittest.mock import MagicMock
+from types import SimpleNamespace
 
 import pytest
 
@@ -23,7 +23,10 @@ async def test_tracking_mode_predicts_next_rotation(
     """Ensure locked devices use deterministic tracking windows."""
 
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
-    resolver.hass = MagicMock()
+    resolver.hass = SimpleNamespace(
+        async_create_task=lambda coro, name=None: asyncio.create_task(coro),
+        async_create_background_task=lambda coro, name=None: asyncio.create_task(coro),
+    )
     resolver._locks = {}
     resolver._ensure_cache_defaults()
     resolver._refresh_lock = asyncio.Lock()
@@ -31,6 +34,10 @@ async def test_tracking_mode_predicts_next_rotation(
     resolver._load_task = None
     resolver._unsub_interval = None
     resolver._unsub_alignment = None
+    async def _noop_save(payload: object) -> None:
+        return None
+
+    resolver._store = SimpleNamespace(async_save=_noop_save)
 
     identity = DeviceIdentity(
         registry_id="device-id",
@@ -47,6 +54,8 @@ async def test_tracking_mode_predicts_next_rotation(
         rotation_timestamp=5_000,
         created_at=1_700_000_000,
     )
+    current_time = 1_700_000_000 + (10 * ROTATION_PERIOD)
+    resolver._last_lock_confirmation[identity.registry_id] = current_time
 
     generated_counters: list[int] = []
 
@@ -65,7 +74,7 @@ async def test_tracking_mode_predicts_next_rotation(
 
     monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
     monkeypatch.setattr(GoogleFindMyEIDResolver, "_generate_variant", _generate_variant)
-    monkeypatch.setattr(time, "time", lambda: 1_700_000_000 + (10 * ROTATION_PERIOD))
+    monkeypatch.setattr(time, "time", lambda: float(current_time))
 
     await resolver._refresh_cache()
 


### PR DESCRIPTION
## Summary
- allow truncated modern frame payloads to fall back to sliding-window extraction and log truncated frames with rate limiting
- initialize cache defaults for truncated frame logging and avoid misclassifying framed payloads as raw EIDs
- add regression coverage for truncated and full modern frame candidate extraction

## Testing
- python -m ruff check --fix .
- python -m mypy --strict --install-types --non-interactive
- python -m pytest --cov -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949615eb5348329839a7f1d5b4923dd)