### PR TITLE
Claude/api abstraction layer 9vd pk

### DIFF
--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -145,6 +145,105 @@ class CacheProtocol(Protocol):
     async def async_set_cached_value(self, key: str, value: Any) -> None: ...
 
 
+@runtime_checkable
+class GoogleFindMyAPIProtocol(Protocol):
+    """Protocol defining the public interface for Google Find My Device API.
+
+    This abstraction layer enables:
+    - Consistent API contract for the coordinator and other consumers
+    - Easy mocking in tests without depending on concrete implementation
+    - Future extensibility for alternative backend implementations
+
+    All methods that interact with Google's servers are available in both
+    sync and async variants where applicable.
+    """
+
+    async def close(self) -> None:
+        """Release resources held by the API instance."""
+        ...
+
+    def set_contributor_mode(
+        self, mode: str | None, *, switch_epoch: int | None = None
+    ) -> None:
+        """Update the contributor mode used for Nova requests."""
+        ...
+
+    async def async_get_basic_device_list(
+        self,
+        *,
+        contributor_mode: str | None = None,
+        switch_epoch: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch the device list from Google Find My Device (async).
+
+        Returns a list of device dictionaries with basic info and capabilities.
+        """
+        ...
+
+    def get_basic_device_list(self) -> list[dict[str, Any]]:
+        """Fetch the device list from Google Find My Device (sync wrapper)."""
+        ...
+
+    def get_devices(self) -> list[dict[str, Any]]:
+        """Legacy alias for get_basic_device_list()."""
+        ...
+
+    async def async_get_device_location(
+        self,
+        device_id: str,
+        device_name: str,
+        *,
+        contributor_mode: str | None = None,
+        switch_epoch: int | None = None,
+    ) -> dict[str, Any]:
+        """Request location for a specific device (async).
+
+        Returns location data dict or empty dict on failure.
+        """
+        ...
+
+    def get_device_location(self, device_id: str, device_name: str) -> dict[str, Any]:
+        """Request location for a specific device (sync wrapper)."""
+        ...
+
+    def locate_device(self, device_id: str) -> dict[str, Any]:
+        """Legacy alias for get_device_location()."""
+        ...
+
+    def is_push_ready(self) -> bool:
+        """Check if push infrastructure is available for actions."""
+        ...
+
+    def push_ready(self) -> bool:
+        """Alias for is_push_ready()."""
+        ...
+
+    def can_play_sound(self, device_id: str) -> bool | None:
+        """Check if a device supports the play sound action."""
+        ...
+
+    def play_sound(self, device_id: str) -> bool:
+        """Play a sound on the device (sync wrapper)."""
+        ...
+
+    def stop_sound(self, device_id: str, request_uuid: str | None = None) -> bool:
+        """Stop playing sound on the device (sync wrapper)."""
+        ...
+
+    async def async_play_sound(self, device_id: str) -> tuple[bool, str | None]:
+        """Play a sound on the device (async).
+
+        Returns (success, request_uuid) tuple.
+        """
+        ...
+
+    async def async_stop_sound(
+        self, device_id: str, request_uuid: str | None = None
+    ) -> bool:
+        """Stop playing sound on the device (async)."""
+        ...
+
+
 # Module-local FCM provider getter; installed by the integration at setup time.
 _FCM_ReceiverGetter: (
     Callable[[str | None], FcmReceiverProtocol]

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -153,6 +153,56 @@ class _IdentityProvider(Protocol):
     def get_active_device_identities(self) -> list[DeviceIdentity]: ...
 
 
+@runtime_checkable
+class GoogleFindMyEIDResolverProtocol(Protocol):
+    """Protocol defining the public interface for EID resolution.
+
+    This abstraction layer enables:
+    - Bermuda and other integrations to resolve EIDs without tight coupling
+    - Easy mocking in tests without depending on concrete implementation
+    - Clear documentation of the public EID resolver API surface
+
+    The resolver maintains a lookup table mapping ephemeral identifiers (EIDs)
+    to device identities, refreshing periodically as EIDs rotate.
+    """
+
+    async def async_refresh(self) -> None:
+        """Refresh the EID lookup table from all active coordinators.
+
+        This rebuilds the mapping of EID bytes to device identities by:
+        1. Collecting identities from all registered coordinators
+        2. Decrypting identity keys where owner keys are available
+        3. Generating EIDs for the current rotation window
+        """
+        ...
+
+    def reset_device_offset(self, registry_id: str) -> None:
+        """Clear cached time offset for a specific device.
+
+        Use when a device's EID timing needs to be re-learned, e.g.,
+        after firmware updates or clock drift corrections.
+        """
+        ...
+
+    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:
+        """Resolve EID bytes to a matching device identity.
+
+        Args:
+            eid_bytes: Raw EID bytes from a BLE advertisement.
+
+        Returns:
+            EIDMatch with device identity info, or None if no match found.
+        """
+        ...
+
+    def stop(self) -> None:
+        """Stop the resolver and release resources.
+
+        Cancels periodic refresh timers and cleanup tasks.
+        """
+        ...
+
+
 @dataclass(slots=True, frozen=True)
 class WorkItem:
     """Normalized device identity with optional lock context."""


### PR DESCRIPTION
<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
