### PR TITLE
fix(coordinator): prevent None values from overwriting valid metadata…

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -239,6 +239,31 @@ _PERSISTED_METADATA_KEYS: tuple[str, ...] = (
 )
 
 
+def _update_preserve_metadata(
+    target: dict[str, Any], source: Mapping[str, Any]
+) -> None:
+    """Merge source into target without overwriting persisted metadata keys with None.
+
+    This prevents a payload with None values (e.g., from a phone device listing
+    that lacks key material) from clobbering valid data already in the target
+    (e.g., from a prior FCM locate response).
+
+    For keys in _PERSISTED_METADATA_KEYS:
+      - Only update if source value is not None
+    For all other keys:
+      - Normal dict.update() semantics apply
+    """
+    for key, value in source.items():
+        if key in _PERSISTED_METADATA_KEYS:
+            # Preserve existing non-None values: only overwrite if new value is not None
+            if value is not None:
+                target[key] = value
+            # If value is None and key already exists with a value, keep the existing
+        else:
+            # Normal update for non-metadata keys
+            target[key] = value
+
+
 def _clamp(value: float, lo: float, hi: float) -> float:
     """Clamp value between lo and hi (inclusive)."""
     try:
@@ -5157,7 +5182,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                         continue
                     payload = source.get(key)
                     if isinstance(payload, Mapping):
-                        merged_device_data.update(payload)
+                        _update_preserve_metadata(merged_device_data, payload)
 
             _LOGGER.debug(
                 "Building Identity for %s: cached_data=%s", canonical_id, merged_device_data
@@ -7510,14 +7535,15 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
         merged = dict(existing)
         if allow_location_update:
-            merged.update(incoming)
+            _update_preserve_metadata(merged, incoming)
         else:
-            merged.update(
+            _update_preserve_metadata(
+                merged,
                 {
                     key: value
                     for key, value in incoming.items()
                     if key not in location_fields
-                }
+                },
             )
 
         # Keep monotonic last_seen timestamps when payloads arrive without a newer value.


### PR DESCRIPTION
… in device cache

When merging device data from multiple sources (cache, live payloads, last data), the dict.update() calls were blindly overwriting existing values even when the new value was None. This caused issues with smartphones being located via Bermuda/EID because:

1. The device listing for phones doesn't include key material (expected)
2. The FCM locate flow provides the keys (encryptedIdentityKey, identity_key, etc.)
3. But subsequent merges with the device listing would overwrite these keys with None

This fix introduces _update_preserve_metadata() which:
- For _PERSISTED_METADATA_KEYS: only updates if the new value is NOT None
- For all other keys: applies normal update semantics

Applied to:
- _build_device_identities_from_cache() line ~5185
- _merge_with_existing_cache_row() lines ~7537-7547

This ensures that valid crypto material from FCM responses is preserved and not clobbered by subsequent device listing updates that lack this data.

Fixes smartphone location via Bermuda using EID-based API calls.

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
