### PR TITLE
fix: invalidate AAS token on persistent 401 errors after token refresh

### DIFF
--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -713,6 +713,23 @@ class AsyncTTLPolicy(TTLPolicy):
         self._aset: Callable[[str, Any], Awaitable[None]] = set_value
         self._arefresh: Callable[[], Awaitable[str | None]] = refresh_fn
 
+    async def async_invalidate_aas_token(self) -> None:
+        """Clear the cached AAS token so the next refresh generates a fresh one.
+
+        This should be called when persistent 401 errors occur after a token
+        refresh, as it indicates the underlying AAS token may be invalid even
+        if gpsoauth didn't explicitly reject it.
+        """
+        self.log.warning(
+            "Invalidating cached AAS token for %s due to persistent 401 errors.",
+            self.username,
+        )
+        for key in self._key_variants(DATA_AAS_TOKEN):
+            try:
+                await self._aset(key, None)
+            except Exception:
+                pass
+
     async def _arm_probe_if_due_async(self, now: float) -> bool:
         startup_left = await self._aget(self.k_startleft)
         probenext = await self._aget(self.k_probenext)
@@ -1121,6 +1138,11 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                             max_auth_retries,
                             sum(_AUTH_RETRY_DELAYS),
                         )
+                        # Invalidate the AAS token so the next poll cycle can attempt
+                        # a fresh token chain (OAuth -> AAS -> ADM). This is critical
+                        # when the underlying AAS token is invalid but gpsoauth didn't
+                        # explicitly reject it with a recognizable error.
+                        await policy.async_invalidate_aas_token()
                         raise NovaAuthError(
                             status,
                             "Unauthorized after token refresh (transient; may self-heal)",

--- a/custom_components/googlefindmy/coordinator/registry.py
+++ b/custom_components/googlefindmy/coordinator/registry.py
@@ -254,7 +254,7 @@ class RegistryOperations:
         )
         return supports_translation
 
-    @callback
+    @callback  # type: ignore[misc, untyped-decorator, unused-ignore]
     def _reindex_poll_targets_from_device_registry(
         self: GoogleFindMyCoordinator,
     ) -> None:

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -863,3 +863,514 @@ def test_async_nova_request_converts_flow_token_with_ephemeral_cache(
     assert session.calls
     headers = session.calls[0]["kwargs"].get("headers", {})
     assert headers.get("Authorization") == "Bearer adm-token"
+
+
+def test_async_ttl_policy_invalidate_aas_token_clears_both_bare_and_namespaced() -> (
+    None
+):
+    """async_invalidate_aas_token must clear AAS token from both bare and namespaced keys.
+
+    This ensures that when persistent 401 errors indicate a potentially invalid
+    AAS token (even without explicit BadAuthentication), subsequent poll cycles
+    can generate a fresh OAuth -> AAS -> ADM token chain.
+    """
+
+    async def _run() -> None:
+        hass = _FakeHass()
+        cache = await TokenCache.create(hass, "entry-invalidate-aas")
+        try:
+            namespace = "entry-invalidate-aas"
+            username = "user@example.com"
+
+            # Seed both bare and namespaced AAS tokens
+            await cache.set(DATA_AAS_TOKEN, "stale-bare-aas")
+            await cache.set(f"{namespace}:{DATA_AAS_TOKEN}", "stale-ns-aas")
+
+            async def _cache_get(key: str) -> Any:
+                return await cache.get(key)
+
+            async def _cache_set(key: str, value: Any) -> None:
+                await cache.set(key, value)
+
+            async def _refresh() -> str:
+                return "fresh-token"
+
+            policy = AsyncTTLPolicy(
+                username=username,
+                logger=logging.getLogger("test_invalidate_aas"),
+                get_value=_cache_get,
+                set_value=_cache_set,
+                refresh_fn=_refresh,
+                set_auth_header_fn=lambda _: None,
+                ns_prefix=namespace,
+            )
+
+            # Verify tokens exist before invalidation
+            assert await cache.get(DATA_AAS_TOKEN) == "stale-bare-aas"
+            assert await cache.get(f"{namespace}:{DATA_AAS_TOKEN}") == "stale-ns-aas"
+
+            # Call the new invalidation method
+            await policy.async_invalidate_aas_token()
+
+            # Both keys must be cleared
+            assert await cache.get(DATA_AAS_TOKEN) is None
+            assert await cache.get(f"{namespace}:{DATA_AAS_TOKEN}") is None
+        finally:
+            await cache.close()
+
+    asyncio.run(_run())
+
+
+def test_async_nova_request_invalidates_aas_token_after_exhausted_401_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Persistent 401 errors after token refresh must invalidate the AAS token.
+
+    When all auth_retries (3 attempts with backoff) are exhausted and 401
+    still persists, the AAS token should be cleared so subsequent poll cycles
+    can generate a fresh token chain (OAuth -> AAS -> ADM).
+
+    This regression test covers the bug where an invalid AAS token would remain
+    cached indefinitely, causing a loop of failed token refreshes.
+    """
+
+    cache = _StubCache()
+    # Need 4 responses: 1 initial 401 + 3 retries all returning 401
+    session = _DummySession(
+        [
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+        ]
+    )
+
+    aas_invalidation_calls: list[str] = []
+
+    async def _exercise() -> None:
+        # Seed the AAS token that should be invalidated
+        await cache.set(DATA_AAS_TOKEN, "stale-aas-token")
+
+        async def _fake_get_adm_token(
+            username: str | None = None,
+            *,
+            retries: int = 2,
+            backoff: float = 1.0,
+            cache: Any,
+        ) -> str:
+            return "initial-adm"
+
+        async def _refresh() -> str:
+            return "refreshed-adm"
+
+        # Mock asyncio.sleep to skip the 6s+12s+24s backoff delays
+        async def _instant_sleep(_: float) -> None:
+            pass
+
+        # Spy on async_invalidate_aas_token to verify it's called
+        original_invalidate = AsyncTTLPolicy.async_invalidate_aas_token
+
+        async def _spy_invalidate(self: AsyncTTLPolicy) -> None:
+            aas_invalidation_calls.append(self.username)
+            await original_invalidate(self)
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+            _fake_get_adm_token,
+        )
+        monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+        monkeypatch.setattr(
+            AsyncTTLPolicy,
+            "async_invalidate_aas_token",
+            _spy_invalidate,
+        )
+
+        await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            token="initial-token",
+            cache=cache,
+            session=session,
+            refresh_override=_refresh,
+        )
+
+    with pytest.raises(NovaAuthError) as err:
+        asyncio.run(_exercise())
+
+    # Verify the error is transient (not permanent)
+    assert err.value.status == 401
+    assert not err.value.is_permanent
+
+    # Verify async_invalidate_aas_token was called
+    assert len(aas_invalidation_calls) == 1
+    assert aas_invalidation_calls[0] == "user@example.com"
+
+
+def test_async_nova_request_aas_token_cleared_enables_fresh_chain_on_next_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After AAS invalidation, next poll cycle should generate fresh token chain.
+
+    This test verifies the complete bug fix scenario:
+    1. First poll cycle: persistent 401s -> AAS token invalidated
+    2. Second poll cycle: AAS token is None -> success (simulating fresh generation)
+    """
+
+    cache = _StubCache()
+    poll_cycle = 0
+    aas_states_before_request: list[tuple[int, str | None]] = []
+
+    async def _exercise() -> tuple[str | None, str | None]:
+        nonlocal poll_cycle
+
+        # Seed initial stale AAS token
+        await cache.set(DATA_AAS_TOKEN, "stale-aas")
+        await cache.set(username_string, "user@example.com")
+
+        async def _fake_get_adm_token(
+            username: str | None = None,
+            *,
+            retries: int = 2,
+            backoff: float = 1.0,
+            cache: Any,
+        ) -> str:
+            return f"adm-cycle-{poll_cycle}"
+
+        async def _refresh() -> str:
+            return f"refreshed-adm-cycle-{poll_cycle}"
+
+        async def _instant_sleep(_: float) -> None:
+            pass
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+            _fake_get_adm_token,
+        )
+        monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+        # First poll cycle: all 401s -> should invalidate AAS token
+        poll_cycle = 1
+        aas_states_before_request.append((poll_cycle, await cache.get(DATA_AAS_TOKEN)))
+        session1 = _DummySession(
+            [
+                _DummyResponse(401, b"Unauthorized"),
+                _DummyResponse(401, b"Unauthorized"),
+                _DummyResponse(401, b"Unauthorized"),
+                _DummyResponse(401, b"Unauthorized"),
+            ]
+        )
+
+        try:
+            await async_nova_request(
+                "testScope",
+                "00",
+                username="user@example.com",
+                cache=cache,
+                session=session1,
+                refresh_override=_refresh,
+            )
+        except NovaAuthError:
+            pass  # Expected
+
+        # Verify AAS token was cleared after first cycle
+        aas_after_first = await cache.get(DATA_AAS_TOKEN)
+
+        # Second poll cycle: success with fresh AAS
+        poll_cycle = 2
+        session2 = _DummySession([_DummyResponse(200, b"\xca\xfe")])
+
+        second_result = await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session2,
+            refresh_override=_refresh,
+        )
+
+        return aas_after_first, second_result
+
+    aas_after_first, second_result = asyncio.run(_exercise())
+
+    # AAS should be None after first failed cycle
+    assert aas_after_first is None
+
+    # Second cycle should succeed with fresh token chain
+    assert second_result == "cafe"
+
+    # Verify AAS state progression:
+    # Cycle 1: AAS = "stale-aas" (before request)
+    # After cycle 1: AAS = None (invalidated due to persistent 401s)
+    assert aas_states_before_request[0] == (1, "stale-aas")
+
+
+def test_async_nova_request_preserves_aas_token_on_successful_401_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AAS token must be preserved when 401 recovery succeeds within retry window.
+
+    If the first 401 triggers a token refresh and the retry succeeds, the AAS
+    token should NOT be invalidated. This prevents unnecessary token regeneration
+    when the issue was transient (e.g., backend propagation delay).
+    """
+
+    cache = _StubCache()
+    # First request: 401, second request after refresh: success
+    session = _DummySession(
+        [
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(200, b"\xbe\xef"),
+        ]
+    )
+
+    aas_invalidation_calls: list[str] = []
+
+    async def _exercise() -> tuple[str, str | None]:
+        await cache.set(DATA_AAS_TOKEN, "original-aas")
+        await cache.set(username_string, "user@example.com")
+
+        async def _fake_get_adm_token(
+            username: str | None = None,
+            *,
+            retries: int = 2,
+            backoff: float = 1.0,
+            cache: Any,
+        ) -> str:
+            return "initial-adm"
+
+        async def _refresh() -> str:
+            return "refreshed-adm"
+
+        # Spy on async_invalidate_aas_token to verify it's NOT called
+        original_invalidate = AsyncTTLPolicy.async_invalidate_aas_token
+
+        async def _spy_invalidate(self: AsyncTTLPolicy) -> None:
+            aas_invalidation_calls.append(self.username)
+            await original_invalidate(self)
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+            _fake_get_adm_token,
+        )
+        monkeypatch.setattr(
+            AsyncTTLPolicy,
+            "async_invalidate_aas_token",
+            _spy_invalidate,
+        )
+
+        # Don't pass token kwarg to avoid overwriting AAS in cache
+        result = await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+            refresh_override=_refresh,
+        )
+
+        final_aas = await cache.get(DATA_AAS_TOKEN)
+        return result, final_aas
+
+    result, final_aas = asyncio.run(_exercise())
+
+    # Request should succeed
+    assert result == "beef"
+
+    # AAS token should be preserved (not invalidated)
+    assert final_aas == "original-aas"
+
+    # async_invalidate_aas_token should NOT have been called
+    assert len(aas_invalidation_calls) == 0
+
+
+def test_async_nova_request_no_double_aas_invalidation_on_repeated_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AAS invalidation must happen exactly once per failed request cycle.
+
+    When 401s persist through all retries, async_invalidate_aas_token should
+    be called exactly once, not multiple times per retry.
+    """
+
+    cache = _StubCache()
+    session = _DummySession(
+        [
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+        ]
+    )
+
+    invalidation_call_count = 0
+
+    async def _exercise() -> None:
+        nonlocal invalidation_call_count
+
+        await cache.set(DATA_AAS_TOKEN, "stale-aas")
+
+        async def _fake_get_adm_token(
+            username: str | None = None,
+            *,
+            retries: int = 2,
+            backoff: float = 1.0,
+            cache: Any,
+        ) -> str:
+            return "initial-adm"
+
+        async def _refresh() -> str:
+            return "refreshed-adm"
+
+        async def _instant_sleep(_: float) -> None:
+            pass
+
+        original_invalidate = AsyncTTLPolicy.async_invalidate_aas_token
+
+        async def _counting_invalidate(self: AsyncTTLPolicy) -> None:
+            nonlocal invalidation_call_count
+            invalidation_call_count += 1
+            await original_invalidate(self)
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+            _fake_get_adm_token,
+        )
+        monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+        monkeypatch.setattr(
+            AsyncTTLPolicy,
+            "async_invalidate_aas_token",
+            _counting_invalidate,
+        )
+
+        await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            token="initial-token",
+            cache=cache,
+            session=session,
+            refresh_override=_refresh,
+        )
+
+    with pytest.raises(NovaAuthError):
+        asyncio.run(_exercise())
+
+    # Invalidation should happen exactly once per failed cycle
+    assert invalidation_call_count == 1
+
+
+def test_async_nova_request_loop_prevention_across_multiple_cycles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token renewal loop prevention must work across multiple consecutive failed cycles.
+
+    This test simulates the exact bug scenario: multiple poll cycles where each
+    cycle exhausts retries. The fix ensures that each cycle invalidates AAS,
+    allowing fresh token generation on subsequent cycles, eventually breaking
+    the loop when valid tokens are available.
+    """
+
+    cache = _StubCache()
+    cycle_count = 0
+    aas_invalidations: list[int] = []
+    aas_states_at_cycle_start: list[tuple[int, str | None]] = []
+
+    async def _exercise() -> str:
+        nonlocal cycle_count
+
+        await cache.set(DATA_AAS_TOKEN, "initial-stale-aas")
+        await cache.set(username_string, "user@example.com")
+
+        async def _fake_get_adm_token(
+            username: str | None = None,
+            *,
+            retries: int = 2,
+            backoff: float = 1.0,
+            cache: Any,
+        ) -> str:
+            return f"adm-cycle-{cycle_count}"
+
+        async def _refresh() -> str:
+            return f"refreshed-adm-cycle-{cycle_count}"
+
+        async def _instant_sleep(_: float) -> None:
+            pass
+
+        original_invalidate = AsyncTTLPolicy.async_invalidate_aas_token
+
+        async def _tracking_invalidate(self: AsyncTTLPolicy) -> None:
+            aas_invalidations.append(cycle_count)
+            await original_invalidate(self)
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+            _fake_get_adm_token,
+        )
+        monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+        monkeypatch.setattr(
+            AsyncTTLPolicy,
+            "async_invalidate_aas_token",
+            _tracking_invalidate,
+        )
+
+        # Simulate 3 failed cycles, then 1 successful cycle
+        for i in range(1, 4):
+            cycle_count = i
+            # Record AAS state at the start of each cycle
+            current_aas = await cache.get(DATA_AAS_TOKEN)
+            aas_states_at_cycle_start.append((i, current_aas))
+
+            session = _DummySession(
+                [
+                    _DummyResponse(401, b"Unauthorized"),
+                    _DummyResponse(401, b"Unauthorized"),
+                    _DummyResponse(401, b"Unauthorized"),
+                    _DummyResponse(401, b"Unauthorized"),
+                ]
+            )
+            try:
+                await async_nova_request(
+                    "testScope",
+                    "00",
+                    username="user@example.com",
+                    cache=cache,
+                    session=session,
+                    refresh_override=_refresh,
+                )
+            except NovaAuthError:
+                pass  # Expected for cycles 1-3
+
+        # Record final AAS state before successful cycle
+        cycle_count = 4
+        final_aas_before_success = await cache.get(DATA_AAS_TOKEN)
+        aas_states_at_cycle_start.append((4, final_aas_before_success))
+
+        session_success = _DummySession([_DummyResponse(200, b"\xde\xad")])
+
+        return await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session_success,
+            refresh_override=_refresh,
+        )
+
+    result = asyncio.run(_exercise())
+
+    # Final cycle should succeed
+    assert result == "dead"
+
+    # AAS should be invalidated once per failed cycle (cycles 1, 2, 3)
+    assert aas_invalidations == [1, 2, 3]
+
+    # Verify the AAS token state progression:
+    # Cycle 1: AAS = "initial-stale-aas" (before invalidation)
+    # Cycle 2: AAS = None (after cycle 1 invalidated it)
+    # Cycle 3: AAS = None (after cycle 2 invalidated it)
+    # Cycle 4: AAS = None (after cycle 3 invalidated it)
+    assert aas_states_at_cycle_start[0] == (1, "initial-stale-aas")
+    assert aas_states_at_cycle_start[1][1] is None  # Cycle 2 sees None
+    assert aas_states_at_cycle_start[2][1] is None  # Cycle 3 sees None
+    assert aas_states_at_cycle_start[3][1] is None  # Cycle 4 sees None


### PR DESCRIPTION
## Summary

Fixes a token renewal loop bug where persistent 401 Unauthorized errors caused polling to fail indefinitely.

## Problem

The token chain works as: `OAuth Token → AAS Token → ADM Token`

When ADM token expired and was refreshed, but the underlying AAS token was also invalid (without triggering explicit `BadAuthentication` from gpsoauth), a loop occurred:

1. 401 error → ADM token refresh using cached AAS token
2. New ADM token still fails with 401
3. After 3 retries (6s+12s+24s=42s), `NovaAuthError` thrown
4. **Bug:** Invalid AAS token remains cached
5. Next poll cycle repeats → infinite loop

### User Impact

- Repeated "Nova API async request to nbe_execute_action: 401 Unauthorized. Refreshing token." errors
- Devices show stale/incorrect locations
- Manual refresh works, but automatic polling never recovers

## Solution

Added `async_invalidate_aas_token()` method to `AsyncTTLPolicy`. When all auth retries are exhausted with persistent 401s, the AAS token is cleared, allowing the next poll cycle to generate a fresh token chain (OAuth → AAS → ADM).

## Changes

**`nova_request.py`:**
- Added `async_invalidate_aas_token()` method to `AsyncTTLPolicy` class
- Call method before raising `NovaAuthError` when auth retries exhausted

**`test_nova_request.py` (+6 new tests):**
1. `test_async_ttl_policy_invalidate_aas_token_clears_both_bare_and_namespaced` - Verifies both cache key variants are cleared
2. `test_async_nova_request_invalidates_aas_token_after_exhausted_401_retries` - Verifies invalidation is called on persistent 401s
3. `test_async_nova_request_aas_token_cleared_enables_fresh_chain_on_next_cycle` - End-to-end test of the fix
4. `test_async_nova_request_preserves_aas_token_on_successful_401_recovery` - Verifies no unnecessary invalidation on transient 401s
5. `test_async_nova_request_no_double_aas_invalidation_on_repeated_failures` - Ensures exactly one invalidation per cycle
6. `test_async_nova_request_loop_prevention_across_multiple_cycles` - Tests loop prevention across consecutive failed cycles

## Test plan

- [x] `ruff format` and `ruff check` pass
- [x] Python 3.13 syntax validation passes
- [x] All 19 nova_request tests pass
- [x] mypy --strict passes for changed files

## Verified Log Line Numbers

The reported error locations match current code:
- `polling.py:1274` ✅ "Poll timed out for %s"
- `nova_request.py:1084` ✅ "401 Unauthorized. Refreshing token."
- `nova_request.py:888` ✅ "Unexpected short TTL"
