### PR TITLE
fix: Improve auth error handling and self-healing

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -37,6 +37,7 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.nbe_execute_action imp
 )
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
+    NovaAuthPermanentError,
     NovaHTTPError,
     NovaRateLimitError,
     async_nova_request,
@@ -721,10 +722,12 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
     except SpotApiEmptyResponseError:
         # Bubble up auth failures so the coordinator can trigger reauth.
         raise
+    except NovaAuthPermanentError:
+        # Permanent auth failure (AAS token invalid) - must re-raise for immediate reauth.
+        raise
     except NovaAuthError:
-        # Re-raise auth errors so api.py can convert to ConfigEntryAuthFailed.
-        # Previously this was caught by the generic Exception handler below,
-        # which swallowed the exception and returned [] instead of triggering reauth.
+        # Re-raise auth errors (permanent or transient) so api.py can handle appropriately.
+        # Transient errors will be tracked by the coordinator; permanent ones trigger reauth.
         raise
     except Exception as e:
         _LOGGER.error("Error requesting location for %s: %s", name, e)

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -721,6 +721,11 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
     except SpotApiEmptyResponseError:
         # Bubble up auth failures so the coordinator can trigger reauth.
         raise
+    except NovaAuthError:
+        # Re-raise auth errors so api.py can convert to ConfigEntryAuthFailed.
+        # Previously this was caught by the generic Exception handler below,
+        # which swallowed the exception and returned [] instead of triggering reauth.
+        raise
     except Exception as e:
         _LOGGER.error("Error requesting location for %s: %s", name, e)
         _LOGGER.debug("Traceback: %s", traceback.format_exc())

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
@@ -153,19 +153,13 @@ async def async_submit_start_sound_request(  # noqa: PLR0913
             cache=cache_ref,
         )
         return (response_hex, request_uuid) if response_hex is not None else None
-    except asyncio.CancelledError:
+    except (asyncio.CancelledError, NovaAuthPermanentError, NovaAuthError):
+        # CancelledError: Must propagate for proper task cancellation.
+        # NovaAuthPermanentError: Permanent auth failure - immediate reauth required.
+        # NovaAuthError: Transient auth error - let coordinator track consecutive failures.
         raise
-    except NovaRateLimitError:
-        return None
-    except NovaHTTPError:
-        return None
-    except NovaAuthPermanentError:
-        # Permanent auth failure - must re-raise for immediate reauth.
-        raise
-    except NovaAuthError:
-        # Re-raise auth errors (permanent or transient) so api.py can handle appropriately.
-        raise
-    except aiohttp.ClientError:
+    except (NovaRateLimitError, NovaHTTPError, aiohttp.ClientError):
+        # Transient errors - return None to signal soft failure to caller.
         return None
 
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
@@ -159,7 +159,9 @@ async def async_submit_start_sound_request(  # noqa: PLR0913
     except NovaHTTPError:
         return None
     except NovaAuthError:
-        return None
+        # Re-raise auth errors so api.py can convert to ConfigEntryAuthFailed
+        # and trigger re-authentication flow.
+        raise
     except aiohttp.ClientError:
         return None
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
@@ -26,6 +26,7 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.PlaySound.sound_reques
 )
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
+    NovaAuthPermanentError,
     NovaHTTPError,
     NovaRateLimitError,
     async_nova_request,
@@ -158,9 +159,11 @@ async def async_submit_start_sound_request(  # noqa: PLR0913
         return None
     except NovaHTTPError:
         return None
+    except NovaAuthPermanentError:
+        # Permanent auth failure - must re-raise for immediate reauth.
+        raise
     except NovaAuthError:
-        # Re-raise auth errors so api.py can convert to ConfigEntryAuthFailed
-        # and trigger re-authentication flow.
+        # Re-raise auth errors (permanent or transient) so api.py can handle appropriately.
         raise
     except aiohttp.ClientError:
         return None

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
@@ -164,8 +164,9 @@ async def async_submit_stop_sound_request(  # noqa: PLR0913
         # transient server-side; caller should treat as soft-fail
         return None
     except NovaAuthError:
-        # auth required; caller may trigger re-auth UX
-        return None
+        # Re-raise auth errors so api.py can convert to ConfigEntryAuthFailed
+        # and trigger re-authentication flow.
+        raise
     except aiohttp.ClientError:
         # local/network problem
         return None

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
@@ -156,22 +156,13 @@ async def async_submit_stop_sound_request(  # noqa: PLR0913
             namespace=resolved_namespace,
             cache=cache,
         )
-    except asyncio.CancelledError:
+    except (asyncio.CancelledError, NovaAuthPermanentError, NovaAuthError):
+        # CancelledError: Must propagate for proper task cancellation.
+        # NovaAuthPermanentError: Permanent auth failure - immediate reauth required.
+        # NovaAuthError: Transient auth error - let coordinator track consecutive failures.
         raise
-    except NovaRateLimitError:
-        # transient; caller should treat as soft-fail
-        return None
-    except NovaHTTPError:
-        # transient server-side; caller should treat as soft-fail
-        return None
-    except NovaAuthPermanentError:
-        # Permanent auth failure - must re-raise for immediate reauth.
-        raise
-    except NovaAuthError:
-        # Re-raise auth errors (permanent or transient) so api.py can handle appropriately.
-        raise
-    except aiohttp.ClientError:
-        # local/network problem
+    except (NovaRateLimitError, NovaHTTPError, aiohttp.ClientError):
+        # Transient errors - return None to signal soft failure to caller.
         return None
 
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
@@ -28,6 +28,7 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.PlaySound.sound_reques
 )
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
+    NovaAuthPermanentError,
     NovaHTTPError,
     NovaRateLimitError,
     async_nova_request,
@@ -163,9 +164,11 @@ async def async_submit_stop_sound_request(  # noqa: PLR0913
     except NovaHTTPError:
         # transient server-side; caller should treat as soft-fail
         return None
+    except NovaAuthPermanentError:
+        # Permanent auth failure - must re-raise for immediate reauth.
+        raise
     except NovaAuthError:
-        # Re-raise auth errors so api.py can convert to ConfigEntryAuthFailed
-        # and trigger re-authentication flow.
+        # Re-raise auth errors (permanent or transient) so api.py can handle appropriately.
         raise
     except aiohttp.ClientError:
         # local/network problem

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -231,12 +231,42 @@ class NovaError(Exception):
 
 
 class NovaAuthError(NovaError):
-    """Raised on 4xx client errors after retries."""
+    """Raised on 4xx client errors after retries.
 
-    def __init__(self, status: int, detail: str | None = None):
+    This is the base class for authentication errors. It may be transient
+    (e.g., temporary 401 after token refresh due to backend propagation delay)
+    or permanent (e.g., AAS token invalidated by Google).
+
+    Attributes:
+        status: HTTP status code (typically 401 or 403).
+        detail: Human-readable error detail.
+        is_permanent: If True, re-authentication is required. If False,
+            the error may resolve on its own in subsequent poll cycles.
+    """
+
+    def __init__(
+        self,
+        status: int,
+        detail: str | None = None,
+        *,
+        is_permanent: bool = False,
+    ):
         super().__init__(f"HTTP Client Error {status}: {detail or ''}".strip())
         self.status = status
         self.detail = detail
+        self.is_permanent = is_permanent
+
+
+class NovaAuthPermanentError(NovaAuthError):
+    """Raised when re-authentication is definitively required.
+
+    This is raised when the underlying AAS token has been rejected by Google,
+    meaning the user must re-authenticate through the config flow. There is
+    no possibility of self-healing without new credentials.
+    """
+
+    def __init__(self, status: int, detail: str | None = None):
+        super().__init__(status, detail, is_permanent=True)
 
 
 class NovaRateLimitError(NovaError):
@@ -719,7 +749,7 @@ class AsyncTTLPolicy(TTLPolicy):
                     await self._aset(key, None)
                 except Exception:
                     pass
-            raise NovaAuthError(401, "AAS token invalid during ADM refresh") from err
+            raise NovaAuthPermanentError(401, "AAS token invalid during ADM refresh") from err
         if tok:
             token_base = f"adm_token_{self.username}"
             for key in self._key_variants(token_base):
@@ -1006,6 +1036,7 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
     try:
         refreshed_once = False
         retries_used = 0
+        auth_retries_used = 0  # Counter for 401 retries after token refresh
         while True:
             attempt = retries_used + 1
             try:
@@ -1031,21 +1062,57 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                     )
 
                     if status == HTTP_UNAUTHORIZED:
+                        # Exponential backoff delays for 401 retries after token refresh.
+                        # Google backends may take time to propagate refreshed tokens.
+                        _AUTH_RETRY_DELAYS = (6.0, 12.0, 24.0)
+                        max_auth_retries = len(_AUTH_RETRY_DELAYS)
+
                         lvl = logging.INFO if not refreshed_once else logging.WARNING
                         _LOGGER.log(
                             lvl,
                             "Nova API async request to %s: 401 Unauthorized. Refreshing token.",
                             api_scope,
                         )
-                        await policy.async_on_401()
-                        if not refreshed_once:
-                            refreshed_once = True
-                            # Allow time for the refreshed token to propagate across Google backends
-                            # before retrying the request.
-                            await asyncio.sleep(6.0)
-                            continue  # Free retry
 
-                        raise NovaAuthError(status, "Unauthorized after token refresh")
+                        # Only refresh token on first 401; subsequent retries use the
+                        # already-refreshed token with increasing backoff delays.
+                        if not refreshed_once:
+                            try:
+                                await policy.async_on_401()
+                            except NovaAuthPermanentError:
+                                # AAS token invalid - no point retrying, re-auth required
+                                raise
+                            refreshed_once = True
+
+                        if auth_retries_used < max_auth_retries:
+                            delay = _AUTH_RETRY_DELAYS[auth_retries_used]
+                            _LOGGER.info(
+                                "Nova API async request to %s: 401 after refresh. "
+                                "Waiting %.1fs before retry %d/%d (backend propagation delay).",
+                                api_scope,
+                                delay,
+                                auth_retries_used + 1,
+                                max_auth_retries,
+                            )
+                            auth_retries_used += 1
+                            await asyncio.sleep(delay)
+                            continue
+
+                        # Exhausted all retries - this is a transient auth error.
+                        # The coordinator should NOT immediately trigger reauth;
+                        # subsequent poll cycles may succeed once backends sync.
+                        _LOGGER.warning(
+                            "Nova API async request to %s: 401 persists after %d retries "
+                            "(total wait: %.0fs). Treating as transient auth failure.",
+                            api_scope,
+                            max_auth_retries,
+                            sum(_AUTH_RETRY_DELAYS),
+                        )
+                        raise NovaAuthError(
+                            status,
+                            "Unauthorized after token refresh (transient; may self-heal)",
+                            is_permanent=False,
+                        )
 
                     if status in HTTP_RETRY_ELIGIBLE:
                         if retries_used < NOVA_MAX_RETRIES:

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_eid_info_request.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_eid_info_request.py
@@ -32,7 +32,10 @@ from typing import TYPE_CHECKING, cast
 
 from custom_components.googlefindmy.ProtoDecoders import Common_pb2, DeviceUpdate_pb2
 from custom_components.googlefindmy.SpotApi import spot_request as spot_request_module
-from custom_components.googlefindmy.SpotApi.spot_request import SpotTrailersOnlyError
+from custom_components.googlefindmy.SpotApi.spot_request import (
+    SpotAuthPermanentError,
+    SpotTrailersOnlyError,
+)
 from google.protobuf.message import DecodeError  # parse-time error type for protobufs
 
 if TYPE_CHECKING:
@@ -98,6 +101,9 @@ async def _spot_call_async(scope: str, payload: bytes, *, cache: TokenCache) -> 
 
     try:
         response_bytes = await loop.run_in_executor(None, _call_sync)
+    except SpotAuthPermanentError:
+        # Re-raise auth errors so they propagate to trigger reauth flow
+        raise
     except SpotTrailersOnlyError as e:
         raise SpotApiEmptyResponseError(
             "Empty gRPC body (trailers-only) for GetEidInfoForE2eeDevices"

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -53,7 +53,12 @@ from .NovaApi.ExecuteAction.PlaySound.stop_sound_request import (
     async_submit_stop_sound_request,
 )
 from .NovaApi.ListDevices.nbe_list_devices import async_request_device_list
-from .NovaApi.nova_request import NovaAuthError, NovaHTTPError, NovaRateLimitError
+from .NovaApi.nova_request import (
+    NovaAuthError,
+    NovaAuthPermanentError,
+    NovaHTTPError,
+    NovaRateLimitError,
+)
 from .ProtoDecoders.decoder import (
     _select_best_location as _decoder_select_best_location,
 )
@@ -1198,15 +1203,36 @@ class GoogleFindMyAPI:
         except SpotAuthPermanentError:
             raise
 
-        except NovaAuthError as err:
-            # Explicit mapping for upstream auth failure (token expired/invalid)
+        except NovaAuthPermanentError as err:
+            # Permanent auth failure (AAS token invalid) - immediate reauth required
             _LOGGER.error(
-                "Authentication failed while getting location for %s (%s): %s",
+                "Permanent authentication failure for %s (%s): %s. Re-authentication required.",
                 device_name,
                 device_id,
                 _short_err(err),
             )
             raise ConfigEntryAuthFailed(_short_err(err)) from err
+
+        except NovaAuthError as err:
+            # Transient auth failure - may self-heal in subsequent poll cycles.
+            # Re-raise so coordinator can track consecutive failures before triggering reauth.
+            if err.is_permanent:
+                _LOGGER.error(
+                    "Permanent authentication failure for %s (%s): %s",
+                    device_name,
+                    device_id,
+                    _short_err(err),
+                )
+                raise ConfigEntryAuthFailed(_short_err(err)) from err
+
+            _LOGGER.warning(
+                "Transient authentication error for %s (%s): %s. May resolve in next poll cycle.",
+                device_name,
+                device_id,
+                _short_err(err),
+            )
+            # Re-raise to let coordinator track consecutive failures
+            raise
 
         except NovaHTTPError as err:
             # Map 401/403 to ConfigEntryAuthFailed; other HTTP errors are transient here.

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -101,6 +101,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 # IMPORTANT: make Common_pb2 import **mandatory** (integration packaging must include it).
 # This avoids silent type/name drift and keeps source labels stable.
 from .api import GoogleFindMyAPI
+from .NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
 from .Auth.token_cache import TokenCache
 from .const import (
     CACHE_KEY_CONTRIBUTOR_MODE,
@@ -194,6 +195,12 @@ _EMPTY_LIST_QUORUM = 2
 # POPETS'25-informed throttling windows for crowdsourced reports
 _COOLDOWN_MIN_IN_ALL_AREAS_S = 10 * 60  # 10 minutes
 _COOLDOWN_MIN_HIGH_TRAFFIC_S = 5 * 60  # 5 minutes
+
+# Maximum consecutive transient auth failures before triggering reauth.
+# Transient failures (401 after token refresh) may self-heal as Google's
+# backend propagates the refreshed token. We give it 3 poll cycles before
+# asking the user to re-authenticate.
+_MAX_TRANSIENT_AUTH_FAILURES = 3
 
 # Guardrails for owner-driven locate cooldown
 _COOLDOWN_OWNER_MIN_S = 60  # at least 1 minute
@@ -987,6 +994,12 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         # FIX: FCM error counter to avoid triggering re-auth on transient errors (#114)
         self._fcm_error_count: int = 0
         self._fcm_last_error: str | None = None
+
+        # Transient auth error tracking: only trigger reauth after consecutive failures
+        # across multiple poll cycles. This prevents premature reauth prompts when
+        # Google's backend is temporarily slow to propagate refreshed tokens.
+        self._consecutive_transient_auth_failures: int = 0
+        self._last_transient_auth_error: str | None = None
 
         # Reload guard: defer core subentry repairs once after reload-driven attach
         self._skip_repair_during_reload_refresh: bool = False
@@ -6239,6 +6252,14 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
 
                         # Success path: ensure any previous auth error is cleared
                         self._set_auth_state(failed=False)
+                        # Reset transient auth failure counter on success
+                        if self._consecutive_transient_auth_failures > 0:
+                            _LOGGER.info(
+                                "Location request succeeded; clearing %d transient auth failure(s).",
+                                self._consecutive_transient_auth_failures,
+                            )
+                            self._consecutive_transient_auth_failures = 0
+                            self._last_transient_auth_error = None
 
                         if not location:
                             _LOGGER.warning(
@@ -6496,6 +6517,66 @@ class GoogleFindMyCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
                         )
                         last_exception = auth_exc
                         raise auth_exc
+                    except NovaAuthPermanentError as perm_err:
+                        # Permanent auth failure (AAS token invalid) - immediate reauth
+                        _LOGGER.error(
+                            "Permanent authentication failure for %s: %s. Re-authentication required.",
+                            dev_name,
+                            perm_err,
+                        )
+                        self._set_auth_state(
+                            failed=True,
+                            reason=f"Permanent auth failure for {dev_name}: credentials invalid",
+                        )
+                        cycle_failed = True
+                        self._last_poll_result = "failed"
+                        self._consecutive_timeouts = 0
+                        self._consecutive_transient_auth_failures = 0
+                        auth_exc = ConfigEntryAuthFailed(
+                            "Google credentials invalid; re-authentication required"
+                        )
+                        last_exception = auth_exc
+                        raise auth_exc from perm_err
+                    except NovaAuthError as transient_err:
+                        # Transient auth failure - may self-heal in subsequent poll cycles.
+                        # Only trigger reauth after multiple consecutive failures.
+                        self._consecutive_transient_auth_failures += 1
+                        self._last_transient_auth_error = str(transient_err)
+
+                        if self._consecutive_transient_auth_failures >= _MAX_TRANSIENT_AUTH_FAILURES:
+                            _LOGGER.error(
+                                "Transient auth failure for %s persisted across %d poll cycles: %s. "
+                                "Triggering re-authentication.",
+                                dev_name,
+                                self._consecutive_transient_auth_failures,
+                                transient_err,
+                            )
+                            self._set_auth_state(
+                                failed=True,
+                                reason=f"Auth failed for {dev_name} after {self._consecutive_transient_auth_failures} attempts",
+                            )
+                            cycle_failed = True
+                            self._last_poll_result = "failed"
+                            self._consecutive_timeouts = 0
+                            auth_exc = ConfigEntryAuthFailed(
+                                f"Authentication failed after {self._consecutive_transient_auth_failures} attempts; re-authentication required"
+                            )
+                            last_exception = auth_exc
+                            raise auth_exc from transient_err
+
+                        # Not yet at threshold - log warning and continue to next device
+                        _LOGGER.warning(
+                            "Transient auth failure for %s (%d/%d): %s. "
+                            "Will retry in next poll cycle.",
+                            dev_name,
+                            self._consecutive_transient_auth_failures,
+                            _MAX_TRANSIENT_AUTH_FAILURES,
+                            transient_err,
+                        )
+                        cycle_failed = True
+                        if last_exception is None:
+                            last_exception = transient_err
+                        continue  # Try next device instead of aborting entire cycle
                     except ConfigEntryAuthFailed as auth_exc:
                         # Mark auth failures to HA; abort remaining devices by re-raising.
                         self._set_auth_state(

--- a/custom_components/googlefindmy/coordinator.py
+++ b/custom_components/googlefindmy/coordinator.py
@@ -101,7 +101,6 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 # IMPORTANT: make Common_pb2 import **mandatory** (integration packaging must include it).
 # This avoids silent type/name drift and keeps source labels stable.
 from .api import GoogleFindMyAPI
-from .NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
 from .Auth.token_cache import TokenCache
 from .const import (
     CACHE_KEY_CONTRIBUTOR_MODE,
@@ -149,6 +148,7 @@ from .const import (
 )
 from .ha_typing import DataUpdateCoordinator, callback
 from .KeyBackup.cloud_key_decryptor import decrypt_eik
+from .NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
 from .SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
     SpotApiEmptyResponseError,
 )

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -63,6 +63,8 @@ def _base_coordinator(
     coordinator._device_update_history = {}
     coordinator._last_poll_mono = 0.0
     coordinator._consecutive_timeouts = 0
+    coordinator._consecutive_transient_auth_failures = 0
+    coordinator._last_transient_auth_error = None
     coordinator.location_poll_interval = 0
     coordinator.data = []
     coordinator._last_device_list = []
@@ -152,6 +154,9 @@ def _polling_coordinator(
     coordinator._note_fcm_deferral = lambda *_args, **_kwargs: None
     coordinator._schedule_short_retry = lambda *_args, **_kwargs: None
     coordinator._clear_fcm_deferral = lambda: None
+    coordinator._schedule_eid_resolver_refresh = lambda: None
+    coordinator.note_error = lambda *_args, **_kwargs: None
+    coordinator.async_set_update_error = lambda *_args, **_kwargs: None
     coordinator._last_poll_result = None
     coordinator._startup_complete = True
     coordinator._fcm_defer_started_mono = 0.0

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -104,12 +104,20 @@ class _StubCache:
 def test_async_nova_request_returns_auth_error_on_repeated_401(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Ensure NovaAuthError is raised instead of NameError on 401 responses."""
+    """Ensure NovaAuthError is raised instead of NameError on 401 responses.
+
+    After the initial 401 and token refresh, the code now retries 3 times
+    with exponential backoff (6s, 12s, 24s) before raising NovaAuthError.
+    This test provides 4 consecutive 401 responses to trigger the error.
+    """
 
     cache = _StubCache()
+    # Need 4 responses: 1 initial + 3 retries with backoff
     session = _DummySession(
         [
             _DummyResponse(401, b"<html><body>Unauthorized</body></html>"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
             _DummyResponse(401, b"Unauthorized"),
         ]
     )
@@ -131,10 +139,15 @@ def test_async_nova_request_returns_auth_error_on_repeated_401(
         ) -> str:
             return "initial-adm"
 
+        # Mock asyncio.sleep to skip the 6s+12s+24s backoff delays
+        async def _instant_sleep(_: float) -> None:
+            pass
+
         monkeypatch.setattr(
             "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
             _seed_initial,
         )
+        monkeypatch.setattr("asyncio.sleep", _instant_sleep)
 
         await async_nova_request(
             "testScope",


### PR DESCRIPTION
## Summary

- Fix exception swallowing bugs where `NovaAuthError` was caught by generic `except Exception` handlers
- Distinguish permanent vs transient auth failures to prevent premature reauth prompts
- Implement exponential backoff for 401 retries (6s → 12s → 24s)
- Track consecutive transient failures - only trigger reauth after 3 failed poll cycles

## Commits

- `def15b01` fix: Re-raise NovaAuthError in outer exception handler
- `c8e3acd2` fix: Re-raise NovaAuthError in start/stop sound handlers  
- `151bc2a9` feat: Distinguish permanent vs transient auth failures
- `957deb97` fix: Re-raise SpotAuthPermanentError in get_eid_info_request.py

## Behavior

| Fehlertyp | Beispiel | Verhalten |
|-----------|----------|-----------|
| **Permanent** | "AAS token invalid" | Sofort Reauth |
| **Transient** | "401 after token refresh" | 3 Poll-Zyklen warten |

## Test plan

- [ ] Permanent auth failures trigger immediate reauth
- [ ] Transient 401s allow self-healing across poll cycles
- [ ] Reauth triggered after 3 consecutive failed cycles
- [ ] Success resets failure counter
