### PR TITLE
Claude/google fmdn upload vke gc

### DIFF
--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -294,6 +294,8 @@ async def _async_handle_area_change(
         area: New area name (semantic location)
         attributes: Entity attributes (scanner, source, etc.)
     """
+    from homeassistant.helpers import device_registry as dr  # noqa: PLC0415
+
     # Get entity registry to find the HA device
     ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(entity_id)
@@ -304,8 +306,19 @@ async def _async_handle_area_change(
 
     ha_device_id = entity_entry.device_id
 
+    # Debug: Log entity and device information
+    dev_reg = dr.async_get(hass)
+    bermuda_device = dev_reg.async_get(ha_device_id)
+    _LOGGER.debug(
+        "Bermuda entity %s: device_id=%s, device_name=%s, identifiers=%s, via_device=%s",
+        entity_id,
+        ha_device_id,
+        bermuda_device.name if bermuda_device else None,
+        bermuda_device.identifiers if bermuda_device else None,
+        bermuda_device.via_device_id if bermuda_device else None,
+    )
+
     # Find the GoogleFindMy device data for this Bermuda tracker
-    # Uses entity name matching (primary) and device identifier matching (fallback)
     device_info = await _async_find_googlefindmy_device(hass, ha_device_id, entity_id)
 
     if not device_info:
@@ -420,20 +433,28 @@ async def _async_find_googlefindmy_device(
             break
 
     if not gfm_entity:
-        # Debug: Log all GoogleFindMy entities in the system
-        all_gfm_entities = [
-            (e.entity_id, e.device_id)
-            for e in ent_reg.entities.values()
-            if e.platform == DOMAIN and e.domain == "device_tracker"
-        ]
+        # Debug: Log all GoogleFindMy entities with their device info
+        from homeassistant.helpers import device_registry as dr  # noqa: PLC0415
+
+        dev_reg = dr.async_get(hass)
+        gfm_devices_info = []
+        for e in ent_reg.entities.values():
+            if e.platform == DOMAIN and e.domain == "device_tracker":
+                device = dev_reg.async_get(e.device_id) if e.device_id else None
+                gfm_devices_info.append({
+                    "entity_id": e.entity_id,
+                    "device_id": e.device_id,
+                    "device_name": device.name if device else None,
+                    "identifiers": list(device.identifiers) if device else None,
+                })
         _LOGGER.debug(
             "No GoogleFindMy device_tracker found for HA device %s "
             "(found %d entities on device, none with platform=%s). "
-            "All GoogleFindMy device_trackers in system: %s",
+            "All GoogleFindMy device_trackers: %s",
             ha_device_id,
             len(device_entities),
             DOMAIN,
-            all_gfm_entities,
+            gfm_devices_info,
         )
         return None
 

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -405,6 +405,13 @@ async def _async_find_googlefindmy_device(
     # Find all entities belonging to this HA device
     device_entities = er.async_entries_for_device(ent_reg, ha_device_id)
 
+    # Debug: Log all entities on this device
+    _LOGGER.debug(
+        "Entities on HA device %s: %s",
+        ha_device_id,
+        [(e.entity_id, e.platform, e.domain) for e in device_entities],
+    )
+
     # Look for a GoogleFindMy device_tracker entity
     gfm_entity = None
     for entity in device_entities:
@@ -413,9 +420,20 @@ async def _async_find_googlefindmy_device(
             break
 
     if not gfm_entity:
+        # Debug: Log all GoogleFindMy entities in the system
+        all_gfm_entities = [
+            (e.entity_id, e.device_id)
+            for e in ent_reg.entities.values()
+            if e.platform == DOMAIN and e.domain == "device_tracker"
+        ]
         _LOGGER.debug(
-            "No GoogleFindMy device_tracker found for HA device %s",
+            "No GoogleFindMy device_tracker found for HA device %s "
+            "(found %d entities on device, none with platform=%s). "
+            "All GoogleFindMy device_trackers in system: %s",
             ha_device_id,
+            len(device_entities),
+            DOMAIN,
+            all_gfm_entities,
         )
         return None
 


### PR DESCRIPTION
<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
