### PR TITLE
Claude/google fmdn upload vke gc

### DIFF
--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -468,29 +468,32 @@ async def _async_find_googlefindmy_device(
         )
         return None
 
-    _LOGGER.debug(
-        "Found GoogleFindMy entity %s with config_entry_id=%s, checking domain_data keys: %s",
-        gfm_entity.entity_id,
-        config_entry_id,
-        list(domain_data.keys()),
-    )
-
-    entry_data = domain_data.get(config_entry_id)
-    if not isinstance(entry_data, dict):
+    # Runtime data is stored in hass.data[DOMAIN]["entries"][config_entry_id]
+    entries_bucket = domain_data.get("entries", {})
+    if not isinstance(entries_bucket, dict):
         _LOGGER.debug(
-            "No entry_data dict for config_entry_id %s (got: %s, type: %s)",
-            config_entry_id,
-            entry_data,
-            type(entry_data).__name__,
+            "No entries bucket in domain_data (got: %s, type: %s)",
+            entries_bucket,
+            type(entries_bucket).__name__,
         )
         return None
 
-    coordinator = entry_data.get("coordinator")
+    runtime_data = entries_bucket.get(config_entry_id)
+    if runtime_data is None:
+        _LOGGER.debug(
+            "No runtime_data for config_entry_id %s (available entries: %s)",
+            config_entry_id,
+            list(entries_bucket.keys()),
+        )
+        return None
+
+    # RuntimeData is a dataclass with .coordinator attribute
+    coordinator = getattr(runtime_data, "coordinator", None)
     if not coordinator:
         _LOGGER.debug(
-            "No coordinator in entry_data for config_entry_id %s (keys: %s)",
+            "No coordinator in runtime_data for config_entry_id %s (runtime_data: %s)",
             config_entry_id,
-            list(entry_data.keys()),
+            type(runtime_data).__name__,
         )
         return None
 

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -462,14 +462,36 @@ async def _async_find_googlefindmy_device(
     # Get coordinator from config entry
     config_entry_id = gfm_entity.config_entry_id
     if not config_entry_id:
+        _LOGGER.debug(
+            "GoogleFindMy entity %s has no config_entry_id",
+            gfm_entity.entity_id,
+        )
         return None
+
+    _LOGGER.debug(
+        "Found GoogleFindMy entity %s with config_entry_id=%s, checking domain_data keys: %s",
+        gfm_entity.entity_id,
+        config_entry_id,
+        list(domain_data.keys()),
+    )
 
     entry_data = domain_data.get(config_entry_id)
     if not isinstance(entry_data, dict):
+        _LOGGER.debug(
+            "No entry_data dict for config_entry_id %s (got: %s, type: %s)",
+            config_entry_id,
+            entry_data,
+            type(entry_data).__name__,
+        )
         return None
 
     coordinator = entry_data.get("coordinator")
     if not coordinator:
+        _LOGGER.debug(
+            "No coordinator in entry_data for config_entry_id %s (keys: %s)",
+            config_entry_id,
+            list(entry_data.keys()),
+        )
         return None
 
     # Extract Google device ID from entity unique_id


### PR DESCRIPTION
<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
