### PR TITLE
Claude/debug tracker sharing 7 h3 oj

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -1989,7 +1989,7 @@ class GoogleFindMyEIDResolver:
         self._heuristic_miss_log_at[raw_prefix] = now
         return True
 
-    def _update_match_state(
+    def _update_match_state(  # noqa: PLR0913
         self,
         match: EIDMatch,
         *,
@@ -2073,7 +2073,7 @@ class GoogleFindMyEIDResolver:
             raw_prefix,
         )
 
-    def _resolve_eid_internal(
+    def _resolve_eid_internal(  # noqa: PLR0911, PLR0912
         self, eid_bytes: bytes
     ) -> tuple[list[EIDMatch], bytes | None, int | None]:
         """Internal EID resolution returning all matches.

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -192,7 +192,8 @@ class GoogleFindMyEIDResolverProtocol(Protocol):
 
         Returns:
             EIDMatch with device identity info, or None if no match found.
-            When multiple accounts share the same device, returns the first match.
+            When multiple accounts share the same device, returns the match
+            with the smallest time_offset (best match).
             Use resolve_eid_all() to get all matches for shared devices.
         """
         ...
@@ -2188,10 +2189,14 @@ class GoogleFindMyEIDResolver:
         """Resolve a scanned payload to a Home Assistant device registry ID.
 
         For shared devices (same tracker across multiple accounts), this returns
-        the first match. Use resolve_eid_all() to get all matches.
+        the match with the smallest time_offset (best match).
+        Use resolve_eid_all() to get all matches.
         """
         matches, _, _ = self._resolve_eid_internal(eid_bytes)
-        return matches[0] if matches else None
+        if not matches:
+            return None
+        # Return the match with the smallest absolute time_offset (best match)
+        return min(matches, key=lambda m: abs(m.time_offset))
 
     def resolve_eid_all(self, eid_bytes: bytes) -> list[EIDMatch]:
         """Resolve a scanned payload to all matching Home Assistant device registry IDs.

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -192,6 +192,23 @@ class GoogleFindMyEIDResolverProtocol(Protocol):
 
         Returns:
             EIDMatch with device identity info, or None if no match found.
+            When multiple accounts share the same device, returns the first match.
+            Use resolve_eid_all() to get all matches for shared devices.
+        """
+        ...
+
+    def resolve_eid_all(self, eid_bytes: bytes) -> list[EIDMatch]:
+        """Resolve EID bytes to all matching device identities.
+
+        This method supports shared devices: when the same physical tracker
+        is shared between accounts, all accounts' matches are returned.
+
+        Args:
+            eid_bytes: Raw EID bytes from a BLE advertisement.
+
+        Returns:
+            List of EIDMatch entries for all accounts that share this device.
+            Empty list if no match found.
         """
         ...
 
@@ -314,9 +331,14 @@ class LearnedHeuristicParams:
 
 @dataclass(slots=True)
 class CacheBuilder:
-    """Immutable-safe cache builder enforcing lookup/metadata invariants."""
+    """Immutable-safe cache builder enforcing lookup/metadata invariants.
 
-    lookup: dict[bytes, EIDMatch] = field(default_factory=dict)
+    Supports multiple matches per EID to handle shared devices across accounts.
+    When the same physical tracker is shared between accounts, each account
+    registers its own EIDMatch for the same EID bytes.
+    """
+
+    lookup: dict[bytes, list[EIDMatch]] = field(default_factory=dict)
     metadata: dict[bytes, dict[str, Any]] = field(default_factory=dict)
 
     def register_eid(
@@ -328,9 +350,13 @@ class CacheBuilder:
         window: WindowCandidate,
         advertisement_reversed: bool,
     ) -> None:
-        """Register an EID and metadata, resolving collisions deterministically."""
+        """Register an EID and metadata, supporting multiple matches per EID.
 
-        existing = self.lookup.get(eid_bytes)
+        When the same EID is registered by multiple accounts (shared devices),
+        all matches are stored. For metadata, the entry with the smallest
+        time_offset is used as the primary.
+        """
+        existing_matches = self.lookup.get(eid_bytes, [])
         existing_metadata = self.metadata.get(eid_bytes)
         existing_bases: set[str] | None = None
         if existing_metadata is not None:
@@ -341,29 +367,56 @@ class CacheBuilder:
                 existing_bases.add(basis)
             existing_bases.add(window.time_basis)
 
-        if existing is not None and abs(existing.time_offset) <= abs(
+        # Check if this device_id already has a match for this EID
+        existing_device_match: EIDMatch | None = None
+        existing_device_idx: int | None = None
+        for idx, existing in enumerate(existing_matches):
+            if existing.device_id == match.device_id:
+                existing_device_match = existing
+                existing_device_idx = idx
+                break
+
+        # If this device already has a match with better or equal offset, skip
+        if existing_device_match is not None and abs(existing_device_match.time_offset) <= abs(
             match.time_offset
         ):
             if existing_metadata is not None and existing_bases is not None:
                 existing_metadata["timestamp_bases"] = existing_bases
             return
 
+        # Add or update the match for this device
+        if existing_device_idx is not None:
+            # Replace existing match for this device
+            existing_matches[existing_device_idx] = match
+        else:
+            # Add new match
+            existing_matches.append(match)
+
+        self.lookup[eid_bytes] = existing_matches
+
+        # Update metadata - use the match with smallest time_offset as primary
+        best_match = min(existing_matches, key=lambda m: abs(m.time_offset))
         timestamp_bases = existing_bases or {window.time_basis}
-        self.lookup[eid_bytes] = match
-        self.metadata[eid_bytes] = {
-            "variant": variant.value,
-            "rotation_timestamp": window.timestamp,
-            "time_offset": match.time_offset,
-            "timestamp_basis": window.time_basis,
-            "timestamp_bases": timestamp_bases,
-            "advertisement_reversed": advertisement_reversed,
-        }
+
+        # Only update metadata if this match is the best (smallest offset)
+        if best_match.device_id == match.device_id:
+            self.metadata[eid_bytes] = {
+                "variant": variant.value,
+                "rotation_timestamp": window.timestamp,
+                "time_offset": match.time_offset,
+                "timestamp_basis": window.time_basis,
+                "timestamp_bases": timestamp_bases,
+                "advertisement_reversed": advertisement_reversed,
+            }
+        elif existing_metadata is not None and existing_bases is not None:
+            existing_metadata["timestamp_bases"] = existing_bases
+
         if __debug__:
             assert set(self.lookup.keys()).issuperset(
                 self.metadata.keys()
             ), "metadata keys diverged after registration"
 
-    def finalize(self) -> tuple[dict[bytes, EIDMatch], dict[bytes, dict[str, Any]]]:
+    def finalize(self) -> tuple[dict[bytes, list[EIDMatch]], dict[bytes, dict[str, Any]]]:
         """Return the finalized lookup tables after invariant validation."""
 
         lookup_keys = set(self.lookup.keys())
@@ -548,10 +601,14 @@ def _normalize_counter_candidate(candidate_value: object, *, basis: str) -> int 
 
 @dataclass(slots=True)
 class GoogleFindMyEIDResolver:
-    """Resolver that precalculates rotating EIDs for known trackers."""
+    """Resolver that precalculates rotating EIDs for known trackers.
+
+    Supports shared devices: when the same physical tracker is shared between
+    accounts, all accounts receive EID match updates via resolve_eid_all().
+    """
 
     hass: HomeAssistant
-    _lookup: dict[bytes, EIDMatch] = field(init=False, default_factory=dict)
+    _lookup: dict[bytes, list[EIDMatch]] = field(init=False, default_factory=dict)
     _lookup_metadata: dict[bytes, dict[str, Any]] = field(
         init=False, default_factory=dict
     )
@@ -1932,12 +1989,102 @@ class GoogleFindMyEIDResolver:
         self._heuristic_miss_log_at[raw_prefix] = now
         return True
 
-    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:  # noqa: PLR0911, PLR0912, PLR0915
-        """Resolve a scanned payload to a Home Assistant device registry ID."""
+    def _update_match_state(
+        self,
+        match: EIDMatch,
+        *,
+        metadata: dict[str, Any],
+        candidate: bytes,
+        observed_frame: int | None,
+        candidate_prefix: str,
+        raw_prefix: str,
+        now: int,
+    ) -> None:
+        """Update internal state (locks, offsets, etc.) for a single match."""
+        self._last_lock_confirmation[match.device_id] = now
+        previous_basis = _normalize_anchor_basis(self._known_timebases.get(match.device_id))
+        raw_time_basis = metadata.get("timestamp_basis")
+        anchor_basis = _normalize_anchor_basis(raw_time_basis)
+        basis_explicitly_invalid = raw_time_basis is not None and anchor_basis is None
+        if anchor_basis is None:
+            if raw_time_basis is None:
+                anchor_basis = previous_basis
+        elif raw_time_basis != anchor_basis:
+            self._known_timebases.pop(match.device_id, None)
+        if anchor_basis is None and not basis_explicitly_invalid:
+            self._known_timebases.pop(match.device_id, None)
 
+        existing_lock = self._locks.get(match.device_id)
+        if existing_lock is None:
+            variant_value = self._normalize_variant_value(
+                metadata.get("variant"),
+                eid_len=len(candidate),
+            )
+            rotation_timestamp = metadata.get("rotation_timestamp")
+            lock = EIDGenerationLock(
+                device_id=match.device_id,
+                canonical_id=match.canonical_id,
+                variant=variant_value,
+                advertisement_reversed=match.is_reversed,
+                eid_length=len(candidate),
+                rotation_timestamp=int(rotation_timestamp)
+                if isinstance(rotation_timestamp, int)
+                and not isinstance(rotation_timestamp, bool)
+                else None,
+                frame_type=observed_frame,
+                time_basis=anchor_basis,
+                created_at=now,
+                drift_offset=match.time_offset,
+                last_seen_at=now,
+            )
+            self._locks[match.device_id] = lock
+            self._persisted_locks[match.device_id] = lock
+            self._schedule_lock_save()
+        else:
+            # Update drift tracking on existing lock
+            drift_changed = existing_lock.drift_offset != match.time_offset
+            existing_lock.drift_offset = match.time_offset
+            existing_lock.last_seen_at = now
+            if drift_changed and match.time_offset != 0:
+                _LOGGER.debug(
+                    "Drift update for %s: offset=%d (using %s window)",
+                    match.device_id,
+                    match.time_offset,
+                    "+1/+2" if match.time_offset > 0 else "-1/-2",
+                )
+            self._schedule_lock_save()
+
+        self._known_advertisement_reversed[match.device_id] = match.is_reversed
+
+        if anchor_basis is not None and not basis_explicitly_invalid:
+            self._known_offsets[(match.device_id, anchor_basis)] = match.time_offset
+            self._known_timebases[match.device_id] = anchor_basis
+
+        _LOGGER.info(
+            (
+                "HIT: device=%s canonical=%s reversed=%s offset=%s "
+                "candidate_prefix=%s raw_prefix=%s"
+            ),
+            match.device_id,
+            match.canonical_id,
+            match.is_reversed,
+            match.time_offset,
+            candidate_prefix,
+            raw_prefix,
+        )
+
+    def _resolve_eid_internal(
+        self, eid_bytes: bytes
+    ) -> tuple[list[EIDMatch], bytes | None, int | None]:
+        """Internal EID resolution returning all matches.
+
+        Returns:
+            Tuple of (matches, matched_candidate, observed_frame).
+            matches is empty if no match found.
+        """
         self._ensure_cache_defaults()
         if not isinstance(eid_bytes, (bytes, bytearray)):
-            return None
+            return [], None, None
 
         raw = bytes(eid_bytes)
         candidates, observed_frame = self._extract_candidates(raw)
@@ -1950,7 +2097,7 @@ class GoogleFindMyEIDResolver:
                 raw_prefix,
                 len(raw),
             )
-            return None
+            return [], None, None
 
         if not self._lookup:
             is_locked = self._refresh_lock.locked()
@@ -1961,7 +2108,7 @@ class GoogleFindMyEIDResolver:
                     is_locked,
                     raw_prefix,
                 )
-                return None
+                return [], None, None
 
             _LOGGER.debug(
                 "RESOLVER NOT READY: empty cache; scheduling refresh for raw_prefix=%s",
@@ -1980,86 +2127,29 @@ class GoogleFindMyEIDResolver:
                         asyncio.create_task(scheduled)
                 except Exception:  # pragma: no cover
                     self._pending_refresh = False
-            return None
+            return [], None, None
 
         for candidate_prefix, candidate in zip(candidate_prefixes, candidates):
-            match = self._lookup.get(candidate)
-            if match is None:
+            matches = self._lookup.get(candidate)
+            if not matches:
                 continue
 
             metadata: dict[str, Any] = self._lookup_metadata.get(candidate) or {}
             now = int(time.time())
-            self._last_lock_confirmation[match.device_id] = now
-            previous_basis = _normalize_anchor_basis(self._known_timebases.get(match.device_id))
-            raw_time_basis = metadata.get("timestamp_basis")
-            anchor_basis = _normalize_anchor_basis(raw_time_basis)
-            basis_explicitly_invalid = raw_time_basis is not None and anchor_basis is None
-            if anchor_basis is None:
-                if raw_time_basis is None:
-                    anchor_basis = previous_basis
-            elif raw_time_basis != anchor_basis:
-                self._known_timebases.pop(match.device_id, None)
-            if anchor_basis is None and not basis_explicitly_invalid:
-                self._known_timebases.pop(match.device_id, None)
-            existing_lock = self._locks.get(match.device_id)
-            if existing_lock is None:
-                variant_value = self._normalize_variant_value(
-                    metadata.get("variant"),
-                    eid_len=len(candidate),
+
+            # Update state for ALL matches (shared devices)
+            for match in matches:
+                self._update_match_state(
+                    match,
+                    metadata=metadata,
+                    candidate=candidate,
+                    observed_frame=observed_frame,
+                    candidate_prefix=candidate_prefix,
+                    raw_prefix=raw_prefix,
+                    now=now,
                 )
-                rotation_timestamp = metadata.get("rotation_timestamp")
-                lock = EIDGenerationLock(
-                    device_id=match.device_id,
-                    canonical_id=match.canonical_id,
-                    variant=variant_value,
-                    advertisement_reversed=match.is_reversed,
-                    eid_length=len(candidate),
-                    rotation_timestamp=int(rotation_timestamp)
-                    if isinstance(rotation_timestamp, int)
-                    and not isinstance(rotation_timestamp, bool)
-                    else None,
-                    frame_type=observed_frame,
-                    time_basis=anchor_basis,
-                    created_at=now,
-                    drift_offset=match.time_offset,
-                    last_seen_at=now,
-                )
-                self._locks[match.device_id] = lock
-                self._persisted_locks[match.device_id] = lock
-                self._schedule_lock_save()
-            else:
-                # Update drift tracking on existing lock
-                drift_changed = existing_lock.drift_offset != match.time_offset
-                existing_lock.drift_offset = match.time_offset
-                existing_lock.last_seen_at = now
-                if drift_changed and match.time_offset != 0:
-                    _LOGGER.debug(
-                        "Drift update for %s: offset=%d (using %s window)",
-                        match.device_id,
-                        match.time_offset,
-                        "+1/+2" if match.time_offset > 0 else "-1/-2",
-                    )
-                self._schedule_lock_save()
 
-            self._known_advertisement_reversed[match.device_id] = match.is_reversed
-
-            if anchor_basis is not None and not basis_explicitly_invalid:
-                self._known_offsets[(match.device_id, anchor_basis)] = match.time_offset
-                self._known_timebases[match.device_id] = anchor_basis
-
-            _LOGGER.info(
-                (
-                    "HIT: device=%s canonical=%s reversed=%s offset=%s "
-                    "candidate_prefix=%s raw_prefix=%s"
-                ),
-                match.device_id,
-                match.canonical_id,
-                match.is_reversed,
-                match.time_offset,
-                candidate_prefix,
-                raw_prefix,
-            )
-            return match
+            return matches, candidate, observed_frame
 
         # =================================================================
         # Heuristic Phone Discovery: Reactive check before logging MISS
@@ -2075,7 +2165,7 @@ class GoogleFindMyEIDResolver:
             self._known_advertisement_reversed[heuristic_match.device_id] = (
                 heuristic_match.is_reversed
             )
-            return heuristic_match
+            return [heuristic_match], None, None
 
         # Log MISS with rate limiting for heuristic failures
         max_prefixes = 8
@@ -2092,7 +2182,34 @@ class GoogleFindMyEIDResolver:
                 len(self._lookup),
                 len(self._cached_identities),
             )
-        return None
+        return [], None, None
+
+    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:  # noqa: PLR0911, PLR0912, PLR0915
+        """Resolve a scanned payload to a Home Assistant device registry ID.
+
+        For shared devices (same tracker across multiple accounts), this returns
+        the first match. Use resolve_eid_all() to get all matches.
+        """
+        matches, _, _ = self._resolve_eid_internal(eid_bytes)
+        return matches[0] if matches else None
+
+    def resolve_eid_all(self, eid_bytes: bytes) -> list[EIDMatch]:
+        """Resolve a scanned payload to all matching Home Assistant device registry IDs.
+
+        This method supports shared devices: when the same physical tracker
+        is shared between accounts, all accounts' matches are returned.
+        Each match represents a different Home Assistant device registry entry
+        for the same physical tracker.
+
+        Args:
+            eid_bytes: Raw EID bytes from a BLE advertisement.
+
+        Returns:
+            List of EIDMatch entries for all accounts that share this device.
+            Empty list if no match found.
+        """
+        matches, _, _ = self._resolve_eid_internal(eid_bytes)
+        return matches
 
     def _extract_candidates(  # noqa: PLR0912
         self, payload: bytes

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -61,7 +61,7 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
 
     _LOGGER.info("Registering Bermuda FMDN beacon listener")
 
-    @callback  # type: ignore[untyped-decorator]
+    @callback  # type: ignore[misc,untyped-decorator,unused-ignore]
     def _bermuda_state_changed(event: Event[EventStateChangedData]) -> None:  # noqa: PLR0911
         """Handle Bermuda entity state changes.
 

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -61,7 +61,7 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
 
     _LOGGER.info("Registering Bermuda FMDN beacon listener")
 
-    @callback  # type: ignore[misc]
+    @callback  # type: ignore[untyped-decorator]
     def _bermuda_state_changed(event: Event[EventStateChangedData]) -> None:  # noqa: PLR0911
         """Handle Bermuda entity state changes.
 

--- a/tests/test_eid_resolver_lock_confirmation.py
+++ b/tests/test_eid_resolver_lock_confirmation.py
@@ -41,13 +41,13 @@ async def test_lock_confirmation_updates_on_match(monkeypatch: pytest.MonkeyPatc
 
     device_id = "device-id"
     eid_bytes = b"\x99" * 20
-    resolver._lookup[eid_bytes] = EIDMatch(
+    resolver._lookup[eid_bytes] = [EIDMatch(
         device_id=device_id,
         config_entry_id="entry-id",
         canonical_id="canonical-id",
         time_offset=0,
         is_reversed=False,
-    )
+    )]
     resolver._lookup_metadata[eid_bytes] = {
         "timestamp_basis": "pair_date",
         "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
@@ -94,13 +94,13 @@ async def test_purge_stale_locks_keeps_recently_confirmed_lock(
 
     device_id = "device-id"
     eid_bytes = b"\x01" * 20
-    resolver._lookup[eid_bytes] = EIDMatch(
+    resolver._lookup[eid_bytes] = [EIDMatch(
         device_id=device_id,
         config_entry_id="entry-id",
         canonical_id="canonical-id",
         time_offset=0,
         is_reversed=False,
-    )
+    )]
     resolver._lookup_metadata[eid_bytes] = {
         "timestamp_basis": "pair_date",
         "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,

--- a/tests/test_eid_resolver_logging.py
+++ b/tests/test_eid_resolver_logging.py
@@ -51,11 +51,11 @@ def test_match_triggers_info_log(
         time_offset=0,
         is_reversed=False,
     )
-    resolver._lookup = {lookup_key: match}
+    resolver._lookup = {lookup_key: [match]}
 
     caplog.set_level(logging.DEBUG)
 
-    assert resolver.resolve_eid(lookup_key) is match
+    assert resolver.resolve_eid(lookup_key) == match
     assert any(
         "HIT: device=" in record.message and record.levelno == logging.INFO
         for record in caplog.records
@@ -97,11 +97,11 @@ def test_resolve_eid_logs_candidate_prefix_not_raw_prefix(
         time_offset=0,
         is_reversed=False,
     )
-    resolver._lookup = {candidate: match}
+    resolver._lookup = {candidate: [match]}
 
     caplog.set_level(logging.DEBUG)
 
-    assert resolver.resolve_eid(raw_payload) is match
+    assert resolver.resolve_eid(raw_payload) == match
 
     messages = [record.message for record in caplog.records]
     assert any("candidate_prefix=11223344" in message for message in messages)

--- a/tests/test_eid_resolver_offset_semantics.py
+++ b/tests/test_eid_resolver_offset_semantics.py
@@ -117,7 +117,8 @@ async def test_pair_date_offset_beats_drifted_unix(
     await resolver._refresh_cache()
 
     assert collision_eid in resolver._lookup
-    match = resolver._lookup[collision_eid]
+    matches = resolver._lookup[collision_eid]
+    match = matches[0]  # Get first match from list
     metadata = resolver._lookup_metadata[collision_eid]
 
     assert match.time_offset == 0

--- a/tests/test_eid_resolver_pipeline.py
+++ b/tests/test_eid_resolver_pipeline.py
@@ -242,7 +242,7 @@ def test_collision_policy_prefers_smallest_offset() -> None:
     )
 
     lookup, metadata = builder.finalize()
-    assert lookup[b"eid"].time_offset == 1
+    assert lookup[b"eid"][0].time_offset == 1  # Get first match from list
     assert metadata[b"eid"]["timestamp_bases"] == {"pair_date", "secrets_creation_date"}
 
 
@@ -273,13 +273,13 @@ async def test_lock_save_scheduled_after_match(monkeypatch: pytest.MonkeyPatch) 
     resolver = _build_resolver(monkeypatch)
     payload = b"B" * LEGACY_EID_LENGTH
     resolver._lookup = {
-        payload: resolver_module.EIDMatch(
+        payload: [resolver_module.EIDMatch(
             device_id="dev-lock",
             config_entry_id="entry-lock",
             canonical_id="can-lock",
             time_offset=0,
             is_reversed=False,
-        )
+        )]
     }
     resolver._lookup_metadata = {
         payload: {

--- a/tests/test_eid_resolver_risk_regressions.py
+++ b/tests/test_eid_resolver_risk_regressions.py
@@ -152,13 +152,13 @@ def test_confirmation_refresh_and_purge_stability(monkeypatch: pytest.MonkeyPatc
 
     resolver = _resolver()
     eid_bytes = b"\x99" * 20
-    resolver._lookup[eid_bytes] = EIDMatch(
+    resolver._lookup[eid_bytes] = [EIDMatch(
         device_id="device-id",
         config_entry_id="entry-id",
         canonical_id="canonical-id",
         time_offset=0,
         is_reversed=False,
-    )
+    )]
     resolver._lookup_metadata[eid_bytes] = {
         "timestamp_basis": "pair_date",
         "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
@@ -271,13 +271,13 @@ def test_resolve_eid_does_not_store_lock_tracking_as_known_timebasis(
 
     resolver = _resolver()
     eid = b"\x11" * 20
-    resolver._lookup[eid] = EIDMatch(
+    resolver._lookup[eid] = [EIDMatch(
         device_id="dev",
         config_entry_id="entry",
         canonical_id="can",
         time_offset=7,
         is_reversed=False,
-    )
+    )]
     resolver._lookup_metadata[eid] = {
         "timestamp_basis": "lock_tracking",
         "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
@@ -306,13 +306,13 @@ def test_resolve_eid_missing_timestamp_basis_uses_previous_valid_basis(
     resolver._known_timebases["dev"] = "pair_date"
 
     eid = b"\x22" * 20
-    resolver._lookup[eid] = EIDMatch(
+    resolver._lookup[eid] = [EIDMatch(
         device_id="dev",
         config_entry_id="entry",
         canonical_id="can",
         time_offset=3,
         is_reversed=False,
-    )
+    )]
     resolver._lookup_metadata[eid] = {
         "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,
     }
@@ -334,13 +334,13 @@ def test_resolve_eid_normalizes_variant_and_never_persists_invalid_lock_variant(
 
     resolver = _resolver()
     eid = b"\x33" * 20
-    resolver._lookup[eid] = EIDMatch(
+    resolver._lookup[eid] = [EIDMatch(
         device_id="dev",
         config_entry_id="entry",
         canonical_id="can",
         time_offset=0,
         is_reversed=False,
-    )
+    )]
     resolver._lookup_metadata[eid] = {
         "timestamp_basis": "pair_date",
         "variant": "0",  # intentionally invalid for EidVariant in many implementations
@@ -466,13 +466,13 @@ def test_resolve_eid_does_not_poison_anchor_offsets_with_lock_tracking_basis(
     resolver._known_offsets[("dev", "pair_date")] = 123
 
     eid = b"\x11" * 20
-    resolver._lookup[eid] = EIDMatch(
+    resolver._lookup[eid] = [EIDMatch(
         device_id="dev",
         config_entry_id="entry",
         canonical_id="can",
         time_offset=7,
         is_reversed=False,
-    )
+    )]
     resolver._lookup_metadata[eid] = {
         "timestamp_basis": "lock_tracking",
         "variant": EidVariant.LEGACY_SECP160R1_X20_BE.value,

--- a/tests/test_eid_resolver_slicing.py
+++ b/tests/test_eid_resolver_slicing.py
@@ -16,7 +16,7 @@ def _build_resolver(lookup_key: bytes, match: EIDMatch) -> GoogleFindMyEIDResolv
 
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = SimpleNamespace()
-    resolver._lookup = {lookup_key: match}
+    resolver._lookup = {lookup_key: [match]}
     resolver._lookup_metadata = {
         lookup_key: {
             "timestamp_basis": "pair_date",

--- a/tests/test_fmdn_frame_filter.py
+++ b/tests/test_fmdn_frame_filter.py
@@ -11,7 +11,7 @@ from custom_components.googlefindmy.eid_resolver import (
 def _build_resolver(lookup_key: bytes, match: EIDMatch) -> GoogleFindMyEIDResolver:
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = SimpleNamespace()
-    resolver._lookup = {lookup_key: match}
+    resolver._lookup = {lookup_key: [match]}
     resolver._lookup_metadata = {}
     resolver._known_offsets = {}
     resolver._known_advertisement_reversed = {}


### PR DESCRIPTION
<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
