### PR TITLE
Fix smartphone EID discovery for offline detection

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -586,7 +586,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 raw_encrypted_identity_key, cache=cache
             )
 
-        _LOGGER.warning(
+        _LOGGER.debug(
             "[DIAG-SECRETS] Structure Analysis:\n"
             "  - DeviceReg String: %s\n"
             "  - Secrets Container Type: %s\n"
@@ -644,7 +644,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 prefix_bytes = secrets_blob[prefix_start:offset]
                 suffix_start = offset + len(raw_encrypted_identity_key)
                 suffix_bytes = secrets_blob[suffix_start : suffix_start + 10]
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "[DIAG-SECRETS-BYTE-SCAN] Cloud key located inside encryptedUserSecrets at offset %d."
                     " Prefix (%d bytes): %s | Suffix (%d bytes): %s",
                     offset,
@@ -654,7 +654,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     suffix_bytes.hex(),
                 )
             else:
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "[DIAG-SECRETS-BYTE-SCAN] Cloud key NOT found inside encryptedUserSecrets blob."
                     " This suggests the blob holds a distinct container or wrapped value."
                 )

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -1049,8 +1049,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 payload.update(metadata_update)
 
             # Safety net: ensure identity key propagates even if metadata lacks it
-            if "identity_key" not in payload and identity_key_bytes:
-                payload["identity_key"] = identity_key_bytes
+            if "identity_key" not in payload and identity_key_hex:
+                payload["identity_key"] = identity_key_hex
 
             if metadata:
                 payload.update(metadata)

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -808,15 +808,25 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         metadata["device_type_information"] = device_type_information_metadata
         metadata.setdefault("deviceTypeInformation", device_type_information_metadata)
 
+    # FIX: Convert bytes to hex strings for consistency with other data sources
+    # This ensures identity_key and encrypted_identity_key are stored in the same
+    # format as data from device listings (hex strings, not raw bytes).
+    identity_key_hex: str | None = None
+    candidates_hex: list[str] | None = None
+    encrypted_key_hex: str | None = None
+
     if identity_key_bytes is not None and len(identity_key_bytes) == _EIK_LEN:
-        metadata_update["identity_key"] = identity_key_bytes
-        metadata_update["identityKey"] = identity_key_bytes
+        identity_key_hex = identity_key_bytes.hex()
+        metadata_update["identity_key"] = identity_key_hex
+        metadata_update["identityKey"] = identity_key_hex
     if identity_key_candidate_bytes:
-        metadata.setdefault("identity_key_candidates", identity_key_candidate_bytes)
-        metadata.setdefault("identityKeyCandidates", identity_key_candidate_bytes)
+        candidates_hex = [c.hex() for c in identity_key_candidate_bytes if c]
+        metadata.setdefault("identity_key_candidates", candidates_hex)
+        metadata.setdefault("identityKeyCandidates", candidates_hex)
     if raw_encrypted_identity_key:
-        metadata_update.setdefault("encrypted_identity_key", raw_encrypted_identity_key)
-        metadata_update.setdefault("encryptedIdentityKey", raw_encrypted_identity_key)
+        encrypted_key_hex = raw_encrypted_identity_key.hex()
+        metadata_update.setdefault("encrypted_identity_key", encrypted_key_hex)
+        metadata_update.setdefault("encryptedIdentityKey", encrypted_key_hex)
     if raw_owner_key_version is not None:
         metadata.setdefault("owner_key_version", raw_owner_key_version)
         metadata.setdefault("ownerKeyVersion", raw_owner_key_version)
@@ -964,10 +974,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "status_code": int(loc.status),
                     "is_own_report": False,
                     "semantic_name": loc.name,
-                    "encrypted_identity_key": raw_encrypted_identity_key,
+                    "encrypted_identity_key": encrypted_key_hex if raw_encrypted_identity_key else None,
                     "owner_key_version": raw_owner_key_version,
-                    "identity_key": identity_key_bytes,
-                    "identity_key_candidates": identity_key_candidate_bytes,
+                    "identity_key": identity_key_hex if identity_key_bytes else None,
+                    "identity_key_candidates": candidates_hex if identity_key_candidate_bytes else None,
                 }
                 # Internal hint helps the coordinator schedule throttling-aware cooldowns.
                 if report_hint:
@@ -1017,10 +1027,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "status_code": int(loc.status),
                     "is_own_report": loc.is_own_report,
                     "semantic_name": None,
-                    "encrypted_identity_key": raw_encrypted_identity_key,
+                    "encrypted_identity_key": encrypted_key_hex,
                     "owner_key_version": raw_owner_key_version,
-                    "identity_key": identity_key_bytes,
-                    "identity_key_candidates": identity_key_candidate_bytes,
+                    "identity_key": identity_key_hex,
+                    "identity_key_candidates": candidates_hex,
                 }
                 if report_hint:
                     payload["_report_hint"] = report_hint

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -407,11 +407,13 @@ def _collect_anchor_metadata(location_candidates: list[dict[str, Any]]) -> dict[
                 if ts_val is not None and union.get(ts_key) is None:
                     union[ts_key] = ts_val
 
-        # identity key material (bytes)
+        # identity key material (convert bytes to hex string for consistency)
         if union.get("identity_key") is None:
             ik_val = cand.get("identity_key")
             if isinstance(ik_val, (bytes, bytearray)) and ik_val:
-                union["identity_key"] = bytes(ik_val)
+                union["identity_key"] = bytes(ik_val).hex()
+            elif isinstance(ik_val, str) and ik_val:
+                union["identity_key"] = ik_val
 
         # encrypted_identity_key (convert bytes to hex string for consistency)
         if union.get("encrypted_identity_key") is None:

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -7059,8 +7059,6 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if not anchor_payload:
             return
 
-        _persist_registry_anchor_metadata(anchor_payload)
-
         existing = self._device_location_data.get(device_id)
         merged: dict[str, Any] = {}
         if isinstance(existing, Mapping):
@@ -7074,6 +7072,11 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             merged["metadata_only"] = True
 
         self._device_location_data[device_id] = merged
+
+        # FIX: Trigger EID refresh AFTER cache is updated, not before.
+        # This ensures the phone's identity_key is available when the resolver
+        # collects device identities.
+        _persist_registry_anchor_metadata(anchor_payload)
 
     def _get_predicted_poll_time(self) -> float | None:
         """Predict the earliest next update time based on device histories."""

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -769,16 +769,10 @@ class GoogleFindMyEIDResolver:
             clean_canonical_id = clean_canonical_id.split(":")[-1]
 
         # FIX: Handle both bytes and hex string formats for identity_key
-        raw_key = identity.identity_key
-        if isinstance(raw_key, (bytes, bytearray)):
-            key_bytes = bytes(raw_key)
-        elif isinstance(raw_key, str):
-            try:
-                key_bytes = bytes.fromhex(raw_key)
-            except ValueError:
-                return None
-        else:
+        key_bytes = _normalize_encrypted_blob(identity.identity_key)
+        if key_bytes is None:
             return None
+
         lock = self._locks.get(identity.registry_id)
         locked_variant: EidVariant | None = None
         rotation_ts: int | None = None
@@ -1406,19 +1400,14 @@ class GoogleFindMyEIDResolver:
         """Decrypt encrypted identity key when owner/shared key material is available."""
 
         self._ensure_cache_defaults()
-        if cache is None or identity.encrypted_identity_key is None:
+        if cache is None:
             return None
 
         # FIX: Handle both bytes and hex string formats for encrypted_identity_key
-        raw_eik = identity.encrypted_identity_key
-        if isinstance(raw_eik, (bytes, bytearray)):
-            encrypted_identity_key = bytes(raw_eik)
-        elif isinstance(raw_eik, str):
-            try:
-                encrypted_identity_key = bytes.fromhex(raw_eik)
-            except ValueError:
-                return None
-        else:
+        encrypted_identity_key = _normalize_encrypted_blob(
+            identity.encrypted_identity_key
+        )
+        if encrypted_identity_key is None:
             return None
 
         owner_key_info = await self._resolve_owner_key(identity, cache=cache)

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -768,7 +768,17 @@ class GoogleFindMyEIDResolver:
         if ":" in clean_canonical_id:
             clean_canonical_id = clean_canonical_id.split(":")[-1]
 
-        key_bytes = bytes(identity.identity_key)
+        # FIX: Handle both bytes and hex string formats for identity_key
+        raw_key = identity.identity_key
+        if isinstance(raw_key, (bytes, bytearray)):
+            key_bytes = bytes(raw_key)
+        elif isinstance(raw_key, str):
+            try:
+                key_bytes = bytes.fromhex(raw_key)
+            except ValueError:
+                return None
+        else:
+            return None
         lock = self._locks.get(identity.registry_id)
         locked_variant: EidVariant | None = None
         rotation_ts: int | None = None
@@ -1396,11 +1406,19 @@ class GoogleFindMyEIDResolver:
         """Decrypt encrypted identity key when owner/shared key material is available."""
 
         self._ensure_cache_defaults()
-        if (
-            cache is None
-            or identity.encrypted_identity_key is None
-            or not isinstance(identity.encrypted_identity_key, (bytes, bytearray))
-        ):
+        if cache is None or identity.encrypted_identity_key is None:
+            return None
+
+        # FIX: Handle both bytes and hex string formats for encrypted_identity_key
+        raw_eik = identity.encrypted_identity_key
+        if isinstance(raw_eik, (bytes, bytearray)):
+            encrypted_identity_key = bytes(raw_eik)
+        elif isinstance(raw_eik, str):
+            try:
+                encrypted_identity_key = bytes.fromhex(raw_eik)
+            except ValueError:
+                return None
+        else:
             return None
 
         owner_key_info = await self._resolve_owner_key(identity, cache=cache)
@@ -1414,8 +1432,6 @@ class GoogleFindMyEIDResolver:
             shared_key = None
         if shared_key is not None:
             key_sources.append(("shared", shared_key))
-
-        encrypted_identity_key = bytes(identity.encrypted_identity_key)
         suggested_mcu = is_mcu_tracker(
             device_type=identity.device_type,
             fast_pair_model_id=identity.fast_pair_model_id,

--- a/tests/test_decoder_location_ranking.py
+++ b/tests/test_decoder_location_ranking.py
@@ -81,9 +81,10 @@ def test_device_list_preserves_anchor_metadata(monkeypatch: pytest.MonkeyPatch) 
         # Anchor + diagnostics payload:
         "pair_date": 1_700_000_100,
         "secrets_creation_date": 1_700_000_200,
-        "identity_key": b"\xaa" * 32,
-        "identity_key_candidates": [b"\xaa" * 32, b"\xbb" * 32],
-        "encrypted_identity_key_candidates": [b"\x01\x02"],
+        # FIX: identity_key is now returned as hex string by decrypt_locations
+        "identity_key": (b"\xaa" * 32).hex(),
+        "identity_key_candidates": [(b"\xaa" * 32).hex(), (b"\xbb" * 32).hex()],
+        "encrypted_identity_key_candidates": [(b"\x01\x02").hex()],
         "device_registration": {"pairDate": 1_700_000_300},
         "encrypted_user_secrets": {"creationDate": 1_700_000_400},
         "time_anchors_debug": {"source": "device_list"},

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -274,13 +274,15 @@ async def test_async_decrypt_location_response_unwraps_60_byte_eik(
     assert len(result) == 1
     entry = result[0]
     assert entry.get("metadata_only") is not True
-    assert entry["identity_key"] == unwrapped_eik
-    assert entry["identity_key_candidates"] == [unwrapped_eik]
-    assert entry["encrypted_identity_key"] == encrypted_eik
+    # FIX: identity_key and encrypted_identity_key are now returned as hex strings
+    assert entry["identity_key"] == unwrapped_eik.hex()
+    assert entry["identity_key_candidates"] == [unwrapped_eik.hex()]
+    assert entry["encrypted_identity_key"] == encrypted_eik.hex()
     assert entry["pair_date"] == int(base_now - 30)
     assert entry["secrets_creation_date"] == int(base_now - 15)
     assert entry["accuracy"] == ACCURACY_METERS
     assert entry["altitude"] == ALTITUDE_METERS
+    # offload_calls still receives bytes internally
     assert offload_calls["identity_key"] == unwrapped_eik
     assert len(offload_calls["identity_key"]) == 32
     assert offload_calls["encrypted_location"] == b"ciphertext"
@@ -322,9 +324,10 @@ async def test_async_decrypt_location_response_locations_normalizes_anchor_units
     assert entry.get("metadata_only") is True
     assert entry["pair_date"] == int(base_now - 300)
     assert entry["secrets_creation_date"] == int(base_now - 150)
-    assert entry["identity_key"] == b"\x51" * 32
-    assert entry["identity_key_candidates"] == [b"\x51" * 32]
-    assert entry["encrypted_identity_key"] == b"\x10" * 32
+    # FIX: identity_key and encrypted_identity_key are now returned as hex strings
+    assert entry["identity_key"] == (b"\x51" * 32).hex()
+    assert entry["identity_key_candidates"] == [(b"\x51" * 32).hex()]
+    assert entry["encrypted_identity_key"] == (b"\x10" * 32).hex()
     assert decrypt_locations._parse_epoch_seconds(  # type: ignore[attr-defined]
         int((base_now - 75) * 1000), base_now
     ) == pytest.approx(base_now - 75)
@@ -366,7 +369,8 @@ async def test_async_decrypt_location_response_reads_registration_anchors(
     entry = result[0]
     assert entry["pair_date"] == int(base_now - 500)
     assert entry["secrets_creation_date"] == int(base_now - 250)
-    assert entry["identity_key"] == b"\x61" * 32
+    # FIX: identity_key is now returned as hex string
+    assert entry["identity_key"] == (b"\x61" * 32).hex()
     type_meta = entry.get("device_type_information")
     assert not type_meta
     registration_meta = entry.get("device_registration")

--- a/tests/test_eid_data_flow.py
+++ b/tests/test_eid_data_flow.py
@@ -175,7 +175,7 @@ class TestEidDataPersistence:
         async def mock_refresh_coro() -> None:
             pass
 
-        mock_resolver.async_trigger_immediate_refresh = lambda: mock_refresh_coro()
+        mock_resolver.async_refresh = lambda: mock_refresh_coro()
 
         # Create coordinator with eid_resolver in hass.data[DOMAIN][DATA_EID_RESOLVER]
         coordinator = _create_test_coordinator(eid_resolver=mock_resolver)

--- a/tests/test_key_propagation_flow.py
+++ b/tests/test_key_propagation_flow.py
@@ -116,4 +116,5 @@ async def test_decrypted_key_reaches_coordinator_cache(
 
     stored_data = coordinator.get_device_location_data("device-1")
     assert stored_data is not None
-    assert stored_data["identity_key"] == identity_key.hex()
+    # Coordinator normalizes identity_key to bytes when storing
+    assert stored_data["identity_key"] == identity_key

--- a/tests/test_key_propagation_flow.py
+++ b/tests/test_key_propagation_flow.py
@@ -61,7 +61,8 @@ def _build_coordinator(monkeypatch: pytest.MonkeyPatch) -> coordinator_module.Go
 async def test_decrypted_key_reaches_coordinator_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    identity_key = b"new_decrypted_bytes_source_of_truth"
+    # FIX: identity_key must be exactly 32 bytes for hex conversion
+    identity_key = b"new_decrypted_key_source_truth!!"  # 32 bytes
     timestamp = int(time.time())
 
     semantic_location = SimpleNamespace(
@@ -107,11 +108,12 @@ async def test_decrypted_key_reaches_coordinator_cache(
 
     assert decrypted_payloads
     payload = decrypted_payloads[0]
-    assert payload["identity_key"] == identity_key
+    # FIX: identity_key is now returned as hex string
+    assert payload["identity_key"] == identity_key.hex()
 
     coordinator = _build_coordinator(monkeypatch)
     coordinator.update_device_cache("device-1", payload)
 
     stored_data = coordinator.get_device_location_data("device-1")
     assert stored_data is not None
-    assert stored_data["identity_key"] == identity_key
+    assert stored_data["identity_key"] == identity_key.hex()

--- a/tests/test_moto_tag_regressions.py
+++ b/tests/test_moto_tag_regressions.py
@@ -107,9 +107,9 @@ def test_persistence_writes_moto_tag_material(monkeypatch: pytest.MonkeyPatch) -
             coro.close()  # type: ignore[union-attr]
         return MagicMock()
 
-    # Create a mock EID resolver with async_trigger_immediate_refresh
+    # Create a mock EID resolver with async_refresh
     mock_eid_resolver = MagicMock()
-    mock_eid_resolver.async_trigger_immediate_refresh = mock_refresh
+    mock_eid_resolver.async_refresh = mock_refresh
 
     coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
         coordinator_module.GoogleFindMyCoordinator

--- a/tests/test_moto_tag_regressions.py
+++ b/tests/test_moto_tag_regressions.py
@@ -26,7 +26,8 @@ async def test_moto_tag_decryption_unwraps_and_injects_metadata(
     base_now = 1_700_000_000
     creation_seconds = base_now - 123
     encrypted_identity_key = b"\x99" * decrypt_locations.EIK_GCM_TOTAL_LEN
-    decrypted_identity_key = b"DecryptedMotoTagIdentityKey!!"[:32]
+    # FIX: decrypted_identity_key must be exactly 32 bytes for hex conversion
+    decrypted_identity_key = b"DecryptedMotoTagIdentityKey!!!!!"  # 32 bytes
 
     location_proto = DeviceUpdate_pb2.Location()
     location_proto.latitude = int(40.0 * 1e7)
@@ -79,7 +80,8 @@ async def test_moto_tag_decryption_unwraps_and_injects_metadata(
     assert decrypt_mock.called
     assert results
     payload = results[0]
-    assert payload["identity_key"] == decrypted_identity_key
+    # FIX: identity_key is now returned as hex string
+    assert payload["identity_key"] == decrypted_identity_key.hex()
     assert payload.get("secrets_creation_date") is not None
     assert payload["secrets_creation_date"] == creation_seconds
 


### PR DESCRIPTION
## Summary
- Fix EID resolver access: Use `hass.data[DOMAIN][DATA_EID_RESOLVER]` instead of `getattr(self, "eid_resolver")`
- Fix method name: `async_trigger_immediate_refresh` → `async_refresh`
- Fix race condition: Cache update BEFORE EID refresh trigger
- Fix `pair_date=0` handling: Phones without `deviceRegistration` are now handled correctly
- Fix metadata persistence: `metadata_update` is now merged when no location reports
- Fix format consistency: Convert `identity_key` and `encrypted_identity_key` to hex strings throughout
- Fix EID resolver type handling: Accept both bytes and hex string formats

## Test plan
- [x] Verify phones with offline detection get discovered via EID
- [x] Verify trackers continue to work as before
- [x] Verify metadata persists even without location reports
- [x] Verify hex string format in logs for cleaner output
- [x] Verify tests pass with updated method names
