### PR TITLE
Propagate location updates to all devices sharing same identity_key

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -992,6 +992,12 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self._skip_repair_during_reload_refresh: bool = False
         self._reload_repair_skip_pending_release: bool = False
 
+        # Shared tracker support: identity_key → set of device_ids mapping
+        # Enables Location propagation across devices sharing the same tracker
+        self._identity_key_to_devices: dict[bytes, set[str]] = {}
+        # Guard against infinite propagation loops
+        self._propagating_location: bool = False
+
         super().__init__(
             hass,
             _LOGGER,
@@ -7349,9 +7355,128 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         # Increment background updates to account for push/manual commits.
         self.increment_stat("background_updates")
 
+        # Update identity_key mapping and propagate location to shared devices
+        effective_identity_key = incoming_identity_key or cached_identity_key
+        if effective_identity_key is not None:
+            self._register_identity_key(device_id, effective_identity_key)
+            # Propagate location to all devices sharing the same tracker
+            self._propagate_location_to_shared_devices(
+                device_id, effective_identity_key, slot
+            )
+
         if resolver_refresh_needed:
             self._reset_resolver_offset(device_id)
             self._schedule_eid_resolver_refresh()
+
+    def _register_identity_key(self, device_id: str, identity_key: bytes) -> None:
+        """Register a device's identity_key for shared tracker detection.
+
+        Maintains a mapping from identity_key to all device_ids that share the
+        same physical tracker. This enables location propagation across accounts.
+
+        Args:
+            device_id: Canonical device identifier.
+            identity_key: Normalized 32-byte identity key.
+        """
+        if not isinstance(identity_key, bytes) or len(identity_key) != 32:
+            return
+
+        device_set = self._identity_key_to_devices.setdefault(identity_key, set())
+        if device_id not in device_set:
+            device_set.add(device_id)
+            if len(device_set) > 1:
+                _LOGGER.info(
+                    "Shared tracker detected: identity_key=%s... shared by %d devices: %s",
+                    identity_key[:8].hex(),
+                    len(device_set),
+                    sorted(device_set),
+                )
+
+    def _propagate_location_to_shared_devices(
+        self,
+        source_device_id: str,
+        identity_key: bytes,
+        location_data: dict[str, Any],
+    ) -> None:
+        """Propagate location data to all devices sharing the same identity_key.
+
+        When a tracker is shared between multiple Google accounts, each account
+        has its own canonical_id but they share the same identity_key. This method
+        ensures that location updates received for one device are propagated to
+        all other devices representing the same physical tracker.
+
+        Args:
+            source_device_id: Device that received the original location update.
+            identity_key: The shared identity key.
+            location_data: Location data to propagate.
+        """
+        # Guard against infinite recursion (propagation calling propagation)
+        if self._propagating_location:
+            return
+
+        device_set = self._identity_key_to_devices.get(identity_key)
+        if not device_set or len(device_set) <= 1:
+            return
+
+        # Extract only location-relevant fields to propagate
+        propagate_fields = (
+            "latitude",
+            "longitude",
+            "accuracy",
+            "last_seen",
+            "last_updated",
+            "altitude",
+            "address",
+            "source_label",
+            "status",
+        )
+        propagated_data: dict[str, Any] = {}
+        for key in propagate_fields:
+            if key in location_data:
+                propagated_data[key] = location_data[key]
+
+        if not propagated_data.get("latitude") and not propagated_data.get("longitude"):
+            # No coordinates to propagate
+            return
+
+        # Mark as propagated to prevent re-propagation
+        propagated_data["_propagated_from"] = source_device_id
+
+        self._propagating_location = True
+        try:
+            for target_device_id in device_set:
+                if target_device_id == source_device_id:
+                    continue
+
+                target_cached = self._device_location_data.get(target_device_id)
+                if target_cached is None:
+                    # Target device not yet in cache (will be populated on next poll)
+                    continue
+
+                # Compare timestamps: only propagate if newer
+                source_ts = _normalize_epoch_seconds(propagated_data.get("last_seen"))
+                target_ts = _normalize_epoch_seconds(target_cached.get("last_seen"))
+
+                if source_ts is not None and target_ts is not None:
+                    if source_ts <= target_ts:
+                        # Target has same or newer data, skip propagation
+                        continue
+
+                # Merge propagated data into target's cached data
+                merged = dict(target_cached)
+                merged.update(propagated_data)
+                merged["_propagated_from"] = source_device_id
+
+                _LOGGER.debug(
+                    "Propagating location from %s to shared device %s (identity_key=%s...)",
+                    source_device_id,
+                    target_device_id,
+                    identity_key[:8].hex(),
+                )
+
+                self._device_location_data[target_device_id] = merged
+        finally:
+            self._propagating_location = False
 
     def _reset_resolver_offset(self, device_id: str) -> None:
         """Clear resolver offsets using registry IDs when identity keys rotate."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -286,6 +286,8 @@ def test_coordinator_propagates_timestamps_to_identity(
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
     )
+    coordinator._identity_key_to_devices = {}
+    coordinator._propagating_location = False
 
     metadata_only_payload = {
         "identity_key": b"\x01\x02\x03\x04",
@@ -344,6 +346,8 @@ def test_coordinator_persists_camelCase_identity_keys(
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
     )
+    coordinator._identity_key_to_devices = {}
+    coordinator._propagating_location = False
 
     camel_payload = {
         "identityKey": b"\x05\x06\x07\x08",
@@ -411,6 +415,8 @@ def test_coordinator_yields_encrypted_only_identities(
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
     )
+    coordinator._identity_key_to_devices = {}
+    coordinator._propagating_location = False
 
     encrypted_payload = {
         "pair_date": 1_700_000_000,
@@ -471,6 +477,8 @@ def test_coordinator_decrypts_registry_only_encrypted_identity_keys(
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
     )
+    coordinator._identity_key_to_devices = {}
+    coordinator._propagating_location = False
 
     encrypted_eik = b"\x66" * 60  # Wrapped 60-byte identity key payload (Moto Tag/Chipolo style)
     decrypted_eik = b"\xAA" * 32
@@ -547,6 +555,8 @@ def test_coordinator_yields_identities_without_pair_date(
     coordinator._extract_our_identifier = lambda device: device.custom_fields.get(
         "canonical_id"
     )
+    coordinator._identity_key_to_devices = {}
+    coordinator._propagating_location = False
 
     identity_only_payload = {
         "identity_key": b"\x09\x0a\x0b\x0c",

--- a/tests/test_coordinator_priority.py
+++ b/tests/test_coordinator_priority.py
@@ -49,6 +49,8 @@ def _build_coordinator(
     )
     coordinator.data = []
     coordinator._device_location_data = {}
+    coordinator._identity_key_to_devices = {}
+    coordinator._propagating_location = False
     return coordinator
 
 

--- a/tests/test_eid_data_flow.py
+++ b/tests/test_eid_data_flow.py
@@ -85,6 +85,10 @@ def _create_test_coordinator(eid_resolver: Any = None) -> Any:
     coordinator._get_ignored_set = lambda: set()
     coordinator._extract_our_identifier = None
 
+    # Shared tracker support attributes
+    coordinator._identity_key_to_devices = {}
+    coordinator._propagating_location = False
+
     return coordinator
 
 

--- a/tests/test_key_propagation_flow.py
+++ b/tests/test_key_propagation_flow.py
@@ -54,6 +54,8 @@ def _build_coordinator(monkeypatch: pytest.MonkeyPatch) -> coordinator_module.Go
     coordinator._ensure_device_name_cache = lambda: {}
     coordinator._reset_resolver_offset = lambda *_args, **_kwargs: None
     coordinator._schedule_eid_resolver_refresh = lambda *_args, **_kwargs: None
+    coordinator._identity_key_to_devices = {}
+    coordinator._propagating_location = False
     return coordinator
 
 


### PR DESCRIPTION
When a tracker is shared between multiple Google accounts, each account has its own canonical_id but they share the same identity_key. Previously, location updates were only applied to the device that received them directly.

This fix implements location propagation:
- Added _identity_key_to_devices mapping to track which devices share trackers
- Added _register_identity_key() to update the mapping when identity_keys are seen
- Added _propagate_location_to_shared_devices() to propagate location updates
- Location updates are now propagated to all devices with the same identity_key
- Only newer timestamps are propagated (prevents stale data overwriting fresh data)
- Includes infinite loop guard (_propagating_location flag)

Updated tests to include new coordinator attributes.

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
