### PR TITLE
refactor(eid_resolver): code quality improvements from peer review

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -86,6 +86,11 @@ TRUNCATED_FRAME_LOG_WINDOW_SECONDS = 60
 VALID_ANCHOR_BASES: set[str] = {"unix", "pair_date", "secrets_creation_date"}
 KNOWN_OFFSET_KEY_LENGTH = 2
 
+# LOCK_TRACKING_WINDOW_STEPS: Number of rotation periods to scan around the
+# expected counter when tracking a locked device. ±2 periods covers ~34 minutes
+# of clock drift at 1024s rotation.
+LOCK_TRACKING_WINDOW_STEPS = 2
+
 
 class EIDMatch(NamedTuple):
     """Resolved mapping between an EID and a Home Assistant device."""
@@ -376,7 +381,11 @@ class EIDGenerationLock:
 def _normalize_counter_candidate(candidate_value: object, *, basis: str) -> int | None:
     """Return a sane u32 counter candidate or ``None`` when unusable."""
 
-    if not isinstance(candidate_value, int) or candidate_value < 0:
+    if (
+        not isinstance(candidate_value, int)
+        or isinstance(candidate_value, bool)
+        or candidate_value < 0
+    ):
         return None
 
     max_millis = FHNA_COUNTER_MASK
@@ -891,7 +900,7 @@ class GoogleFindMyEIDResolver:
         expected_counter = work_item.rotation_ts + (
             periods_elapsed * params.rotation_period
         )
-        for step in range(-2, 3):
+        for step in range(-LOCK_TRACKING_WINDOW_STEPS, LOCK_TRACKING_WINDOW_STEPS + 1):
             offset_periods = periods_elapsed + step
             window_ts = work_item.rotation_ts + (offset_periods * params.rotation_period)
             if window_ts < 0:
@@ -1753,29 +1762,35 @@ class GoogleFindMyEIDResolver:
             raw_len,
         )
 
+    @staticmethod
+    def _cancel_callback(unsub: CALLBACK_TYPE | None, name: str) -> None:
+        """Cancel a callback or close a coroutine, logging any errors."""
+        if unsub is None:
+            return
+        try:
+            if callable(unsub):
+                unsub()
+            elif asyncio.iscoroutine(unsub):
+                unsub.close()
+        except Exception as err:  # pragma: no cover - defensive
+            _LOGGER.debug("Failed to cancel %s: %s", name, err)
+
     def stop(self) -> None:
         """Cancel background timers and clear cached state."""
 
-        if self._unsub_alignment is not None:
-            unsub = self._unsub_alignment
-            self._unsub_alignment = None
-            try:
-                if callable(unsub):
-                    unsub()
-                elif asyncio.iscoroutine(unsub):
-                    unsub.close()
-            except Exception as err:  # pragma: no cover - defensive
-                _LOGGER.debug("Failed to cancel alignment timer: %s", err)
-        if self._unsub_interval is not None:
-            unsub = self._unsub_interval
-            self._unsub_interval = None
-            try:
-                if callable(unsub):
-                    unsub()
-                elif asyncio.iscoroutine(unsub):
-                    unsub.close()
-            except Exception as err:  # pragma: no cover - defensive
-                _LOGGER.debug("Failed to cancel refresh interval: %s", err)
+        self._cancel_callback(self._unsub_alignment, "alignment timer")
+        self._unsub_alignment = None
+
+        self._cancel_callback(self._unsub_interval, "refresh interval")
+        self._unsub_interval = None
+
+        if self._load_task is not None:
+            load_task = self._load_task
+            self._load_task = None
+            if not load_task.done():
+                load_task.cancel()
+
         self._lookup.clear()
         self._lookup_metadata.clear()
         self._locks.clear()
+        self._persisted_locks.clear()

--- a/tests/test_eid_resolver_lifecycle.py
+++ b/tests/test_eid_resolver_lifecycle.py
@@ -1,0 +1,176 @@
+# tests/test_eid_resolver_lifecycle.py
+"""Lifecycle management tests for the EID resolver (stop, cleanup)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.eid_resolver import (
+    EIDGenerationLock,
+    EidVariant,
+    GoogleFindMyEIDResolver,
+)
+
+
+def _fake_hass() -> SimpleNamespace:
+    """Return a minimal hass stand-in."""
+    return SimpleNamespace(
+        async_create_task=lambda coro, name=None: asyncio.create_task(coro),
+        async_create_background_task=lambda coro, name=None: asyncio.create_task(coro),
+    )
+
+
+def _build_resolver() -> GoogleFindMyEIDResolver:
+    """Build a resolver with pre-populated state for stop() testing."""
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = _fake_hass()
+    resolver._lookup = {b"test": MagicMock()}
+    resolver._lookup_metadata = {b"test": {"variant": "test"}}
+    resolver._locks = {
+        "device-1": EIDGenerationLock(
+            device_id="device-1",
+            canonical_id="canonical-1",
+            variant=EidVariant.MODERN_P256_X32_BE.value,
+            advertisement_reversed=False,
+            eid_length=32,
+        )
+    }
+    resolver._persisted_locks = dict(resolver._locks)
+    resolver._known_offsets = {}
+    resolver._known_advertisement_reversed = {}
+    resolver._known_timebases = {}
+    resolver._decryption_status = {}
+    resolver._last_lock_confirmation = {}
+    resolver._provisioning_warn_at = {}
+    resolver._lock_miss_counts = {}
+    resolver._truncated_frame_log_at = {}
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._load_task = None
+    return resolver
+
+
+def test_stop_clears_all_caches() -> None:
+    """stop() should clear lookup, metadata, locks, and persisted_locks."""
+    resolver = _build_resolver()
+
+    assert resolver._lookup
+    assert resolver._lookup_metadata
+    assert resolver._locks
+    assert resolver._persisted_locks
+
+    resolver.stop()
+
+    assert resolver._lookup == {}
+    assert resolver._lookup_metadata == {}
+    assert resolver._locks == {}
+    assert resolver._persisted_locks == {}
+
+
+def test_stop_cancels_unsub_callbacks() -> None:
+    """stop() should call unsub callbacks and set them to None."""
+    resolver = _build_resolver()
+
+    alignment_unsub = MagicMock()
+    interval_unsub = MagicMock()
+    resolver._unsub_alignment = alignment_unsub
+    resolver._unsub_interval = interval_unsub
+
+    resolver.stop()
+
+    alignment_unsub.assert_called_once()
+    interval_unsub.assert_called_once()
+    assert resolver._unsub_alignment is None
+    assert resolver._unsub_interval is None
+
+
+def test_stop_handles_none_unsub_gracefully() -> None:
+    """stop() should not crash when unsub callbacks are None."""
+    resolver = _build_resolver()
+    resolver._unsub_alignment = None
+    resolver._unsub_interval = None
+
+    # Should not raise
+    resolver.stop()
+
+    assert resolver._unsub_alignment is None
+    assert resolver._unsub_interval is None
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_running_load_task() -> None:
+    """stop() should cancel a running _load_task."""
+    resolver = _build_resolver()
+
+    # Create a long-running task
+    async def slow_load() -> None:
+        await asyncio.sleep(10)
+
+    resolver._load_task = asyncio.create_task(slow_load())
+    assert not resolver._load_task.done()
+
+    resolver.stop()
+
+    # Task should be cancelled
+    assert resolver._load_task is None
+
+    # Give the event loop a chance to process the cancellation
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_stop_handles_completed_load_task() -> None:
+    """stop() should handle an already-completed _load_task."""
+    resolver = _build_resolver()
+
+    async def quick_load() -> None:
+        return None
+
+    task = asyncio.create_task(quick_load())
+    await task  # Let it complete
+    resolver._load_task = task
+
+    assert resolver._load_task.done()
+
+    # Should not raise
+    resolver.stop()
+
+    assert resolver._lookup == {}
+
+
+def test_stop_handles_unsub_exception() -> None:
+    """stop() should log but not raise if unsub callback fails."""
+    resolver = _build_resolver()
+
+    def failing_unsub() -> None:
+        raise RuntimeError("unsub failed")
+
+    resolver._unsub_alignment = failing_unsub
+    resolver._unsub_interval = None
+
+    # Should not raise
+    resolver.stop()
+
+    assert resolver._unsub_alignment is None
+    assert resolver._lookup == {}
+
+
+def test_cancel_callback_helper_handles_coroutine() -> None:
+    """_cancel_callback should close coroutines properly."""
+
+    async def sample_coro() -> None:
+        await asyncio.sleep(1)
+
+    coro = sample_coro()
+
+    # Should not raise
+    GoogleFindMyEIDResolver._cancel_callback(coro, "test coroutine")
+
+    # Coroutine should be closed (calling close again is safe)
+    coro.close()

--- a/tests/test_eid_resolver_risk_regressions.py
+++ b/tests/test_eid_resolver_risk_regressions.py
@@ -488,3 +488,20 @@ def test_resolve_eid_does_not_poison_anchor_offsets_with_lock_tracking_basis(
         "Fix: if timestamp_basis is explicitly invalid (e.g., lock_tracking), "
         "do not persist match.time_offset under any anchor basis."
     )
+
+
+def test_normalize_counter_candidate_rejects_bool() -> None:
+    """AC7: bool values must be rejected even though bool is a subclass of int."""
+
+    assert _normalize_counter_candidate(True, basis="pair_date") is None, (
+        "FAIL: _normalize_counter_candidate accepted True as valid counter. "
+        "Fix: add explicit `isinstance(candidate_value, bool)` check."
+    )
+    assert _normalize_counter_candidate(False, basis="pair_date") is None, (
+        "FAIL: _normalize_counter_candidate accepted False as valid counter. "
+        "Fix: add explicit `isinstance(candidate_value, bool)` check."
+    )
+
+    # Valid integers should still work
+    assert _normalize_counter_candidate(1000, basis="pair_date") == 1000
+    assert _normalize_counter_candidate(0, basis="pair_date") == 0

--- a/tests/test_eid_resolver_tracking.py
+++ b/tests/test_eid_resolver_tracking.py
@@ -9,6 +9,7 @@ import pytest
 
 from custom_components.googlefindmy.coordinator import DeviceIdentity
 from custom_components.googlefindmy.eid_resolver import (
+    LOCK_TRACKING_WINDOW_STEPS,
     ROTATION_PERIOD,
     EIDGenerationLock,
     EidVariant,
@@ -79,6 +80,7 @@ async def test_tracking_mode_predicts_next_rotation(
     await resolver._refresh_cache()
 
     expected_counters = {
-        5_000 + ((10 + step) * ROTATION_PERIOD) for step in range(-2, 3)
+        5_000 + ((10 + step) * ROTATION_PERIOD)
+        for step in range(-LOCK_TRACKING_WINDOW_STEPS, LOCK_TRACKING_WINDOW_STEPS + 1)
     }
     assert set(generated_counters) == expected_counters


### PR DESCRIPTION
- Add bool check in _normalize_counter_candidate to reject True/False (bool is a subclass of int, which could cause silent bugs)
- Extract timer cleanup into _cancel_callback helper method
- Fix stop() to cancel _load_task and clear _persisted_locks
- Add LOCK_TRACKING_WINDOW_STEPS constant with documentation
- Add comprehensive tests for stop() lifecycle management
- Add regression test for bool rejection in counter normalization

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
