### PR TITLE
Fix Bermuda EID decryption: Propagate encrypted_identity_key and owne…

### DIFF
--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -245,6 +245,8 @@ _ANCHOR_METADATA_KEYS: tuple[str, ...] = (
     "identity_key",
     "identity_key_candidates",
     "encrypted_identity_key_candidates",
+    "encrypted_identity_key",
+    "owner_key_version",
     "time_anchors_debug",
     "metadata_only",
 )
@@ -406,11 +408,24 @@ def _collect_anchor_metadata(location_candidates: list[dict[str, Any]]) -> dict[
                     union[ts_key] = ts_val
 
         # identity key material (bytes)
-        for b_key in ("identity_key",):
-            if union.get(b_key) is None:
-                b_val = cand.get(b_key)
-                if isinstance(b_val, (bytes, bytearray)) and b_val:
-                    union[b_key] = bytes(b_val)
+        if union.get("identity_key") is None:
+            ik_val = cand.get("identity_key")
+            if isinstance(ik_val, (bytes, bytearray)) and ik_val:
+                union["identity_key"] = bytes(ik_val)
+
+        # encrypted_identity_key (convert bytes to hex string for consistency)
+        if union.get("encrypted_identity_key") is None:
+            eik_val = cand.get("encrypted_identity_key")
+            if isinstance(eik_val, (bytes, bytearray)) and eik_val:
+                union["encrypted_identity_key"] = bytes(eik_val).hex()
+            elif isinstance(eik_val, str) and eik_val:
+                union["encrypted_identity_key"] = eik_val
+
+        # owner_key_version (int)
+        if union.get("owner_key_version") is None:
+            okv = cand.get("owner_key_version")
+            if isinstance(okv, int) and okv > 0:
+                union["owner_key_version"] = okv
 
         # list unions
         for list_key in ("identity_key_candidates", "encrypted_identity_key_candidates"):


### PR DESCRIPTION
…r_key_version from FCM response

For Android devices (smartphones), encryption keys are only provided via the FCM/Locate flow, not in the list_devices protobuf. The decrypt_locations module correctly decrypts and includes these keys in location payloads, but the decoder was not extracting them from location_candidates.

Changes:
- Add encrypted_identity_key and owner_key_version to _ANCHOR_METADATA_KEYS
- Extend _collect_anchor_metadata to extract these fields from location_candidates
- Convert encrypted_identity_key from bytes to hex string for consistency with proto-sourced values
- These values now properly propagate to the coordinator for Bermuda integration

Fixes issue where Bermuda could not locate smartphones via EID due to missing key data in coordinator logs.

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
