### PR TITLE
Claude/google fmdn upload vke gc

### DIFF
--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -518,7 +518,7 @@ async def _async_find_googlefindmy_device(  # noqa: PLR0911
     }
 
 
-async def _async_get_device_eid(  # noqa: PLR0911
+async def _async_get_device_eid(  # noqa: PLR0911, PLR0912, PLR0915
     hass: HomeAssistant,
     coordinator: Any,
     device_id: str,
@@ -604,21 +604,54 @@ async def _async_get_device_eid(  # noqa: PLR0911
         current_time = int(time_module.time())
         beacon_time_counter = (current_time - pair_date) // rotation_period
 
+        # Determine EID variant - check EID resolver's persisted lock first
+        variant = EidVariant.LEGACY_SECP160R1_X20_BE  # Default for most FMDN trackers
+        eid_resolver = hass.data.get(DOMAIN, {}).get("eid_resolver")
+        if eid_resolver:
+            # Get the HA device registry ID from the identity
+            registry_id = getattr(identity, "registry_id", None)
+            if registry_id:
+                # Check for persisted lock with known variant
+                locks = getattr(eid_resolver, "_persisted_locks", {})
+                lock = locks.get(registry_id)
+                if lock:
+                    lock_variant_str = getattr(lock, "variant", None)
+                    if lock_variant_str:
+                        try:
+                            locked_variant = EidVariant(lock_variant_str)
+                            # Only use SECP160r1 variants for encryption (encrypt() only supports SECP160r1)
+                            if locked_variant == EidVariant.LEGACY_SECP160R1_X20_BE:
+                                variant = locked_variant
+                                _LOGGER.debug(
+                                    "Using locked EID variant for device %s: %s",
+                                    device_id,
+                                    variant.value,
+                                )
+                            else:
+                                _LOGGER.warning(
+                                    "Device %s uses %s variant which is not supported for upload "
+                                    "(encrypt() only supports SECP160r1). Trying LEGACY_SECP160R1_X20_BE.",
+                                    device_id,
+                                    lock_variant_str,
+                                )
+                        except ValueError:
+                            _LOGGER.debug("Unknown variant in lock: %s", lock_variant_str)
+
         _LOGGER.debug(
-            "Generating EID for device %s: pair_date=%s, current=%s, counter=%s",
+            "Generating EID for device %s: pair_date=%s, current=%s, counter=%s, variant=%s",
             device_id,
             pair_date,
             current_time,
             beacon_time_counter,
+            variant.value,
         )
 
-        # Generate EID using LEGACY SECP160r1 variant
-        # The encrypt() function in foreign_tracker_cryptor.py uses SECP160r1
-        # which requires a 20-byte x-coordinate from the secp160r1 curve
+        # Generate EID using the determined variant
+        # Note: encrypt() in foreign_tracker_cryptor.py only supports SECP160r1 (20-byte EID)
         eid = generate_eid_variant(
             eik=identity_key,
             time_counter_u32=beacon_time_counter,
-            variant=EidVariant.LEGACY_SECP160R1_X20_BE,
+            variant=variant,
         )
 
         _LOGGER.debug(

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -371,7 +371,7 @@ async def _async_handle_area_change(
     )
 
 
-async def _async_find_googlefindmy_device(
+async def _async_find_googlefindmy_device(  # noqa: PLR0911
     hass: HomeAssistant,
     ha_device_id: str,
     entity_id: str | None = None,
@@ -518,7 +518,7 @@ async def _async_find_googlefindmy_device(
     }
 
 
-async def _async_get_device_eid(
+async def _async_get_device_eid(  # noqa: PLR0911
     hass: HomeAssistant,
     coordinator: Any,
     device_id: str,
@@ -612,11 +612,13 @@ async def _async_get_device_eid(
             beacon_time_counter,
         )
 
-        # Generate EID
+        # Generate EID using LEGACY SECP160r1 variant
+        # The encrypt() function in foreign_tracker_cryptor.py uses SECP160r1
+        # which requires a 20-byte x-coordinate from the secp160r1 curve
         eid = generate_eid_variant(
             eik=identity_key,
             time_counter_u32=beacon_time_counter,
-            variant=EidVariant.MODERN_P256_X20_TRUNC_BE,
+            variant=EidVariant.LEGACY_SECP160R1_X20_BE,
         )
 
         _LOGGER.debug(


### PR DESCRIPTION
<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
