### PR TITLE
feat(fmdn): Add debouncing, semantic location, and improved throttling

### DIFF
--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -31,8 +31,11 @@ References:
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import EVENT_STATE_CHANGED
@@ -58,12 +61,25 @@ ATTR_SOURCE = "source"
 # Data storage keys
 DATA_BERMUDA_UNSUBSCRIBE = "fmdn_finder_bermuda_unsub"
 DATA_LAST_AREA_CACHE = "fmdn_finder_last_area"
+DATA_AREA_DEBOUNCE = "fmdn_finder_area_debounce"
 
-# Throttling
+# Debouncing - area must be stable for this duration before triggering upload
+AREA_STABILIZATION_SECONDS = 30  # Wait 30 seconds after area change to confirm it's stable
 MIN_UPLOAD_INTERVAL_SECONDS = 60  # Minimum time between uploads for same device
 
 # Log formatting
 EID_LOG_PREFIX_LENGTH = 8  # Number of hex chars to show in logs
+
+
+@dataclass
+class AreaDebounceState:
+    """Track area debouncing state for an entity."""
+
+    entity_id: str
+    area: str
+    first_seen: float
+    last_seen: float
+    upload_scheduled: bool = False
 
 
 async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
@@ -77,15 +93,17 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
     """
     _LOGGER.info("Registering Bermuda FMDN beacon listener")
 
-    # Initialize area cache for change detection
+    # Initialize caches
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN].setdefault(DATA_LAST_AREA_CACHE, {})
+    hass.data[DOMAIN].setdefault(DATA_AREA_DEBOUNCE, {})
 
     @callback  # type: ignore[misc]
     def _bermuda_state_changed(event: Event[EventStateChangedData]) -> None:
-        """Handle Bermuda device_tracker state changes.
+        """Handle Bermuda device_tracker state changes with debouncing.
 
-        Filters for Bermuda tracker entities and triggers FMDN uploads on area change.
+        Filters for Bermuda tracker entities and triggers FMDN uploads
+        only after area has been stable for AREA_STABILIZATION_SECONDS.
         """
         entity_id: str | None = event.data.get("entity_id")
         new_state: State | None = event.data.get("new_state")
@@ -103,25 +121,55 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
         new_area = new_state.attributes.get(ATTR_AREA)
         old_area = old_state.attributes.get(ATTR_AREA) if old_state else None
 
-        # Skip if no area or area unchanged
+        # Skip if no area
         if not new_area:
             _LOGGER.debug("Bermuda tracker %s has no area attribute", entity_id)
             return
 
-        if new_area == old_area:
+        # Get debounce cache
+        debounce_cache: dict[str, AreaDebounceState] = hass.data[DOMAIN].get(
+            DATA_AREA_DEBOUNCE, {}
+        )
+        current_time = time.time()
+        debounce_state = debounce_cache.get(entity_id)
+
+        # Check if this is a new area or same area as debounce state
+        if debounce_state and debounce_state.area == new_area:
+            # Same area, update last_seen time
+            debounce_state.last_seen = current_time
+            _LOGGER.debug(
+                "Bermuda %s still in area '%s' (stable for %.1fs)",
+                entity_id,
+                new_area,
+                current_time - debounce_state.first_seen,
+            )
             return
 
-        _LOGGER.info(
-            "Bermuda area change detected: %s -> %s (entity: %s)",
-            old_area,
-            new_area,
-            entity_id,
+        # Area changed (or first detection) - reset debounce
+        if new_area != old_area:
+            _LOGGER.info(
+                "Bermuda area change detected: %s -> %s (entity: %s), starting %ds stabilization",
+                old_area,
+                new_area,
+                entity_id,
+                AREA_STABILIZATION_SECONDS,
+            )
+
+        # Create/update debounce state
+        debounce_cache[entity_id] = AreaDebounceState(
+            entity_id=entity_id,
+            area=new_area,
+            first_seen=current_time,
+            last_seen=current_time,
+            upload_scheduled=False,
         )
 
-        # Trigger async upload task
+        # Schedule delayed upload check
         hass.async_create_task(
-            _async_handle_area_change(hass, entity_id, new_area, new_state.attributes),
-            name=f"fmdn_upload_{entity_id}",
+            _async_debounced_area_upload(
+                hass, entity_id, new_area, new_state.attributes, current_time
+            ),
+            name=f"fmdn_debounce_{entity_id}",
         )
 
     # Register state change listener
@@ -131,6 +179,77 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
     hass.data[DOMAIN][DATA_BERMUDA_UNSUBSCRIBE] = unsubscribe
 
     _LOGGER.info("Bermuda FMDN beacon listener registered successfully")
+
+
+async def _async_debounced_area_upload(
+    hass: HomeAssistant,
+    entity_id: str,
+    expected_area: str,
+    attributes: dict[str, Any],
+    debounce_start_time: float,
+) -> None:
+    """Wait for stabilization period then trigger upload if area is still the same.
+
+    Args:
+        hass: Home Assistant instance
+        entity_id: Bermuda tracker entity ID
+        expected_area: Area that triggered this debounce
+        attributes: Entity attributes at the time of area change
+        debounce_start_time: When this debounce was started
+    """
+    # Wait for stabilization period
+    await asyncio.sleep(AREA_STABILIZATION_SECONDS)
+
+    # Get current debounce state
+    debounce_cache: dict[str, AreaDebounceState] = hass.data.get(DOMAIN, {}).get(
+        DATA_AREA_DEBOUNCE, {}
+    )
+    debounce_state = debounce_cache.get(entity_id)
+
+    if not debounce_state:
+        _LOGGER.debug(
+            "Debounce state cleared for %s during stabilization, skipping upload",
+            entity_id,
+        )
+        return
+
+    # Check if area changed during stabilization
+    if debounce_state.area != expected_area:
+        _LOGGER.info(
+            "Area changed during stabilization for %s: %s -> %s, skipping upload",
+            entity_id,
+            expected_area,
+            debounce_state.area,
+        )
+        return
+
+    # Check if this debounce was superseded by a newer one
+    if debounce_state.first_seen != debounce_start_time:
+        _LOGGER.debug(
+            "Superseded debounce for %s (started %.1f, current %.1f), skipping",
+            entity_id,
+            debounce_start_time,
+            debounce_state.first_seen,
+        )
+        return
+
+    # Check if already uploaded (prevent duplicate uploads)
+    if debounce_state.upload_scheduled:
+        _LOGGER.debug("Upload already scheduled for %s in area '%s'", entity_id, expected_area)
+        return
+
+    # Mark as scheduled to prevent duplicates
+    debounce_state.upload_scheduled = True
+
+    _LOGGER.info(
+        "Area '%s' stable for %ds for %s, triggering FMDN upload",
+        expected_area,
+        AREA_STABILIZATION_SECONDS,
+        entity_id,
+    )
+
+    # Trigger the actual upload
+    await _async_handle_area_change(hass, entity_id, expected_area, attributes)
 
 
 async def _async_handle_area_change(

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -126,6 +126,11 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
             _LOGGER.debug("Bermuda tracker %s has no area attribute", entity_id)
             return
 
+        # Skip if area unchanged (unless first detection)
+        if new_area == old_area:
+            _LOGGER.debug("Bermuda tracker %s area unchanged: %s", entity_id, new_area)
+            return
+
         # Get debounce cache
         debounce_cache: dict[str, AreaDebounceState] = hass.data[DOMAIN].get(
             DATA_AREA_DEBOUNCE, {}
@@ -133,9 +138,9 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
         current_time = time.time()
         debounce_state = debounce_cache.get(entity_id)
 
-        # Check if this is a new area or same area as debounce state
+        # Check if this is the same area as current debounce state
         if debounce_state and debounce_state.area == new_area:
-            # Same area, update last_seen time
+            # Same area as debounce, update last_seen time
             debounce_state.last_seen = current_time
             _LOGGER.debug(
                 "Bermuda %s still in area '%s' (stable for %.1fs)",
@@ -145,15 +150,14 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
             )
             return
 
-        # Area changed (or first detection) - reset debounce
-        if new_area != old_area:
-            _LOGGER.info(
-                "Bermuda area change detected: %s -> %s (entity: %s), starting %ds stabilization",
-                old_area,
-                new_area,
-                entity_id,
-                AREA_STABILIZATION_SECONDS,
-            )
+        # Area changed - log and start debounce
+        _LOGGER.info(
+            "Bermuda area change detected: %s -> %s (entity: %s), starting %ds stabilization",
+            old_area,
+            new_area,
+            entity_id,
+            AREA_STABILIZATION_SECONDS,
+        )
 
         # Create/update debounce state
         debounce_cache[entity_id] = AreaDebounceState(

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -122,7 +122,7 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
     hass.data[DOMAIN].setdefault(DATA_LAST_AREA_CACHE, {})
     hass.data[DOMAIN].setdefault(DATA_AREA_DEBOUNCE, {})
 
-    @callback  # type: ignore[untyped-decorator]
+    @callback  # type: ignore[misc, untyped-decorator, unused-ignore]
     def _bermuda_state_changed(event: Event[EventStateChangedData]) -> None:
         """Handle Bermuda device_tracker state changes with debouncing.
 

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -122,7 +122,7 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
     hass.data[DOMAIN].setdefault(DATA_LAST_AREA_CACHE, {})
     hass.data[DOMAIN].setdefault(DATA_AREA_DEBOUNCE, {})
 
-    @callback  # type: ignore[misc]
+    @callback  # type: ignore[untyped-decorator]
     def _bermuda_state_changed(event: Event[EventStateChangedData]) -> None:
         """Handle Bermuda device_tracker state changes with debouncing.
 

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -280,9 +280,9 @@ async def _async_handle_area_change(
 
     ha_device_id = entity_entry.device_id
 
-    # Find the GoogleFindMy device data for this HA device
-    # For FMDN devices, Bermuda uses the same identifiers as GoogleFindMy
-    device_info = await _async_find_googlefindmy_device(hass, ha_device_id)
+    # Find the GoogleFindMy device data for this Bermuda tracker
+    # Uses entity name matching (primary) and device identifier matching (fallback)
+    device_info = await _async_find_googlefindmy_device(hass, ha_device_id, entity_id)
 
     if not device_info:
         # This is normal for non-FMDN BLE devices tracked by Bermuda
@@ -337,20 +337,21 @@ async def _async_handle_area_change(
 async def _async_find_googlefindmy_device(
     hass: HomeAssistant,
     ha_device_id: str,
+    entity_id: str | None = None,
 ) -> dict[str, Any] | None:
-    """Find GoogleFindMy device data for a Home Assistant device.
+    """Find GoogleFindMy device data for a Bermuda tracker.
 
-    For FMDN devices (GoogleFindMy trackers), Bermuda uses the same device
-    identifiers as GoogleFindMy via the "congealment" mechanism. This means
-    the Bermuda entity's HA device will have GoogleFindMy identifiers, making
-    matching straightforward.
-
-    See: jleinenbach/bermuda - custom_components/bermuda/entity.py
-         docs/google_find_my_support.md
+    Strategy for matching Bermuda trackers to GoogleFindMy devices:
+    1. Entity name matching: Extract base name from Bermuda entity ID
+       - Bermuda: device_tracker.moto_tag_jens_schlusselbund_bermuda_tracker_2
+       - GoogleFindMy: device_tracker.moto_tag_jens_schlusselbund
+       - Base name: moto_tag_jens_schlusselbund
+    2. Device identifier matching (congealment fallback)
 
     Args:
         hass: Home Assistant instance
-        ha_device_id: Home Assistant device registry ID
+        ha_device_id: Home Assistant device registry ID (Bermuda device)
+        entity_id: Bermuda entity ID for name-based matching
 
     Returns:
         Dict with device_id, config_entry_id, coordinator, or None if not found
@@ -359,7 +360,112 @@ async def _async_find_googlefindmy_device(
     if not domain_data:
         return None
 
-    # Get device registry to check identifiers
+    # Strategy 1: Match by entity name pattern
+    if entity_id:
+        match = await _match_by_entity_name(hass, entity_id, domain_data)
+        if match:
+            return match
+
+    # Strategy 2: Fall back to device identifier matching (congealment)
+    match = await _match_by_device_identifiers(hass, ha_device_id, domain_data)
+    if match:
+        return match
+
+    return None
+
+
+async def _match_by_entity_name(  # noqa: PLR0911
+    hass: HomeAssistant,
+    bermuda_entity_id: str,
+    domain_data: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Match Bermuda entity to GoogleFindMy device by entity name pattern.
+
+    Bermuda creates entities with pattern: {googlefindmy_entity}_bermuda_tracker[_N]
+    We extract the base name and look for a matching GoogleFindMy entity.
+    """
+    import re  # noqa: PLC0415
+
+    # Extract base name: device_tracker.{name}_bermuda_tracker[_N] -> {name}
+    match = re.match(
+        r"device_tracker\.(.+?)_bermuda_tracker(?:_\d+)?$",
+        bermuda_entity_id,
+    )
+    if not match:
+        _LOGGER.debug("Cannot extract base name from Bermuda entity: %s", bermuda_entity_id)
+        return None
+
+    base_name = match.group(1)
+    target_entity_id = f"device_tracker.{base_name}"
+
+    _LOGGER.debug(
+        "Bermuda entity %s -> looking for GoogleFindMy entity %s",
+        bermuda_entity_id,
+        target_entity_id,
+    )
+
+    # Get entity registry to find the GoogleFindMy entity
+    ent_reg = er.async_get(hass)
+    gfm_entity = ent_reg.async_get(target_entity_id)
+
+    if not gfm_entity:
+        _LOGGER.debug("No GoogleFindMy entity found with ID: %s", target_entity_id)
+        return None
+
+    if gfm_entity.domain != "device_tracker" or gfm_entity.platform != DOMAIN:
+        _LOGGER.debug(
+            "Entity %s is not a GoogleFindMy device_tracker (domain=%s, platform=%s)",
+            target_entity_id,
+            gfm_entity.domain,
+            gfm_entity.platform,
+        )
+        return None
+
+    # Found GoogleFindMy entity - get its coordinator
+    gfm_device_id = gfm_entity.device_id
+    config_entry_id = gfm_entity.config_entry_id
+
+    if not config_entry_id:
+        return None
+
+    entry_data = domain_data.get(config_entry_id)
+    if not isinstance(entry_data, dict):
+        return None
+
+    coordinator = entry_data.get("coordinator")
+    if not coordinator:
+        return None
+
+    # Extract Google device ID from entity unique_id
+    # Format: "{config_entry_id}:{google_device_id}" or just "{google_device_id}"
+    google_device_id = gfm_entity.unique_id
+    if google_device_id and ":" in google_device_id:
+        google_device_id = google_device_id.split(":")[-1]
+
+    _LOGGER.info(
+        "Matched Bermuda entity %s to GoogleFindMy device %s",
+        bermuda_entity_id,
+        google_device_id,
+    )
+
+    return {
+        "device_id": google_device_id,
+        "config_entry_id": config_entry_id,
+        "coordinator": coordinator,
+        "ha_device_id": gfm_device_id,
+    }
+
+
+async def _match_by_device_identifiers(
+    hass: HomeAssistant,
+    ha_device_id: str,
+    domain_data: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Match by device identifiers (congealment fallback).
+
+    For FMDN devices using congealment, the Bermuda entity's HA device
+    will have GoogleFindMy identifiers, making matching straightforward.
+    """
     dev_reg = dr.async_get(hass)
     device_entry = dev_reg.async_get(ha_device_id)
 
@@ -375,23 +481,15 @@ async def _async_find_googlefindmy_device(
         if not coordinator:
             continue
 
-        # Check if this coordinator has a device matching our HA device
         device_identities = getattr(coordinator, "_device_identities", {})
 
         for google_device_id, identity in device_identities.items():
-            # For FMDN devices, Bermuda copies GoogleFindMy's identifiers
-            # so we check if any identifier contains the google_device_id.
-            # Identifier formats:
-            #   - (DOMAIN, "device_id")
-            #   - (DOMAIN, "entry_id:device_id")
-            #   - (DOMAIN, "entry_id:subentry_id:device_id")
             for identifier in device_entry.identifiers:
                 if identifier[0] == DOMAIN:
                     id_str = str(identifier[1])
-                    # Check exact match or suffix match (for namespaced IDs)
                     if id_str == google_device_id or id_str.endswith(f":{google_device_id}"):
                         _LOGGER.debug(
-                            "FMDN device matched: ha_device=%s, google_device=%s",
+                            "FMDN device matched via identifiers: ha_device=%s, google_device=%s",
                             ha_device_id,
                             google_device_id,
                         )
@@ -402,7 +500,6 @@ async def _async_find_googlefindmy_device(
                             "identity": identity,
                         }
 
-    # No match found - this is normal for non-FMDN BLE devices tracked by Bermuda
     return None
 
 

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -3,6 +3,33 @@
 Listens to Bermuda device_tracker state changes to detect area changes
 and trigger FMDN location uploads to Google's Find My Device network.
 
+CRITICAL: Device Matching via Congealment
+=========================================
+Bermuda uses "congealment" to attach its entities to EXISTING HA devices.
+This means:
+
+    ┌─────────────────────────────────────────────────────────────────┐
+    │  SAME HA Device (e.g., "moto tag Jens' Schlüsselbund")          │
+    │  HA Device ID: 11b2838b4bb2ba2eb5f4f4b2c742cbf9                 │
+    │                                                                 │
+    │  ┌─────────────────────────┐  ┌─────────────────────────────┐  │
+    │  │ GoogleFindMy Entity     │  │ Bermuda Entity              │  │
+    │  │ device_tracker.moto_... │  │ device_tracker.moto_..._2   │  │
+    │  │ platform: googlefindmy  │  │ platform: bermuda           │  │
+    │  └─────────────────────────┘  └─────────────────────────────┘  │
+    └─────────────────────────────────────────────────────────────────┘
+
+To find the GoogleFindMy device for a Bermuda tracker:
+1. Get the HA device_id from the Bermuda entity (via entity registry)
+2. Find ALL entities belonging to that HA device
+3. Look for the entity with platform="googlefindmy" and domain="device_tracker"
+4. Extract the Google device ID from that entity's unique_id
+
+WARNING: DO NOT match by:
+- Entity names (users can rename entities at any time!)
+- Device identifiers (Bermuda doesn't add googlefindmy identifiers)
+- MAC addresses (BLE MACs rotate for privacy)
+
 Architecture
 ------------
 Bermuda (jleinenbach/bermuda fork) integrates with GoogleFindMy via the
@@ -10,16 +37,14 @@ EID Resolver API (see docs/google_find_my_support.md):
 
 1. Bermuda detects FMDN BLE advertisements containing EIDs
 2. EID Resolver maps EIDs to GoogleFindMy devices via precomputed lookup
-3. Bermuda creates "metadevices" with fmdn_device_id pointing to HA Device Registry
-4. For FMDN devices, Bermuda uses the SAME identifiers as GoogleFindMy (congealment)
-   - This means Bermuda entities appear under the same HA device as GoogleFindMy
-   - Identifier matching works because both share (DOMAIN, device_id) tuples
+3. Bermuda attaches its entities to the SAME HA device as GoogleFindMy
+4. Both integrations share one HA device, but have separate entities
 
 Entity Pattern: device_tracker.*_bermuda_tracker*
 Attributes: area (semantic location), scanner (BLE scanner name)
 
 Flow:
-- Bermuda area change detected → find GoogleFindMy device via shared identifiers
+- Bermuda area change detected → find GoogleFindMy entity on SAME HA device
 - Get current EID from GoogleFindMy coordinator's identity keys
 - Upload semantic location to Google FMDN backend
 
@@ -340,11 +365,27 @@ async def _async_find_googlefindmy_device(
 ) -> dict[str, Any] | None:
     """Find GoogleFindMy device data for a Bermuda tracker.
 
-    Via Bermuda's "congealment" mechanism, Bermuda entities are attached to
-    the SAME HA device as GoogleFindMy entities. So we:
-    1. Find all entities belonging to the same HA device
-    2. Look for a GoogleFindMy device_tracker entity among them
-    3. Extract the Google device ID from that entity
+    CRITICAL: This uses Bermuda's "congealment" mechanism where Bermuda
+    entities are attached to the SAME HA device as GoogleFindMy entities.
+
+    Algorithm:
+        1. Use entity registry to find ALL entities for the given HA device
+        2. Filter for entities where platform="googlefindmy" AND domain="device_tracker"
+        3. Extract Google device ID from the entity's unique_id
+
+    Example:
+        HA Device: "moto tag Jens' Schlüsselbund" (ID: 11b2838b...)
+        Contains:
+          - device_tracker.moto_tag_jens_schlusselbund (platform=googlefindmy)
+          - device_tracker.moto_tag_jens_schlusselbund_bermuda_tracker_2 (platform=bermuda)
+
+        When Bermuda triggers with ha_device_id="11b2838b...", we find the
+        googlefindmy entity and extract its Google device ID.
+
+    WARNING - DO NOT USE THESE MATCHING STRATEGIES:
+        - Entity name matching: Users can rename entities!
+        - Device identifier matching: Bermuda doesn't add googlefindmy identifiers
+        - MAC address matching: BLE MACs rotate for privacy
 
     Args:
         hass: Home Assistant instance

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -40,7 +40,6 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import Event, HomeAssistant, State, callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 if TYPE_CHECKING:
@@ -341,17 +340,16 @@ async def _async_find_googlefindmy_device(
 ) -> dict[str, Any] | None:
     """Find GoogleFindMy device data for a Bermuda tracker.
 
-    Strategy for matching Bermuda trackers to GoogleFindMy devices:
-    1. Entity name matching: Extract base name from Bermuda entity ID
-       - Bermuda: device_tracker.moto_tag_jens_schlusselbund_bermuda_tracker_2
-       - GoogleFindMy: device_tracker.moto_tag_jens_schlusselbund
-       - Base name: moto_tag_jens_schlusselbund
-    2. Device identifier matching (congealment fallback)
+    Via Bermuda's "congealment" mechanism, Bermuda entities are attached to
+    the SAME HA device as GoogleFindMy entities. So we:
+    1. Find all entities belonging to the same HA device
+    2. Look for a GoogleFindMy device_tracker entity among them
+    3. Extract the Google device ID from that entity
 
     Args:
         hass: Home Assistant instance
-        ha_device_id: Home Assistant device registry ID (Bermuda device)
-        entity_id: Bermuda entity ID for name-based matching
+        ha_device_id: Home Assistant device registry ID (shared by both integrations)
+        entity_id: Bermuda entity ID (unused, kept for API compatibility)
 
     Returns:
         Dict with device_id, config_entry_id, coordinator, or None if not found
@@ -360,71 +358,28 @@ async def _async_find_googlefindmy_device(
     if not domain_data:
         return None
 
-    # Strategy 1: Match by entity name pattern
-    if entity_id:
-        match = await _match_by_entity_name(hass, entity_id, domain_data)
-        if match:
-            return match
-
-    # Strategy 2: Fall back to device identifier matching (congealment)
-    match = await _match_by_device_identifiers(hass, ha_device_id, domain_data)
-    if match:
-        return match
-
-    return None
-
-
-async def _match_by_entity_name(  # noqa: PLR0911
-    hass: HomeAssistant,
-    bermuda_entity_id: str,
-    domain_data: dict[str, Any],
-) -> dict[str, Any] | None:
-    """Match Bermuda entity to GoogleFindMy device by entity name pattern.
-
-    Bermuda creates entities with pattern: {googlefindmy_entity}_bermuda_tracker[_N]
-    We extract the base name and look for a matching GoogleFindMy entity.
-    """
-    import re  # noqa: PLC0415
-
-    # Extract base name: device_tracker.{name}_bermuda_tracker[_N] -> {name}
-    match = re.match(
-        r"device_tracker\.(.+?)_bermuda_tracker(?:_\d+)?$",
-        bermuda_entity_id,
-    )
-    if not match:
-        _LOGGER.debug("Cannot extract base name from Bermuda entity: %s", bermuda_entity_id)
-        return None
-
-    base_name = match.group(1)
-    target_entity_id = f"device_tracker.{base_name}"
-
-    _LOGGER.debug(
-        "Bermuda entity %s -> looking for GoogleFindMy entity %s",
-        bermuda_entity_id,
-        target_entity_id,
-    )
-
-    # Get entity registry to find the GoogleFindMy entity
+    # Get entity registry to find all entities for this device
     ent_reg = er.async_get(hass)
-    gfm_entity = ent_reg.async_get(target_entity_id)
+
+    # Find all entities belonging to this HA device
+    device_entities = er.async_entries_for_device(ent_reg, ha_device_id)
+
+    # Look for a GoogleFindMy device_tracker entity
+    gfm_entity = None
+    for entity in device_entities:
+        if entity.domain == "device_tracker" and entity.platform == DOMAIN:
+            gfm_entity = entity
+            break
 
     if not gfm_entity:
-        _LOGGER.debug("No GoogleFindMy entity found with ID: %s", target_entity_id)
-        return None
-
-    if gfm_entity.domain != "device_tracker" or gfm_entity.platform != DOMAIN:
         _LOGGER.debug(
-            "Entity %s is not a GoogleFindMy device_tracker (domain=%s, platform=%s)",
-            target_entity_id,
-            gfm_entity.domain,
-            gfm_entity.platform,
+            "No GoogleFindMy device_tracker found for HA device %s",
+            ha_device_id,
         )
         return None
 
-    # Found GoogleFindMy entity - get its coordinator
-    gfm_device_id = gfm_entity.device_id
+    # Get coordinator from config entry
     config_entry_id = gfm_entity.config_entry_id
-
     if not config_entry_id:
         return None
 
@@ -443,64 +398,18 @@ async def _match_by_entity_name(  # noqa: PLR0911
         google_device_id = google_device_id.split(":")[-1]
 
     _LOGGER.info(
-        "Matched Bermuda entity %s to GoogleFindMy device %s",
-        bermuda_entity_id,
+        "Found GoogleFindMy device %s for HA device %s (entity: %s)",
         google_device_id,
+        ha_device_id,
+        gfm_entity.entity_id,
     )
 
     return {
         "device_id": google_device_id,
         "config_entry_id": config_entry_id,
         "coordinator": coordinator,
-        "ha_device_id": gfm_device_id,
+        "ha_device_id": ha_device_id,
     }
-
-
-async def _match_by_device_identifiers(
-    hass: HomeAssistant,
-    ha_device_id: str,
-    domain_data: dict[str, Any],
-) -> dict[str, Any] | None:
-    """Match by device identifiers (congealment fallback).
-
-    For FMDN devices using congealment, the Bermuda entity's HA device
-    will have GoogleFindMy identifiers, making matching straightforward.
-    """
-    dev_reg = dr.async_get(hass)
-    device_entry = dev_reg.async_get(ha_device_id)
-
-    if not device_entry:
-        return None
-
-    # Check each config entry's coordinator for matching devices
-    for entry_id, entry_data in domain_data.items():
-        if not isinstance(entry_data, dict):
-            continue
-
-        coordinator = entry_data.get("coordinator")
-        if not coordinator:
-            continue
-
-        device_identities = getattr(coordinator, "_device_identities", {})
-
-        for google_device_id, identity in device_identities.items():
-            for identifier in device_entry.identifiers:
-                if identifier[0] == DOMAIN:
-                    id_str = str(identifier[1])
-                    if id_str == google_device_id or id_str.endswith(f":{google_device_id}"):
-                        _LOGGER.debug(
-                            "FMDN device matched via identifiers: ha_device=%s, google_device=%s",
-                            ha_device_id,
-                            google_device_id,
-                        )
-                        return {
-                            "device_id": google_device_id,
-                            "config_entry_id": entry_id,
-                            "coordinator": coordinator,
-                            "identity": identity,
-                        }
-
-    return None
 
 
 async def _async_get_device_eid(

--- a/custom_components/googlefindmy/fmdn_finder/location_uploader.py
+++ b/custom_components/googlefindmy/fmdn_finder/location_uploader.py
@@ -32,7 +32,8 @@ _LOGGER = logging.getLogger(__name__)
 
 # Upload throttling constants (per FMDN spec Section 4)
 MIN_UPLOAD_DISTANCE_METERS = 50  # Minimum distance change to trigger upload
-MIN_UPLOAD_INTERVAL_SECONDS = 300  # 5 minutes minimum between uploads
+MIN_UPLOAD_INTERVAL_SECONDS = 300  # 5 minutes minimum between uploads for GPS-only
+MIN_UPLOAD_INTERVAL_SEMANTIC = 60  # 1 minute minimum for semantic location changes
 MIN_UPLOAD_INTERVAL_SCREEN_OFF = 300  # Additional delay when screen off
 MIN_UPLOAD_INTERVAL_BATTERY_SAVER = 900  # 15 minutes in battery saver mode
 
@@ -75,6 +76,7 @@ class UploadCacheEntry:
     eid_hex: str
     location: LocationData
     timestamp: float
+    semantic_area: str | None = None  # Track semantic area for change detection
 
 
 async def async_process_fmdn_beacon_detection(  # noqa: PLR0913
@@ -137,12 +139,14 @@ async def async_process_fmdn_beacon_detection(  # noqa: PLR0913
         location.zone_name,
     )
 
-    # 2. Check upload throttling
-    should_upload, reason = await _should_upload_location(hass, eid_hex, location)
+    # 2. Check upload throttling (pass area for semantic upload handling)
+    should_upload, reason = await _should_upload_location(hass, eid_hex, location, area)
 
     if not should_upload:
         _LOGGER.debug("Upload throttled for EID %s...: %s", eid_hex[:EID_LOG_PREFIX_LENGTH], reason)
         return False
+
+    _LOGGER.info("Upload allowed for EID %s...: %s", eid_hex[:EID_LOG_PREFIX_LENGTH], reason)
 
     _LOGGER.info(
         "Uploading FMDN location report: EID=%s..., zone=%s, accuracy=%dm",
@@ -161,8 +165,8 @@ async def async_process_fmdn_beacon_detection(  # noqa: PLR0913
         success = await _encrypt_and_upload_location(hass, eid, location, area)
 
         if success:
-            # Update cache on successful upload
-            _update_upload_cache(hass, eid_hex, location)
+            # Update cache on successful upload (including semantic area for throttling)
+            _update_upload_cache(hass, eid_hex, location, area)
 
             # Update semantic_name in coordinator for device_tracker display
             if google_device_id and coordinator and area:
@@ -284,10 +288,11 @@ async def _get_scanner_device_location(
     return None
 
 
-async def _should_upload_location(
+async def _should_upload_location(  # noqa: PLR0911
     hass: HomeAssistant,
     eid_hex: str,
     new_location: LocationData,
+    semantic_area: str | None = None,
 ) -> tuple[bool, str]:
     """Check if location should be uploaded (throttling per FMDN spec).
 
@@ -295,10 +300,15 @@ async def _should_upload_location(
     - Upload if distance_grew OR accuracy_improved OR sufficient_time_elapsed
     - Additional delays when screen_off or battery_saver mode
 
+    For semantic location uploads (from Bermuda areas):
+    - Allow upload if semantic area changed (even without GPS distance change)
+    - Use shorter throttle interval (MIN_UPLOAD_INTERVAL_SEMANTIC)
+
     Args:
         hass: Home Assistant instance
         eid_hex: EID as hex string (cache key)
         new_location: New location to upload
+        semantic_area: Semantic location name (e.g., "Büro", "Wohnzimmer")
 
     Returns:
         Tuple of (should_upload: bool, reason: str)
@@ -317,7 +327,20 @@ async def _should_upload_location(
     # Check time elapsed
     elapsed = time.time() - last_upload.timestamp
 
-    if elapsed < MIN_UPLOAD_INTERVAL_SECONDS:
+    # For semantic area uploads, check if area changed
+    if semantic_area:
+        # If area changed, use shorter throttle interval
+        if last_upload.semantic_area != semantic_area:
+            if elapsed >= MIN_UPLOAD_INTERVAL_SEMANTIC:
+                return True, f"semantic_area_changed ({last_upload.semantic_area} -> {semantic_area})"
+            return False, f"semantic_area_changed_too_soon ({elapsed:.0f}s < {MIN_UPLOAD_INTERVAL_SEMANTIC}s)"
+
+        # Same area - use longer interval and require significant change
+        if elapsed < MIN_UPLOAD_INTERVAL_SECONDS:
+            return False, f"same_area_too_soon ({elapsed:.0f}s < {MIN_UPLOAD_INTERVAL_SECONDS}s)"
+
+    # GPS-only upload - standard throttling
+    elif elapsed < MIN_UPLOAD_INTERVAL_SECONDS:
         return False, f"too_soon ({elapsed:.0f}s < {MIN_UPLOAD_INTERVAL_SECONDS}s)"
 
     # After minimum interval, upload if ANY of: distance grew, accuracy improved
@@ -339,6 +362,10 @@ async def _should_upload_location(
 
     if accuracy_improved:
         return True, f"accuracy_improved ({new_location.accuracy}m < {last_upload.location.accuracy}m)"
+
+    # For semantic uploads, allow periodic refresh even without GPS change
+    if semantic_area and elapsed >= MIN_UPLOAD_INTERVAL_SECONDS:
+        return True, f"semantic_periodic_refresh (elapsed={elapsed:.0f}s)"
 
     # No significant change
     return False, f"too_close ({distance:.0f}m < {MIN_UPLOAD_DISTANCE_METERS}m, accuracy not improved)"
@@ -449,11 +476,19 @@ async def _encrypt_and_upload_location(
     Uses existing crypto primitives from foreign_tracker_cryptor.py
     and protobuf definitions from LocationReportsUpload_pb2.
 
+    For semantic locations (from Bermuda areas), we send:
+    - status = SEMANTIC (0)
+    - semanticLocation.locationName = area name
+
+    For GPS locations, we additionally send:
+    - geoLocation.encryptedReport with encrypted GPS data
+    - geoLocation.accuracy
+
     Args:
         hass: Home Assistant instance
         eid: Ephemeral Identity Key (20 or 32 bytes)
         location: Location to upload
-        semantic_area: Optional semantic location name for logging
+        semantic_area: Optional semantic location name (e.g., "Büro", "Wohnzimmer")
 
     Returns:
         True if upload succeeded, False otherwise
@@ -464,34 +499,34 @@ async def _encrypt_and_upload_location(
     """
     # Lazy imports to avoid loading heavy crypto libraries at startup
     from ..FMDNCrypto.foreign_tracker_cryptor import encrypt  # noqa: PLC0415
-    from ..ProtoDecoders.Common_pb2 import LocationReport  # noqa: PLC0415
+    from ..ProtoDecoders.Common_pb2 import (  # noqa: PLC0415
+        EncryptedReport,
+        GeoLocation,
+        LocationReport,
+        SemanticLocation,
+        Status,
+    )
     from ..ProtoDecoders.LocationReportsUpload_pb2 import (  # noqa: PLC0415
         LocationReportsUpload,
     )
 
-    # 1. Create LocationReport protobuf
-    location_proto = LocationReport()
-    location_proto.latitudeE7 = int(location.latitude * 1e7)
-    location_proto.longitudeE7 = int(location.longitude * 1e7)
-    location_proto.accuracyMeters = location.accuracy
-    location_proto.timestampMs = int(time.time() * 1000)
-
-    location_bytes = location_proto.SerializeToString()
+    # 1. Create raw GPS data for encryption (simple lat/lon format)
+    # Note: This is the inner encrypted payload, not the outer protobuf
+    gps_data = f"{location.latitude:.7f},{location.longitude:.7f}".encode()
 
     _LOGGER.debug(
-        "Location protobuf: %d bytes, lat=%d, lon=%d, acc=%dm",
-        len(location_bytes),
-        location_proto.latitudeE7,
-        location_proto.longitudeE7,
-        location_proto.accuracyMeters,
+        "GPS data for encryption: %s (accuracy=%dm, zone=%s)",
+        gps_data.decode(),
+        location.accuracy,
+        location.zone_name,
     )
 
-    # 2. Encrypt with EID public key (ECDH + AES-EAX)
+    # 2. Encrypt GPS data with EID public key (ECDH + AES-EAX)
     random_bytes = secrets.token_bytes(32)
 
     try:
         encrypted_and_tag, Sx = encrypt(
-            message=location_bytes,
+            message=gps_data,
             random=random_bytes,
             eid=eid,
         )
@@ -505,7 +540,42 @@ async def _encrypt_and_upload_location(
         Sx.hex()[:16],
     )
 
-    # 3. Create LocationReportsUpload protobuf
+    # 3. Create LocationReport protobuf with proper structure
+    location_report = LocationReport()
+
+    # Set semantic location if available (primary for Bermuda area-based uploads)
+    if semantic_area:
+        location_report.semanticLocation.CopyFrom(
+            SemanticLocation(locationName=semantic_area)
+        )
+        location_report.status = Status.SEMANTIC
+        _LOGGER.debug("Setting semantic location: '%s'", semantic_area)
+    else:
+        location_report.status = Status.CROWDSOURCED
+
+    # Add encrypted GPS data
+    encrypted_report = EncryptedReport(
+        publicKeyRandom=Sx,  # Ephemeral public key (x-coordinate)
+        encryptedLocation=encrypted_and_tag,
+        isOwnReport=True,  # This is from our own scanner
+    )
+
+    location_report.geoLocation.CopyFrom(
+        GeoLocation(
+            encryptedReport=encrypted_report,
+            deviceTimeOffset=0,  # Offset from report.time
+            accuracy=float(location.accuracy),
+        )
+    )
+
+    _LOGGER.debug(
+        "LocationReport: status=%s, semantic='%s', accuracy=%.0fm",
+        Status.Name(location_report.status),
+        semantic_area or "(none)",
+        location.accuracy,
+    )
+
+    # 4. Create LocationReportsUpload protobuf
     upload = LocationReportsUpload()
     upload.random1 = secrets.randbits(64)
     upload.random2 = secrets.randbits(64)
@@ -514,33 +584,36 @@ async def _encrypt_and_upload_location(
     report.advertisement.identifier.truncatedEid = eid[:10]
     report.advertisement.unwantedTrackingModeEnabled = 0
     report.time.seconds = int(time.time())
-
-    # Note: The protobuf structure may need adjustment based on actual FMDN API
-    # Current structure based on LocationReportsUpload.proto
-    # Encrypted data and ephemeral key need to be embedded correctly
-    # This is a placeholder - actual field mapping TBD from Google API analysis
+    report.location.CopyFrom(location_report)
 
     upload_bytes = upload.SerializeToString()
 
-    _LOGGER.debug(
-        "Upload protobuf: %d bytes%s",
+    _LOGGER.info(
+        "Upload protobuf: %d bytes, semantic='%s', EID=%s...",
         len(upload_bytes),
-        f", semantic_area='{semantic_area}'" if semantic_area else "",
+        semantic_area or "(GPS only)",
+        eid[:8].hex(),
     )
 
-    # 4. Upload to Google FMDN backend
+    # 5. Upload to Google FMDN backend
     from .google_uploader import async_upload_to_google_fmdn  # noqa: PLC0415
 
     return await async_upload_to_google_fmdn(hass, upload_bytes, eid[:10].hex())
 
 
-def _update_upload_cache(hass: HomeAssistant, eid_hex: str, location: LocationData) -> None:
+def _update_upload_cache(
+    hass: HomeAssistant,
+    eid_hex: str,
+    location: LocationData,
+    semantic_area: str | None = None,
+) -> None:
     """Update upload cache with latest upload timestamp and location.
 
     Args:
         hass: Home Assistant instance
         eid_hex: EID as hex string
         location: Uploaded location
+        semantic_area: Semantic location name for throttling comparison
     """
     upload_cache: dict[str, UploadCacheEntry] = hass.data.setdefault(
         DATA_FMDN_UPLOAD_CACHE, {}
@@ -550,6 +623,7 @@ def _update_upload_cache(hass: HomeAssistant, eid_hex: str, location: LocationDa
         eid_hex=eid_hex,
         location=location,
         timestamp=time.time(),
+        semantic_area=semantic_area,
     )
 
     # Cleanup old entries (keep last UPLOAD_CACHE_MAX_ENTRIES)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1596,6 +1596,19 @@ def _stub_homeassistant() -> None:
         _async_entries_for_config_entry
     )
 
+    def _async_entries_for_device(
+        registry: _StubEntityRegistry,
+        device_id: str,
+        include_disabled_entities: bool = False,
+    ) -> list[_StubEntityRegistryEntry]:
+        """Get all entity registry entries for a device."""
+        return [
+            entry for entry in registry.entities.values()
+            if getattr(entry, "device_id", None) == device_id
+        ]
+
+    entity_registry_module.async_entries_for_device = _async_entries_for_device
+
     util_pkg = sys.modules.setdefault(
         "homeassistant.util", ModuleType("homeassistant.util")
     )

--- a/tests/test_fmdn_finder_bermuda_listener.py
+++ b/tests/test_fmdn_finder_bermuda_listener.py
@@ -237,3 +237,224 @@ def hass_mock() -> MagicMock:
     hass.bus.async_listen = MagicMock(return_value=MagicMock())  # Return unsubscribe callable
     hass.async_create_task = MagicMock()
     return hass
+
+
+# =============================================================================
+# Tests for Congealment-based Device Matching
+# =============================================================================
+# CRITICAL: These tests verify that we correctly find GoogleFindMy devices
+# via Bermuda's congealment mechanism (shared HA device).
+#
+# The matching MUST use:
+#   1. Entity registry lookup by HA device_id
+#   2. Filter entities by platform="googlefindmy" and domain="device_tracker"
+#
+# The matching MUST NOT use:
+#   - Entity name matching (users can rename!)
+#   - Device identifier matching (Bermuda doesn't add googlefindmy identifiers)
+#   - MAC address matching (BLE MACs rotate)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_find_googlefindmy_device_via_congealment() -> None:
+    """Test finding GoogleFindMy device when it shares HA device with Bermuda.
+
+    This is the CRITICAL test for congealment. Bermuda attaches its entity
+    to the SAME HA device as GoogleFindMy. We must find the GoogleFindMy
+    entity by looking up ALL entities for the shared HA device.
+    """
+    from unittest.mock import patch
+
+    from custom_components.googlefindmy.fmdn_finder.bermuda_listener import (
+        _async_find_googlefindmy_device,
+    )
+
+    # Setup mock hass with domain data
+    hass = MagicMock()
+    mock_coordinator = MagicMock()
+    hass.data = {
+        "googlefindmy": {
+            "test_config_entry_id": {
+                "coordinator": mock_coordinator,
+            }
+        }
+    }
+
+    # Create mock entity registry entries for SAME HA device
+    ha_device_id = "11b2838b4bb2ba2eb5f4f4b2c742cbf9"
+
+    # GoogleFindMy entity (platform=googlefindmy)
+    gfm_entity = MagicMock()
+    gfm_entity.entity_id = "device_tracker.moto_tag_jens_schlusselbund"
+    gfm_entity.domain = "device_tracker"
+    gfm_entity.platform = "googlefindmy"
+    gfm_entity.device_id = ha_device_id
+    gfm_entity.config_entry_id = "test_config_entry_id"
+    gfm_entity.unique_id = "test_config_entry_id:google_device_12345"
+
+    # Bermuda entity (platform=bermuda) - same HA device!
+    bermuda_entity = MagicMock()
+    bermuda_entity.entity_id = "device_tracker.moto_tag_jens_schlusselbund_bermuda_tracker_2"
+    bermuda_entity.domain = "device_tracker"
+    bermuda_entity.platform = "bermuda"
+    bermuda_entity.device_id = ha_device_id  # SAME device!
+
+    # Mock entity registry
+    mock_ent_reg = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get",
+        return_value=mock_ent_reg,
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_device",
+        return_value=[gfm_entity, bermuda_entity],  # Both entities on same device
+    ):
+        result = await _async_find_googlefindmy_device(hass, ha_device_id)
+
+    # Should find the GoogleFindMy entity
+    assert result is not None
+    assert result["device_id"] == "google_device_12345"
+    assert result["config_entry_id"] == "test_config_entry_id"
+    assert result["coordinator"] == mock_coordinator
+
+
+@pytest.mark.asyncio
+async def test_find_googlefindmy_device_no_gfm_entity_on_device() -> None:
+    """Test that we return None when no GoogleFindMy entity exists on the device.
+
+    This can happen for regular BLE devices tracked by Bermuda that are
+    NOT GoogleFindMy/FMDN devices.
+    """
+    from unittest.mock import patch
+
+    from custom_components.googlefindmy.fmdn_finder.bermuda_listener import (
+        _async_find_googlefindmy_device,
+    )
+
+    hass = MagicMock()
+    hass.data = {"googlefindmy": {"config_entry": {"coordinator": MagicMock()}}}
+
+    ha_device_id = "some_other_device_id"
+
+    # Only Bermuda entity, no GoogleFindMy entity
+    bermuda_only_entity = MagicMock()
+    bermuda_only_entity.entity_id = "device_tracker.tile_wallet_bermuda_tracker"
+    bermuda_only_entity.domain = "device_tracker"
+    bermuda_only_entity.platform = "bermuda"
+    bermuda_only_entity.device_id = ha_device_id
+
+    mock_ent_reg = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get",
+        return_value=mock_ent_reg,
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_device",
+        return_value=[bermuda_only_entity],  # No GoogleFindMy entity
+    ):
+        result = await _async_find_googlefindmy_device(hass, ha_device_id)
+
+    # Should return None - no GoogleFindMy device
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_googlefindmy_device_extracts_device_id_from_unique_id() -> None:
+    """Test that Google device ID is correctly extracted from unique_id.
+
+    unique_id format: "{config_entry_id}:{google_device_id}"
+    We need to extract just the google_device_id part.
+    """
+    from unittest.mock import patch
+
+    from custom_components.googlefindmy.fmdn_finder.bermuda_listener import (
+        _async_find_googlefindmy_device,
+    )
+
+    hass = MagicMock()
+    hass.data = {
+        "googlefindmy": {
+            "entry_abc123": {"coordinator": MagicMock()},
+        }
+    }
+
+    ha_device_id = "shared_device_id"
+
+    gfm_entity = MagicMock()
+    gfm_entity.entity_id = "device_tracker.pixel_buds"
+    gfm_entity.domain = "device_tracker"
+    gfm_entity.platform = "googlefindmy"
+    gfm_entity.device_id = ha_device_id
+    gfm_entity.config_entry_id = "entry_abc123"
+    # unique_id with colon separator
+    gfm_entity.unique_id = "entry_abc123:actual_google_device_id_xyz"
+
+    mock_ent_reg = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get",
+        return_value=mock_ent_reg,
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_device",
+        return_value=[gfm_entity],
+    ):
+        result = await _async_find_googlefindmy_device(hass, ha_device_id)
+
+    assert result is not None
+    # Should extract the part after the colon
+    assert result["device_id"] == "actual_google_device_id_xyz"
+
+
+@pytest.mark.asyncio
+async def test_find_googlefindmy_device_ignores_non_device_tracker_entities() -> None:
+    """Test that we only match device_tracker entities, not sensors etc.
+
+    GoogleFindMy creates multiple entity types. We specifically need
+    the device_tracker for location uploads.
+    """
+    from unittest.mock import patch
+
+    from custom_components.googlefindmy.fmdn_finder.bermuda_listener import (
+        _async_find_googlefindmy_device,
+    )
+
+    hass = MagicMock()
+    hass.data = {
+        "googlefindmy": {
+            "config_entry": {"coordinator": MagicMock()},
+        }
+    }
+
+    ha_device_id = "device_with_sensors"
+
+    # GoogleFindMy sensor (NOT device_tracker)
+    gfm_sensor = MagicMock()
+    gfm_sensor.entity_id = "sensor.moto_tag_battery"
+    gfm_sensor.domain = "sensor"  # NOT device_tracker
+    gfm_sensor.platform = "googlefindmy"
+    gfm_sensor.device_id = ha_device_id
+
+    # GoogleFindMy device_tracker (this is what we want)
+    gfm_tracker = MagicMock()
+    gfm_tracker.entity_id = "device_tracker.moto_tag"
+    gfm_tracker.domain = "device_tracker"
+    gfm_tracker.platform = "googlefindmy"
+    gfm_tracker.device_id = ha_device_id
+    gfm_tracker.config_entry_id = "config_entry"
+    gfm_tracker.unique_id = "target_device_id"
+
+    mock_ent_reg = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get",
+        return_value=mock_ent_reg,
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_device",
+        return_value=[gfm_sensor, gfm_tracker],  # Sensor comes first
+    ):
+        result = await _async_find_googlefindmy_device(hass, ha_device_id)
+
+    assert result is not None
+    # Should find the device_tracker, not the sensor
+    assert result["device_id"] == "target_device_id"


### PR DESCRIPTION
- bermuda_listener: Add 30-second area stabilization before upload
  - Prevents rapid "jumping" room changes from triggering uploads
  - AreaDebounceState dataclass tracks debounce state per entity
  - Only uploads after area is stable for AREA_STABILIZATION_SECONDS

- location_uploader: Fix protobuf structure for semantic locations
  - Use correct LocationReport fields (semanticLocation, geoLocation, status)
  - Set status=SEMANTIC for Bermuda area-based uploads
  - Include semanticLocation.locationName with area name
  - Add encrypted GPS data in geoLocation.encryptedReport

- location_uploader: Improved throttling for semantic uploads
  - Add MIN_UPLOAD_INTERVAL_SEMANTIC (60s) for area changes
  - Allow uploads when semantic_area changes (even without GPS change)
  - Track semantic_area in UploadCacheEntry for throttle comparison
  - Add "Upload allowed" info logging with reason

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
