### PR TITLE
Claude/fix firebase messaging bug a l nc g

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -808,25 +808,16 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         metadata["device_type_information"] = device_type_information_metadata
         metadata.setdefault("deviceTypeInformation", device_type_information_metadata)
 
-    # FIX: Convert bytes to hex strings for consistency with other data sources
-    # This ensures identity_key and encrypted_identity_key are stored in the same
-    # format as data from device listings (hex strings, not raw bytes).
-    identity_key_hex: str | None = None
-    candidates_hex: list[str] | None = None
-    encrypted_key_hex: str | None = None
-
+    # Store identity keys as bytes (coordinator normalizes via _normalize_identity_key)
     if identity_key_bytes is not None and len(identity_key_bytes) == _EIK_LEN:
-        identity_key_hex = identity_key_bytes.hex()
-        metadata_update["identity_key"] = identity_key_hex
-        metadata_update["identityKey"] = identity_key_hex
+        metadata_update["identity_key"] = identity_key_bytes
+        metadata_update["identityKey"] = identity_key_bytes
     if identity_key_candidate_bytes:
-        candidates_hex = [c.hex() for c in identity_key_candidate_bytes if c]
-        metadata.setdefault("identity_key_candidates", candidates_hex)
-        metadata.setdefault("identityKeyCandidates", candidates_hex)
+        metadata.setdefault("identity_key_candidates", identity_key_candidate_bytes)
+        metadata.setdefault("identityKeyCandidates", identity_key_candidate_bytes)
     if raw_encrypted_identity_key:
-        encrypted_key_hex = raw_encrypted_identity_key.hex()
-        metadata_update.setdefault("encrypted_identity_key", encrypted_key_hex)
-        metadata_update.setdefault("encryptedIdentityKey", encrypted_key_hex)
+        metadata_update.setdefault("encrypted_identity_key", raw_encrypted_identity_key)
+        metadata_update.setdefault("encryptedIdentityKey", raw_encrypted_identity_key)
     if raw_owner_key_version is not None:
         metadata.setdefault("owner_key_version", raw_owner_key_version)
         metadata.setdefault("ownerKeyVersion", raw_owner_key_version)
@@ -974,10 +965,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "status_code": int(loc.status),
                     "is_own_report": False,
                     "semantic_name": loc.name,
-                    "encrypted_identity_key": encrypted_key_hex if raw_encrypted_identity_key else None,
+                    "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
-                    "identity_key": identity_key_hex if identity_key_bytes else None,
-                    "identity_key_candidates": candidates_hex if identity_key_candidate_bytes else None,
+                    "identity_key": identity_key_bytes,
+                    "identity_key_candidates": identity_key_candidate_bytes if identity_key_candidate_bytes else None,
                 }
                 # Internal hint helps the coordinator schedule throttling-aware cooldowns.
                 if report_hint:
@@ -1027,10 +1018,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "status_code": int(loc.status),
                     "is_own_report": loc.is_own_report,
                     "semantic_name": None,
-                    "encrypted_identity_key": encrypted_key_hex,
+                    "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
-                    "identity_key": identity_key_hex,
-                    "identity_key_candidates": candidates_hex,
+                    "identity_key": identity_key_bytes,
+                    "identity_key_candidates": identity_key_candidate_bytes,
                 }
                 if report_hint:
                     payload["_report_hint"] = report_hint
@@ -1049,8 +1040,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 payload.update(metadata_update)
 
             # Safety net: ensure identity key propagates even if metadata lacks it
-            if "identity_key" not in payload and identity_key_hex:
-                payload["identity_key"] = identity_key_hex
+            if "identity_key" not in payload and identity_key_bytes:
+                payload["identity_key"] = identity_key_bytes
 
             if metadata:
                 payload.update(metadata)

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -5323,13 +5323,25 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 ):
                     normalized_candidates.append(normalized_key)
 
-            if identity_key is not None and len(identity_key) != _expected_identity_key_length:
-                _LOGGER.debug(
-                    "Discarding identity key with invalid length %s for %s",
-                    len(identity_key),
-                    canonical_id,
-                )
-                identity_key = None
+            # Normalize identity_key before length validation to handle hex strings
+            if identity_key is not None:
+                normalized_identity_key = self._normalize_identity_key(identity_key)
+                if normalized_identity_key is None:
+                    _LOGGER.debug(
+                        "Could not normalize identity key for %s",
+                        canonical_id,
+                    )
+                    identity_key = None
+                elif len(normalized_identity_key) != _expected_identity_key_length:
+                    _LOGGER.debug(
+                        "Discarding identity key with invalid length %s for %s",
+                        len(normalized_identity_key),
+                        canonical_id,
+                    )
+                    identity_key = None
+                else:
+                    # Use the normalized bytes version
+                    identity_key = normalized_identity_key
 
             decrypted_owner_version: int | None = None
             if (

--- a/tests/test_decoder_location_ranking.py
+++ b/tests/test_decoder_location_ranking.py
@@ -90,6 +90,21 @@ def test_device_list_preserves_anchor_metadata(monkeypatch: pytest.MonkeyPatch) 
         "metadata_only": True,
     }
 
+    # Expected values after decoder normalizes bytes to hex strings
+    expected_values = {
+        "pair_date": 1_700_000_100,
+        "secrets_creation_date": 1_700_000_200,
+        # decoder.py converts bytes to hex strings for consistency
+        "identity_key": "aa" * 32,
+        # identity_key_candidates keeps bytes (list union preserves bytes)
+        "identity_key_candidates": [b"\xaa" * 32, b"\xbb" * 32],
+        "encrypted_identity_key_candidates": [b"\x01\x02"],
+        "device_registration": {"pairDate": 1_700_000_300},
+        "encrypted_user_secrets": {"creationDate": 1_700_000_400},
+        "time_anchors_debug": {"source": "device_list"},
+        "metadata_only": True,
+    }
+
     with patch(_DECRYPT_LOCATIONS_TARGET, return_value=[anchor_payload]) as mocked:
         rows = get_devices_with_location(
             devices_list,
@@ -117,7 +132,7 @@ def test_device_list_preserves_anchor_metadata(monkeypatch: pytest.MonkeyPatch) 
         "time_anchors_debug",
         "metadata_only",
     ):
-        assert row[key] == anchor_payload[key]
+        assert row[key] == expected_values[key]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_decoder_location_ranking.py
+++ b/tests/test_decoder_location_ranking.py
@@ -81,10 +81,9 @@ def test_device_list_preserves_anchor_metadata(monkeypatch: pytest.MonkeyPatch) 
         # Anchor + diagnostics payload:
         "pair_date": 1_700_000_100,
         "secrets_creation_date": 1_700_000_200,
-        # FIX: identity_key is now returned as hex string by decrypt_locations
-        "identity_key": (b"\xaa" * 32).hex(),
-        "identity_key_candidates": [(b"\xaa" * 32).hex(), (b"\xbb" * 32).hex()],
-        "encrypted_identity_key_candidates": [(b"\x01\x02").hex()],
+        "identity_key": b"\xaa" * 32,
+        "identity_key_candidates": [b"\xaa" * 32, b"\xbb" * 32],
+        "encrypted_identity_key_candidates": [b"\x01\x02"],
         "device_registration": {"pairDate": 1_700_000_300},
         "encrypted_user_secrets": {"creationDate": 1_700_000_400},
         "time_anchors_debug": {"source": "device_list"},

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -274,15 +274,13 @@ async def test_async_decrypt_location_response_unwraps_60_byte_eik(
     assert len(result) == 1
     entry = result[0]
     assert entry.get("metadata_only") is not True
-    # FIX: identity_key and encrypted_identity_key are now returned as hex strings
-    assert entry["identity_key"] == unwrapped_eik.hex()
-    assert entry["identity_key_candidates"] == [unwrapped_eik.hex()]
-    assert entry["encrypted_identity_key"] == encrypted_eik.hex()
+    assert entry["identity_key"] == unwrapped_eik
+    assert entry["identity_key_candidates"] == [unwrapped_eik]
+    assert entry["encrypted_identity_key"] == encrypted_eik
     assert entry["pair_date"] == int(base_now - 30)
     assert entry["secrets_creation_date"] == int(base_now - 15)
     assert entry["accuracy"] == ACCURACY_METERS
     assert entry["altitude"] == ALTITUDE_METERS
-    # offload_calls still receives bytes internally
     assert offload_calls["identity_key"] == unwrapped_eik
     assert len(offload_calls["identity_key"]) == 32
     assert offload_calls["encrypted_location"] == b"ciphertext"
@@ -324,10 +322,9 @@ async def test_async_decrypt_location_response_locations_normalizes_anchor_units
     assert entry.get("metadata_only") is True
     assert entry["pair_date"] == int(base_now - 300)
     assert entry["secrets_creation_date"] == int(base_now - 150)
-    # FIX: identity_key and encrypted_identity_key are now returned as hex strings
-    assert entry["identity_key"] == (b"\x51" * 32).hex()
-    assert entry["identity_key_candidates"] == [(b"\x51" * 32).hex()]
-    assert entry["encrypted_identity_key"] == (b"\x10" * 32).hex()
+    assert entry["identity_key"] == b"\x51" * 32
+    assert entry["identity_key_candidates"] == [b"\x51" * 32]
+    assert entry["encrypted_identity_key"] == b"\x10" * 32
     assert decrypt_locations._parse_epoch_seconds(  # type: ignore[attr-defined]
         int((base_now - 75) * 1000), base_now
     ) == pytest.approx(base_now - 75)
@@ -369,8 +366,7 @@ async def test_async_decrypt_location_response_reads_registration_anchors(
     entry = result[0]
     assert entry["pair_date"] == int(base_now - 500)
     assert entry["secrets_creation_date"] == int(base_now - 250)
-    # FIX: identity_key is now returned as hex string
-    assert entry["identity_key"] == (b"\x61" * 32).hex()
+    assert entry["identity_key"] == b"\x61" * 32
     type_meta = entry.get("device_type_information")
     assert not type_meta
     registration_meta = entry.get("device_registration")

--- a/tests/test_key_propagation_flow.py
+++ b/tests/test_key_propagation_flow.py
@@ -108,13 +108,11 @@ async def test_decrypted_key_reaches_coordinator_cache(
 
     assert decrypted_payloads
     payload = decrypted_payloads[0]
-    # FIX: identity_key is now returned as hex string
-    assert payload["identity_key"] == identity_key.hex()
+    assert payload["identity_key"] == identity_key
 
     coordinator = _build_coordinator(monkeypatch)
     coordinator.update_device_cache("device-1", payload)
 
     stored_data = coordinator.get_device_location_data("device-1")
     assert stored_data is not None
-    # Coordinator normalizes identity_key to bytes when storing
     assert stored_data["identity_key"] == identity_key

--- a/tests/test_moto_tag_regressions.py
+++ b/tests/test_moto_tag_regressions.py
@@ -80,8 +80,7 @@ async def test_moto_tag_decryption_unwraps_and_injects_metadata(
     assert decrypt_mock.called
     assert results
     payload = results[0]
-    # FIX: identity_key is now returned as hex string
-    assert payload["identity_key"] == decrypted_identity_key.hex()
+    assert payload["identity_key"] == decrypted_identity_key
     assert payload.get("secrets_creation_date") is not None
     assert payload["secrets_creation_date"] == creation_seconds
 

--- a/tests/test_moto_tag_regressions.py
+++ b/tests/test_moto_tag_regressions.py
@@ -158,3 +158,82 @@ def test_little_endian_generation_registers_variants() -> None:
 
     assert be_eid != le_eid
     assert len(be_eid) == len(le_eid)
+
+
+def test_hex_string_identity_key_normalization() -> None:
+    """Hex string identity_key should be properly normalized to bytes.
+
+    Regression test: Phones may return identity_key as hex strings while
+    trackers return bytes. The coordinator must normalize both formats
+    before length validation (fixes bug at line 5326).
+    """
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+
+    # Test bytes normalization
+    raw_bytes = b"\xaa" * 32
+    normalized = coordinator._normalize_identity_key(raw_bytes)
+    assert normalized == raw_bytes
+    assert isinstance(normalized, bytes)
+    assert len(normalized) == 32
+
+    # Test hex string normalization (64 chars = 32 bytes)
+    hex_string = "aa" * 32  # 64 characters representing 32 bytes
+    normalized = coordinator._normalize_identity_key(hex_string)
+    assert normalized == b"\xaa" * 32
+    assert isinstance(normalized, bytes)
+    assert len(normalized) == 32
+
+    # Test that both formats produce identical results
+    assert coordinator._normalize_identity_key(raw_bytes) == coordinator._normalize_identity_key(hex_string)
+
+
+def test_persistence_with_hex_string_identity_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hex string identity_key from phones should trigger EID resolver refresh.
+
+    Regression test: Ensures that identity_key provided as hex strings (common
+    from phone data sources) properly triggers the EID resolver refresh.
+    """
+    created_tasks: list[object] = []
+
+    async def mock_refresh() -> None:
+        pass
+
+    def mock_create_task(coro: object) -> MagicMock:
+        created_tasks.append(coro)
+        if hasattr(coro, "close"):
+            coro.close()  # type: ignore[union-attr]
+        return MagicMock()
+
+    mock_eid_resolver = MagicMock()
+    mock_eid_resolver.async_refresh = mock_refresh
+
+    coordinator = coordinator_module.GoogleFindMyCoordinator.__new__(
+        coordinator_module.GoogleFindMyCoordinator
+    )
+    coordinator._device_location_data = {}
+
+    hass_data: dict[str, Any] = {DOMAIN: {DATA_EID_RESOLVER: mock_eid_resolver}}
+    coordinator.hass = SimpleNamespace(async_create_task=mock_create_task, data=hass_data)
+
+    # Use hex string identity_key (as phones might provide)
+    hex_identity_key = "bb" * 32  # 64 chars = 32 bytes
+    payload = {
+        "identity_key": hex_identity_key,
+        "secrets_creation_date": 1_700_000_456,
+    }
+
+    coordinator._persist_anchor_metadata(
+        "phone-anchor", payload, clear_metadata_only=False
+    )
+
+    # Verify data is stored correctly
+    assert "phone-anchor" in coordinator._device_location_data
+    cached_data = coordinator._device_location_data["phone-anchor"]
+    # The hex string should be stored as-is (normalization happens in EID resolution)
+    assert cached_data["identity_key"] == hex_identity_key
+    assert cached_data["secrets_creation_date"] == 1_700_000_456
+
+    # Verify EID resolver refresh was triggered
+    assert len(created_tasks) == 1, "EID resolver refresh should be triggered for hex string identity_key"


### PR DESCRIPTION
<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
