### PR TITLE
Implement heuristic EID resolution for Android phone discovery

### DIFF
--- a/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
+++ b/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from dataclasses import dataclass
 from enum import Enum
 from typing import Final, Literal
 
@@ -25,14 +26,20 @@ __all__ = [
     "EidVariant",
     "EIK_LENGTH",
     "FHNA_K",
+    "HeuristicBasis",
+    "HeuristicEidResult",
     "K",
     "LEGACY_EID_LENGTH",
     "MODERN_EID_LENGTH",
     "P256_ORDER",
     "ROTATION_PERIOD",
+    "ROTATION_PERIOD_900",
+    "ROTATION_PERIOD_3600",
+    "build_heuristic_prf_input",
     "build_table10_prf_input",
     "generate_eid",
     "generate_eid_variant",
+    "generate_heuristic_eid",
     "get_masked_counter",
     "prf_aes_256_ecb",
 ]
@@ -47,13 +54,18 @@ from custom_components.googlefindmy.FMDNCrypto._ecdsa_shim import (
 
 FHNA_K: Final[int] = 10
 K: Final[int] = FHNA_K
-ROTATION_PERIOD: Final[int] = 1 << FHNA_K
+ROTATION_PERIOD: Final[int] = 1 << FHNA_K  # 1024 seconds (standard FMDN trackers)
+ROTATION_PERIOD_900: Final[int] = 900  # 15 minutes (Android phone MAC sync)
+ROTATION_PERIOD_3600: Final[int] = 3600  # 1 hour (alternative phone period)
 EIK_LENGTH: Final[int] = 32
 LEGACY_EID_LENGTH: Final[int] = 20
 MODERN_EID_LENGTH: Final[int] = 32
 FHNA_PRF_INPUT_LENGTH: Final[int] = 32
 FHNA_ROTATION_MASK: Final[int] = (1 << FHNA_K) - 1
 FHNA_COUNTER_MASK: Final[int] = 0xFFFFFFFF
+
+# Heuristic rotation periods for phone discovery (ordered by likelihood)
+HEURISTIC_ROTATION_PERIODS: Final[tuple[int, ...]] = (900, 3600, 1024)
 P256_ORDER: Final[int] = (
     0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
 )
@@ -71,6 +83,37 @@ class EidVariant(str, Enum):
     MODERN_P256_X20_TRUNC_BE = "modern_p256_x20_trunc_be"
     MODERN_P256_X32_LE_SCALAR = "modern_p256_x32_le_scalar"
     MODERN_P256_X20_TRUNC_LE = "modern_p256_x20_trunc_le"
+
+
+class HeuristicBasis(str, Enum):
+    """Time basis modes for heuristic EID generation.
+
+    Android phones with "Offline Finding" may use different time bases than
+    the standard FMDN tracker protocol:
+
+    - RELATIVE: counter = (now - anchor) // period  (standard FMDN)
+    - ABSOLUTE: counter = now // period  (Android phone style)
+    """
+
+    RELATIVE = "relative"
+    ABSOLUTE = "absolute"
+
+
+@dataclass(frozen=True, slots=True)
+class HeuristicEidResult:
+    """Result of a successful heuristic EID match.
+
+    Contains the discovered parameters that successfully matched the payload,
+    allowing the resolver to cache and reuse them for future lookups.
+    """
+
+    eid_bytes: bytes
+    rotation_period: int
+    basis: HeuristicBasis
+    variant: EidVariant
+    counter: int
+    drift_offset: int  # -1, 0, or +1 from the expected counter
+    is_reversed: bool
 
 
 def _normalize_time_counter(time_counter_u32: int, *, strict: bool) -> int:
@@ -338,6 +381,266 @@ def generate_eid(
         stacklevel=2,
     )
     return generate_eid_variant(eik, time_counter_u32, variant, k=k, strict=strict)
+
+
+# =============================================================================
+# Heuristic EID Generation for Android Phone Discovery
+# =============================================================================
+#
+# Android phones with "Offline Finding" may use different parameters than
+# standard FMDN trackers:
+# - Rotation period: 900s (15 min) or 3600s (1 hour) instead of 1024s
+# - Time basis: Absolute Unix time instead of relative (now - anchor)
+#
+# These functions support flexible rotation periods using integer division
+# instead of the power-of-2 bitwise operations required by FHNA spec.
+# =============================================================================
+
+
+def _align_to_rotation_flexible(
+    timestamp: int, *, rotation_period: int
+) -> int:
+    """Align a timestamp to the start of its rotation window using integer division.
+
+    Unlike ``_align_to_rotation`` which uses bitwise masking (power-of-2 only),
+    this function supports arbitrary rotation periods like 900s or 3600s.
+
+    Args:
+        timestamp: Unix timestamp in seconds.
+        rotation_period: Rotation period in seconds (e.g., 900, 1024, 3600).
+
+    Returns:
+        The timestamp aligned to the start of its rotation window.
+    """
+    if rotation_period <= 0:
+        raise ValueError(f"rotation_period must be positive; got {rotation_period}")
+    return (timestamp // rotation_period) * rotation_period
+
+
+def _compute_heuristic_counter(
+    now_unix: int,
+    *,
+    rotation_period: int,
+    basis: HeuristicBasis,
+    anchor: int | None = None,
+) -> int:
+    """Compute the EID counter based on the specified time basis.
+
+    Args:
+        now_unix: Current Unix timestamp in seconds.
+        rotation_period: Rotation period in seconds.
+        basis: Time basis mode (ABSOLUTE or RELATIVE).
+        anchor: Anchor timestamp for relative basis (pair_date or secrets_creation_date).
+
+    Returns:
+        The counter value aligned to the rotation period.
+
+    Raises:
+        ValueError: If RELATIVE basis is used without an anchor.
+    """
+    if basis == HeuristicBasis.ABSOLUTE:
+        # Android phone style: counter based on absolute Unix time
+        return _align_to_rotation_flexible(now_unix, rotation_period=rotation_period)
+
+    # RELATIVE basis: counter based on elapsed time since anchor
+    if anchor is None or anchor <= 0:
+        raise ValueError(
+            f"RELATIVE basis requires a valid anchor timestamp; got {anchor}"
+        )
+    elapsed = now_unix - anchor
+    if elapsed < 0:
+        _LOGGER.debug(
+            "Negative elapsed time (%s - %s = %s); using 0",
+            now_unix,
+            anchor,
+            elapsed,
+        )
+        elapsed = 0
+    return _align_to_rotation_flexible(elapsed, rotation_period=rotation_period)
+
+
+def build_heuristic_prf_input(
+    counter: int,
+    *,
+    rotation_period: int,
+) -> bytes:
+    """Build PRF input for heuristic EID generation with flexible rotation period.
+
+    This function constructs a Table 10-like PRF input buffer but uses the
+    rotation period directly in the exponent field, allowing non-power-of-2
+    periods to be encoded.
+
+    For compatibility with the standard FHNA crypto, we still use the Table 10
+    structure but encode the rotation-aligned counter directly.
+
+    Args:
+        counter: The rotation-aligned counter value.
+        rotation_period: Rotation period in seconds (for logging/diagnostics).
+
+    Returns:
+        32-byte PRF input buffer.
+    """
+    # Normalize counter to u32 range
+    counter_u32 = counter & FHNA_COUNTER_MASK
+    counter_bytes = counter_u32.to_bytes(4, byteorder="big", signed=False)
+
+    # Compute an effective K value for the PRF input structure
+    # For standard periods, use log2; for others, use FHNA_K as default
+    effective_k = FHNA_K
+    if rotation_period == ROTATION_PERIOD:
+        effective_k = FHNA_K  # 1024 = 2^10
+    elif rotation_period == ROTATION_PERIOD_900:
+        # 900 is not a power of 2; use a marker value
+        # The crypto still works because the counter is already aligned
+        effective_k = 9  # Approximation: 2^9 = 512 < 900 < 1024 = 2^10
+    elif rotation_period == ROTATION_PERIOD_3600:
+        effective_k = 12  # Approximation: 2^12 = 4096 > 3600
+
+    block = bytearray(FHNA_PRF_INPUT_LENGTH)
+    block[0:11] = b"\xff" * 11
+    block[11] = effective_k
+    block[12:16] = counter_bytes
+    block[16:27] = b"\x00" * 11
+    block[27] = effective_k
+    block[28:32] = counter_bytes
+
+    return bytes(block)
+
+
+def _generate_heuristic_eid_single(
+    eik: bytes,
+    counter: int,
+    variant: EidVariant,
+) -> bytes:
+    """Generate a single EID using the heuristic counter.
+
+    This is a lightweight wrapper around the scalar derivation that uses
+    an already-computed counter value.
+    """
+    if len(eik) != EIK_LENGTH:
+        raise ValueError(f"Ephemeral Identity Key must be {EIK_LENGTH} bytes")
+
+    # Build PRF input with the pre-computed counter
+    # For heuristic mode, we use the counter directly as the time value
+    prf_input = build_heuristic_prf_input(counter, rotation_period=ROTATION_PERIOD)
+    r_dash = prf_aes_256_ecb(eik, prf_input)
+
+    match variant:
+        case EidVariant.LEGACY_SECP160R1_X20_BE:
+            curve_order = int(_CURVE.order)
+            r_dash_int = int.from_bytes(r_dash, byteorder="big", signed=False)
+            scalar = r_dash_int % curve_order
+            return _serialize_legacy_x(scalar)
+
+        case EidVariant.MODERN_P256_X32_BE:
+            r_dash_int = int.from_bytes(r_dash, byteorder="big", signed=False)
+            scalar = (r_dash_int % (P256_ORDER - 1)) + 1
+            return _serialize_p256_x(scalar)
+
+        case EidVariant.MODERN_P256_X20_TRUNC_BE:
+            full = _generate_heuristic_eid_single(eik, counter, EidVariant.MODERN_P256_X32_BE)
+            return full[:LEGACY_EID_LENGTH]
+
+        case EidVariant.MODERN_P256_X32_LE_SCALAR:
+            r_dash_int = int.from_bytes(r_dash, byteorder="little", signed=False)
+            scalar = (r_dash_int % (P256_ORDER - 1)) + 1
+            return _serialize_p256_x(scalar)
+
+        case EidVariant.MODERN_P256_X20_TRUNC_LE:
+            full = _generate_heuristic_eid_single(
+                eik, counter, EidVariant.MODERN_P256_X32_LE_SCALAR
+            )
+            return full[:LEGACY_EID_LENGTH]
+
+        case _:
+            raise ValueError(f"Unsupported EID variant: {variant}")
+
+
+def generate_heuristic_eid(  # noqa: PLR0913
+    eik: bytes,
+    now_unix: int,
+    *,
+    rotation_period: int,
+    basis: HeuristicBasis,
+    variant: EidVariant,
+    anchor: int | None = None,
+    drift_offsets: tuple[int, ...] = (-1, 0, 1),
+) -> list[HeuristicEidResult]:
+    """Generate EID candidates using heuristic parameters for phone discovery.
+
+    This function supports flexible rotation periods (900s, 1024s, 3600s) and
+    both absolute and relative time bases, allowing discovery of Android phones
+    that don't follow the standard FMDN tracker protocol.
+
+    Args:
+        eik: 32-byte Ephemeral Identity Key.
+        now_unix: Current Unix timestamp in seconds.
+        rotation_period: Rotation period in seconds (e.g., 900, 1024, 3600).
+        basis: Time basis mode (ABSOLUTE or RELATIVE).
+        variant: EID variant to generate.
+        anchor: Anchor timestamp for RELATIVE basis (required if basis=RELATIVE).
+        drift_offsets: Counter offsets to check for clock skew (default: -1, 0, +1).
+
+    Returns:
+        List of HeuristicEidResult objects for each drift offset, containing
+        both the normal and reversed EID bytes.
+    """
+    if len(eik) != EIK_LENGTH:
+        raise ValueError(f"Ephemeral Identity Key must be {EIK_LENGTH} bytes")
+
+    base_counter = _compute_heuristic_counter(
+        now_unix,
+        rotation_period=rotation_period,
+        basis=basis,
+        anchor=anchor,
+    )
+
+    results: list[HeuristicEidResult] = []
+
+    for drift in drift_offsets:
+        counter = base_counter + (drift * rotation_period)
+        if counter < 0:
+            continue
+
+        try:
+            eid_bytes = _generate_heuristic_eid_single(eik, counter, variant)
+        except Exception as exc:
+            _LOGGER.debug(
+                "Heuristic EID generation failed: period=%s basis=%s drift=%s: %s",
+                rotation_period,
+                basis.value,
+                drift,
+                exc,
+            )
+            continue
+
+        # Add normal orientation
+        results.append(
+            HeuristicEidResult(
+                eid_bytes=eid_bytes,
+                rotation_period=rotation_period,
+                basis=basis,
+                variant=variant,
+                counter=counter,
+                drift_offset=drift,
+                is_reversed=False,
+            )
+        )
+
+        # Add reversed orientation (some devices advertise bytes in reverse)
+        results.append(
+            HeuristicEidResult(
+                eid_bytes=eid_bytes[::-1],
+                rotation_period=rotation_period,
+                basis=basis,
+                variant=variant,
+                counter=counter,
+                drift_offset=drift,
+                is_reversed=True,
+            )
+        )
+
+    return results
 
 
 if __name__ == "__main__":

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -32,8 +32,12 @@ from .FMDNCrypto.eid_generator import (
     LEGACY_EID_LENGTH,
     MODERN_EID_LENGTH,
     ROTATION_PERIOD,
+    ROTATION_PERIOD_900,
+    ROTATION_PERIOD_3600,
     EidVariant,
+    HeuristicBasis,
     generate_eid_variant,
+    generate_heuristic_eid,
 )
 from .FMDNCrypto.mcu_utils import flip_bits, is_mcu_tracker
 from .KeyBackup.cloud_key_decryptor import decrypt_eik
@@ -90,6 +94,40 @@ KNOWN_OFFSET_KEY_LENGTH = 2
 # expected counter when tracking a locked device. ±2 periods covers ~34 minutes
 # of clock drift at 1024s rotation.
 LOCK_TRACKING_WINDOW_STEPS = 2
+
+# =============================================================================
+# Heuristic Phone Discovery Configuration
+# =============================================================================
+# Android phones with "Offline Finding" may use different parameters than
+# standard FMDN trackers. The heuristic resolver tests multiple hypotheses
+# when the standard lookup fails.
+
+# ENABLE_HEURISTIC_PHONE_DISCOVERY: Enable the reactive heuristic check for
+# packets that would otherwise be logged as MISS. This only runs when the
+# standard cache lookup fails.
+ENABLE_HEURISTIC_PHONE_DISCOVERY: bool = True
+
+# HEURISTIC_HYPOTHESES: Ordered list of (rotation_period, basis) tuples to test.
+# Ordered by likelihood based on Android phone behavior analysis.
+HEURISTIC_HYPOTHESES: tuple[tuple[int, HeuristicBasis], ...] = (
+    (ROTATION_PERIOD_900, HeuristicBasis.ABSOLUTE),   # Most likely for phones
+    (ROTATION_PERIOD_3600, HeuristicBasis.ABSOLUTE),  # 1-hour rotation
+    (ROTATION_PERIOD_900, HeuristicBasis.RELATIVE),   # 15-min with anchor
+    (ROTATION_PERIOD, HeuristicBasis.ABSOLUTE),       # 1024s with absolute time
+)
+
+# HEURISTIC_VARIANTS_TO_TEST: EID variants to test during heuristic resolution.
+# P-256 variants are most common for modern Android phones.
+HEURISTIC_VARIANTS_TO_TEST: tuple[EidVariant, ...] = (
+    EidVariant.MODERN_P256_X20_TRUNC_BE,
+    EidVariant.MODERN_P256_X32_BE,
+    EidVariant.MODERN_P256_X20_TRUNC_LE,
+    EidVariant.LEGACY_SECP160R1_X20_BE,
+)
+
+# HEURISTIC_LOG_INTERVAL_SECONDS: Minimum interval between heuristic miss logs
+# for the same device to prevent log spam.
+HEURISTIC_LOG_INTERVAL_SECONDS: int = 300  # 5 minutes
 
 
 class EIDMatch(NamedTuple):
@@ -179,6 +217,51 @@ class RotationParams:
     min_unix_window: int
     min_relative_window: int
     max_window: int
+
+
+@dataclass(slots=True)
+class LearnedHeuristicParams:
+    """Learned heuristic parameters for a device discovered via heuristic resolution.
+
+    When a device is successfully matched using heuristic parameters, those
+    parameters are cached here to speed up future lookups.
+    """
+
+    device_id: str
+    canonical_id: str
+    rotation_period: int
+    basis: HeuristicBasis
+    variant: EidVariant
+    discovered_at: int  # Unix timestamp when discovered
+    last_confirmed_at: int  # Unix timestamp of last successful match
+    confirmation_count: int = 1  # Number of successful matches
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for storage."""
+        return {
+            "device_id": self.device_id,
+            "canonical_id": self.canonical_id,
+            "rotation_period": self.rotation_period,
+            "basis": self.basis.value,
+            "variant": self.variant.value,
+            "discovered_at": self.discovered_at,
+            "last_confirmed_at": self.last_confirmed_at,
+            "confirmation_count": self.confirmation_count,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LearnedHeuristicParams:
+        """Deserialize from storage."""
+        return cls(
+            device_id=str(data["device_id"]),
+            canonical_id=str(data.get("canonical_id", "")),
+            rotation_period=int(data["rotation_period"]),
+            basis=HeuristicBasis(data["basis"]),
+            variant=EidVariant(data["variant"]),
+            discovered_at=int(data.get("discovered_at", 0)),
+            last_confirmed_at=int(data.get("last_confirmed_at", 0)),
+            confirmation_count=int(data.get("confirmation_count", 1)),
+        )
 
 
 @dataclass(slots=True)
@@ -438,6 +521,12 @@ class GoogleFindMyEIDResolver:
     _refresh_lock: asyncio.Lock = field(init=False, default_factory=asyncio.Lock)
     _pending_refresh: bool = field(init=False, default=False)
     _load_task: asyncio.Task[None] | None = field(init=False, default=None)
+    # Heuristic phone discovery state
+    _learned_heuristic_params: dict[str, LearnedHeuristicParams] = field(
+        init=False, default_factory=dict
+    )
+    _heuristic_miss_log_at: dict[str, float] = field(init=False, default_factory=dict)
+    _cached_identities: list[DeviceIdentity] = field(init=False, default_factory=list)
 
     def __post_init__(self) -> None:
         """Set up caches and schedule the first rotation-aligned refresh."""
@@ -447,7 +536,7 @@ class GoogleFindMyEIDResolver:
         self._load_task = self.hass.async_create_task(self._async_load_locks())
         self._start_alignment_timer()
 
-    def _ensure_cache_defaults(self) -> None:
+    def _ensure_cache_defaults(self) -> None:  # noqa: PLR0912
         """Initialize optional caches when stubs bypass __init__."""
 
         if not hasattr(self, "_known_offsets"):
@@ -470,6 +559,13 @@ class GoogleFindMyEIDResolver:
             self._lock_miss_counts = {}
         if not hasattr(self, "_truncated_frame_log_at"):
             self._truncated_frame_log_at = {}
+        # Heuristic phone discovery state
+        if not hasattr(self, "_learned_heuristic_params"):
+            self._learned_heuristic_params = {}
+        if not hasattr(self, "_heuristic_miss_log_at"):
+            self._heuristic_miss_log_at = {}
+        if not hasattr(self, "_cached_identities"):
+            self._cached_identities = []
 
     def _clear_lock_state(self, device_id: str) -> bool:
         """Remove all cached state associated with a device lock."""
@@ -1210,6 +1306,8 @@ class GoogleFindMyEIDResolver:
         rotation_params = self._build_rotation_params()
 
         identities = await self._collect_device_secrets()
+        # Cache identities for heuristic phone discovery
+        self._cached_identities = list(identities)
         _LOGGER.debug("Refresh start: %d identities discovered", len(identities))
         work_items = self._collect_work_items(identities, now_unix=now_unix)
         _LOGGER.debug("Refresh stage: collected %d work items", len(work_items))
@@ -1568,7 +1666,253 @@ class GoogleFindMyEIDResolver:
 
         return owner_key_info
 
-    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:  # noqa: PLR0912, PLR0915
+    # =========================================================================
+    # Heuristic Phone Discovery
+    # =========================================================================
+    # These methods implement a reactive heuristic check for Android phones
+    # that don't follow the standard FMDN tracker protocol. When a packet
+    # fails the normal cache lookup, these methods test alternative hypotheses
+    # (different rotation periods and time bases) to find a match.
+    # =========================================================================
+
+    def _heuristic_resolve(
+        self,
+        candidates: list[bytes],
+        *,
+        now_unix: int,
+    ) -> EIDMatch | None:
+        """Attempt heuristic resolution for packets that missed the standard cache.
+
+        This method tests multiple hypotheses about the EID generation parameters:
+        - Rotation periods: 900s, 1024s, 3600s
+        - Time bases: ABSOLUTE (now // period) vs RELATIVE ((now - anchor) // period)
+
+        Args:
+            candidates: EID byte candidates extracted from the BLE payload.
+            now_unix: Current Unix timestamp in seconds.
+
+        Returns:
+            EIDMatch if a heuristic match is found, None otherwise.
+        """
+        if not ENABLE_HEURISTIC_PHONE_DISCOVERY:
+            return None
+
+        if not self._cached_identities:
+            _LOGGER.debug("Heuristic resolve skipped: no cached identities")
+            return None
+
+        # Build a lookup set for fast candidate matching
+        candidate_set = set(candidates)
+
+        # First, check devices with learned parameters (fast path)
+        for device_id, learned in self._learned_heuristic_params.items():
+            match = self._heuristic_check_learned(
+                device_id,
+                learned,
+                candidate_set,
+                now_unix=now_unix,
+            )
+            if match is not None:
+                return match
+
+        # Fall back to full hypothesis testing (slow path)
+        for identity in self._cached_identities:
+            if identity.identity_key is None:
+                continue
+
+            match = self._heuristic_test_hypotheses(
+                identity,
+                candidate_set,
+                now_unix=now_unix,
+            )
+            if match is not None:
+                return match
+
+        return None
+
+    def _heuristic_check_learned(
+        self,
+        device_id: str,
+        learned: LearnedHeuristicParams,
+        candidate_set: set[bytes],
+        *,
+        now_unix: int,
+    ) -> EIDMatch | None:
+        """Check if a payload matches a device with previously learned parameters.
+
+        This is the fast path for devices that have been successfully matched
+        using heuristic parameters before.
+        """
+        # Find the identity for this device
+        identity: DeviceIdentity | None = None
+        for ident in self._cached_identities:
+            if ident.registry_id == device_id:
+                identity = ident
+                break
+
+        if identity is None or identity.identity_key is None:
+            return None
+
+        key_bytes = self._normalize_key_bytes(identity.identity_key)
+        if key_bytes is None:
+            return None
+
+        anchor = self._get_best_anchor(identity)
+
+        try:
+            results = generate_heuristic_eid(
+                key_bytes,
+                now_unix,
+                rotation_period=learned.rotation_period,
+                basis=learned.basis,
+                variant=learned.variant,
+                anchor=anchor if learned.basis == HeuristicBasis.RELATIVE else None,
+            )
+        except Exception as exc:
+            _LOGGER.debug(
+                "Heuristic learned check failed for %s: %s",
+                device_id,
+                exc,
+            )
+            return None
+
+        for result in results:
+            if result.eid_bytes in candidate_set:
+                # Update confirmation tracking
+                learned.last_confirmed_at = now_unix
+                learned.confirmation_count += 1
+
+                _LOGGER.info(
+                    "HEURISTIC HIT (learned): device=%s period=%ds basis=%s "
+                    "variant=%s drift=%d reversed=%s",
+                    device_id,
+                    learned.rotation_period,
+                    learned.basis.value,
+                    learned.variant.value,
+                    result.drift_offset,
+                    result.is_reversed,
+                )
+
+                return EIDMatch(
+                    device_id=device_id,
+                    config_entry_id=str(identity.config_entry_id or ""),
+                    canonical_id=identity.canonical_id,
+                    time_offset=result.drift_offset * learned.rotation_period,
+                    is_reversed=result.is_reversed,
+                )
+
+        return None
+
+    def _heuristic_test_hypotheses(
+        self,
+        identity: DeviceIdentity,
+        candidate_set: set[bytes],
+        *,
+        now_unix: int,
+    ) -> EIDMatch | None:
+        """Test all hypotheses against a device identity.
+
+        This is the slow path that tests all combinations of rotation periods,
+        time bases, and EID variants.
+        """
+        key_bytes = self._normalize_key_bytes(identity.identity_key)
+        if key_bytes is None:
+            return None
+
+        anchor = self._get_best_anchor(identity)
+        device_id = identity.registry_id
+
+        for rotation_period, basis in HEURISTIC_HYPOTHESES:
+            # Skip RELATIVE basis if no valid anchor
+            if basis == HeuristicBasis.RELATIVE and (anchor is None or anchor <= 0):
+                continue
+
+            for variant in HEURISTIC_VARIANTS_TO_TEST:
+                try:
+                    results = generate_heuristic_eid(
+                        key_bytes,
+                        now_unix,
+                        rotation_period=rotation_period,
+                        basis=basis,
+                        variant=variant,
+                        anchor=anchor if basis == HeuristicBasis.RELATIVE else None,
+                    )
+                except Exception as exc:
+                    _LOGGER.debug(
+                        "Heuristic generation failed: device=%s period=%d basis=%s variant=%s: %s",
+                        device_id,
+                        rotation_period,
+                        basis.value,
+                        variant.value,
+                        exc,
+                    )
+                    continue
+
+                for result in results:
+                    if result.eid_bytes in candidate_set:
+                        # Found a match! Store the learned parameters
+                        self._learned_heuristic_params[device_id] = LearnedHeuristicParams(
+                            device_id=device_id,
+                            canonical_id=identity.canonical_id,
+                            rotation_period=rotation_period,
+                            basis=basis,
+                            variant=variant,
+                            discovered_at=now_unix,
+                            last_confirmed_at=now_unix,
+                            confirmation_count=1,
+                        )
+
+                        _LOGGER.info(
+                            "HEURISTIC HIT (discovery): device=%s period=%ds basis=%s "
+                            "variant=%s drift=%d reversed=%s. Caching parameters.",
+                            device_id,
+                            rotation_period,
+                            basis.value,
+                            variant.value,
+                            result.drift_offset,
+                            result.is_reversed,
+                        )
+
+                        return EIDMatch(
+                            device_id=device_id,
+                            config_entry_id=str(identity.config_entry_id or ""),
+                            canonical_id=identity.canonical_id,
+                            time_offset=result.drift_offset * rotation_period,
+                            is_reversed=result.is_reversed,
+                        )
+
+        return None
+
+    def _normalize_key_bytes(self, key: Any) -> bytes | None:
+        """Normalize an identity key to bytes."""
+        if isinstance(key, (bytes, bytearray)):
+            return bytes(key)
+        if isinstance(key, str):
+            try:
+                return bytes.fromhex(key)
+            except ValueError:
+                return None
+        return None
+
+    def _get_best_anchor(self, identity: DeviceIdentity) -> int | None:
+        """Get the best available time anchor for an identity."""
+        anchors: list[int] = []
+        if isinstance(identity.pair_date, int) and identity.pair_date > 0:
+            anchors.append(identity.pair_date)
+        if isinstance(identity.secrets_creation_date, int) and identity.secrets_creation_date > 0:
+            anchors.append(identity.secrets_creation_date)
+        return max(anchors) if anchors else None
+
+    def _should_log_heuristic_miss(self, raw_prefix: str) -> bool:
+        """Check if a heuristic miss should be logged (rate limited)."""
+        now = time.time()
+        last_log = self._heuristic_miss_log_at.get(raw_prefix)
+        if last_log is not None and now - last_log < HEURISTIC_LOG_INTERVAL_SECONDS:
+            return False
+        self._heuristic_miss_log_at[raw_prefix] = now
+        return True
+
+    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:  # noqa: PLR0911, PLR0912, PLR0915
         """Resolve a scanned payload to a Home Assistant device registry ID."""
 
         self._ensure_cache_defaults()
@@ -1682,17 +2026,37 @@ class GoogleFindMyEIDResolver:
             )
             return match
 
+        # =================================================================
+        # Heuristic Phone Discovery: Reactive check before logging MISS
+        # =================================================================
+        # If the standard cache lookup failed, attempt heuristic resolution
+        # for Android phones that may use different rotation periods or
+        # time bases than standard FMDN trackers.
+        now_unix = int(time.time())
+        heuristic_match = self._heuristic_resolve(candidates, now_unix=now_unix)
+        if heuristic_match is not None:
+            # Update standard tracking state for the heuristic match
+            self._last_lock_confirmation[heuristic_match.device_id] = now_unix
+            self._known_advertisement_reversed[heuristic_match.device_id] = (
+                heuristic_match.is_reversed
+            )
+            return heuristic_match
+
+        # Log MISS with rate limiting for heuristic failures
         max_prefixes = 8
         prefix_log = ", ".join(candidate_prefixes[:max_prefixes])
         if len(candidate_prefixes) > max_prefixes:
             prefix_log = f"{prefix_log}, ..."
 
-        _LOGGER.debug(
-            "MISS: candidate_prefixes=%s raw_prefix=%s cache_size=%d",
-            prefix_log or "<none>",
-            raw_prefix,
-            len(self._lookup),
-        )
+        if self._should_log_heuristic_miss(raw_prefix):
+            _LOGGER.debug(
+                "MISS (after heuristic): candidate_prefixes=%s raw_prefix=%s "
+                "cache_size=%d identities=%d",
+                prefix_log or "<none>",
+                raw_prefix,
+                len(self._lookup),
+                len(self._cached_identities),
+            )
         return None
 
     def _extract_candidates(  # noqa: PLR0912


### PR DESCRIPTION
This commit adds a reactive heuristic resolver for Android phones that don't follow the standard FMDN tracker protocol. When a BLE packet fails the standard cache lookup, the system now tests alternative hypotheses.

Key changes to eid_generator.py:
- Add ROTATION_PERIOD_900 (15 min) and ROTATION_PERIOD_3600 (1 hour)
- Add HeuristicBasis enum (RELATIVE vs ABSOLUTE time bases)
- Add HeuristicEidResult dataclass for matched results
- Add _align_to_rotation_flexible() for non-power-of-2 periods
- Add _compute_heuristic_counter() for flexible time calculations
- Add generate_heuristic_eid() for hypothesis-based EID generation

Key changes to eid_resolver.py:
- Add HEURISTIC_HYPOTHESES configuration (period/basis combinations)
- Add LearnedHeuristicParams for caching discovered parameters
- Add _heuristic_resolve() reactive check before MISS logging
- Add _heuristic_check_learned() fast path for known devices
- Add _heuristic_test_hypotheses() slow path for discovery
- Hook heuristic check into resolve_eid() before MISS

The heuristic resolver tests these hypotheses in order:
1. 900s period + ABSOLUTE time (most common for phones)
2. 3600s period + ABSOLUTE time
3. 900s period + RELATIVE time (with anchor)
4. 1024s period + ABSOLUTE time

When a match is found, the parameters are cached in _learned_heuristic_params for fast subsequent lookups. This addresses the Samsung discovery failures caused by rotation period and time basis mismatches.

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
