### PR TITLE
Implement lazy-loading for cryptography dependencies (P8)

### DIFF
--- a/custom_components/googlefindmy/FMDNCrypto/_ecdsa_shim.py
+++ b/custom_components/googlefindmy/FMDNCrypto/_ecdsa_shim.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol, cast
 
-import ecdsa
+from ._lazy_crypto import get_curve_fp_class, get_point_class, get_secp160r1_curve
 
 
 class CurveFpProtocol(Protocol):
@@ -29,22 +29,21 @@ class CurveParametersProtocol(Protocol):
 
 
 def load_curve() -> CurveParametersProtocol:
-    """Load the SECP160r1 curve parameters with runtime imports.
+    """Load the SECP160r1 curve parameters with lazy imports.
 
-    The eager module-level import keeps the returned object fully typed while
-    matching the access pattern used by the other helpers below.
+    The import is deferred until first call to improve startup time.
     """
 
-    return cast(CurveParametersProtocol, ecdsa.SECP160r1)
+    return cast(CurveParametersProtocol, get_secp160r1_curve())
 
 
 def load_curve_fp_class() -> type[CurveFpProtocol]:
     """Return the ``CurveFp`` class from ``ecdsa.ellipticcurve``."""
 
-    return cast(type[CurveFpProtocol], ecdsa.ellipticcurve.CurveFp)
+    return cast(type[CurveFpProtocol], get_curve_fp_class())
 
 
-def load_point_class() -> type[Any]:
+def load_point_class() -> type:
     """Return the ``Point`` class from ``ecdsa.ellipticcurve``."""
 
-    return cast(type[Any], ecdsa.ellipticcurve.Point)
+    return get_point_class()

--- a/custom_components/googlefindmy/FMDNCrypto/_lazy_crypto.py
+++ b/custom_components/googlefindmy/FMDNCrypto/_lazy_crypto.py
@@ -1,0 +1,151 @@
+# custom_components/googlefindmy/FMDNCrypto/_lazy_crypto.py
+"""Lazy-loading wrappers for heavy cryptography dependencies.
+
+This module provides cached factory functions that defer the import of
+expensive cryptography libraries (cryptography, ecdsa, Cryptodome) until
+they are actually needed. This improves integration startup time by avoiding
+loading crypto modules during Home Assistant initialization.
+
+Usage:
+    from ._lazy_crypto import get_aesgcm_class, get_aes_cipher
+
+    # Instead of: from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+    AESGCM = get_aesgcm_class()
+    cipher = AESGCM(key)
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+# -----------------------------------------------------------------------------
+# cryptography library lazy loaders
+# -----------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def get_aesgcm_class() -> type[AESGCM]:
+    """Lazily load and cache the AESGCM class from cryptography."""
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # noqa: PLC0415
+
+    return AESGCM
+
+
+@lru_cache(maxsize=1)
+def get_cipher_class() -> Any:
+    """Lazily load and cache the Cipher class from cryptography."""
+    from cryptography.hazmat.primitives.ciphers import Cipher  # noqa: PLC0415
+
+    return Cipher
+
+
+@lru_cache(maxsize=1)
+def get_algorithms_module() -> Any:
+    """Lazily load and cache the algorithms module from cryptography."""
+    from cryptography.hazmat.primitives.ciphers import algorithms  # noqa: PLC0415
+
+    return algorithms
+
+
+@lru_cache(maxsize=1)
+def get_modes_module() -> Any:
+    """Lazily load and cache the modes module from cryptography."""
+    from cryptography.hazmat.primitives.ciphers import modes  # noqa: PLC0415
+
+    return modes
+
+
+@lru_cache(maxsize=1)
+def get_ec_module() -> Any:
+    """Lazily load and cache the ec module from cryptography."""
+    from cryptography.hazmat.primitives.asymmetric import ec  # noqa: PLC0415
+
+    return ec
+
+
+@lru_cache(maxsize=1)
+def get_p256_curve() -> Any:
+    """Lazily load and cache the P-256 curve instance."""
+    ec = get_ec_module()
+    return ec.SECP256R1()
+
+
+@lru_cache(maxsize=1)
+def get_invalid_tag_exception() -> type[Exception]:
+    """Lazily load and cache the InvalidTag exception class."""
+    from cryptography.exceptions import InvalidTag  # noqa: PLC0415
+
+    return InvalidTag
+
+
+# -----------------------------------------------------------------------------
+# ecdsa library lazy loaders
+# -----------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def get_ecdsa_module() -> Any:
+    """Lazily load and cache the ecdsa module."""
+    import ecdsa  # noqa: PLC0415
+
+    return ecdsa
+
+
+@lru_cache(maxsize=1)
+def get_secp160r1_curve() -> Any:
+    """Lazily load and cache the SECP160r1 curve parameters."""
+    ecdsa = get_ecdsa_module()
+    return ecdsa.SECP160r1
+
+
+@lru_cache(maxsize=1)
+def get_curve_fp_class() -> type:
+    """Lazily load and cache the CurveFp class from ecdsa."""
+    ecdsa = get_ecdsa_module()
+    return ecdsa.ellipticcurve.CurveFp  # type: ignore[no-any-return]
+
+
+@lru_cache(maxsize=1)
+def get_point_class() -> type:
+    """Lazily load and cache the Point class from ecdsa."""
+    ecdsa = get_ecdsa_module()
+    return ecdsa.ellipticcurve.Point  # type: ignore[no-any-return]
+
+
+# -----------------------------------------------------------------------------
+# Cryptodome library lazy loaders
+# -----------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def get_aes_class() -> Any:
+    """Lazily load and cache the AES class from Cryptodome."""
+    from Cryptodome.Cipher import AES  # noqa: PLC0415
+
+    return AES
+
+
+# -----------------------------------------------------------------------------
+# cryptography HKDF lazy loaders
+# -----------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def get_hashes_module() -> Any:
+    """Lazily load and cache the hashes module from cryptography."""
+    from cryptography.hazmat.primitives import hashes  # noqa: PLC0415
+
+    return hashes
+
+
+@lru_cache(maxsize=1)
+def get_hkdf_class() -> Any:
+    """Lazily load and cache the HKDF class from cryptography."""
+    from cryptography.hazmat.primitives.kdf.hkdf import HKDF  # noqa: PLC0415
+
+    return HKDF

--- a/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
+++ b/custom_components/googlefindmy/FMDNCrypto/eid_generator.py
@@ -44,12 +44,16 @@ __all__ = [
     "prf_aes_256_ecb",
 ]
 
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-
 from custom_components.googlefindmy.FMDNCrypto._ecdsa_shim import (
     CurveParametersProtocol,
     load_curve,
+)
+from custom_components.googlefindmy.FMDNCrypto._lazy_crypto import (
+    get_algorithms_module,
+    get_cipher_class,
+    get_ec_module,
+    get_modes_module,
+    get_p256_curve,
 )
 
 FHNA_K: Final[int] = 10
@@ -69,10 +73,28 @@ HEURISTIC_ROTATION_PERIODS: Final[tuple[int, ...]] = (900, 3600, 1024)
 P256_ORDER: Final[int] = (
     0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
 )
-_CURVE: CurveParametersProtocol = load_curve()
-_P256_CURVE: Final[ec.SECP256R1] = ec.SECP256R1()
+
+# Lazy-loaded curve instances (deferred to first use for faster startup)
+_CURVE: CurveParametersProtocol | None = None
+_P256_CURVE: object | None = None
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _get_curve() -> CurveParametersProtocol:
+    """Get the SECP160r1 curve, loading lazily on first access."""
+    global _CURVE  # noqa: PLW0603
+    if _CURVE is None:
+        _CURVE = load_curve()
+    return _CURVE
+
+
+def _get_p256_curve() -> object:
+    """Get the P-256 curve, loading lazily on first access."""
+    global _P256_CURVE  # noqa: PLW0603
+    if _P256_CURVE is None:
+        _P256_CURVE = get_p256_curve()
+    return _P256_CURVE
 
 
 class EidVariant(str, Enum):
@@ -200,6 +222,10 @@ def prf_aes_256_ecb(eik: bytes, prf_input: bytes) -> bytes:
     if len(prf_input) != FHNA_PRF_INPUT_LENGTH:
         raise ValueError(f"PRF input must be {FHNA_PRF_INPUT_LENGTH} bytes")
 
+    # Lazy-load cryptography modules for faster startup
+    Cipher = get_cipher_class()
+    algorithms = get_algorithms_module()
+    modes = get_modes_module()
     cipher = Cipher(algorithms.AES(eik), modes.ECB())
     encryptor = cipher.encryptor()
     ciphertext: bytes = encryptor.update(prf_input) + encryptor.finalize()
@@ -256,7 +282,7 @@ def _derive_scalar(  # noqa: PLR0913
 def _serialize_legacy_x(scalar_r: int) -> bytes:
     """Return the big-endian x-coordinate for ``R = r * G`` on secp160r1."""
 
-    curve = _CURVE
+    curve = _get_curve()
     generator = curve.generator
     R = scalar_r * generator
 
@@ -266,8 +292,9 @@ def _serialize_legacy_x(scalar_r: int) -> bytes:
 
 def _serialize_p256_x(scalar_r: int) -> bytes:
     """Return the big-endian x-coordinate for ``R = r * G`` on secp256r1."""
+    ec = get_ec_module()
     public_numbers = (
-        ec.derive_private_key(scalar_r, _P256_CURVE).public_key().public_numbers()
+        ec.derive_private_key(scalar_r, _get_p256_curve()).public_key().public_numbers()
     )
 
     x_int: int = int(public_numbers.x)
@@ -289,7 +316,7 @@ def generate_eid_variant(
 
     match variant:
         case EidVariant.LEGACY_SECP160R1_X20_BE:
-            curve_order: int = int(_CURVE.order)
+            curve_order: int = int(_get_curve().order)
             scalar = _derive_scalar(
                 eik,
                 counter_u32,
@@ -527,7 +554,7 @@ def _generate_heuristic_eid_single(
 
     match variant:
         case EidVariant.LEGACY_SECP160R1_X20_BE:
-            curve_order = int(_CURVE.order)
+            curve_order = int(_get_curve().order)
             r_dash_int = int.from_bytes(r_dash, byteorder="big", signed=False)
             scalar = r_dash_int % curve_order
             return _serialize_legacy_x(scalar)

--- a/custom_components/googlefindmy/FMDNCrypto/foreign_tracker_cryptor.py
+++ b/custom_components/googlefindmy/FMDNCrypto/foreign_tracker_cryptor.py
@@ -25,10 +25,6 @@ from __future__ import annotations
 import asyncio
 import secrets
 
-from Cryptodome.Cipher import AES
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.hkdf import HKDF
-
 from custom_components.googlefindmy.example_data_provider import get_example_data
 from custom_components.googlefindmy.FMDNCrypto._ecdsa_shim import (
     CurveFpProtocol,
@@ -36,6 +32,11 @@ from custom_components.googlefindmy.FMDNCrypto._ecdsa_shim import (
     load_curve,
     load_curve_fp_class,
     load_point_class,
+)
+from custom_components.googlefindmy.FMDNCrypto._lazy_crypto import (
+    get_aes_class,
+    get_hashes_module,
+    get_hkdf_class,
 )
 from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
     FHNA_K,
@@ -57,9 +58,23 @@ _COORD_LEN: int = 20
 # Nonce is constructed as LRx(8) || LSx(8) = 16 bytes (see spec used here)
 _NONCE_LEN: int = 16
 
-_CURVE: CurveParametersProtocol = load_curve()
-CurveFp = load_curve_fp_class()
-Point = load_point_class()
+# Use module-level caching for lazy-loaded curve instances
+# The getters always return valid objects after first load
+
+
+def _get_curve() -> CurveParametersProtocol:
+    """Get the SECP160r1 curve, loading lazily on first access."""
+    return load_curve()
+
+
+def _get_curve_fp() -> type:
+    """Get the CurveFp class, loading lazily on first access."""
+    return load_curve_fp_class()
+
+
+def _get_point() -> type:
+    """Get the Point class, loading lazily on first access."""
+    return load_point_class()
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -201,6 +216,7 @@ def encrypt_aes_eax(data: bytes, nonce: bytes, key: bytes) -> tuple[bytes, bytes
     _require_len("nonce", nonce, _NONCE_LEN)
     _require_len("key", key, _AES_KEY_LEN)
 
+    AES = get_aes_class()
     cipher = AES.new(key, AES.MODE_EAX, nonce=nonce)
     m_dash, tag = cipher.encrypt_and_digest(data)
     return m_dash, tag
@@ -212,6 +228,7 @@ def decrypt_aes_eax(m_dash: bytes, tag: bytes, nonce: bytes, key: bytes) -> byte
     _require_len("key", key, _AES_KEY_LEN)
     _require_len("tag", tag, _AES_TAG_LEN)
 
+    AES = get_aes_class()
     cipher = AES.new(key, AES.MODE_EAX, nonce=nonce)
     plaintext: bytes = cipher.decrypt(m_dash)
     cipher.verify(tag)
@@ -229,7 +246,7 @@ def calculate_r(identity_key: bytes, time_counter_u32: int) -> int:
     prf_input = build_table10_prf_input(time_counter_u32, k=FHNA_K)
     prf_output = prf_aes_256_ecb(identity_key, prf_input)
     r_dash_int = int.from_bytes(prf_output, byteorder="big", signed=False)
-    order: int = int(_CURVE.order)
+    order: int = int(_get_curve().order)
     return (r_dash_int % (order - 1)) + 1
 
 
@@ -249,7 +266,7 @@ def encrypt(message: bytes, random: bytes, eid: bytes) -> tuple[bytes, bytes]:
         ValueError: On invalid inputs (lengths) or curve mismatch.
     """
     # Curve parameters
-    curve = _CURVE
+    curve = _get_curve()
     order: int = int(curve.order)
 
     # Validate EID length (x coordinate on SECP160r1)
@@ -268,9 +285,12 @@ def encrypt(message: bytes, random: bytes, eid: bytes) -> tuple[bytes, bytes]:
     # Rebuild R from EID (x only) and choose even Y
     Rx = int.from_bytes(eid, byteorder="big")
     Ry = rx_to_ry(Rx, curve.curve)
+    Point = _get_point()
     R = Point(curve.curve, Rx, Ry)
 
     # Derive AES-256 key via HKDF-SHA256 over (s·R).x (20 bytes)
+    HKDF = get_hkdf_class()
+    hashes = get_hashes_module()
     hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=None, info=b"")
     k: bytes = hkdf.derive((s * R).x().to_bytes(_COORD_LEN, "big"))
 
@@ -320,7 +340,7 @@ def decrypt(
     tag: bytes = encryptedAndTag[-_AES_TAG_LEN:]
 
     # Curve and scalar r
-    curve = _CURVE
+    curve = _get_curve()
     order: int = int(curve.order)
     r = calculate_r(identity_key, beacon_time_counter) % order
 
@@ -336,9 +356,12 @@ def decrypt(
     Sy = rx_to_ry(Sx_int, curve.curve)
 
     curve_fp: CurveFpProtocol = curve.curve
+    Point = _get_point()
     S = Point(curve_fp, Sx_int, Sy)
 
     # Derive AES-256 key via HKDF-SHA256 over (r·S).x (20 bytes)
+    HKDF = get_hkdf_class()
+    hashes = get_hashes_module()
     hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=None, info=b"")
     k: bytes = hkdf.derive((r * S).x().to_bytes(_COORD_LEN, "big"))
 

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -18,8 +18,6 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, runtime_checkable
 
-from cryptography.exceptions import InvalidTag
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.storage import Store
@@ -27,6 +25,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import DeviceIdentity, GoogleFindMyCoordinator
+from .FMDNCrypto._lazy_crypto import get_aesgcm_class, get_invalid_tag_exception
 from .FMDNCrypto.eid_generator import (
     FHNA_COUNTER_MASK,
     LEGACY_EID_LENGTH,
@@ -1493,6 +1492,8 @@ class GoogleFindMyEIDResolver:
         cache: TokenCache | None,
     ) -> DecryptionResult | None:
         """Decrypt encrypted identity key when owner/shared key material is available."""
+        # Lazy-load crypto exception for startup performance
+        InvalidTag = get_invalid_tag_exception()
 
         self._ensure_cache_defaults()
         if cache is None:
@@ -1574,6 +1575,9 @@ class GoogleFindMyEIDResolver:
         aad_value: str,
     ) -> DecryptionResult | None:
         """Attempt to unwrap an AES-GCM envelope using the provided key."""
+        # Lazy-load crypto classes for startup performance
+        AESGCM = get_aesgcm_class()
+        InvalidTag = get_invalid_tag_exception()
 
         if len(envelope) <= AESGCM_NONCE_LENGTH:
             return None

--- a/tests/test_eid_resolver_owner_key_refresh.py
+++ b/tests/test_eid_resolver_owner_key_refresh.py
@@ -6,6 +6,10 @@ import pytest
 
 from custom_components.googlefindmy import eid_resolver
 from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.FMDNCrypto._lazy_crypto import (
+    get_aesgcm_class,
+    get_invalid_tag_exception,
+)
 from tests.helpers import DummyCache
 
 
@@ -63,7 +67,9 @@ async def test_try_decrypt_identity_key_unwraps_aes_gcm_envelope(
     nonce = b"\x00" * 12
     plaintext = b"\x99" * 32
     aad = b"reg-wrap"
-    ciphertext = eid_resolver.AESGCM(key).encrypt(nonce, plaintext, aad)
+    AESGCM = get_aesgcm_class()
+    InvalidTag = get_invalid_tag_exception()
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, aad)
     envelope = nonce + ciphertext
 
     async def fake_async_get_owner_key(*, cache: object, **kwargs):  # type: ignore[no-untyped-def]
@@ -73,7 +79,7 @@ async def test_try_decrypt_identity_key_unwraps_aes_gcm_envelope(
         raise RuntimeError("shared key unavailable")
 
     def fake_decrypt_eik(owner_key: bytes, encrypted_identity_key: bytes) -> bytes:  # noqa: ARG001
-        raise eid_resolver.InvalidTag("wrapped")
+        raise InvalidTag("wrapped")
 
     async def fake_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]
         return func(*args, **kwargs)


### PR DESCRIPTION
Add centralized lazy-loading infrastructure for heavy crypto libraries to improve integration startup time by deferring imports until first use.

Changes:
- Add _lazy_crypto.py with lru_cache-backed factory functions for:
  - cryptography: AESGCM, Cipher, algorithms, modes, ec, InvalidTag, HKDF
  - ecdsa: SECP160r1, CurveFp, Point
  - Cryptodome: AES

- Update _ecdsa_shim.py to use lazy loaders instead of module-level import

- Update eid_generator.py:
  - Replace eager cryptography imports with lazy getters
  - Replace module-level _CURVE and _P256_CURVE with lazy _get_curve() and _get_p256_curve() helpers

- Update foreign_tracker_cryptor.py:
  - Replace Cryptodome.Cipher.AES and cryptography HKDF/hashes imports with lazy getters
  - Simplify curve access through wrapper functions

- Update eid_resolver.py:
  - Replace AESGCM and InvalidTag imports with lazy getters
  - Load crypto classes on-demand within methods

- Update test_eid_resolver_owner_key_refresh.py to use lazy loaders instead of accessing eid_resolver.AESGCM directly

Impact: Faster Home Assistant startup by deferring crypto module loading until tracker decryption or EID resolution is actually needed.

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
