### PR TITLE
fix(bermuda_listener): Use coordinator.get_active_device_identities()…

### DIFF
--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -530,60 +530,106 @@ async def _async_get_device_eid(
     Args:
         hass: Home Assistant instance
         coordinator: GoogleFindMyCoordinator instance
-        device_id: Google device ID
+        device_id: Google device UUID (e.g., "68419b51-0000-2131-873b-fc411691d329")
 
     Returns:
         Current EID bytes (20 or 32 bytes), or None if unavailable
     """
-    # Try to get EID from the EID resolver
-    eid_resolver = hass.data.get(DOMAIN, {}).get("eid_resolver")
+    # Get device identities from coordinator
+    get_identities = getattr(coordinator, "get_active_device_identities", None)
+    if not callable(get_identities):
+        _LOGGER.debug("Coordinator does not have get_active_device_identities method")
+        return None
 
-    if eid_resolver:
-        # Get device identity from coordinator
-        device_identities = getattr(coordinator, "_device_identities", {})
-        identity = device_identities.get(device_id)
+    try:
+        identities = get_identities()
+    except Exception as err:
+        _LOGGER.debug("Failed to get device identities: %s", err)
+        return None
 
-        if identity:
-            # Generate current EID using the identity key
-            identity_key = getattr(identity, "identity_key", None)
-            if identity_key:
-                try:
-                    import time  # noqa: PLC0415
+    if not identities:
+        _LOGGER.debug("No device identities available from coordinator")
+        return None
 
-                    from ..FMDNCrypto.eid_generator import (  # noqa: PLC0415
-                        EidVariant,
-                        generate_eid_variant,
-                    )
+    # Find identity matching our device_id
+    # canonical_id format: "{entry_id}:{device_uuid}" or just "{device_uuid}"
+    # We match if device_id equals canonical_id or is the suffix after ":"
+    identity = None
+    for ident in identities:
+        canonical_id = getattr(ident, "canonical_id", None)
+        if not canonical_id:
+            continue
 
-                    # Calculate beacon time counter
-                    rotation_period = 1024  # Default FMDN rotation period
-                    pair_date = getattr(identity, "pair_date", 0) or 0
-                    current_time = int(time.time())
-                    beacon_time_counter = (current_time - pair_date) // rotation_period
+        # Check for exact match or suffix match
+        if canonical_id == device_id or canonical_id.endswith(f":{device_id}"):
+            identity = ident
+            _LOGGER.debug(
+                "Found matching identity for device %s (canonical_id: %s)",
+                device_id,
+                canonical_id,
+            )
+            break
 
-                    # Generate EID
-                    eid = generate_eid_variant(
-                        eik=identity_key,
-                        time_counter_u32=beacon_time_counter,
-                        variant=EidVariant.MODERN_P256_X20_TRUNC_BE,
-                    )
-                    return eid
-                except Exception as err:
-                    _LOGGER.debug("Failed to generate EID: %s", err)
+    if not identity:
+        _LOGGER.debug(
+            "No identity found for device %s in %d identities. Available canonical_ids: %s",
+            device_id,
+            len(identities),
+            [getattr(i, "canonical_id", "?") for i in identities[:10]],  # Limit for logging
+        )
+        return None
 
-    # Fallback: try to get from coordinator's cached data
-    device_cache = getattr(coordinator, "_device_location_data", {})
-    cached = device_cache.get(device_id, {})
+    # Get identity key
+    identity_key = getattr(identity, "identity_key", None)
+    if not identity_key:
+        _LOGGER.debug(
+            "Identity for device %s has no identity_key (encrypted_identity_key present: %s)",
+            device_id,
+            getattr(identity, "encrypted_identity_key", None) is not None,
+        )
+        return None
 
-    # Check for pre-computed EID in cache (if available)
-    eid_hex = cached.get("current_eid")
-    if eid_hex:
-        try:
-            return bytes.fromhex(eid_hex)
-        except (ValueError, TypeError):
-            pass
+    # Generate EID
+    try:
+        import time as time_module  # noqa: PLC0415
 
-    return None
+        from ..FMDNCrypto.eid_generator import (  # noqa: PLC0415
+            EidVariant,
+            generate_eid_variant,
+        )
+
+        # Calculate beacon time counter
+        rotation_period = 1024  # Default FMDN rotation period in seconds
+        pair_date = getattr(identity, "pair_date", None) or 0
+        current_time = int(time_module.time())
+        beacon_time_counter = (current_time - pair_date) // rotation_period
+
+        _LOGGER.debug(
+            "Generating EID for device %s: pair_date=%s, current=%s, counter=%s",
+            device_id,
+            pair_date,
+            current_time,
+            beacon_time_counter,
+        )
+
+        # Generate EID
+        eid = generate_eid_variant(
+            eik=identity_key,
+            time_counter_u32=beacon_time_counter,
+            variant=EidVariant.MODERN_P256_X20_TRUNC_BE,
+        )
+
+        _LOGGER.debug(
+            "Generated EID for device %s: %s...",
+            device_id,
+            eid[:EID_LOG_PREFIX_LENGTH].hex() if len(eid) >= EID_LOG_PREFIX_LENGTH else eid.hex(),
+        )
+
+        return eid
+
+    except Exception as err:
+        _LOGGER.warning("Failed to generate EID for device %s: %s", device_id, err)
+        return None
 
 
 async def _async_upload_semantic_location(  # noqa: PLR0913


### PR DESCRIPTION
… for EID

The coordinator does not have a _device_identities dict attribute. Instead, it has a get_active_device_identities() method that returns a list of DeviceIdentity dataclass objects.

Changes:
- Call get_active_device_identities() to get list of DeviceIdentity
- Search for identity matching device_id by canonical_id suffix
- Add detailed debug logging for identity lookup and EID generation

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
