### PR TITLE
Fix EID resolution for phones with offline detection

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -723,6 +723,20 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             metadata_update.setdefault("pair_date", pair_date_raw)
             metadata_update.setdefault("pairDate", pair_date_raw)
 
+        # FIX: Extract manufacturer, model, and fast_pair_model_id for EID resolver
+        manufacturer_raw = getattr(device_registration, "manufacturer", None)
+        if manufacturer_raw and isinstance(manufacturer_raw, str):
+            metadata_update.setdefault("manufacturer", manufacturer_raw)
+
+        model_raw = getattr(device_registration, "model", None)
+        if model_raw and isinstance(model_raw, str):
+            metadata_update.setdefault("model", model_raw)
+
+        fast_pair_model_id_raw = getattr(device_registration, "fastPairModelId", None)
+        if fast_pair_model_id_raw and isinstance(fast_pair_model_id_raw, str):
+            metadata_update.setdefault("fast_pair_model_id", fast_pair_model_id_raw)
+            metadata_update.setdefault("fastPairModelId", fast_pair_model_id_raw)
+
     if encrypted_user_secrets:
         creation = getattr(encrypted_user_secrets, "creationDate", None)
         if creation is not None:
@@ -907,8 +921,16 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
 
     if not wrapped:
         _LOGGER.debug("[DecryptLocations] No locations found.")
-        if metadata:
-            metadata_only = dict(metadata)
+        # FIX: Merge metadata_update into the returned payload even when no locations.
+        # This ensures encrypted_identity_key, secrets_creation_date, owner_key_version,
+        # identity_key, etc. are returned for devices (like phones) that have these
+        # fields but no location reports yet.
+        if metadata or metadata_update:
+            metadata_only: dict[str, Any] = {}
+            if metadata:
+                metadata_only.update(metadata)
+            if metadata_update:
+                metadata_only.update(metadata_update)
             metadata_only["metadata_only"] = True
             return [metadata_only]
         return []

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -6976,9 +6976,10 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                         "Triggering EID Resolver refresh for %s (identity_key in anchor_payload)",
                         device_id,
                     )
-                    refresh_task = getattr(eid_resolver, "async_trigger_immediate_refresh", None)
-                    if callable(refresh_task):
-                        hass_obj.async_create_task(refresh_task())
+                    # FIX: The method is called async_refresh, not async_trigger_immediate_refresh
+                    refresh_coro = getattr(eid_resolver, "async_refresh", None)
+                    if callable(refresh_coro):
+                        hass_obj.async_create_task(refresh_coro())
 
         def _normalize_anchor_value(value: Any) -> int | Any:
             normalized = normalize_epoch_seconds(value)

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -236,6 +236,10 @@ _PERSISTED_METADATA_KEYS: tuple[str, ...] = (
     "encrypted_identity_key_candidates",
     "owner_key_version",
     "time_anchors_debug",
+    # FIX: Add device metadata fields for phones
+    "manufacturer",
+    "model",
+    "fast_pair_model_id",
 )
 
 


### PR DESCRIPTION
## Summary

This PR fixes multiple issues preventing smartphones with offline detection from being discovered via EID.

### Fixes:
1. **EID resolver trigger** - use `hass.data[DOMAIN][DATA_EID_RESOLVER]` instead of `self.eid_resolver`
2. **Method name mismatch** - `async_trigger_immediate_refresh` → `async_refresh`  
3. **pair_date=0 handling** - reject zero values, use `secrets_creation_date`
4. **Metadata persistence** - merge `metadata_update` when no location reports
5. **Device metadata extraction** - add `manufacturer`, `model`, `fast_pair_model_id`

## Test plan
- [ ] Phone appears in EID resolver logs with correct window groups
- [ ] Phone `cached_data` contains `encrypted_identity_key`, `secrets_creation_date`
- [ ] Phone can be matched by Bermuda via EID
- [ ] Existing tracker EID resolution still works
