### PR TITLE
Prevent lock_tracking hits from poisoning anchor offsets

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -83,6 +83,8 @@ LOCK_TTL_SECONDS = 7 * 24 * 60 * 60
 LOCK_CONFIRMATION_TTL_SECONDS = 90 * 60
 LOCK_MISS_THRESHOLD = 3
 TRUNCATED_FRAME_LOG_WINDOW_SECONDS = 60
+VALID_ANCHOR_BASES: set[str] = {"unix", "pair_date", "secrets_creation_date"}
+KNOWN_OFFSET_KEY_LENGTH = 2
 
 
 class EIDMatch(NamedTuple):
@@ -283,6 +285,15 @@ def _normalize_optional_string(value: object) -> str | None:
     return None
 
 
+def _normalize_anchor_basis(value: object) -> str | None:
+    """Return a valid anchor basis or ``None``."""
+
+    if not isinstance(value, str):
+        return None
+    basis = value.strip()
+    return basis if basis in VALID_ANCHOR_BASES else None
+
+
 def _normalize_encrypted_blob(value: object) -> bytes | None:
     """Normalize encrypted payloads encoded as bytes or hex strings."""
 
@@ -474,7 +485,15 @@ class GoogleFindMyEIDResolver:
         if not isinstance(mapping, dict) or not mapping:
             return False
 
-        to_delete = [key for key in mapping if key[0] == device_id]
+        to_delete: list[tuple[str, str]] = []
+        for key in list(mapping.keys()):
+            if (
+                isinstance(key, tuple)
+                and len(key) == KNOWN_OFFSET_KEY_LENGTH
+                and isinstance(key[0], str)
+                and key[0] == device_id
+            ):
+                to_delete.append(key)
         for key in to_delete:
             mapping.pop(key, None)
 
@@ -915,6 +934,10 @@ class GoogleFindMyEIDResolver:
             ("pair_date", "pair_date"),
             ("secrets_creation_date", "secrets_creation_date"),
         )
+        if not ENABLE_ABSOLUTE_UNIX_BASIS:
+            counter_bases = tuple(
+                (basis, label) for basis, label in counter_bases if basis != "unix"
+            )
         if not allow_unix_basis:
             counter_bases = tuple(
                 (basis, label) for basis, label in counter_bases if basis != "unix"
@@ -1045,14 +1068,14 @@ class GoogleFindMyEIDResolver:
                 if key not in key_index:
                     key_index[key] = len(basis_windows[spec.time_basis])
                     basis_windows[spec.time_basis].append(window)
-                    basis_candidate_value.setdefault(spec.time_basis, spec.candidate_value)
+                    basis_candidate_value.setdefault(spec.time_basis, window.candidate_value)
                     continue
 
                 idx = key_index[key]
                 current = basis_windows[spec.time_basis][idx]
                 if abs(window.semantic_offset) < abs(current.semantic_offset):
                     basis_windows[spec.time_basis][idx] = window
-                    basis_candidate_value[spec.time_basis] = spec.candidate_value
+                    basis_candidate_value[spec.time_basis] = window.candidate_value
 
         return [
             WindowSpec(
@@ -1194,6 +1217,37 @@ class GoogleFindMyEIDResolver:
             len(work_items),
             len(self._lookup),
         )
+
+    def _normalize_variant_value(self, raw: object, *, eid_len: int) -> str:
+        """Return a valid `EidVariant` value string for persistence."""
+
+        try:
+            return EidVariant(raw).value
+        except Exception:
+            pass
+
+        if isinstance(raw, str):
+            stripped = raw.strip()
+            if stripped:
+                try:
+                    return EidVariant(stripped).value
+                except Exception:
+                    if stripped.isdigit():
+                        try:
+                            return EidVariant(int(stripped)).value
+                        except Exception:
+                            pass
+        elif isinstance(raw, int) and not isinstance(raw, bool):
+            try:
+                return EidVariant(raw).value
+            except Exception:
+                pass
+
+        inferred = self._infer_variant_from_length(eid_len)
+        try:
+            return EidVariant(inferred).value
+        except Exception:
+            return inferred
 
     @staticmethod
     def _infer_variant_from_length(eid_length: int) -> str:
@@ -1517,14 +1571,22 @@ class GoogleFindMyEIDResolver:
             metadata: dict[str, Any] = self._lookup_metadata.get(candidate) or {}
             now = int(time.time())
             self._last_lock_confirmation[match.device_id] = now
-            time_basis = metadata.get("timestamp_basis")
+            previous_basis = _normalize_anchor_basis(self._known_timebases.get(match.device_id))
+            raw_time_basis = metadata.get("timestamp_basis")
+            anchor_basis = _normalize_anchor_basis(raw_time_basis)
+            basis_explicitly_invalid = raw_time_basis is not None and anchor_basis is None
+            if anchor_basis is None:
+                if raw_time_basis is None:
+                    anchor_basis = previous_basis
+            elif raw_time_basis != anchor_basis:
+                self._known_timebases.pop(match.device_id, None)
+            if anchor_basis is None and not basis_explicitly_invalid:
+                self._known_timebases.pop(match.device_id, None)
             if match.device_id not in self._locks:
-                variant_str = str(metadata.get("variant") or "")
-                try:
-                    variant_value = variant_str or self._infer_variant_from_length(len(candidate))
-                except Exception:
-                    variant_value = EidVariant.MODERN_P256_X32_BE.value
-                time_basis = metadata.get("timestamp_basis")
+                variant_value = self._normalize_variant_value(
+                    metadata.get("variant"),
+                    eid_len=len(candidate),
+                )
                 rotation_timestamp = metadata.get("rotation_timestamp")
                 lock = EIDGenerationLock(
                     device_id=match.device_id,
@@ -1537,7 +1599,7 @@ class GoogleFindMyEIDResolver:
                     and not isinstance(rotation_timestamp, bool)
                     else None,
                     frame_type=observed_frame,
-                    time_basis=time_basis if isinstance(time_basis, str) else None,
+                    time_basis=anchor_basis,
                     created_at=now,
                 )
                 self._locks[match.device_id] = lock
@@ -1547,9 +1609,9 @@ class GoogleFindMyEIDResolver:
             self._known_advertisement_reversed[match.device_id] = match.is_reversed
             self._lock_miss_counts[match.device_id] = 0
 
-            if isinstance(time_basis, str):
-                self._known_offsets[(match.device_id, time_basis)] = match.time_offset
-                self._known_timebases[match.device_id] = time_basis
+            if anchor_basis is not None and not basis_explicitly_invalid:
+                self._known_offsets[(match.device_id, anchor_basis)] = match.time_offset
+                self._known_timebases[match.device_id] = anchor_basis
 
             _LOGGER.info(
                 (

--- a/tests/test_eid_resolver_risk_regressions.py
+++ b/tests/test_eid_resolver_risk_regressions.py
@@ -262,3 +262,229 @@ def test_soft_gate_keeps_discovery_windows(monkeypatch: pytest.MonkeyPatch) -> N
         "Ensure `_compute_time_windows` keeps lock_tracking first and still includes discovery windows "
         "after deduplication so self-healing remains deterministic."
     )
+
+
+def test_resolve_eid_does_not_store_lock_tracking_as_known_timebasis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC3/Task A: resolve_eid must sanitize anchor bases before persistence."""
+
+    resolver = _resolver()
+    eid = b"\x11" * 20
+    resolver._lookup[eid] = EIDMatch(
+        device_id="dev",
+        config_entry_id="entry",
+        canonical_id="can",
+        time_offset=7,
+        is_reversed=False,
+    )
+    resolver._lookup_metadata[eid] = {
+        "timestamp_basis": "lock_tracking",
+        "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
+    }
+
+    monkeypatch.setattr(time, "time", lambda: 1000.0)
+    assert resolver.resolve_eid(eid) is not None
+
+    assert resolver._known_timebases.get("dev") != "lock_tracking", (
+        "FAIL: resolve_eid stored 'lock_tracking' into _known_timebases. "
+        "Fix: sanitize metadata['timestamp_basis'] in resolve_eid() so only "
+        "{'unix','pair_date','secrets_creation_date'} are persisted as anchor bases."
+    )
+    assert ("dev", "lock_tracking") not in resolver._known_offsets, (
+        "FAIL: resolve_eid stored an offset under ('dev','lock_tracking'). "
+        "Fix: only store known offsets when the basis is a valid anchor basis."
+    )
+
+
+def test_resolve_eid_missing_timestamp_basis_uses_previous_valid_basis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC4/Task A: missing basis must fall back to a prior valid anchor basis."""
+
+    resolver = _resolver()
+    resolver._known_timebases["dev"] = "pair_date"
+
+    eid = b"\x22" * 20
+    resolver._lookup[eid] = EIDMatch(
+        device_id="dev",
+        config_entry_id="entry",
+        canonical_id="can",
+        time_offset=3,
+        is_reversed=False,
+    )
+    resolver._lookup_metadata[eid] = {
+        "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
+    }
+
+    monkeypatch.setattr(time, "time", lambda: 1000.0)
+    assert resolver.resolve_eid(eid) is not None
+
+    assert resolver._known_offsets.get(("dev", "pair_date")) == 3, (
+        "FAIL: resolve_eid did not store basis-aware known_offset when timestamp_basis was missing. "
+        "Fix: in resolve_eid(), if metadata basis is missing/invalid, fall back to a previously known "
+        "valid anchor basis for that device (e.g., _known_timebases[device_id]) before storing offsets."
+    )
+
+
+def test_resolve_eid_normalizes_variant_and_never_persists_invalid_lock_variant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC6/Task B: invalid metadata variant must not poison persisted locks."""
+
+    resolver = _resolver()
+    eid = b"\x33" * 20
+    resolver._lookup[eid] = EIDMatch(
+        device_id="dev",
+        config_entry_id="entry",
+        canonical_id="can",
+        time_offset=0,
+        is_reversed=False,
+    )
+    resolver._lookup_metadata[eid] = {
+        "timestamp_basis": "pair_date",
+        "variant": "0",  # intentionally invalid for EidVariant in many implementations
+    }
+
+    monkeypatch.setattr(time, "time", lambda: 1000.0)
+    assert resolver.resolve_eid(eid) is not None
+
+    lock = resolver._locks.get("dev")
+    assert lock is not None
+    try:
+        EidVariant(lock.variant)
+    except Exception as err:  # pragma: no cover - explicit assert helper
+        raise AssertionError(
+            "FAIL: resolve_eid persisted an invalid EIDGenerationLock.variant. "
+            "Fix: normalize/validate metadata['variant'] in resolve_eid(); "
+            "if it is not parseable as EidVariant, ignore it and infer from EID length. "
+            f"Observed error: {err!r}"
+        )
+
+
+def test_purge_known_offsets_for_device_is_defensive_against_malformed_keys() -> None:
+    """AC2/Task D: purge helper must tolerate malformed offset keys."""
+
+    resolver = _resolver()
+    resolver._known_offsets = {
+        ("dev", "pair_date"): 1,
+        "dev": 999,
+        ("dev",): 888,
+        ("other", "pair_date"): 2,
+    }
+
+    removed = resolver._purge_known_offsets_for_device("dev")
+    assert removed is True
+    assert ("dev", "pair_date") not in resolver._known_offsets
+    assert ("other", "pair_date") in resolver._known_offsets
+
+
+def test_dedupe_keeps_best_window_and_aligns_candidate_value() -> None:
+    """AC5/Task C: dedupe must align spec candidate values with kept windows."""
+
+    resolver = _resolver()
+
+    w1 = WindowCandidate(
+        timestamp=10,
+        semantic_offset=5,
+        time_basis="pair_date",
+        candidate_value=100,
+    )
+    w2 = WindowCandidate(
+        timestamp=10,
+        semantic_offset=0,
+        time_basis="pair_date",
+        candidate_value=200,
+    )
+
+    specs = [
+        WindowSpec(time_basis="pair_date", candidate_value=100, windows=(w1,)),
+        WindowSpec(time_basis="pair_date", candidate_value=999, windows=(w2,)),
+    ]
+
+    out = resolver._dedupe_windows(specs)
+    assert out and len(out[0].windows) == 1
+    kept = out[0].windows[0]
+
+    assert kept.semantic_offset == 0, (
+        "FAIL: _dedupe_windows did not keep the best semantic_offset candidate. "
+        "Fix: when duplicates share (basis,timestamp), choose the smallest abs(semantic_offset)."
+    )
+    assert out[0].candidate_value == kept.candidate_value, (
+        "FAIL: _dedupe_windows produced WindowSpec.candidate_value that does not match the kept WindowCandidate. "
+        "Fix: set basis_candidate_value[basis] from the kept WindowCandidate.candidate_value, not spec.candidate_value."
+    )
+
+
+def test_unix_hint_is_ignored_when_absolute_unix_disabled() -> None:
+    """AC4: unix basis hint must not collapse windows when absolute unix scan is disabled."""
+
+    resolver = _resolver()
+    params = resolver._build_rotation_params()
+    identity = _identity()
+
+    resolver._known_timebases[identity.registry_id] = "unix"
+
+    work_item = WorkItem(
+        registry_id=identity.registry_id,
+        config_entry_id=identity.config_entry_id,
+        canonical_id=identity.canonical_id,
+        key_bytes=b"\xCC" * 16,
+        identity=identity,
+        lock=None,
+        locked_variant=None,
+        rotation_ts=None,
+        basis_hint="unix",
+    )
+
+    counter_windows, invalid_hint = resolver._compute_relative_windows(
+        work_item,
+        now_unix=10_000,
+        params=params,
+        min_relative_window=params.min_relative_window,
+        allow_unix_basis=True,
+    )
+
+    assert counter_windows, (
+        "FAIL: unix basis hint collapsed window generation when ENABLE_ABSOLUTE_UNIX_BASIS is False. "
+        "Fix: exclude 'unix' from available bases when absolute unix scanning is disabled so the hint "
+        "becomes invalid and pair_date/secrets_creation_date windows are generated."
+    )
+    assert invalid_hint is True, (
+        "FAIL: unix basis hint should be treated as invalid when absolute unix scanning is disabled. "
+        "Fix: remove unix from available_bases / counter_bases under ENABLE_ABSOLUTE_UNIX_BASIS=False."
+    )
+
+
+def test_resolve_eid_does_not_poison_anchor_offsets_with_lock_tracking_basis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lock-tracking hits must not overwrite anchor-based known offsets/timebases."""
+
+    resolver = _resolver()
+    resolver._known_timebases["dev"] = "pair_date"
+    resolver._known_offsets[("dev", "pair_date")] = 123
+
+    eid = b"\x11" * 20
+    resolver._lookup[eid] = EIDMatch(
+        device_id="dev",
+        config_entry_id="entry",
+        canonical_id="can",
+        time_offset=7,
+        is_reversed=False,
+    )
+    resolver._lookup_metadata[eid] = {
+        "timestamp_basis": "lock_tracking",
+        "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
+    }
+
+    monkeypatch.setattr(time, "time", lambda: 1000.0)
+    assert resolver.resolve_eid(eid) is not None
+
+    assert resolver._known_timebases.get("dev") == "pair_date"
+    assert ("dev", "lock_tracking") not in resolver._known_offsets
+    assert resolver._known_offsets.get(("dev", "pair_date")) == 123, (
+        "FAIL: lock-tracking hit overwrote anchor-based known offset. "
+        "Fix: if timestamp_basis is explicitly invalid (e.g., lock_tracking), "
+        "do not persist match.time_offset under any anchor basis."
+    )

--- a/tests/test_eid_resolver_slicing.py
+++ b/tests/test_eid_resolver_slicing.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 from custom_components.googlefindmy.eid_resolver import (
     EIDMatch,
+    EidVariant,
     GoogleFindMyEIDResolver,
 )
 
@@ -19,7 +20,7 @@ def _build_resolver(lookup_key: bytes, match: EIDMatch) -> GoogleFindMyEIDResolv
     resolver._lookup_metadata = {
         lookup_key: {
             "timestamp_basis": "pair_date",
-            "variant": match.time_offset,
+            "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
         }
     }
     resolver._known_offsets = {}


### PR DESCRIPTION
## Summary
- guard resolve_eid so explicitly invalid timestamp bases (e.g., lock_tracking) no longer overwrite anchor-based known offsets or timebases
- add regression coverage ensuring lock_tracking hits keep existing anchor offsets intact and unix hints remain invalid when absolute unix scanning is disabled

## Testing
- make test-stubs
- python -m ruff check
- python -m mypy --strict --install-types --non-interactive
- python -m pytest -q --cov


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ca7eb478832987564ad8cdbad700)