### PR TITLE
Fix phone duplication and thread safety in FCM receiver

### DIFF
--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -738,11 +738,21 @@ def get_devices_with_location(
 
     for device in getattr(device_list, "deviceMetadata", []):
         # Resolve canonic IDs for this device (Android vs. generic path)
+        # FIX: For phones (IDENTIFIER_ANDROID), use only the FIRST canonical ID.
+        # Phones can have multiple canonical IDs in the array (e.g., after re-pairing),
+        # but only the first/primary ID should be used to avoid creating duplicate
+        # device entries. This matches fcm_receiver_ha._extract_canonic_id_from_response().
+        is_android_device = False
         try:
-            if device.identifierInformation.type == DeviceUpdate_pb2.IDENTIFIER_ANDROID:
-                canonic_ids = (
+            is_android_device = (
+                device.identifierInformation.type == DeviceUpdate_pb2.IDENTIFIER_ANDROID
+            )
+            if is_android_device:
+                all_ids = (
                     device.identifierInformation.phoneInformation.canonicIds.canonicId
                 )
+                # Use only the first canonical ID for phones to prevent duplicates
+                canonic_ids = all_ids[:1] if all_ids else []
             else:
                 canonic_ids = device.identifierInformation.canonicIds.canonicId
         except Exception:
@@ -928,17 +938,8 @@ def get_devices_with_location(
                 [str(getattr(canonic_id, "id", "")) for canonic_id in canonic_ids]
             )
 
-            # Check if this is a phone/Android device (keys come from Locate flow)
-            is_android_device = False
-            try:
-                is_android_device = (
-                    device.identifierInformation.type
-                    == DeviceUpdate_pb2.IDENTIFIER_ANDROID
-                )
-            except Exception:
-                pass
-
             # Check if device has reduced fields (no 'information' block)
+            # Note: is_android_device is already set at the top of the device loop
             has_information_block = device.HasField("information")
 
             # Phone devices legitimately don't have keys in list_devices - this is expected.

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -121,11 +121,13 @@ from .const import (
     EVENT_AUTH_OK,
     INTEGRATION_VERSION,
     ISSUE_AUTH_EXPIRED_KEY,
+    LEGACY_SERVICE_IDENTIFIER,
     LOCATION_REQUEST_TIMEOUT_S,
     # Helpers
     MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S,
     OPT_IGNORED_DEVICES,
     OPT_SEMANTIC_LOCATIONS,
+    SERVICE_DEVICE_IDENTIFIER_PREFIX,
     SERVICE_DEVICE_MANUFACTURER,
     # Integration "service device" metadata
     SERVICE_DEVICE_MODEL,
@@ -2075,6 +2077,11 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     return ident.split(":", 1)[1]  # return canonical device_id
                 # Identifier belongs to a different entry; ignore.
                 continue
+
+            # Skip service device identifiers (integration_<entry_id> or legacy "integration")
+            if ident.startswith(SERVICE_DEVICE_IDENTIFIER_PREFIX) or ident == LEGACY_SERVICE_IDENTIFIER:
+                continue
+
             # Legacy format -> accept as-is
             return ident
         return None


### PR DESCRIPTION
## Summary

- **Fix phone device duplication**: Phones (IDENTIFIER_ANDROID) can have multiple canonical IDs in their API response. The decoder now uses only the first canonical ID, preventing duplicate device entries in Home Assistant.
- **Fix service device in EID collection**: Service device identifiers (`integration_<entry_id>`) were incorrectly included in EID identity collection, causing "Missing crypto material" warnings.
- **Thread safety improvements for FCM receiver** (P0/P1 fixes):
  - Loop-safe dispatch via `_dispatch_to_hass_loop()` and `_track_task()`
  - Exception handling in `_run_callback_async()`
  - Executor offload for protobuf parsing
  - Scoped cache provider context manager

## Test plan

- [x] All 928 existing tests pass
- [x] New test file `test_fcm_receiver_thread_safety.py` covers P0/P1 fixes
- [x] Phone device with multiple canonical IDs now creates single device entry
- [x] Service devices no longer appear in EID resolver logs
