### PR TITLE
feat: Add feature flag to disable FMDN Finder (Bermuda listener)

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -158,6 +158,7 @@ from .const import (
     DEFAULT_MIN_POLL_INTERVAL,
     DEFAULT_OPTIONS,
     DOMAIN,
+    FEATURE_FMDN_FINDER_ENABLED,
     LEGACY_SERVICE_IDENTIFIER,
     OPT_ALLOW_HISTORY_FALLBACK,
     OPT_CONTRIBUTOR_MODE,
@@ -7300,17 +7301,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
     # Setup FMDN Finder (Bermuda integration listener for location uploads)
     # This allows Home Assistant to act as a "Finder" in Google's FMDN network,
     # uploading encrypted location reports for detected FMDN beacons.
-    try:
-        from .fmdn_finder import async_setup_fmdn_finder
-        fmdn_setup_success = await async_setup_fmdn_finder(hass)
-        if fmdn_setup_success:
-            _LOGGER.info("FMDN Finder enabled - will upload location reports for FMDN beacons detected by Bermuda")
-        else:
-            _LOGGER.warning("FMDN Finder setup failed - location uploads disabled")
-    except ImportError:
-        _LOGGER.debug("FMDN Finder module not available (optional feature)")
-    except Exception as err:  # noqa: BLE001
-        _LOGGER.warning("FMDN Finder setup failed: %s", err, exc_info=True)
+    # Feature is disabled by default via FEATURE_FMDN_FINDER_ENABLED in const.py.
+    if FEATURE_FMDN_FINDER_ENABLED:
+        try:
+            from .fmdn_finder import async_setup_fmdn_finder
+            fmdn_setup_success = await async_setup_fmdn_finder(hass)
+            if fmdn_setup_success:
+                _LOGGER.info("FMDN Finder enabled - will upload location reports for FMDN beacons detected by Bermuda")
+            else:
+                _LOGGER.warning("FMDN Finder setup failed - location uploads disabled")
+        except ImportError:
+            _LOGGER.debug("FMDN Finder module not available (optional feature)")
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("FMDN Finder setup failed: %s", err, exc_info=True)
 
     parent_platforms_forwarded = bool(
         getattr(entry, "_gfm_parent_platforms_forwarded", False)

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -395,6 +395,14 @@ FCM_MONITOR_INTERVAL_S: int = 1
 FCM_ABORT_ON_SEQ_ERROR_COUNT: int = 3
 
 # --------------------------------------------------------------------------------------
+# Feature Flags (compile-time toggles for optional functionality)
+# --------------------------------------------------------------------------------------
+# FMDN Finder: Upload location reports to Google for FMDN beacons detected by Bermuda.
+# This feature is prepared but disabled by default. Set to True to enable.
+# When disabled, no Bermuda listeners are registered and no logs are produced.
+FEATURE_FMDN_FINDER_ENABLED: bool = False
+
+# --------------------------------------------------------------------------------------
 # Events & Repairs (auth status)
 # --------------------------------------------------------------------------------------
 # Events fired by the coordinator to allow user automations.

--- a/custom_components/googlefindmy/fmdn_finder/__init__.py
+++ b/custom_components/googlefindmy/fmdn_finder/__init__.py
@@ -13,6 +13,10 @@ Privacy & Security:
 - End-to-end encryption (only device owner can decrypt)
 - Upload throttling per FMDN specification
 - Opt-in only (respects user privacy)
+
+NOTE: This feature is disabled by default. Set FEATURE_FMDN_FINDER_ENABLED=True
+in const.py to enable. When disabled, no listeners are registered and no logs
+are produced.
 """
 
 from __future__ import annotations
@@ -35,8 +39,15 @@ async def async_setup_fmdn_finder(hass: HomeAssistant) -> bool:
         hass: Home Assistant instance
 
     Returns:
-        True if setup successful, False otherwise
+        True if setup successful, False if disabled or failed
     """
+    from ..const import FEATURE_FMDN_FINDER_ENABLED  # noqa: PLC0415
+
+    # Guard: Feature must be explicitly enabled via const.py
+    if not FEATURE_FMDN_FINDER_ENABLED:
+        _LOGGER.debug("FMDN Finder disabled (FEATURE_FMDN_FINDER_ENABLED=False)")
+        return False
+
     from .bermuda_listener import async_setup_bermuda_listener  # noqa: PLC0415
 
     _LOGGER.info("Setting up FMDN Finder integration")


### PR DESCRIPTION
Add FEATURE_FMDN_FINDER_ENABLED constant (default: False) to const.py to control the FMDN Finder functionality. When disabled:
- No Bermuda state change listeners are registered
- No log spam from bermuda_listener.py
- Code is preserved for future activation

This addresses the log spam issue where INFO/DEBUG messages about Bermuda area changes were being produced without any user-facing functionality being available.

To enable in the future, set FEATURE_FMDN_FINDER_ENABLED=True in const.py.

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
