### PR TITLE
fix(google_uploader): Fix unclosed gRPC channels and add Find Hub end…

### DIFF
--- a/custom_components/googlefindmy/fmdn_finder/google_uploader.py
+++ b/custom_components/googlefindmy/fmdn_finder/google_uploader.py
@@ -52,6 +52,8 @@ FMDN_SERVICE_CANDIDATES = [
     "google.internal.nearby.v1.FinderService",  # Potential finder-specific service
     "google.internal.fmdn.v1.FinderService",  # FMDN-specific
     "google.internal.findmydevice.v1.FinderService",  # FMD-specific
+    "google.internal.findhub.v1.FindHubService",  # Find Hub (new name for FMDN)
+    "google.internal.findhub.v1.ContributorService",  # Contributor-specific
 ]
 
 # Alternative servers to try
@@ -59,6 +61,7 @@ FMDN_SERVER_CANDIDATES = [
     "spot-pa.googleapis.com",  # Default (confirmed for owner ops)
     "nearbyfinder-pa.googleapis.com",  # Nearby Finder
     "findmydevice.googleapis.com",  # Find My Device
+    "find-my.googleapis.com",  # Find Hub (documented for lookup endpoint)
 ]
 
 # Track which combination worked (persistent across calls)
@@ -366,9 +369,9 @@ async def _try_grpc_upload(
         raise _ConnectionError(f"Connection to {server} failed: {err}") from err
 
     finally:
-        # Clean up transport
+        # Clean up transport (properly close the channel)
         try:
-            await transport.close()
+            await transport.async_close()
         except Exception:  # noqa: BLE001, S110
             pass
 
@@ -423,15 +426,15 @@ async def async_discover_fmdn_endpoints(hass: HomeAssistant) -> dict[str, str]:
 CURRENT STATUS:
 - All SpotService methods on spot-pa.googleapis.com returned UNIMPLEMENTED
 - Now trying multiple combinations:
-  - Servers: spot-pa, nearbyfinder-pa, findmydevice
-  - Services: SpotService, FinderService (various namespaces)
+  - Servers: spot-pa, nearbyfinder-pa, findmydevice, find-my (Find Hub)
+  - Services: SpotService, FinderService, FindHubService, ContributorService
   - Methods: ReportDeviceSighting, ContributeLocationReport, etc.
 
-Total combinations: 3 servers × 4 services × 8 methods = 96 attempts
+Total combinations: 4 servers × 6 services × 8 methods = 192 attempts
 
-The FMDN network distinguishes between:
+The FMDN network (now "Find Hub") distinguishes between:
 - OWNER operations: CreateBleDevice, GetEidInfoForE2eeDevices (confirmed on SpotService)
-- FINDER operations: Reporting sightings (endpoint unknown - trying alternatives)
+- FINDER/CONTRIBUTOR operations: Reporting sightings (endpoint unknown - trying alternatives)
 
 See: docs/FMDN_ENDPOINT_DISCOVERY.md for network capture instructions
 """


### PR DESCRIPTION
…points

- Fix: Use async_close() instead of close() for proper channel cleanup
- Add find-my.googleapis.com server (Find Hub documented endpoint)
- Add FindHubService and ContributorService as service candidates
- Expands to 192 combinations (4 servers × 6 services × 8 methods)

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
