### PR TITLE
Harden EID resolver dedupe and offset tracking

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -74,6 +74,10 @@ MIN_UNIX_WINDOW_SIZE: int = 128
 # 5 * 1024s ~= 85 mins. Essential to absorb 1h Daylight Saving Time (DST) shifts.
 MIN_RELATIVE_WINDOW_SIZE: int = 5
 
+# LOCK_FALLBACK_RELATIVE_WINDOW_SIZE: When a lock exists, we still generate a limited
+# set of relative discovery windows as a self-healing fallback.
+LOCK_FALLBACK_RELATIVE_WINDOW_SIZE: int = 3
+
 EID_LENGTH = LEGACY_EID_LENGTH
 LOCK_TTL_SECONDS = 7 * 24 * 60 * 60
 LOCK_CONFIRMATION_TTL_SECONDS = 90 * 60
@@ -387,7 +391,7 @@ class GoogleFindMyEIDResolver:
     _lookup_metadata: dict[bytes, dict[str, Any]] = field(
         init=False, default_factory=dict
     )
-    _known_offsets: dict[str, int] = field(init=False, default_factory=dict)
+    _known_offsets: dict[tuple[str, str], int] = field(init=False, default_factory=dict)
     _known_advertisement_reversed: dict[str, bool] = field(
         init=False, default_factory=dict
     )
@@ -446,11 +450,13 @@ class GoogleFindMyEIDResolver:
         """Remove all cached state associated with a device lock."""
 
         removed = False
+        if self._purge_known_offsets_for_device(device_id):
+            removed = True
+
         for attr in (
             "_locks",
             "_persisted_locks",
             "_lock_miss_counts",
-            "_known_offsets",
             "_known_advertisement_reversed",
             "_known_timebases",
             "_last_lock_confirmation",
@@ -460,6 +466,19 @@ class GoogleFindMyEIDResolver:
                 mapping.pop(device_id, None)
                 removed = True
         return removed
+
+    def _purge_known_offsets_for_device(self, device_id: str) -> bool:
+        """Remove any stored known offsets for the device across bases."""
+
+        mapping = getattr(self, "_known_offsets", None)
+        if not isinstance(mapping, dict) or not mapping:
+            return False
+
+        to_delete = [key for key in mapping if key[0] == device_id]
+        for key in to_delete:
+            mapping.pop(key, None)
+
+        return bool(to_delete)
 
     def _update_lock_health(self, device_id: str, *, now: int) -> bool:
         """Track consecutive unconfirmed refresh cycles for locked devices."""
@@ -580,19 +599,19 @@ class GoogleFindMyEIDResolver:
         except Exception as err:  # pragma: no cover - defensive log
             _LOGGER.error("Failed to schedule EID lock persistence: %s", err)
 
-    def _purge_stale_locks(self, *, now: int) -> None:
+    def _purge_stale_locks(self, *, now: int) -> None:  # noqa: PLR0912
         """Drop expired generation locks to keep cache fresh."""
 
         expired_by_confirmation: dict[str, int | None] = {}
         expired_by_created: list[str] = []
         for device_id, lock in list(self._locks.items()):
             last_confirmation = self._last_lock_confirmation.get(device_id)
-            confirmation_age = (
-                now - last_confirmation
-                if isinstance(last_confirmation, int)
-                and not isinstance(last_confirmation, bool)
-                else None
-            )
+            if isinstance(last_confirmation, int) and not isinstance(last_confirmation, bool):
+                confirmation_age: int | None = now - last_confirmation
+                last_activity = last_confirmation
+            else:
+                confirmation_age = None
+                last_activity = lock.created_at
             if confirmation_age is None:
                 if now - lock.created_at > LOCK_CONFIRMATION_TTL_SECONDS:
                     expired_by_confirmation[device_id] = None
@@ -601,7 +620,7 @@ class GoogleFindMyEIDResolver:
                 expired_by_confirmation[device_id] = confirmation_age
                 continue
 
-            if now - lock.created_at > LOCK_TTL_SECONDS:
+            if now - last_activity > LOCK_TTL_SECONDS:
                 expired_by_created.append(device_id)
 
         removed: list[str] = []
@@ -636,26 +655,40 @@ class GoogleFindMyEIDResolver:
                 await self._refresh_cache()
 
     def reset_device_offset(self, registry_id: str) -> None:
-        """Reset resolver state for a single device to force rediscovery."""
+        """Forget cached offsets/locks for a given device registry ID."""
 
-        self._ensure_cache_defaults()
-        changed = self._clear_lock_state(registry_id)
-
-        if not changed:
+        if not registry_id:
             return
 
-        try:
-            self._schedule_lock_save()
-        except Exception as err:  # pragma: no cover - defensive log
-            _LOGGER.debug(
-                "Failed to schedule lock persistence after reset for %s: %s",
-                registry_id,
-                err,
-            )
+        self._ensure_cache_defaults()
+        removed = self._clear_lock_state(registry_id)
+        removed = self._purge_known_offsets_for_device(registry_id) or removed
+        removed = (
+            self._known_advertisement_reversed.pop(registry_id, None) is not None
+            or removed
+        )
+        removed = (
+            self._known_timebases.pop(registry_id, None) is not None or removed
+        )
+        removed = (
+            self._last_lock_confirmation.pop(registry_id, None) is not None
+            or removed
+        )
+
+        if removed:
+            try:
+                self._schedule_lock_save()
+            except Exception as err:  # pragma: no cover - defensive log
+                _LOGGER.debug(
+                    "Failed to schedule lock persistence after reset for %s: %s",
+                    registry_id,
+                    err,
+                )
 
         refresh = getattr(self, "async_refresh", None)
         create_task = getattr(self.hass, "async_create_task", None)
         if callable(refresh) and callable(create_task):
+            self._pending_refresh = True
             try:
                 refresh_coro = refresh()
                 scheduled = create_task(
@@ -732,7 +765,16 @@ class GoogleFindMyEIDResolver:
                 locked_variant = EidVariant.MODERN_P256_X32_BE
 
             if is_legacy:
-                valid_hint = lock_time_basis if lock_time_basis in {"unix", "pair_date", "secrets_creation_date"} else None
+                valid_hint = (
+                    lock_time_basis
+                    if lock_time_basis
+                    in {
+                        "unix",
+                        "pair_date",
+                        "secrets_creation_date",
+                    }
+                    else None
+                )
                 _LOGGER.warning(
                     "Discarding invalid/legacy lock for %s (legacy=%s). Force re-discovery.",
                     identity.registry_id,
@@ -793,10 +835,24 @@ class GoogleFindMyEIDResolver:
         """Compute time windows for a work item and report hint validity."""
 
         lock_windows = self._compute_lock_windows(work_item, now_unix=now_unix, params=params)
+        fallback_discovery = bool(lock_windows)
+        min_relative_window = (
+            LOCK_FALLBACK_RELATIVE_WINDOW_SIZE
+            if fallback_discovery
+            else params.min_relative_window
+        )
+        relative_windows, invalid_hint = self._compute_relative_windows(
+            work_item,
+            now_unix=now_unix,
+            params=params,
+            min_relative_window=min_relative_window,
+            allow_unix_basis=not fallback_discovery,
+        )
         if lock_windows:
-            return lock_windows, False
+            lock_windows.extend(relative_windows)
+            return self._dedupe_windows(lock_windows), invalid_hint
 
-        return self._compute_relative_windows(work_item, now_unix=now_unix, params=params)
+        return self._dedupe_windows(relative_windows), invalid_hint
 
     def _compute_lock_windows(
         self,
@@ -813,18 +869,21 @@ class GoogleFindMyEIDResolver:
         counter_windows: list[WindowCandidate] = []
         time_since_lock = max(0, now_unix - work_item.lock.created_at)
         periods_elapsed = time_since_lock // params.rotation_period
+        expected_counter = work_item.rotation_ts + (
+            periods_elapsed * params.rotation_period
+        )
         for step in range(-2, 3):
             offset_periods = periods_elapsed + step
             window_ts = work_item.rotation_ts + (offset_periods * params.rotation_period)
             if window_ts < 0:
                 continue
-            semantic_offset = window_ts - now_unix
+            semantic_offset = window_ts - expected_counter
             counter_windows.append(
                 WindowCandidate(
                     timestamp=window_ts,
                     semantic_offset=semantic_offset,
                     time_basis="lock_tracking",
-                    candidate_value=work_item.rotation_ts,
+                    candidate_value=expected_counter,
                 )
             )
 
@@ -834,17 +893,19 @@ class GoogleFindMyEIDResolver:
         return [
             WindowSpec(
                 time_basis="lock_tracking",
-                candidate_value=work_item.rotation_ts,
+                candidate_value=expected_counter,
                 windows=tuple(counter_windows),
             )
         ]
 
-    def _compute_relative_windows(
+    def _compute_relative_windows(  # noqa: PLR0912, PLR0915
         self,
         work_item: WorkItem,
         *,
         now_unix: int,
         params: RotationParams,
+        min_relative_window: int,
+        allow_unix_basis: bool,
     ) -> tuple[list[WindowSpec], bool]:
         """Return relative/absolute windows and whether the basis hint was invalid."""
 
@@ -854,6 +915,10 @@ class GoogleFindMyEIDResolver:
             ("pair_date", "pair_date"),
             ("secrets_creation_date", "secrets_creation_date"),
         )
+        if not allow_unix_basis:
+            counter_bases = tuple(
+                (basis, label) for basis, label in counter_bases if basis != "unix"
+            )
         anchor_candidates: list[int] = []
         if isinstance(work_item.identity.pair_date, int) and work_item.identity.pair_date > 0:
             anchor_candidates.append(work_item.identity.pair_date)
@@ -880,12 +945,14 @@ class GoogleFindMyEIDResolver:
 
         for basis, label in filtered_bases:
             candidate_value: int | None = None
+            reference_ts = now_unix
             total_window: int = 0
 
             if basis == "unix":
                 if not ENABLE_ABSOLUTE_UNIX_BASIS:
                     continue
                 candidate_value = now_unix
+                reference_ts = now_unix
                 try:
                     tz_offset = dt_util.now().utcoffset()
                     tz_windows = (
@@ -902,11 +969,34 @@ class GoogleFindMyEIDResolver:
                 if anchor_value is None:
                     continue
                 candidate_value = now_unix - anchor_value
-                total_window = min(params.min_relative_window + drift_windows, params.max_window)
+                reference_ts = candidate_value
+
+                safety_buffer = 2
+                known_offset = self._known_offsets.get((work_item.registry_id, basis))
+                if known_offset is not None:
+                    max_offset = 5 * params.rotation_period
+                    if abs(known_offset) <= max_offset:
+                        candidate_value = candidate_value + known_offset
+                        reference_ts = candidate_value
+                        total_window = min(3, params.max_window)
+                    else:
+                        _LOGGER.debug(
+                            "Ignoring implausible known_offset=%s for %s (basis=%s); falling back to discovery window",
+                            known_offset,
+                            work_item.registry_id,
+                            basis,
+                        )
+                        known_offset = None
+                if known_offset is None:
+                    total_window = min(
+                        max(min_relative_window, 3 + drift_windows + safety_buffer),
+                        params.max_window,
+                    )
 
             normalized = _normalize_counter_candidate(candidate_value, basis=basis)
             if normalized is None:
                 continue
+            reference_ts = normalized
 
             window_candidates: list[WindowCandidate] = []
             for ts in iter_rotation_windows(
@@ -917,7 +1007,7 @@ class GoogleFindMyEIDResolver:
             ):
                 if ts < 0:
                     continue
-                semantic_offset = ts - normalized
+                semantic_offset = ts - reference_ts
                 window_candidates.append(
                     WindowCandidate(
                         timestamp=ts,
@@ -936,6 +1026,43 @@ class GoogleFindMyEIDResolver:
                 )
 
         return counter_windows, invalid_hint
+
+    @staticmethod
+    def _dedupe_windows(specs: list[WindowSpec]) -> list[WindowSpec]:
+        """Remove duplicate windows by (basis, timestamp) while preserving order."""
+
+        basis_order: list[str] = []
+        basis_windows: dict[str, list[WindowCandidate]] = {}
+        basis_candidate_value: dict[str, int] = {}
+        key_index: dict[tuple[str, int], int] = {}
+
+        for spec in specs:
+            if spec.time_basis not in basis_order:
+                basis_order.append(spec.time_basis)
+                basis_windows.setdefault(spec.time_basis, [])
+            for window in spec.windows:
+                key = (spec.time_basis, window.timestamp)
+                if key not in key_index:
+                    key_index[key] = len(basis_windows[spec.time_basis])
+                    basis_windows[spec.time_basis].append(window)
+                    basis_candidate_value.setdefault(spec.time_basis, spec.candidate_value)
+                    continue
+
+                idx = key_index[key]
+                current = basis_windows[spec.time_basis][idx]
+                if abs(window.semantic_offset) < abs(current.semantic_offset):
+                    basis_windows[spec.time_basis][idx] = window
+                    basis_candidate_value[spec.time_basis] = spec.candidate_value
+
+        return [
+            WindowSpec(
+                time_basis=basis,
+                candidate_value=basis_candidate_value[basis],
+                windows=tuple(basis_windows[basis]),
+            )
+            for basis in basis_order
+            if basis_windows.get(basis)
+        ]
 
     def _compute_variants(
         self,
@@ -1390,7 +1517,7 @@ class GoogleFindMyEIDResolver:
             metadata: dict[str, Any] = self._lookup_metadata.get(candidate) or {}
             now = int(time.time())
             self._last_lock_confirmation[match.device_id] = now
-
+            time_basis = metadata.get("timestamp_basis")
             if match.device_id not in self._locks:
                 variant_str = str(metadata.get("variant") or "")
                 try:
@@ -1417,13 +1544,12 @@ class GoogleFindMyEIDResolver:
                 self._persisted_locks[match.device_id] = lock
                 self._schedule_lock_save()
 
-            self._known_offsets[match.device_id] = match.time_offset
             self._known_advertisement_reversed[match.device_id] = match.is_reversed
             self._lock_miss_counts[match.device_id] = 0
 
-            timestamp_basis = metadata.get("timestamp_basis")
-            if isinstance(timestamp_basis, str):
-                self._known_timebases[match.device_id] = timestamp_basis
+            if isinstance(time_basis, str):
+                self._known_offsets[(match.device_id, time_basis)] = match.time_offset
+                self._known_timebases[match.device_id] = time_basis
 
             _LOGGER.info(
                 (
@@ -1507,7 +1633,9 @@ class GoogleFindMyEIDResolver:
                         return RAW_HEADER_LENGTH + 1
                     return RAW_HEADER_LENGTH
 
-                if frame_type == FMDN_FRAME_TYPE and length >= RAW_HEADER_LENGTH + LEGACY_EID_LENGTH:
+                if frame_type == FMDN_FRAME_TYPE and length >= (
+                    RAW_HEADER_LENGTH + LEGACY_EID_LENGTH
+                ):
                     payload_start = _legacy_payload_start()
                     candidates.append(
                         payload[payload_start : payload_start + LEGACY_EID_LENGTH]
@@ -1518,7 +1646,9 @@ class GoogleFindMyEIDResolver:
                             payload[RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + MODERN_EID_LENGTH]
                         )
                         return candidates, observed_frame
-                    elif RAW_HEADER_LENGTH + LEGACY_EID_LENGTH <= length <= RAW_HEADER_LENGTH + LEGACY_EID_LENGTH + 1:
+                    elif RAW_HEADER_LENGTH + LEGACY_EID_LENGTH <= length <= (
+                        RAW_HEADER_LENGTH + LEGACY_EID_LENGTH + 1
+                    ):
                         payload_start = _legacy_payload_start()
                         candidates.append(
                             payload[payload_start : payload_start + LEGACY_EID_LENGTH]

--- a/tests/test_eid_resolver_lock_confirmation.py
+++ b/tests/test_eid_resolver_lock_confirmation.py
@@ -76,6 +76,62 @@ async def test_lock_confirmation_updates_on_match(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.asyncio
+async def test_purge_stale_locks_keeps_recently_confirmed_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recently confirmed lock must not be purged by confirmation TTL."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = _fake_hass()
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._ensure_cache_defaults()
+
+    device_id = "device-id"
+    eid_bytes = b"\x01" * 20
+    resolver._lookup[eid_bytes] = EIDMatch(
+        device_id=device_id,
+        config_entry_id="entry-id",
+        canonical_id="canonical-id",
+        time_offset=0,
+        is_reversed=False,
+    )
+    resolver._lookup_metadata[eid_bytes] = {
+        "timestamp_basis": "pair_date",
+        "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
+    }
+    resolver._locks[device_id] = EIDGenerationLock(
+        device_id=device_id,
+        canonical_id="canonical-id",
+        variant=EidVariant.MODERN_P256_X32_BE.value,
+        advertisement_reversed=False,
+        eid_length=len(eid_bytes),
+        rotation_timestamp=100,
+        created_at=50,
+    )
+    initial_confirmation = 10
+    resolver._last_lock_confirmation[device_id] = initial_confirmation
+
+    now = 1_000
+    monkeypatch.setattr(time, "time", lambda: float(now))
+    match = resolver.resolve_eid(eid_bytes)
+    assert match is not None
+
+    purge_time = now + 120  # Well within the confirmation TTL window
+    resolver._purge_stale_locks(now=purge_time)
+
+    assert device_id in resolver._locks, (
+        "FAIL: active lock was purged despite recent confirmation. "
+        "_purge_stale_locks must respect _last_lock_confirmation timestamps."
+    )
+
+
+@pytest.mark.asyncio
 async def test_stale_lock_removed_by_confirmation_ttl() -> None:
     """BUG C: stale locks must clear when they are no longer confirmed."""
 
@@ -112,7 +168,7 @@ async def test_stale_lock_removed_by_confirmation_ttl() -> None:
     )
     resolver._locks[device_id] = lock
     resolver._persisted_locks[device_id] = lock
-    resolver._known_offsets[device_id] = 4
+    resolver._known_offsets[(device_id, "pair_date")] = 4
     resolver._known_advertisement_reversed[device_id] = True
     resolver._known_timebases[device_id] = "pair_date"
     resolver._lock_miss_counts[device_id] = 2
@@ -131,7 +187,7 @@ async def test_stale_lock_removed_by_confirmation_ttl() -> None:
         "Add LOCK_CONFIRMATION_TTL_SECONDS logic to purge and remove related caches."
     )
     assert device_id not in resolver._persisted_locks
-    assert device_id not in resolver._known_offsets
+    assert not any(key[0] == device_id for key in resolver._known_offsets)
     assert device_id not in resolver._known_advertisement_reversed
     assert device_id not in resolver._known_timebases
     assert device_id not in resolver._lock_miss_counts

--- a/tests/test_eid_resolver_pipeline.py
+++ b/tests/test_eid_resolver_pipeline.py
@@ -72,7 +72,7 @@ async def test_reset_device_offset_clears_state_and_schedules_refresh(
         )
     }
     resolver._persisted_locks = dict(resolver._locks)
-    resolver._known_offsets = {"reg-1": -1}
+    resolver._known_offsets = {("reg-1", "pair_date"): -1}
     resolver._known_timebases = {"reg-1": "pair_date"}
     resolver._known_advertisement_reversed = {"reg-1": True}
     resolver._lock_miss_counts = {"reg-1": 2}
@@ -121,7 +121,7 @@ def test_reset_device_offset_noop_when_unknown(monkeypatch: pytest.MonkeyPatch) 
     resolver = _build_resolver(monkeypatch)
     resolver._locks = {"other": MagicMock()}
     resolver._persisted_locks = dict(resolver._locks)
-    resolver._known_offsets = {"other": 0}
+    resolver._known_offsets = {("other", "pair_date"): 0}
     resolver._known_timebases = {"other": "pair_date"}
     resolver._known_advertisement_reversed = {"other": False}
     resolver._lock_miss_counts = {"other": 1}
@@ -144,7 +144,7 @@ def test_reset_device_offset_noop_when_unknown(monkeypatch: pytest.MonkeyPatch) 
 
     assert resolver._locks == {"other": resolver._locks["other"]}
     assert resolver._persisted_locks == {"other": resolver._locks["other"]}
-    assert resolver._known_offsets == {"other": 0}
+    assert resolver._known_offsets == {("other", "pair_date"): 0}
     assert resolver._known_timebases == {"other": "pair_date"}
     assert resolver._known_advertisement_reversed == {"other": False}
     assert resolver._lock_miss_counts == {"other": 1}

--- a/tests/test_eid_resolver_risk_regressions.py
+++ b/tests/test_eid_resolver_risk_regressions.py
@@ -1,0 +1,264 @@
+# tests/test_eid_resolver_risk_regressions.py
+"""LOUD regression tests for subtle resolver risks (dedupe, offsets, confirmation, soft-gate)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import (
+    LOCK_CONFIRMATION_TTL_SECONDS,
+    EIDGenerationLock,
+    EIDMatch,
+    EidVariant,
+    GoogleFindMyEIDResolver,
+    WindowCandidate,
+    WindowSpec,
+    WorkItem,
+    _normalize_counter_candidate,
+)
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import ROTATION_PERIOD
+
+
+def _resolver() -> GoogleFindMyEIDResolver:
+    """Return a resolver with initialized caches and fake hass."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = SimpleNamespace(
+        async_create_task=lambda coro, name=None: asyncio.create_task(coro),
+        async_create_background_task=lambda coro, name=None: asyncio.create_task(coro),
+    )
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._known_offsets = {}
+    resolver._known_advertisement_reversed = {}
+    resolver._known_timebases = {}
+    resolver._persisted_locks = {}
+    resolver._decryption_status = {}
+    resolver._last_lock_confirmation = {}
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._provisioning_warn_at = {}
+    resolver._ensure_cache_defaults()
+    return resolver
+
+
+def _identity() -> DeviceIdentity:
+    """Baseline device identity."""
+
+    return DeviceIdentity(
+        registry_id="device-id",
+        canonical_id="canonical-id",
+        identity_key=b"\xAA" * 16,
+        config_entry_id="entry-id",
+        manufacturer="",
+        model="",
+        pair_date=1_000,
+        secrets_creation_date=2_000,
+    )
+
+
+def test_dedupe_prefers_best_metadata() -> None:
+    """AC4/R1: dedupe must keep the best semantic_offset, not first wins."""
+
+    resolver = _resolver()
+    w_bad = WindowCandidate(
+        timestamp=12345,
+        semantic_offset=1024,
+        time_basis="pair_date",
+        candidate_value=11111,
+    )
+    w_good = WindowCandidate(
+        timestamp=12345,
+        semantic_offset=0,
+        time_basis="pair_date",
+        candidate_value=11111,
+    )
+    specs = [
+        WindowSpec(
+            time_basis="pair_date",
+            candidate_value=11111,
+            windows=(w_bad,),
+        ),
+        WindowSpec(
+            time_basis="pair_date",
+            candidate_value=11111,
+            windows=(w_good,),
+        ),
+    ]
+
+    deduped = resolver._dedupe_windows(specs)
+    assert deduped and len(deduped[0].windows) == 1
+    kept = deduped[0].windows[0]
+    assert kept.semantic_offset == 0, (
+        "FAIL (R1): _dedupe_windows kept the first duplicate instead of the best one. "
+        "Fix: In `GoogleFindMyEIDResolver._dedupe_windows`, when duplicates share (basis, timestamp), "
+        "select the candidate with the smallest abs(semantic_offset) and keep deterministic ordering "
+        "so better match metadata is preserved."
+    )
+
+
+def test_known_offset_does_not_cross_bases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC3/R2: known_offset must not leak between time bases even when plausible."""
+
+    resolver = _resolver()
+    params = resolver._build_rotation_params()
+    identity = _identity()
+    resolver._known_offsets[(identity.registry_id, "pair_date")] = 2 * ROTATION_PERIOD
+
+    now_unix = 10_000
+    work_item = WorkItem(
+        registry_id=identity.registry_id,
+        config_entry_id=identity.config_entry_id,
+        canonical_id=identity.canonical_id,
+        key_bytes=b"\xBB" * 16,
+        identity=identity,
+        lock=None,
+        locked_variant=None,
+        rotation_ts=None,
+        basis_hint=None,
+    )
+
+    counter_windows, invalid_hint = resolver._compute_relative_windows(
+        work_item,
+        now_unix=now_unix,
+        params=params,
+        min_relative_window=params.min_relative_window,
+        allow_unix_basis=True,
+    )
+    assert invalid_hint is False
+    basis_map = {spec.time_basis: spec for spec in counter_windows}
+    secrets_spec = basis_map.get("secrets_creation_date")
+    assert secrets_spec is not None
+
+    base_candidate = now_unix - identity.secrets_creation_date
+    expected_normalized = _normalize_counter_candidate(base_candidate, basis="secrets_creation_date")
+
+    assert secrets_spec.candidate_value == expected_normalized, (
+        "FAIL (R2): known_offset was applied across time bases (pair_date -> secrets_creation_date). "
+        "Fix: Track offsets with basis provenance (for example, `_known_offsets[(device_id, basis)]`) "
+        "and only apply the offset for the current basis inside `_compute_relative_windows`."
+    )
+
+
+def test_confirmation_refresh_and_purge_stability(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC1/R3: confirmation must refresh on HIT and prevent premature purge."""
+
+    resolver = _resolver()
+    eid_bytes = b"\x99" * 20
+    resolver._lookup[eid_bytes] = EIDMatch(
+        device_id="device-id",
+        config_entry_id="entry-id",
+        canonical_id="canonical-id",
+        time_offset=0,
+        is_reversed=False,
+    )
+    resolver._lookup_metadata[eid_bytes] = {
+        "timestamp_basis": "pair_date",
+        "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
+    }
+    resolver._locks["device-id"] = EIDGenerationLock(
+        device_id="device-id",
+        canonical_id="canonical-id",
+        variant=EidVariant.MODERN_P256_X32_BE.value,
+        advertisement_reversed=False,
+        eid_length=len(eid_bytes),
+        created_at=0,
+    )
+    resolver._last_lock_confirmation["device-id"] = 1
+
+    now = 1_000
+    monkeypatch.setattr(time, "time", lambda: float(now))
+
+    match = resolver.resolve_eid(eid_bytes)
+    assert match is not None
+    assert resolver._last_lock_confirmation["device-id"] == now, (
+        "FAIL (AC1): resolve_eid did not refresh last_lock_confirmation on HIT. "
+        "Fix: In `resolve_eid` match-found path, set `_last_lock_confirmation[device_id] = int(time.time())` "
+        "before returning so active locks are not purged."
+    )
+
+    resolver._purge_stale_locks(now=now + LOCK_CONFIRMATION_TTL_SECONDS // 2)
+    assert "device-id" in resolver._locks, (
+        "FAIL (AC1): active lock was purged despite recent confirmation. "
+        "Ensure `_purge_stale_locks` respects updated `_last_lock_confirmation` timestamps."
+    )
+
+
+def test_soft_gate_keeps_discovery_windows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC5/R4: soft-gate must keep discovery windows after dedupe with deterministic ordering."""
+
+    resolver = _resolver()
+    params = resolver._build_rotation_params()
+    identity = _identity()
+    work_item = WorkItem(
+        registry_id=identity.registry_id,
+        config_entry_id=identity.config_entry_id,
+        canonical_id=identity.canonical_id,
+        key_bytes=b"\xCC" * 16,
+        identity=identity,
+        lock=None,
+        locked_variant=None,
+        rotation_ts=None,
+        basis_hint=None,
+    )
+
+    lock_windows = [
+        WindowSpec(
+            time_basis="lock_tracking",
+            candidate_value=1000,
+            windows=(
+                WindowCandidate(
+                    timestamp=5000,
+                    semantic_offset=0,
+                    time_basis="lock_tracking",
+                    candidate_value=1000,
+                ),
+            ),
+        )
+    ]
+    discovery_windows = [
+        WindowSpec(
+            time_basis="pair_date",
+            candidate_value=2000,
+            windows=(
+                WindowCandidate(
+                    timestamp=5000,
+                    semantic_offset=1,
+                    time_basis="pair_date",
+                    candidate_value=2000,
+                ),
+            ),
+        )
+    ]
+
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_compute_lock_windows",
+        lambda _self, *_args, **_: lock_windows,
+    )
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_compute_relative_windows",
+        lambda _self, *_args, **_: (discovery_windows, False),
+    )
+
+    merged, invalid_hint = resolver._compute_time_windows(
+        work_item,
+        now_unix=10_000,
+        params=params,
+    )
+
+    assert invalid_hint is False
+    bases = [spec.time_basis for spec in merged]
+    assert bases[:2] == ["lock_tracking", "pair_date"], (
+        "FAIL (AC5): soft-gate/dedupe removed or reordered discovery windows. "
+        "Ensure `_compute_time_windows` keeps lock_tracking first and still includes discovery windows "
+        "after deduplication so self-healing remains deterministic."
+    )

--- a/tests/test_eid_resolver_slicing.py
+++ b/tests/test_eid_resolver_slicing.py
@@ -16,7 +16,12 @@ def _build_resolver(lookup_key: bytes, match: EIDMatch) -> GoogleFindMyEIDResolv
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = SimpleNamespace()
     resolver._lookup = {lookup_key: match}
-    resolver._lookup_metadata = {}
+    resolver._lookup_metadata = {
+        lookup_key: {
+            "timestamp_basis": "pair_date",
+            "variant": match.time_offset,
+        }
+    }
     resolver._known_offsets = {}
     resolver._known_advertisement_reversed = {}
     resolver._known_timebases = {}
@@ -48,7 +53,7 @@ def test_resolve_eid_slices_raw_payload() -> None:
     resolved = resolver.resolve_eid(payload)
 
     assert resolved == match
-    assert resolver._known_offsets.get("device-raw") == 0
+    assert resolver._known_offsets.get(("device-raw", "pair_date")) == 0
     assert resolver._known_advertisement_reversed.get("device-raw") is False
 
 
@@ -68,7 +73,7 @@ def test_resolve_eid_accepts_pure_eid() -> None:
     resolved = resolver.resolve_eid(eid)
 
     assert resolved == match
-    assert resolver._known_offsets.get("device-pure") == 5
+    assert resolver._known_offsets.get(("device-pure", "pair_date")) == 5
     assert resolver._known_advertisement_reversed.get("device-pure") is True
 
 

--- a/tests/test_eid_resolver_window_semantics.py
+++ b/tests/test_eid_resolver_window_semantics.py
@@ -1,0 +1,220 @@
+# tests/test_eid_resolver_window_semantics.py
+"""Window semantics and confirmation handling for the EID resolver."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import (
+    EIDGenerationLock,
+    EidVariant,
+    GoogleFindMyEIDResolver,
+    WindowCandidate,
+    WindowSpec,
+    WorkItem,
+    _normalize_counter_candidate,
+)
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import ROTATION_PERIOD
+
+
+def _resolver() -> GoogleFindMyEIDResolver:
+    """Return a resolver with initialized caches and a fake hass."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = SimpleNamespace(
+        async_create_task=lambda coro, name=None: asyncio.create_task(coro),
+        async_create_background_task=lambda coro, name=None: asyncio.create_task(coro),
+    )
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._ensure_cache_defaults()
+    return resolver
+
+
+def _identity() -> DeviceIdentity:
+    """Construct a baseline device identity."""
+
+    return DeviceIdentity(
+        registry_id="device-id",
+        canonical_id="canonical-id",
+        identity_key=b"\x01" * 16,
+        config_entry_id="entry-id",
+        manufacturer="",
+        model="",
+        pair_date=1_000,
+        secrets_creation_date=1_000,
+    )
+
+
+def test_compute_lock_windows_uses_expected_counter_for_candidate_value() -> None:
+    """Lock windows should carry the expected counter as their candidate value."""
+
+    resolver = _resolver()
+    params = resolver._build_rotation_params()
+    identity = _identity()
+    rotation_timestamp = 2_000
+    lock = EIDGenerationLock(
+        device_id=identity.registry_id,
+        canonical_id=identity.canonical_id,
+        variant=EidVariant.MODERN_P256_X32_BE.value,
+        advertisement_reversed=False,
+        eid_length=20,
+        rotation_timestamp=rotation_timestamp,
+        created_at=100,
+    )
+    work_item = WorkItem(
+        registry_id=identity.registry_id,
+        config_entry_id=identity.config_entry_id,
+        canonical_id=identity.canonical_id,
+        key_bytes=b"\xAA" * 16,
+        identity=identity,
+        lock=lock,
+        locked_variant=EidVariant.MODERN_P256_X32_BE,
+        rotation_ts=rotation_timestamp,
+        basis_hint=None,
+    )
+
+    now_unix = rotation_timestamp + (params.rotation_period * 3)
+    windows = resolver._compute_lock_windows(work_item, now_unix=now_unix, params=params)
+    assert windows
+
+    expected_counter = rotation_timestamp + (
+        (now_unix - lock.created_at) // params.rotation_period
+    ) * params.rotation_period
+    assert (
+        windows[0].candidate_value == expected_counter
+    ), "FAIL: lock WindowSpec.candidate_value must equal expected_counter (counter 'now')."
+
+
+def test_known_offset_out_of_range_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Implausible known offsets must not narrow the discovery window."""
+
+    resolver = _resolver()
+    params = resolver._build_rotation_params()
+    identity = _identity()
+    resolver._known_offsets[(identity.registry_id, "pair_date")] = -1_759_000_000
+
+    now_unix = 10_000
+    work_item = WorkItem(
+        registry_id=identity.registry_id,
+        config_entry_id=identity.config_entry_id,
+        canonical_id=identity.canonical_id,
+        key_bytes=b"\xBB" * 16,
+        identity=identity,
+        lock=None,
+        locked_variant=None,
+        rotation_ts=None,
+        basis_hint=None,
+    )
+
+    counter_windows, invalid_hint = resolver._compute_relative_windows(
+        work_item,
+        now_unix=now_unix,
+        params=params,
+        min_relative_window=params.min_relative_window,
+        allow_unix_basis=True,
+    )
+    assert invalid_hint is False
+    assert counter_windows
+
+    pair_date_window = next(
+        spec for spec in counter_windows if spec.time_basis == "pair_date"
+    )
+    base_candidate = now_unix - identity.pair_date
+    normalized = _normalize_counter_candidate(base_candidate, basis="pair_date")
+
+    assert (
+        pair_date_window.candidate_value == normalized
+    ), "FAIL: implausible known_offset was applied; candidate_value must remain unshifted."
+    assert len(pair_date_window.windows) > 3, (
+        "FAIL: implausible known_offset was applied, narrowing discovery and risking silent death. "
+        "Bound known_offset before applying it."
+    )
+
+
+def test_time_windows_are_deduplicated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Merged windows should deduplicate timestamps per basis."""
+
+    resolver = _resolver()
+    params = resolver._build_rotation_params()
+    identity = _identity()
+    work_item = WorkItem(
+        registry_id=identity.registry_id,
+        config_entry_id=identity.config_entry_id,
+        canonical_id=identity.canonical_id,
+        key_bytes=b"\xCC" * 16,
+        identity=identity,
+        lock=None,
+        locked_variant=None,
+        rotation_ts=None,
+        basis_hint=None,
+    )
+
+    duplicate_ts = ROTATION_PERIOD * 5
+    lock_windows = [
+        WindowSpec(
+            time_basis="pair_date",
+            candidate_value=duplicate_ts,
+            windows=(
+                WindowCandidate(
+                    timestamp=duplicate_ts,
+                    semantic_offset=0,
+                    time_basis="pair_date",
+                    candidate_value=duplicate_ts,
+                ),
+            ),
+        )
+    ]
+    relative_windows = [
+        WindowSpec(
+            time_basis="pair_date",
+            candidate_value=duplicate_ts,
+            windows=(
+                WindowCandidate(
+                    timestamp=duplicate_ts,
+                    semantic_offset=0,
+                    time_basis="pair_date",
+                    candidate_value=duplicate_ts,
+                ),
+                WindowCandidate(
+                    timestamp=duplicate_ts,
+                    semantic_offset=0,
+                    time_basis="pair_date",
+                    candidate_value=duplicate_ts,
+                ),
+            ),
+        )
+    ]
+
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver, "_compute_lock_windows", lambda _self, *a, **k: lock_windows
+    )
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_compute_relative_windows",
+        lambda _self, *a, **k: (relative_windows, False),
+    )
+
+    merged, invalid_hint = resolver._compute_time_windows(
+        work_item,
+        now_unix=10_000,
+        params=params,
+    )
+
+    assert invalid_hint is False
+    assert merged
+
+    timestamps = [(spec.time_basis, window.timestamp) for spec in merged for window in spec.windows]
+    assert timestamps == [("pair_date", duplicate_ts)], (
+        "FAIL: duplicate windows detected after merging lock and discovery windows. "
+        "Deduplicate by (time_basis, timestamp) before variant generation."
+    )


### PR DESCRIPTION
## Summary
- scope known offsets to a device and time basis and purge them when clearing lock state
- prefer the best semantic offset while deduplicating windows and keep discovery windows alongside lock tracking
- add targeted risk regressions for confirmation refresh, basis-aware offsets, dedupe metadata, and soft-gate discovery retention

## Testing
- make test-stubs
- python -m ruff check --fix
- python -m mypy --strict --install-types --non-interactive
- python -m pytest --cov -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694993abea908329b14c48cc8f8f23a7)