### PR TITLE
Clear latched FCM fatal errors after recovery

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -267,6 +267,23 @@ class FcmReceiverHA:
         self._entry_health: dict[str, bool] = {}
         self._entry_last_connected_wall: dict[str, float] = {}
 
+    def _clear_fatal_error_for_entry(
+        self, entry_id: str, *, reason: str | None = None
+    ) -> None:
+        """Clear any latched fatal registration error for a config entry."""
+
+        if entry_id in self._fatal_errors:
+            if reason:
+                _LOGGER.debug(
+                    "[entry=%s] Clearing latched FCM fatal error (%s)", entry_id, reason
+                )
+            else:
+                _LOGGER.debug("[entry=%s] Clearing latched FCM fatal error", entry_id)
+
+            self._fatal_errors.pop(entry_id, None)
+
+        self._fatal_error = next(iter(self._fatal_errors.values()), None)
+
     @staticmethod
     def _ensure_cache_entry_id(cache: Any, entry_id: str) -> None:
         """Attach the entry_id to a cache instance when possible."""
@@ -789,6 +806,9 @@ class FcmReceiverHA:
                 if token:
                     self._update_token_routing(token, {entry_id})
                     await self._persist_routing_token(entry_id, token)
+                self._clear_fatal_error_for_entry(
+                    entry_id, reason="Registration succeeded"
+                )
                 return True
             _LOGGER.warning("[entry=%s] FCM registration returned no token", entry_id)
             return False
@@ -951,6 +971,9 @@ class FcmReceiverHA:
             else:
                 self._entry_caches.pop(entry_id, None)
                 self._purge_entry_tokens(entry_id)
+                self._clear_fatal_error_for_entry(
+                    entry_id, reason="Entry unregistered"
+                )
 
     # -------------------- Incoming notifications --------------------
 
@@ -1503,6 +1526,9 @@ class FcmReceiverHA:
         if token:
             self._update_token_routing(token, {entry_id})
             asyncio.create_task(self._persist_routing_token(entry_id, token))
+        self._clear_fatal_error_for_entry(
+            entry_id, reason="Credentials updated for entry"
+        )
 
         asyncio.create_task(self._async_save_credentials_for_entry(entry_id))
         _LOGGER.info("[entry=%s] FCM credentials updated", entry_id)

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -272,6 +272,7 @@ class FcmReceiverHA:
     ) -> None:
         """Clear any latched fatal registration error for a config entry."""
 
+        removed = False
         if entry_id in self._fatal_errors:
             if reason:
                 _LOGGER.debug(
@@ -281,8 +282,10 @@ class FcmReceiverHA:
                 _LOGGER.debug("[entry=%s] Clearing latched FCM fatal error", entry_id)
 
             self._fatal_errors.pop(entry_id, None)
+            removed = True
 
-        self._fatal_error = next(iter(self._fatal_errors.values()), None)
+        if removed:
+            self._fatal_error = next(iter(self._fatal_errors.values()), None)
 
     @staticmethod
     def _ensure_cache_entry_id(cache: Any, entry_id: str) -> None:

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -1,8 +1,9 @@
 # tests/test_fcm_receiver.py
 from __future__ import annotations
 
+import asyncio
 import importlib
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -285,3 +286,89 @@ def test_domain_provider_sets_default_entry_on_selected_receiver() -> None:
 async def _async_release(receiver: FcmReceiverHA, hass: Any, entry: _DummyEntry) -> None:
     receiver.request_stop()
     await _async_release_shared_fcm(hass, entry)
+
+
+@pytest.mark.asyncio
+async def test_register_clears_latched_fatal_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    receiver = FcmReceiverHA()
+    entry_id = "entry-id"
+    receiver._fatal_errors[entry_id] = "BadAuthentication"
+    receiver._fatal_error = "BadAuthentication"
+
+    class _DummyPc:
+        async def checkin_or_register(self) -> dict[str, str]:
+            return {"ok": "true"}
+
+    receiver.pcs[entry_id] = _DummyPc()
+
+    token_routes: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver,
+        "_update_token_routing",
+        lambda token, entries: token_routes.append((token, set(entries))),
+    )
+
+    persisted_tokens: list[tuple[str, str]] = []
+
+    async def _persist(entry_arg: str, token_arg: str) -> None:
+        persisted_tokens.append((entry_arg, token_arg))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _entry_id=None: "token-123")
+
+    result = await receiver._register_for_fcm_entry(entry_id)
+
+    assert result is True
+    assert entry_id not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    assert token_routes == [("token-123", {entry_id})]
+    assert persisted_tokens == [(entry_id, "token-123")]
+
+
+@pytest.mark.asyncio
+async def test_credentials_update_clears_latched_fatal_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receiver = FcmReceiverHA()
+    entry_id = "entry-credentials"
+    receiver._fatal_errors[entry_id] = "BadAuthentication"
+    receiver._fatal_error = "BadAuthentication"
+
+    loop = asyncio.get_running_loop()
+    captured_tasks: list[asyncio.Task[object]] = []
+
+    def _capture_task(
+        coro: Awaitable[object], *, name: str | None = None
+    ) -> asyncio.Task[object]:
+        task = loop.create_task(coro, name=name)
+        captured_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", _capture_task)
+
+    token_routes: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver,
+        "_update_token_routing",
+        lambda token, entries: token_routes.append((token, set(entries))),
+    )
+
+    async def _persist(entry_arg: str, token_arg: str) -> None:
+        token_routes.append((token_arg, {entry_arg}))
+
+    async def _save(entry_arg: str) -> None:
+        token_routes.append(("save", {entry_arg}))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(receiver, "_async_save_credentials_for_entry", _save)
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _entry_id=None: "token-abc")
+
+    receiver._on_credentials_updated_for_entry(
+        entry_id, {"fcm": {"registration": {"token": "token-abc"}}}
+    )
+
+    await asyncio.gather(*captured_tasks)
+
+    assert entry_id not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    assert token_routes[0] == ("token-abc", {entry_id})

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 import pytest
 
+import custom_components.googlefindmy.Auth.fcm_receiver_ha as fcm_receiver_module
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
 from custom_components.googlefindmy.const import DOMAIN
 
@@ -344,7 +345,7 @@ async def test_credentials_update_clears_latched_fatal_error(
         captured_tasks.append(task)
         return task
 
-    monkeypatch.setattr(asyncio, "create_task", _capture_task)
+    monkeypatch.setattr(fcm_receiver_module.asyncio, "create_task", _capture_task)
 
     token_routes: list[tuple[str, set[str]]] = []
     monkeypatch.setattr(
@@ -371,4 +372,8 @@ async def test_credentials_update_clears_latched_fatal_error(
 
     assert entry_id not in receiver._fatal_errors
     assert receiver._fatal_error is None
-    assert token_routes[0] == ("token-abc", {entry_id})
+    assert token_routes == [
+        ("token-abc", {entry_id}),
+        ("token-abc", {entry_id}),
+        ("save", {entry_id}),
+    ]


### PR DESCRIPTION
## Summary
- add a helper to clear per-entry fatal FCM errors and keep the global fatal state in sync
- clear latched fatal errors after successful registration, credential updates, and entry unregister
- add regression tests ensuring fatal errors are removed after successful registration and credential refresh

## Testing
- python -m ruff check --fix .
- python -m mypy --strict --install-types --non-interactive
- python -m pytest --cov -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b06104a388329b363486f6696960c)