### PR TITLE
Fix EID resolver not triggered for phones with offline detection

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -6960,7 +6960,17 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             # The EID resolver refresh ensures that newly-received identity keys from
             # decrypt_locations are immediately used for EID generation.
             if "identity_key" in anchor_payload:
-                eid_resolver = getattr(self, "eid_resolver", None)
+                # FIX: Get eid_resolver from hass.data[DOMAIN][DATA_EID_RESOLVER],
+                # NOT from self.eid_resolver (which was never set on the coordinator).
+                # This was causing phones with offline detection to never trigger
+                # EID resolver refresh, even though identity_key was being received.
+                hass_obj = getattr(self, "hass", None)
+                if hass_obj is None:
+                    return
+                domain_bucket = hass_obj.data.get(DOMAIN) if hasattr(hass_obj, "data") else None
+                if not isinstance(domain_bucket, dict):
+                    return
+                eid_resolver = domain_bucket.get(DATA_EID_RESOLVER)
                 if eid_resolver is not None:
                     _LOGGER.debug(
                         "Triggering EID Resolver refresh for %s (identity_key in anchor_payload)",
@@ -6968,9 +6978,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     )
                     refresh_task = getattr(eid_resolver, "async_trigger_immediate_refresh", None)
                     if callable(refresh_task):
-                        hass_obj = getattr(self, "hass", None)
-                        if hass_obj is not None:
-                            hass_obj.async_create_task(refresh_task())
+                        hass_obj.async_create_task(refresh_task())
 
         def _normalize_anchor_value(value: Any) -> int | Any:
             normalized = normalize_epoch_seconds(value)

--- a/tests/test_eid_data_flow.py
+++ b/tests/test_eid_data_flow.py
@@ -17,13 +17,19 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
+from custom_components.googlefindmy.const import DOMAIN, DATA_EID_RESOLVER
+
 # ============================================================================
 # Test fixtures and helpers
 # ============================================================================
 
 
-def _fake_hass() -> SimpleNamespace:
-    """Return a minimal hass stand-in with async task helpers."""
+def _fake_hass(eid_resolver: Any = None) -> SimpleNamespace:
+    """Return a minimal hass stand-in with async task helpers.
+
+    Args:
+        eid_resolver: Optional EID resolver to put in hass.data[DOMAIN][DATA_EID_RESOLVER]
+    """
     created_coros: list[Any] = []
 
     def create_task(coro: Any, name: str | None = None) -> MagicMock:
@@ -34,10 +40,15 @@ def _fake_hass() -> SimpleNamespace:
             coro.close()
         return MagicMock()
 
+    # Build data dict with optional EID resolver (stored at domain level)
+    data: dict[str, Any] = {}
+    if eid_resolver is not None:
+        data[DOMAIN] = {DATA_EID_RESOLVER: eid_resolver}
+
     return SimpleNamespace(
         async_create_task=create_task,
         async_create_background_task=create_task,
-        data={},
+        data=data,
         _created_coros=created_coros,
     )
 
@@ -51,19 +62,22 @@ def _fake_config_entry(entry_id: str = "test_entry_123") -> SimpleNamespace:
     )
 
 
-def _create_test_coordinator() -> Any:
-    """Create a minimal coordinator instance for testing EID data flow."""
+def _create_test_coordinator(eid_resolver: Any = None) -> Any:
+    """Create a minimal coordinator instance for testing EID data flow.
+
+    Args:
+        eid_resolver: Optional EID resolver to set up in hass.data[DOMAIN][DATA_EID_RESOLVER]
+    """
     from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 
     # Create a minimal coordinator without full initialization
     coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
-    coordinator.hass = _fake_hass()
+    coordinator.hass = _fake_hass(eid_resolver=eid_resolver)
     coordinator.config_entry = _fake_config_entry()
     coordinator._device_location_data = {}
     coordinator._last_device_list = []
     coordinator._enabled_poll_device_ids = set()
     coordinator.data = []
-    coordinator.eid_resolver = None
     coordinator.logger = MagicMock()
 
     # Add minimal required methods
@@ -155,8 +169,6 @@ class TestEidDataPersistence:
 
     def test_persist_anchor_metadata_triggers_eid_resolver_refresh(self) -> None:
         """When identity_key is in payload, EID resolver refresh should be triggered."""
-        coordinator = _create_test_coordinator()
-
         # Set up a mock EID resolver with a simple callable
         mock_resolver = MagicMock()
 
@@ -164,7 +176,9 @@ class TestEidDataPersistence:
             pass
 
         mock_resolver.async_trigger_immediate_refresh = lambda: mock_refresh_coro()
-        coordinator.eid_resolver = mock_resolver
+
+        # Create coordinator with eid_resolver in hass.data[DOMAIN][DATA_EID_RESOLVER]
+        coordinator = _create_test_coordinator(eid_resolver=mock_resolver)
 
         location_data: dict[str, Any] = {
             "identity_key": b"\x01\x02\x03\x04" * 8,

--- a/tests/test_eid_data_flow.py
+++ b/tests/test_eid_data_flow.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
-from custom_components.googlefindmy.const import DOMAIN, DATA_EID_RESOLVER
+from custom_components.googlefindmy.const import DATA_EID_RESOLVER, DOMAIN
 
 # ============================================================================
 # Test fixtures and helpers

--- a/tests/test_moto_tag_regressions.py
+++ b/tests/test_moto_tag_regressions.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 import custom_components.googlefindmy.coordinator as coordinator_module
+from custom_components.googlefindmy.const import DOMAIN, DATA_EID_RESOLVER
 from custom_components.googlefindmy.FMDNCrypto import eid_generator
 from custom_components.googlefindmy.KeyBackup import cloud_key_decryptor
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
@@ -113,8 +115,11 @@ def test_persistence_writes_moto_tag_material(monkeypatch: pytest.MonkeyPatch) -
         coordinator_module.GoogleFindMyCoordinator
     )
     coordinator._device_location_data = {}
-    coordinator.hass = SimpleNamespace(async_create_task=mock_create_task)
-    coordinator.eid_resolver = mock_eid_resolver
+
+    # Set up hass with eid_resolver in hass.data[DOMAIN][DATA_EID_RESOLVER]
+    # (the correct location for the domain-level singleton)
+    hass_data: dict[str, Any] = {DOMAIN: {DATA_EID_RESOLVER: mock_eid_resolver}}
+    coordinator.hass = SimpleNamespace(async_create_task=mock_create_task, data=hass_data)
 
     payload = {
         "identity_key": b"\xaa" * 32,

--- a/tests/test_moto_tag_regressions.py
+++ b/tests/test_moto_tag_regressions.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import custom_components.googlefindmy.coordinator as coordinator_module
-from custom_components.googlefindmy.const import DOMAIN, DATA_EID_RESOLVER
+from custom_components.googlefindmy.const import DATA_EID_RESOLVER, DOMAIN
 from custom_components.googlefindmy.FMDNCrypto import eid_generator
 from custom_components.googlefindmy.KeyBackup import cloud_key_decryptor
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (


### PR DESCRIPTION
The EID resolver refresh was never triggered for phones with offline detection enabled because _persist_registry_anchor_metadata() tried to access self.eid_resolver, which was never set on the coordinator.

The eid_resolver is stored as a domain-level singleton in hass.data[DOMAIN][DATA_EID_RESOLVER], not on individual coordinators.

This caused:
- No "Triggering EID Resolver refresh" logs when FCM data arrived
- identity_key was successfully decrypted but never used for EID generation
- Bermuda could see phone BLE broadcasts but couldn't match them to EIDs

Fix: Get eid_resolver from hass.data[DOMAIN][DATA_EID_RESOLVER] instead of getattr(self, "eid_resolver", None).

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
