### PR TITLE
Defer EID resolver shutdown until parent unload succeeds

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -7759,14 +7759,6 @@ async def _async_unload_parent_entry(hass: HomeAssistant, entry: MyConfigEntry) 
         runtime_data.subentry_retry_attempts.clear()
         _cleanup_cloud_discovery_runtime(runtime_data)
 
-    resolver = bucket.get(DATA_EID_RESOLVER)
-    if isinstance(resolver, GoogleFindMyEIDResolver):
-        if not entries_bucket:
-            resolver.stop()
-            bucket.pop(DATA_EID_RESOLVER, None)
-        else:
-            hass.async_create_task(resolver.async_refresh())
-
     subentries = _collect_entry_subentries(entry)
 
     forwarded_parent_platforms_flag = getattr(
@@ -8032,6 +8024,14 @@ async def _async_unload_parent_entry(hass: HomeAssistant, entry: MyConfigEntry) 
                 )
         except Exception as err:
             _LOGGER.debug("Owner-index cleanup failed: %s", err)
+
+        resolver = bucket.get(DATA_EID_RESOLVER)
+        if isinstance(resolver, GoogleFindMyEIDResolver):
+            if not entries_bucket:
+                resolver.stop()
+                bucket.pop(DATA_EID_RESOLVER, None)
+            else:
+                hass.async_create_task(resolver.async_refresh())
 
         try:
             await _maybe_close_spot_transport(entries_bucket)

--- a/tests/test_subentry_setup_trigger.py
+++ b/tests/test_subentry_setup_trigger.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-from collections.abc import Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from types import SimpleNamespace
 from typing import Any
 
@@ -22,11 +22,13 @@ from custom_components.googlefindmy import (
     _async_unload_parent_entry,
 )
 from custom_components.googlefindmy.const import (
+    DATA_EID_RESOLVER,
     DOMAIN,
     SUBENTRY_TYPE_SERVICE,
     SUBENTRY_TYPE_TRACKER,
     TRACKER_FEATURE_PLATFORMS,
 )
+from custom_components.googlefindmy.eid_resolver import GoogleFindMyEIDResolver
 from custom_components.googlefindmy.entity import schedule_add_entities
 from tests.helpers.homeassistant import (
     FakeConfigEntriesManager,
@@ -50,6 +52,24 @@ def _attach_runtime(entry: FakeConfigEntry) -> RuntimeData:
     )
     entry.runtime_data = runtime_data
     return runtime_data
+
+
+def _resolver_stub() -> GoogleFindMyEIDResolver:
+    """Build a resolver double without invoking the real initializer."""
+
+    class _ResolverDouble(GoogleFindMyEIDResolver):
+        __slots__ = ("stop_called", "refresh_called")
+
+        def stop(self) -> None:  # type: ignore[override]
+            self.stop_called = True
+
+        async def async_refresh(self) -> None:
+            self.refresh_called = True
+
+    resolver = _ResolverDouble.__new__(_ResolverDouble)
+    resolver.stop_called = False
+    resolver.refresh_called = False
+    return resolver
 
 
 @pytest.mark.asyncio
@@ -863,3 +883,123 @@ async def test_async_unload_entry_cancels_retry_handles() -> None:
     assert handle.cancelled is True
     assert runtime_data.subentry_retry_handles == {}
     assert runtime_data.subentry_retry_attempts == {}
+
+
+@pytest.mark.asyncio
+async def test_parent_unload_failure_preserves_resolver() -> None:
+    """Resolver should remain running when parent unload aborts."""
+
+    parent_entry = FakeConfigEntry(entry_id="parent-entry")
+    runtime_data = _attach_runtime(parent_entry)
+    config_entries = FakeConfigEntriesManager([parent_entry])
+    config_entries.async_unload_platforms = lambda entry, platforms: False  # type: ignore[attr-defined]
+    hass = FakeHass(config_entries=config_entries)
+    hass.async_create_task = (
+        lambda coro, name=None: asyncio.create_task(coro)  # noqa: ARG005
+    )
+
+    bucket = hass.data.setdefault(DOMAIN, {})
+    entries_bucket = bucket.setdefault("entries", {})
+    resolver = _resolver_stub()
+    entries_bucket[parent_entry.entry_id] = runtime_data
+    bucket[DATA_EID_RESOLVER] = resolver
+
+    assert await _async_unload_parent_entry(hass, parent_entry) is False
+    assert entries_bucket[parent_entry.entry_id] is runtime_data
+    assert bucket[DATA_EID_RESOLVER] is resolver
+    assert resolver.stop_called is False  # type: ignore[attr-defined]
+    assert resolver.refresh_called is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_parent_unload_success_stops_resolver_when_last_entry() -> None:
+    """Resolver should stop only after a successful unload of the final entry."""
+
+    parent_entry = FakeConfigEntry(entry_id="parent-entry")
+    runtime_data = _attach_runtime(parent_entry)
+    config_entries = FakeConfigEntriesManager([parent_entry])
+    config_entries.async_unload_platforms = lambda entry, platforms: True  # type: ignore[attr-defined]
+    hass = FakeHass(config_entries=config_entries)
+    hass.async_create_task = (
+        lambda coro, name=None: asyncio.create_task(coro)  # noqa: ARG005
+    )
+
+    bucket = hass.data.setdefault(DOMAIN, {})
+    entries_bucket = bucket.setdefault("entries", {})
+    resolver = _resolver_stub()
+    entries_bucket[parent_entry.entry_id] = runtime_data
+    bucket[DATA_EID_RESOLVER] = resolver
+
+    assert await _async_unload_parent_entry(hass, parent_entry) is True
+    assert parent_entry.entry_id not in entries_bucket
+    assert resolver.stop_called is True  # type: ignore[attr-defined]
+    assert bucket.get(DATA_EID_RESOLVER) is None
+
+
+@pytest.mark.asyncio
+async def test_parent_unload_success_refreshes_resolver_when_entries_remain() -> None:
+    """Resolver should refresh only after a successful unload when others remain."""
+
+    parent_entry = FakeConfigEntry(entry_id="parent-entry")
+    other_entry = FakeConfigEntry(entry_id="other-entry")
+    runtime_data = _attach_runtime(parent_entry)
+    _attach_runtime(other_entry)
+    config_entries = FakeConfigEntriesManager([parent_entry, other_entry])
+    config_entries.async_unload_platforms = lambda entry, platforms: True  # type: ignore[attr-defined]
+    hass = FakeHass(config_entries=config_entries)
+
+    tasks: list[asyncio.Task[object]] = []
+
+    def _capture_task(coro: Awaitable[object], name: str | None = None) -> asyncio.Task[object]:  # noqa: ARG001
+        task = asyncio.create_task(coro)
+        tasks.append(task)
+        return task
+
+    hass.async_create_task = _capture_task
+
+    bucket = hass.data.setdefault(DOMAIN, {})
+    entries_bucket = bucket.setdefault("entries", {})
+    resolver = _resolver_stub()
+    entries_bucket[parent_entry.entry_id] = runtime_data
+    entries_bucket[other_entry.entry_id] = other_entry.runtime_data  # type: ignore[index]
+    bucket[DATA_EID_RESOLVER] = resolver
+
+    assert await _async_unload_parent_entry(hass, parent_entry) is True
+    for task in tasks:
+        await task
+
+    assert parent_entry.entry_id not in entries_bucket
+    assert other_entry.entry_id in entries_bucket
+    assert resolver.stop_called is False  # type: ignore[attr-defined]
+    assert resolver.refresh_called is True  # type: ignore[attr-defined]
+    assert bucket.get(DATA_EID_RESOLVER) is resolver
+
+
+@pytest.mark.asyncio
+async def test_parent_unload_failure_does_not_refresh_resolver() -> None:
+    """Resolver refresh should not be scheduled when unload fails."""
+
+    parent_entry = FakeConfigEntry(entry_id="parent-entry")
+    other_entry = FakeConfigEntry(entry_id="other-entry")
+    runtime_data = _attach_runtime(parent_entry)
+    _attach_runtime(other_entry)
+    config_entries = FakeConfigEntriesManager([parent_entry, other_entry])
+    config_entries.async_unload_platforms = lambda entry, platforms: False  # type: ignore[attr-defined]
+    hass = FakeHass(config_entries=config_entries)
+
+    hass.async_create_task = (
+        lambda coro, name=None: asyncio.create_task(coro)  # noqa: ARG005
+    )
+
+    bucket = hass.data.setdefault(DOMAIN, {})
+    entries_bucket = bucket.setdefault("entries", {})
+    resolver = _resolver_stub()
+    entries_bucket[parent_entry.entry_id] = runtime_data
+    entries_bucket[other_entry.entry_id] = other_entry.runtime_data  # type: ignore[index]
+    bucket[DATA_EID_RESOLVER] = resolver
+
+    assert await _async_unload_parent_entry(hass, parent_entry) is False
+    assert parent_entry.entry_id in entries_bucket
+    assert resolver.stop_called is False  # type: ignore[attr-defined]
+    assert resolver.refresh_called is False  # type: ignore[attr-defined]
+    assert bucket.get(DATA_EID_RESOLVER) is resolver


### PR DESCRIPTION
## Summary
- defer stopping or refreshing the shared GoogleFindMyEIDResolver until parent unload succeeds to avoid zombie unload scenarios
- add regression tests covering resolver lifecycle during successful and failed parent unload attempts

## Testing
- python -m ruff check --fix .
- python -m mypy --strict --install-types --non-interactive
- python -m pytest --cov -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ad2eef67c8329b98fb81f9aae1f5c)