### PR TITLE
feat(bermuda_listener): Add multi-strategy device matching

### DIFF
--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -3,14 +3,30 @@
 Listens to Bermuda device_tracker state changes to detect area changes
 and trigger FMDN location uploads to Google's Find My Device network.
 
-Architecture:
-- Bermuda creates device_tracker entities for GoogleFindMy devices (same HA device)
-- Entity pattern: device_tracker.*_bermuda_tracker*
-- When area changes, we find the GoogleFindMy device via Device Registry
-- Get the current EID from GoogleFindMy coordinator
+Architecture
+------------
+Bermuda (jleinenbach/bermuda fork) integrates with GoogleFindMy via the
+EID Resolver API (see docs/google_find_my_support.md):
+
+1. Bermuda detects FMDN BLE advertisements containing EIDs
+2. EID Resolver maps EIDs to GoogleFindMy devices via precomputed lookup
+3. Bermuda creates "metadevices" with fmdn_device_id pointing to HA Device Registry
+4. For FMDN devices, Bermuda uses the SAME identifiers as GoogleFindMy (congealment)
+   - This means Bermuda entities appear under the same HA device as GoogleFindMy
+   - Identifier matching works because both share (DOMAIN, device_id) tuples
+
+Entity Pattern: device_tracker.*_bermuda_tracker*
+Attributes: area (semantic location), scanner (BLE scanner name)
+
+Flow:
+- Bermuda area change detected → find GoogleFindMy device via shared identifiers
+- Get current EID from GoogleFindMy coordinator's identity keys
 - Upload semantic location to Google FMDN backend
 
-Bermuda Integration: https://github.com/jleinenbach/bermuda
+References:
+- Bermuda Fork: https://github.com/jleinenbach/bermuda
+- EID Resolver API: docs/google_find_my_support.md
+- Bermuda entity congealment: custom_components/bermuda/entity.py
 """
 
 from __future__ import annotations
@@ -142,11 +158,14 @@ async def _async_handle_area_change(
     ha_device_id = entity_entry.device_id
 
     # Find the GoogleFindMy device data for this HA device
+    # For FMDN devices, Bermuda uses the same identifiers as GoogleFindMy
     device_info = await _async_find_googlefindmy_device(hass, ha_device_id)
 
     if not device_info:
+        # This is normal for non-FMDN BLE devices tracked by Bermuda
+        # (e.g., regular Bluetooth devices without GoogleFindMy integration)
         _LOGGER.debug(
-            "No GoogleFindMy device found for HA device %s (entity: %s)",
+            "No GoogleFindMy device found for HA device %s (entity: %s) - not an FMDN device",
             ha_device_id,
             entity_id,
         )
@@ -196,8 +215,13 @@ async def _async_find_googlefindmy_device(
 ) -> dict[str, Any] | None:
     """Find GoogleFindMy device data for a Home Assistant device.
 
-    Searches through all GoogleFindMy config entries to find a device
-    that matches the given HA device registry ID.
+    For FMDN devices (GoogleFindMy trackers), Bermuda uses the same device
+    identifiers as GoogleFindMy via the "congealment" mechanism. This means
+    the Bermuda entity's HA device will have GoogleFindMy identifiers, making
+    matching straightforward.
+
+    See: jleinenbach/bermuda - custom_components/bermuda/entity.py
+         docs/google_find_my_support.md
 
     Args:
         hass: Home Assistant instance
@@ -230,17 +254,30 @@ async def _async_find_googlefindmy_device(
         device_identities = getattr(coordinator, "_device_identities", {})
 
         for google_device_id, identity in device_identities.items():
-            # Check if identifiers match
-            # GoogleFindMy uses (DOMAIN, device_id) as identifier
+            # For FMDN devices, Bermuda copies GoogleFindMy's identifiers
+            # so we check if any identifier contains the google_device_id.
+            # Identifier formats:
+            #   - (DOMAIN, "device_id")
+            #   - (DOMAIN, "entry_id:device_id")
+            #   - (DOMAIN, "entry_id:subentry_id:device_id")
             for identifier in device_entry.identifiers:
-                if identifier[0] == DOMAIN and identifier[1] == google_device_id:
-                    return {
-                        "device_id": google_device_id,
-                        "config_entry_id": entry_id,
-                        "coordinator": coordinator,
-                        "identity": identity,
-                    }
+                if identifier[0] == DOMAIN:
+                    id_str = str(identifier[1])
+                    # Check exact match or suffix match (for namespaced IDs)
+                    if id_str == google_device_id or id_str.endswith(f":{google_device_id}"):
+                        _LOGGER.debug(
+                            "FMDN device matched: ha_device=%s, google_device=%s",
+                            ha_device_id,
+                            google_device_id,
+                        )
+                        return {
+                            "device_id": google_device_id,
+                            "config_entry_id": entry_id,
+                            "coordinator": coordinator,
+                            "identity": identity,
+                        }
 
+    # No match found - this is normal for non-FMDN BLE devices tracked by Bermuda
     return None
 
 


### PR DESCRIPTION
Simplify device matching for Bermuda FMDN integration:

- For FMDN devices, Bermuda uses the SAME identifiers as GoogleFindMy via the "congealment" mechanism (see bermuda/entity.py)
- This means identifier matching works because both share the same (DOMAIN, device_id) tuples in the HA Device Registry
- Removed incorrect MAC and name matching strategies (MAC rotates, name matching is fragile)
- Added comprehensive documentation explaining the architecture

The matching now relies on Bermuda's proper FMDN integration where metadevices have fmdn_device_id pointing to the GoogleFindMy HA device.

References:
- jleinenbach/bermuda fork FMDN integration
- docs/google_find_my_support.md (EID Resolver API)

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
