### PR TITLE
feat(fmdn): Add upload response logging and semantic_name update

### DIFF
--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -206,6 +206,8 @@ async def _async_handle_area_change(
         area=area,
         config_entry_id=config_entry_id,
         scanner=attributes.get(ATTR_SCANNER),
+        google_device_id=google_device_id,
+        coordinator=coordinator,
     )
 
 
@@ -349,12 +351,14 @@ async def _async_get_device_eid(
     return None
 
 
-async def _async_upload_semantic_location(
+async def _async_upload_semantic_location(  # noqa: PLR0913
     hass: HomeAssistant,
     eid: bytes,
     area: str,
     config_entry_id: str,
     scanner: str | None = None,
+    google_device_id: str | None = None,
+    coordinator: Any | None = None,
 ) -> None:
     """Upload semantic location to Google FMDN backend.
 
@@ -364,6 +368,8 @@ async def _async_upload_semantic_location(
         area: Semantic location name (e.g., "Windfang", "Wohnzimmer")
         config_entry_id: Config entry ID for authentication
         scanner: Optional scanner name for logging
+        google_device_id: Google device ID for semantic_name update
+        coordinator: GoogleFindMy coordinator for semantic_name update
     """
     from .location_uploader import async_process_fmdn_beacon_detection  # noqa: PLC0415
 
@@ -384,6 +390,8 @@ async def _async_upload_semantic_location(
         scanner_device_id=None,
         fmdn_device_id=None,
         entity_id=f"bermuda_semantic_{area}",
+        google_device_id=google_device_id,
+        coordinator=coordinator,
     )
 
 

--- a/custom_components/googlefindmy/fmdn_finder/google_uploader.py
+++ b/custom_components/googlefindmy/fmdn_finder/google_uploader.py
@@ -44,13 +44,16 @@ async def async_upload_to_google_fmdn(
     hass: HomeAssistant,
     payload: bytes,
     truncated_eid_hex: str,
-) -> None:
+) -> bool:
     """Upload encrypted location report to Google FMDN backend.
 
     Args:
         hass: Home Assistant instance
         payload: Serialized LocationReportsUpload protobuf
         truncated_eid_hex: Truncated EID (first 10 bytes) for logging
+
+    Returns:
+        True if upload succeeded, False otherwise
 
     Raises:
         RuntimeError: If GoogleFindMy integration not available or no cache
@@ -64,7 +67,7 @@ async def async_upload_to_google_fmdn(
             len(payload),
             truncated_eid_hex[:8],
         )
-        return
+        return False
 
     # Get cache from integration data (entry-scoped on 1.7.0-3)
     cache = await _get_cache_from_hass(hass)
@@ -76,8 +79,19 @@ async def async_upload_to_google_fmdn(
     )
 
     try:
-        await _upload_via_spot_request(cache, payload)
-        _LOGGER.info("FMDN location report uploaded successfully")
+        response = await _upload_via_spot_request(cache, payload)
+        _LOGGER.info(
+            "FMDN location report uploaded successfully for EID %s... (response: %d bytes)",
+            truncated_eid_hex[:8],
+            len(response),
+        )
+        _LOGGER.debug(
+            "Upload success - EID=%s, payload=%d bytes, response=%d bytes",
+            truncated_eid_hex,
+            len(payload),
+            len(response),
+        )
+        return True
     except Exception as err:  # noqa: BLE001
         _LOGGER.error("Failed to upload FMDN report: %s", err, exc_info=True)
         raise ValueError(f"Upload failed: {err}") from err
@@ -120,7 +134,7 @@ async def _get_cache_from_hass(hass: HomeAssistant) -> TokenCache:
     return cast(TokenCache, cache)
 
 
-async def _upload_via_spot_request(cache: TokenCache, payload: bytes) -> None:
+async def _upload_via_spot_request(cache: TokenCache, payload: bytes) -> bytes:
     """Upload payload using Spot API (gRPC over HTTP/2).
 
     Implementation follows the pattern of existing Spot API calls on 1.7.0-3:
@@ -132,6 +146,9 @@ async def _upload_via_spot_request(cache: TokenCache, payload: bytes) -> None:
     Args:
         cache: Entry-scoped TokenCache for authentication
         payload: Serialized LocationReportsUpload protobuf
+
+    Returns:
+        Response bytes from server
 
     Raises:
         ValueError: If upload fails
@@ -150,7 +167,14 @@ async def _upload_via_spot_request(cache: TokenCache, payload: bytes) -> None:
         cache=cache,
     )
 
-    _LOGGER.debug("FMDN upload response: %d bytes", len(response) if response else 0)
+    response_len = len(response) if response else 0
+    _LOGGER.debug(
+        "FMDN upload response: %d bytes%s",
+        response_len,
+        f", data={response.hex()[:64]}..." if response and response_len > 0 else " (empty)",
+    )
+
+    return response if response else b""
 
 
 # ============================================================================

--- a/custom_components/googlefindmy/fmdn_finder/location_uploader.py
+++ b/custom_components/googlefindmy/fmdn_finder/location_uploader.py
@@ -23,7 +23,7 @@ import math
 import secrets
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, State
@@ -87,7 +87,9 @@ async def async_process_fmdn_beacon_detection(  # noqa: PLR0913
     scanner_device_id: str | None,
     fmdn_device_id: str | None,
     entity_id: str,
-) -> None:
+    google_device_id: str | None = None,
+    coordinator: Any | None = None,
+) -> bool:
     """Process FMDN beacon detection and upload location report.
 
     Main entry point from bermuda_listener. Coordinates location resolution,
@@ -102,6 +104,11 @@ async def async_process_fmdn_beacon_detection(  # noqa: PLR0913
         scanner_device_id: HA device registry ID of scanner
         fmdn_device_id: HA device registry ID of FMDN device
         entity_id: Bermuda entity ID for logging
+        google_device_id: Google device ID for semantic_name update
+        coordinator: GoogleFindMy coordinator for semantic_name update
+
+    Returns:
+        True if upload succeeded, False otherwise
     """
     eid_hex = eid.hex()
     _LOGGER.debug(
@@ -120,7 +127,7 @@ async def async_process_fmdn_beacon_detection(  # noqa: PLR0913
             area,
             scanner_address,
         )
-        return
+        return False
 
     _LOGGER.debug(
         "Resolved location: lat=%.6f, lon=%.6f, accuracy=%dm, zone=%s",
@@ -135,7 +142,7 @@ async def async_process_fmdn_beacon_detection(  # noqa: PLR0913
 
     if not should_upload:
         _LOGGER.debug("Upload throttled for EID %s...: %s", eid_hex[:EID_LOG_PREFIX_LENGTH], reason)
-        return
+        return False
 
     _LOGGER.info(
         "Uploading FMDN location report: EID=%s..., zone=%s, accuracy=%dm",
@@ -151,12 +158,28 @@ async def async_process_fmdn_beacon_detection(  # noqa: PLR0913
 
     # 4. Encrypt and upload
     try:
-        await _encrypt_and_upload_location(hass, eid, location)
+        success = await _encrypt_and_upload_location(hass, eid, location, area)
 
-        # Update cache on successful upload
-        _update_upload_cache(hass, eid_hex, location)
+        if success:
+            # Update cache on successful upload
+            _update_upload_cache(hass, eid_hex, location)
 
-        _LOGGER.info("FMDN location report uploaded successfully for EID %s...", eid_hex[:EID_LOG_PREFIX_LENGTH])
+            # Update semantic_name in coordinator for device_tracker display
+            if google_device_id and coordinator and area:
+                _update_semantic_name(coordinator, google_device_id, area)
+                _LOGGER.debug(
+                    "Updated semantic_name='%s' for device %s",
+                    area,
+                    google_device_id,
+                )
+
+            _LOGGER.info(
+                "FMDN location report uploaded successfully for EID %s... (semantic: %s)",
+                eid_hex[:EID_LOG_PREFIX_LENGTH],
+                area,
+            )
+
+        return success
 
     except Exception as err:  # noqa: BLE001
         _LOGGER.error(
@@ -165,6 +188,7 @@ async def async_process_fmdn_beacon_detection(  # noqa: PLR0913
             err,
             exc_info=True,
         )
+        return False
 
 
 async def _resolve_scanner_location(
@@ -383,11 +407,43 @@ def _calculate_accuracy_from_rssi(rssi: int, zone_accuracy: int) -> int:
     return max(estimated_distance, zone_accuracy)
 
 
+def _update_semantic_name(coordinator: Any, google_device_id: str, area: str) -> None:
+    """Update semantic_name in coordinator's device data.
+
+    This updates the device_tracker's location_name attribute after
+    a successful FMDN location upload.
+
+    Args:
+        coordinator: GoogleFindMy coordinator
+        google_device_id: Google device ID
+        area: Semantic location name (e.g., "Büro", "Wohnzimmer")
+    """
+    device_location_data = getattr(coordinator, "_device_location_data", None)
+    if device_location_data is None:
+        return
+
+    device_data = device_location_data.get(google_device_id)
+    if device_data is None:
+        # Create minimal entry if not exists
+        device_location_data[google_device_id] = {"semantic_name": area}
+    else:
+        device_data["semantic_name"] = area
+
+    # Trigger entity update by requesting refresh
+    # The coordinator will propagate this to the device_tracker entity
+    if hasattr(coordinator, "async_request_refresh"):
+        # Don't await - just schedule the refresh
+        import asyncio  # noqa: PLC0415
+
+        asyncio.create_task(coordinator.async_request_refresh())
+
+
 async def _encrypt_and_upload_location(
     hass: HomeAssistant,
     eid: bytes,
     location: LocationData,
-) -> None:
+    semantic_area: str | None = None,
+) -> bool:
     """Encrypt location and upload to Google FMDN backend.
 
     Uses existing crypto primitives from foreign_tracker_cryptor.py
@@ -397,6 +453,10 @@ async def _encrypt_and_upload_location(
         hass: Home Assistant instance
         eid: Ephemeral Identity Key (20 or 32 bytes)
         location: Location to upload
+        semantic_area: Optional semantic location name for logging
+
+    Returns:
+        True if upload succeeded, False otherwise
 
     Raises:
         ImportError: If crypto or protobuf modules not available
@@ -462,12 +522,16 @@ async def _encrypt_and_upload_location(
 
     upload_bytes = upload.SerializeToString()
 
-    _LOGGER.debug("Upload protobuf: %d bytes", len(upload_bytes))
+    _LOGGER.debug(
+        "Upload protobuf: %d bytes%s",
+        len(upload_bytes),
+        f", semantic_area='{semantic_area}'" if semantic_area else "",
+    )
 
     # 4. Upload to Google FMDN backend
     from .google_uploader import async_upload_to_google_fmdn  # noqa: PLC0415
 
-    await async_upload_to_google_fmdn(hass, upload_bytes, eid[:10].hex())
+    return await async_upload_to_google_fmdn(hass, upload_bytes, eid[:10].hex())
 
 
 def _update_upload_cache(hass: HomeAssistant, eid_hex: str, location: LocationData) -> None:


### PR DESCRIPTION
- Add detailed DEBUG logging for successful uploads with response size
- Add INFO log with semantic location on successful upload
- Update device_tracker semantic_name attribute after successful FMDN upload
- Trigger coordinator refresh to update entity state
- Pass google_device_id and coordinator through the upload chain

After successful upload, the device_tracker will show the semantic location (e.g., "Büro", "Wohnzimmer") in its location_name attribute.

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
