### PR TITLE
Claude/review spot request a qo88

### DIFF
--- a/custom_components/googlefindmy/SpotApi/spot_request.py
+++ b/custom_components/googlefindmy/SpotApi/spot_request.py
@@ -70,7 +70,6 @@ from custom_components.googlefindmy.SpotApi.spot_grpc_transport import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Constants
 _SPOT_MAX_RETRIES: Final[int] = 3
 _SPOT_INITIAL_BACKOFF_S: Final[float] = 1.0
 _SPOT_BACKOFF_FACTOR: Final[float] = 2.0
@@ -78,7 +77,8 @@ _SPOT_MAX_BACKOFF_S: Final[float] = 60.0
 _SPOT_REQUEST_TIMEOUT_S: Final[float] = 30.0
 _USER_AGENT: Final[str] = "com.google.android.gms/244433022 grpc-java-cronet/1.69.0-SNAPSHOT"
 
-# Set global user agent for grpclib
+# WARNING: This mutates global grpclib state and affects all users in the process.
+# Ideally this should be set per-channel, but grpclib doesn't support that cleanly.
 cast(Any, grpclib_client).USER_AGENT = _USER_AGENT
 
 # Indirection for test mocking
@@ -113,12 +113,9 @@ class SpotRequestFailedAfterRetries(SpotError):
     """Transient failures exhausted the retry budget."""
 
 
-class SpotTokenRetrievalError(SpotError):
-    """Token retrieval failed with a non-recoverable error."""
-
-
 def _compute_delay(attempt: int) -> float:
     """Compute exponential backoff with jitter bounded to sixty seconds."""
+
     base = (_SPOT_BACKOFF_FACTOR ** (attempt - 1)) * _SPOT_INITIAL_BACKOFF_S
     return min(random.uniform(0.0, base), _SPOT_MAX_BACKOFF_S)
 
@@ -126,21 +123,8 @@ def _compute_delay(attempt: int) -> float:
 async def _pick_auth_token_async(
     *, prefer_adm: bool = False, cache: TokenCache
 ) -> tuple[str, str, str]:
-    """Select an authentication token using the entry-scoped cache.
+    """Select an authentication token using the entry-scoped cache."""
 
-    Args:
-        prefer_adm: If True, skip SPOT token and try ADM directly.
-        cache: The entry-scoped token cache.
-
-    Returns:
-        A tuple of (token, token_kind, username).
-
-    Raises:
-        MissingTokenCacheError: If cache is None.
-        InvalidAasTokenError: If AAS token is invalid (re-raised for caller handling).
-        RuntimeError: If username is not configured or no valid token is available.
-        SpotTokenRetrievalError: If token retrieval fails with an unexpected error.
-    """
     if cache is None:
         raise MissingTokenCacheError()
 
@@ -153,10 +137,8 @@ async def _pick_auth_token_async(
             spot_token = await async_get_spot_token(username, cache=cache)
         except InvalidAasTokenError:
             raise
-        except (OSError, TimeoutError, ConnectionError) as err:
-            _LOGGER.debug("SPOT token retrieval failed due to network error: %s", err)
-        except ValueError as err:
-            _LOGGER.debug("SPOT token retrieval failed due to invalid data: %s", err)
+        except Exception as err:  # pragma: no cover - defensive fallback to ADM
+            _LOGGER.debug("SPOT token retrieval failed: %s", err)
         else:
             if spot_token:
                 return spot_token, "spot", username
@@ -171,16 +153,8 @@ async def _pick_auth_token_async(
 async def _invalidate_token_async(
     kind: str, username: str, *, cache: TokenCache | None = None
 ) -> None:
-    """Invalidate cached tokens in the entry-scoped cache only.
+    """Invalidate cached tokens in the entry-scoped cache only."""
 
-    Args:
-        kind: Token kind ('spot' or 'adm').
-        username: The username associated with the token.
-        cache: The entry-scoped token cache.
-
-    Raises:
-        MissingTokenCacheError: If cache is None.
-    """
     if cache is None:
         raise MissingTokenCacheError()
 
@@ -192,14 +166,8 @@ async def _invalidate_token_async(
 
 
 async def _clear_aas_token_async(*, cache: TokenCache | None = None) -> None:
-    """Clear the cached AAS token in the entry-scoped cache.
+    """Clear the cached AAS token in the entry-scoped cache."""
 
-    Args:
-        cache: The entry-scoped token cache.
-
-    Raises:
-        MissingTokenCacheError: If cache is None.
-    """
     if cache is None:
         raise MissingTokenCacheError()
 
@@ -213,7 +181,8 @@ async def async_spot_request(
     cache: TokenCache,
     transport: SpotGrpcTransport | None = None,
 ) -> bytes:
-    """Perform a SPOT unary gRPC request using grpclib.
+    """
+    Perform a SPOT unary gRPC request using grpclib.
 
     Design intent:
     - Reuse the shared grpclib channel for HTTP/2 multiplexing.
@@ -225,26 +194,10 @@ async def async_spot_request(
     Retry budget:
     - Up to _SPOT_MAX_RETRIES (3) retries for transient errors.
     - One auth refresh attempt on UNAUTHENTICATED/PERMISSION_DENIED.
-    - One AAS token clear attempt on InvalidAasTokenError.
-    - Maximum total attempts: _SPOT_MAX_RETRIES + 1 (initial) + auth refreshes.
-
-    Args:
-        api_scope: The SPOT API scope (method name).
-        payload: The serialized request payload.
-        cache: The entry-scoped token cache.
-        transport: Optional custom transport (defaults to shared global transport).
-
-    Returns:
-        The raw response bytes.
-
-    Raises:
-        SpotAuthPermanentError: Authentication failed after refresh.
-        SpotRateLimitError: Rate limited after retries.
-        SpotGrpcStatusError: Non-retriable gRPC status error.
-        SpotNetworkError: Transport/network error after retries.
-        SpotTrailersOnlyError: OK status but empty response payload.
-        SpotRequestFailedAfterRetries: Transient failures exhausted retry budget.
+    - One AAS token clear attempt on InvalidAasTokenError (counts toward retry budget).
+    - Maximum total attempts: _SPOT_MAX_RETRIES + 1 (initial) + 1 (auth refresh).
     """
+
     active_transport = transport or SPOT_GRPC_TRANSPORT
     method_path = f"/google.internal.spot.v1.SpotService/{api_scope}"
 
@@ -274,16 +227,12 @@ async def async_spot_request(
                 continue
             raise SpotAuthPermanentError("AAS token invalid after refresh.") from err
 
-        metadata: Collection[tuple[str, str]] = (
-            ("authorization", f"Bearer {token}"),
-        )
+        metadata: Collection[tuple[str, str]] = (("authorization", f"Bearer {token}"),)
         channel = await active_transport.get_channel()
         method = UnaryUnaryMethod(channel, method_path, bytes, bytes)
 
         try:
-            async with method.open(
-                metadata=metadata, timeout=_SPOT_REQUEST_TIMEOUT_S
-            ) as stream:
+            async with method.open(metadata=metadata, timeout=_SPOT_REQUEST_TIMEOUT_S) as stream:
                 await stream.send_message(payload, end=True)
                 reply_bytes = await stream.recv_message()
         except grpclib_exceptions.GRPCError as err:
@@ -294,9 +243,7 @@ async def async_spot_request(
                     refreshed_once = True
                     await _invalidate_token_async(token_kind, token_user, cache=cache)
                     continue
-                raise SpotAuthPermanentError(
-                    "Authentication failed after refresh."
-                ) from err
+                raise SpotAuthPermanentError("Authentication failed after refresh.") from err
 
             if status == Status.RESOURCE_EXHAUSTED:
                 if retries_used < _SPOT_MAX_RETRIES:
@@ -356,12 +303,11 @@ async def async_spot_request(
                 continue
             raise SpotTrailersOnlyError("OK status but empty reply payload.")
 
-        # reply_bytes is guaranteed to be bytes per grpclib protocol
-        return reply_bytes
+        assert isinstance(reply_bytes, (bytes, bytearray))
+        return bytes(reply_bytes)
 
 
 def spot_request(*_args: object, **_kwargs: object) -> bytes:
     """Deprecated sync shim preserved for legacy call sites."""
-    raise RuntimeError(
-        "spot_request is no longer synchronous; use async_spot_request with cache="
-    )
+
+    raise RuntimeError("spot_request is no longer synchronous; use async_spot_request with cache=")

--- a/custom_components/googlefindmy/SpotApi/spot_request.py
+++ b/custom_components/googlefindmy/SpotApi/spot_request.py
@@ -6,7 +6,7 @@ import logging
 import random
 import socket
 from collections.abc import Collection
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Final, Protocol, cast
 
 if TYPE_CHECKING:
     class _UnaryStreamContext(Protocol):
@@ -70,11 +70,18 @@ from custom_components.googlefindmy.SpotApi.spot_grpc_transport import (
 
 _LOGGER = logging.getLogger(__name__)
 
-_SPOT_MAX_RETRIES = 3
-_SPOT_INITIAL_BACKOFF_S = 1.0
-_SPOT_BACKOFF_FACTOR = 2.0
-_USER_AGENT = "com.google.android.gms/244433022 grpc-java-cronet/1.69.0-SNAPSHOT"
+# Constants
+_SPOT_MAX_RETRIES: Final[int] = 3
+_SPOT_INITIAL_BACKOFF_S: Final[float] = 1.0
+_SPOT_BACKOFF_FACTOR: Final[float] = 2.0
+_SPOT_MAX_BACKOFF_S: Final[float] = 60.0
+_SPOT_REQUEST_TIMEOUT_S: Final[float] = 30.0
+_USER_AGENT: Final[str] = "com.google.android.gms/244433022 grpc-java-cronet/1.69.0-SNAPSHOT"
+
+# Set global user agent for grpclib
 cast(Any, grpclib_client).USER_AGENT = _USER_AGENT
+
+# Indirection for test mocking
 _async_sleep = asyncio.sleep
 
 
@@ -106,18 +113,34 @@ class SpotRequestFailedAfterRetries(SpotError):
     """Transient failures exhausted the retry budget."""
 
 
+class SpotTokenRetrievalError(SpotError):
+    """Token retrieval failed with a non-recoverable error."""
+
+
 def _compute_delay(attempt: int) -> float:
     """Compute exponential backoff with jitter bounded to sixty seconds."""
-
     base = (_SPOT_BACKOFF_FACTOR ** (attempt - 1)) * _SPOT_INITIAL_BACKOFF_S
-    return min(random.uniform(0.0, base), 60.0)
+    return min(random.uniform(0.0, base), _SPOT_MAX_BACKOFF_S)
 
 
 async def _pick_auth_token_async(
     *, prefer_adm: bool = False, cache: TokenCache
 ) -> tuple[str, str, str]:
-    """Select an authentication token using the entry-scoped cache."""
+    """Select an authentication token using the entry-scoped cache.
 
+    Args:
+        prefer_adm: If True, skip SPOT token and try ADM directly.
+        cache: The entry-scoped token cache.
+
+    Returns:
+        A tuple of (token, token_kind, username).
+
+    Raises:
+        MissingTokenCacheError: If cache is None.
+        InvalidAasTokenError: If AAS token is invalid (re-raised for caller handling).
+        RuntimeError: If username is not configured or no valid token is available.
+        SpotTokenRetrievalError: If token retrieval fails with an unexpected error.
+    """
     if cache is None:
         raise MissingTokenCacheError()
 
@@ -130,8 +153,10 @@ async def _pick_auth_token_async(
             spot_token = await async_get_spot_token(username, cache=cache)
         except InvalidAasTokenError:
             raise
-        except Exception as err:  # pragma: no cover - defensive logging only
-            _LOGGER.debug("SPOT token retrieval failed: %s", err)
+        except (OSError, TimeoutError, ConnectionError) as err:
+            _LOGGER.debug("SPOT token retrieval failed due to network error: %s", err)
+        except ValueError as err:
+            _LOGGER.debug("SPOT token retrieval failed due to invalid data: %s", err)
         else:
             if spot_token:
                 return spot_token, "spot", username
@@ -143,22 +168,38 @@ async def _pick_auth_token_async(
     raise RuntimeError("No valid SPOT or ADM token available for the current user.")
 
 
-async def _invalidate_token_async(kind: str, username: str, *, cache: TokenCache | None = None) -> None:
-    """Invalidate cached tokens in the entry-scoped cache only."""
+async def _invalidate_token_async(
+    kind: str, username: str, *, cache: TokenCache | None = None
+) -> None:
+    """Invalidate cached tokens in the entry-scoped cache only.
 
+    Args:
+        kind: Token kind ('spot' or 'adm').
+        username: The username associated with the token.
+        cache: The entry-scoped token cache.
+
+    Raises:
+        MissingTokenCacheError: If cache is None.
+    """
     if cache is None:
         raise MissingTokenCacheError()
 
     if kind == "spot":
         await cache.set(f"spot_token_{username}", None)
-    if kind == "adm":
+    elif kind == "adm":
         await cache.set(f"adm_token_{username}", None)
     await cache.set(DATA_AAS_TOKEN, None)
 
 
 async def _clear_aas_token_async(*, cache: TokenCache | None = None) -> None:
-    """Clear the cached AAS token in the entry-scoped cache."""
+    """Clear the cached AAS token in the entry-scoped cache.
 
+    Args:
+        cache: The entry-scoped token cache.
+
+    Raises:
+        MissingTokenCacheError: If cache is None.
+    """
     if cache is None:
         raise MissingTokenCacheError()
 
@@ -172,8 +213,7 @@ async def async_spot_request(
     cache: TokenCache,
     transport: SpotGrpcTransport | None = None,
 ) -> bytes:
-    """
-    Perform a SPOT unary gRPC request using grpclib.
+    """Perform a SPOT unary gRPC request using grpclib.
 
     Design intent:
     - Reuse the shared grpclib channel for HTTP/2 multiplexing.
@@ -181,8 +221,30 @@ async def async_spot_request(
     - Retry bounded times for transient statuses and rate limits.
     - Refresh authentication once before surfacing permanent failures.
     - Treat empty replies as transport anomalies before raising trailers-only.
-    """
 
+    Retry budget:
+    - Up to _SPOT_MAX_RETRIES (3) retries for transient errors.
+    - One auth refresh attempt on UNAUTHENTICATED/PERMISSION_DENIED.
+    - One AAS token clear attempt on InvalidAasTokenError.
+    - Maximum total attempts: _SPOT_MAX_RETRIES + 1 (initial) + auth refreshes.
+
+    Args:
+        api_scope: The SPOT API scope (method name).
+        payload: The serialized request payload.
+        cache: The entry-scoped token cache.
+        transport: Optional custom transport (defaults to shared global transport).
+
+    Returns:
+        The raw response bytes.
+
+    Raises:
+        SpotAuthPermanentError: Authentication failed after refresh.
+        SpotRateLimitError: Rate limited after retries.
+        SpotGrpcStatusError: Non-retriable gRPC status error.
+        SpotNetworkError: Transport/network error after retries.
+        SpotTrailersOnlyError: OK status but empty response payload.
+        SpotRequestFailedAfterRetries: Transient failures exhausted retry budget.
+    """
     active_transport = transport or SPOT_GRPC_TRANSPORT
     method_path = f"/google.internal.spot.v1.SpotService/{api_scope}"
 
@@ -203,15 +265,25 @@ async def async_spot_request(
             if not aas_cleared_once:
                 aas_cleared_once = True
                 await _clear_aas_token_async(cache=cache)
+                # Count this as a retry to prevent infinite loops
+                retries_used += 1
+                if retries_used > _SPOT_MAX_RETRIES:
+                    raise SpotAuthPermanentError(
+                        "AAS token invalid; retry budget exhausted."
+                    ) from err
                 continue
             raise SpotAuthPermanentError("AAS token invalid after refresh.") from err
 
-        metadata: Collection[tuple[str, str]] = (("authorization", f"Bearer {token}"),)
+        metadata: Collection[tuple[str, str]] = (
+            ("authorization", f"Bearer {token}"),
+        )
         channel = await active_transport.get_channel()
         method = UnaryUnaryMethod(channel, method_path, bytes, bytes)
 
         try:
-            async with method.open(metadata=metadata, timeout=30.0) as stream:
+            async with method.open(
+                metadata=metadata, timeout=_SPOT_REQUEST_TIMEOUT_S
+            ) as stream:
                 await stream.send_message(payload, end=True)
                 reply_bytes = await stream.recv_message()
         except grpclib_exceptions.GRPCError as err:
@@ -222,7 +294,9 @@ async def async_spot_request(
                     refreshed_once = True
                     await _invalidate_token_async(token_kind, token_user, cache=cache)
                     continue
-                raise SpotAuthPermanentError("Authentication failed after refresh.") from err
+                raise SpotAuthPermanentError(
+                    "Authentication failed after refresh."
+                ) from err
 
             if status == Status.RESOURCE_EXHAUSTED:
                 if retries_used < _SPOT_MAX_RETRIES:
@@ -282,11 +356,12 @@ async def async_spot_request(
                 continue
             raise SpotTrailersOnlyError("OK status but empty reply payload.")
 
-        assert isinstance(reply_bytes, (bytes, bytearray))
-        return bytes(reply_bytes)
+        # reply_bytes is guaranteed to be bytes per grpclib protocol
+        return reply_bytes
 
 
 def spot_request(*_args: object, **_kwargs: object) -> bytes:
     """Deprecated sync shim preserved for legacy call sites."""
-
-    raise RuntimeError("spot_request is no longer synchronous; use async_spot_request with cache=")
+    raise RuntimeError(
+        "spot_request is no longer synchronous; use async_spot_request with cache="
+    )


### PR DESCRIPTION
<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
