### PR TITLE
fix: Return None from _get_entry_cache when cache is closed

### DIFF
--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -3680,32 +3680,47 @@ class ConfigFlow(
         )
 
     def _get_entry_cache(self, entry: ConfigEntry) -> Any | None:
-        """Return the TokenCache (or equivalent) for this entry if available."""
+        """Return the TokenCache (or equivalent) for this entry if available.
+
+        Returns None if the cache is closed (unusable state) to allow
+        self-healing during reauth flows.
+        """
+        cache = None
 
         rd = getattr(entry, "runtime_data", None)
         if rd is not None:
             for attr in ("token_cache", "cache", "_cache"):
                 if hasattr(rd, attr):
                     try:
-                        return getattr(rd, attr)
+                        cache = getattr(rd, attr)
+                        break
                     except Exception:  # pragma: no cover
                         pass
 
-        runtime_container = getattr(self.hass, "data", {}) if self.hass else {}
-        runtime_bucket = runtime_container.get(DOMAIN, {}).get("entries", {})
-        runtime_entry = runtime_bucket.get(entry.entry_id)
-        if runtime_entry is not None:
-            for attr in ("_cache", "cache"):
-                if hasattr(runtime_entry, attr):
-                    try:
-                        return getattr(runtime_entry, attr)
-                    except Exception:  # pragma: no cover
-                        pass
-            if isinstance(runtime_entry, dict):
-                cache = runtime_entry.get("cache") or runtime_entry.get("_cache")
-                if cache is not None:
-                    return cache
-        return None
+        if cache is None:
+            runtime_container = getattr(self.hass, "data", {}) if self.hass else {}
+            runtime_bucket = runtime_container.get(DOMAIN, {}).get("entries", {})
+            runtime_entry = runtime_bucket.get(entry.entry_id)
+            if runtime_entry is not None:
+                for attr in ("_cache", "cache"):
+                    if hasattr(runtime_entry, attr):
+                        try:
+                            cache = getattr(runtime_entry, attr)
+                            break
+                        except Exception:  # pragma: no cover
+                            pass
+                if cache is None and isinstance(runtime_entry, dict):
+                    cache = runtime_entry.get("cache") or runtime_entry.get("_cache")
+
+        # Check if cache is closed (unusable) - return None to allow self-healing
+        if cache is not None and getattr(cache, "_closed", False):
+            _LOGGER.debug(
+                "TokenCache for entry '%s' is closed; returning None to allow self-healing",
+                getattr(entry, "entry_id", "unknown"),
+            )
+            return None
+
+        return cache
 
     @staticmethod
     async def _async_trigger_core_subentry_repair(


### PR DESCRIPTION
The _get_entry_cache method now checks if the TokenCache._closed flag is True before returning the cache instance. When a cache is closed (e.g., after a failed reload or during shutdown), returning it would cause writes to fail with "TokenCache is closed" errors.

By returning None for closed caches, the reauth flow can proceed properly and self-heal, as the entry will be fully reloaded with a fresh cache instance when async_update_reload_and_abort() completes.

This prevents scenarios where:
1. Entry enters auth-failed state
2. Cache gets closed but runtime_data is not cleared
3. Reauth flow attempts to use the closed cache
4. Writes fail, preventing recovery even with valid new secrets

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
