### PR TITLE
Claude/debug tracker sharing 7 h3 oj

### DIFF
--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -7418,7 +7418,7 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         if not device_set or len(device_set) <= 1:
             return
 
-        # Extract only location-relevant fields to propagate
+        # Extract location-relevant and Bermuda-specific fields to propagate
         propagate_fields = (
             "latitude",
             "longitude",
@@ -7429,14 +7429,25 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             "address",
             "source_label",
             "status",
+            # Bermuda-specific fields
+            "bermuda_area",
+            "bermuda_rssi",
+            "bermuda_distance",
+            "bermuda_floor",
+            "bermuda_scanner",
+            "bermuda_last_seen",
         )
         propagated_data: dict[str, Any] = {}
         for key in propagate_fields:
             if key in location_data:
                 propagated_data[key] = location_data[key]
 
-        if not propagated_data.get("latitude") and not propagated_data.get("longitude"):
-            # No coordinates to propagate
+        # Check if we have any data worth propagating (coordinates OR Bermuda data)
+        has_coordinates = propagated_data.get("latitude") or propagated_data.get("longitude")
+        has_bermuda_data = any(k.startswith("bermuda_") for k in propagated_data)
+
+        if not has_coordinates and not has_bermuda_data:
+            # No data to propagate
             return
 
         # Mark as propagated to prevent re-propagation
@@ -7454,13 +7465,31 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                     continue
 
                 # Compare timestamps: only propagate if newer
-                source_ts = _normalize_epoch_seconds(propagated_data.get("last_seen"))
-                target_ts = _normalize_epoch_seconds(target_cached.get("last_seen"))
+                # For location data, use last_seen; for Bermuda data, use bermuda_last_seen
+                should_propagate = True
 
-                if source_ts is not None and target_ts is not None:
-                    if source_ts <= target_ts:
-                        # Target has same or newer data, skip propagation
-                        continue
+                if has_coordinates:
+                    source_ts = _normalize_epoch_seconds(propagated_data.get("last_seen"))
+                    target_ts = _normalize_epoch_seconds(target_cached.get("last_seen"))
+
+                    if source_ts is not None and target_ts is not None:
+                        if source_ts <= target_ts:
+                            # Target has same or newer location data
+                            should_propagate = False
+
+                if has_bermuda_data and should_propagate:
+                    # For Bermuda data, compare bermuda_last_seen
+                    source_bermuda_ts = propagated_data.get("bermuda_last_seen")
+                    target_bermuda_ts = target_cached.get("bermuda_last_seen")
+
+                    if source_bermuda_ts and target_bermuda_ts:
+                        if source_bermuda_ts <= target_bermuda_ts:
+                            # Target has same or newer Bermuda data, but still might need coordinates
+                            if not has_coordinates:
+                                should_propagate = False
+
+                if not should_propagate:
+                    continue
 
                 # Merge propagated data into target's cached data
                 merged = dict(target_cached)
@@ -7468,10 +7497,13 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                 merged["_propagated_from"] = source_device_id
 
                 _LOGGER.debug(
-                    "Propagating location from %s to shared device %s (identity_key=%s...)",
+                    "Propagating data from %s to shared device %s (identity_key=%s..., "
+                    "has_coords=%s, has_bermuda=%s)",
                     source_device_id,
                     target_device_id,
                     identity_key[:8].hex(),
+                    has_coordinates,
+                    has_bermuda_data,
                 )
 
                 self._device_location_data[target_device_id] = merged

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -10,8 +10,9 @@ FMDN Specification: FMDN.md Section 3 (BLE Advertising & EID)
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import Event, HomeAssistant, State, callback
@@ -29,6 +30,8 @@ ATTR_RSSI = "rssi"
 ATTR_SOURCE = "source"
 ATTR_SCANNER_DEVICE_ID = "scanner_device_id"
 ATTR_FMDN_DEVICE_ID = "fmdn_device_id"
+ATTR_DISTANCE = "distance"
+ATTR_FLOOR = "floor"
 
 # Data storage key
 DATA_BERMUDA_LISTENER = "fmdn_finder_bermuda_listener"
@@ -135,6 +138,10 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
             )
             return
 
+        # Extract additional Bermuda attributes for propagation
+        distance = attrs.get(ATTR_DISTANCE)
+        floor = attrs.get(ATTR_FLOOR)
+
         # Pass to location uploader (async task)
         hass.async_create_task(
             async_process_fmdn_beacon_detection(
@@ -150,6 +157,20 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
             name=f"fmdn_finder_upload_{entity_id}",
         )
 
+        # Propagate Bermuda data to all devices sharing this EID
+        hass.async_create_task(
+            _async_propagate_bermuda_data_to_shared_devices(
+                hass=hass,
+                eid=eid_bytes,
+                area=area,
+                rssi=rssi,
+                distance=distance,
+                floor=floor,
+                scanner_source=scanner_source,
+            ),
+            name=f"fmdn_finder_propagate_{entity_id}",
+        )
+
     # Register state change listener
     # Using async_track_state_change_event for efficient filtering
     unsubscribe = hass.bus.async_listen(EVENT_STATE_CHANGED, _bermuda_state_changed)
@@ -159,6 +180,120 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
     hass.data[BERMUDA_DOMAIN][DATA_BERMUDA_UNSUBSCRIBE] = unsubscribe
 
     _LOGGER.info("Bermuda FMDN beacon listener registered successfully")
+
+
+async def _async_propagate_bermuda_data_to_shared_devices(  # noqa: PLR0913
+    hass: HomeAssistant,
+    *,
+    eid: bytes,
+    area: str | None,
+    rssi: int | None,
+    distance: float | None,
+    floor: str | None,
+    scanner_source: str | None,
+) -> None:
+    """Propagate Bermuda detection data to all devices sharing the same EID.
+
+    When a tracker is detected by Bermuda, this function resolves the EID to find
+    ALL devices that share the same physical tracker (across multiple accounts).
+    The Bermuda data (area, rssi, distance, floor) is then sent to the coordinator
+    for each device, which will propagate the data to all shared devices.
+
+    Args:
+        hass: Home Assistant instance
+        eid: Ephemeral Identity Key bytes
+        area: Bermuda area/room name
+        rssi: Signal strength (dBm)
+        distance: Estimated distance (meters)
+        floor: Floor/level name
+        scanner_source: Scanner identifier
+    """
+    # Import here to avoid circular dependencies
+    from ..const import DATA_EID_RESOLVER, DOMAIN  # noqa: PLC0415
+
+    eid_hex = eid.hex()
+    eid_prefix = eid_hex[:EID_LOG_PREFIX_LENGTH] if len(eid_hex) >= EID_LOG_PREFIX_LENGTH else eid_hex
+
+    # Get EID resolver from hass.data
+    domain_bucket = hass.data.get(DOMAIN)
+    if not isinstance(domain_bucket, dict):
+        _LOGGER.debug("No GoogleFindMy domain bucket found, skipping propagation")
+        return
+
+    eid_resolver = domain_bucket.get(DATA_EID_RESOLVER)
+    if eid_resolver is None:
+        _LOGGER.debug("No EID resolver found, skipping propagation")
+        return
+
+    # Resolve EID to ALL matching devices (not just the best match)
+    resolve_all = getattr(eid_resolver, "resolve_eid_all", None)
+    if not callable(resolve_all):
+        _LOGGER.debug("EID resolver does not support resolve_eid_all, skipping propagation")
+        return
+
+    matches = resolve_all(eid)
+    if not matches:
+        _LOGGER.debug("No EID matches found for %s..., skipping propagation", eid_prefix)
+        return
+
+    _LOGGER.debug(
+        "Found %d EID matches for %s..., propagating Bermuda data",
+        len(matches),
+        eid_prefix,
+    )
+
+    # Build Bermuda data payload
+    bermuda_data: dict[str, Any] = {
+        "bermuda_area": area,
+        "bermuda_rssi": rssi,
+        "bermuda_distance": distance,
+        "bermuda_floor": floor,
+        "bermuda_scanner": scanner_source,
+        "bermuda_last_seen": time.time(),
+    }
+
+    # Filter out None values
+    bermuda_data = {k: v for k, v in bermuda_data.items() if v is not None}
+
+    if not bermuda_data:
+        _LOGGER.debug("No Bermuda data to propagate for %s...", eid_prefix)
+        return
+
+    # Get all coordinators and update each matched device
+    for match in matches:
+        device_id = match.device_id
+        config_entry_id = match.config_entry_id
+
+        if not device_id or not config_entry_id:
+            continue
+
+        # Find the coordinator for this config entry
+        entry_bucket = domain_bucket.get(config_entry_id)
+        if not isinstance(entry_bucket, dict):
+            continue
+
+        coordinator = entry_bucket.get("coordinator")
+        if coordinator is None:
+            continue
+
+        # Update device cache with Bermuda data
+        update_cache = getattr(coordinator, "update_device_cache", None)
+        if callable(update_cache):
+            _LOGGER.debug(
+                "Propagating Bermuda data to device %s (entry=%s): area=%s, rssi=%s",
+                device_id,
+                config_entry_id,
+                area,
+                rssi,
+            )
+            try:
+                update_cache(device_id, bermuda_data)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Failed to propagate Bermuda data to %s: %s",
+                    device_id,
+                    err,
+                )
 
 
 async def async_unload_bermuda_listener(hass: HomeAssistant) -> None:

--- a/tests/test_python315_compat_guard.py
+++ b/tests/test_python315_compat_guard.py
@@ -51,7 +51,12 @@ SKIP_PARTS = {
     "build",
     "venv",
     ".venv",
+    ".venv313",
     "__pycache__",
+    # Skip external packages - we only check our own code
+    "site-packages",
+    "lib",
+    "lib64",
 }
 
 


### PR DESCRIPTION
<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
