### PR TITLE
feat(auth): implement step-based 401 retry with AAS TTL learning

### DIFF
--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import secrets
+import time
 from collections.abc import Mapping
 from types import ModuleType
 from typing import Any
@@ -433,6 +434,7 @@ async def async_get_aas_token(
 
     Persistence:
         - Stored under key `DATA_AAS_TOKEN` in the selected cache.
+        - Issuance timestamp stored under `aas_token_issued_at_<username>` for TTL learning.
 
     Retry policy:
         - Non-retryable auth failures (e.g., "BadAuthentication", "invalid_grant",
@@ -449,6 +451,10 @@ async def async_get_aas_token(
     """
     if cache is None:
         raise ValueError("TokenCache instance is required for multi-account safety.")
+
+    # Check if AAS token already exists (for TTL tracking)
+    existing_token = await cache.get(DATA_AAS_TOKEN)
+    was_cached = existing_token is not None and isinstance(existing_token, str)
 
     async def _gen_with_retries() -> str:
         last_exc: Exception | None = None
@@ -487,6 +493,22 @@ async def async_get_aas_token(
         raise last_exc
 
     token: str = await cache.get_or_set(DATA_AAS_TOKEN, _gen_with_retries)
+
+    # Record AAS token issuance timestamp if a fresh token was generated
+    # This enables TTL learning for proactive AAS refresh
+    if not was_cached:
+        username_val = await cache.get(username_string)
+        if isinstance(username_val, str) and username_val:
+            issued_key = f"aas_token_issued_at_{username_val.strip().lower()}"
+            try:
+                await cache.set(issued_key, time.time())
+                _LOGGER.debug(
+                    "Recorded AAS token issuance timestamp for TTL learning.",
+                    extra={"user": _mask_email_for_logs(username_val)},
+                )
+            except Exception as err:  # noqa: BLE001 - defensive cache write
+                _LOGGER.debug("Failed to record AAS issuance timestamp: %s", err)
+
     return token
 
 

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -1128,25 +1128,23 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                             await asyncio.sleep(delay)
                             continue
 
-                        # Exhausted all retries - this is a transient auth error.
-                        # The coordinator should NOT immediately trigger reauth;
-                        # subsequent poll cycles may succeed once backends sync.
-                        _LOGGER.warning(
+                        # Exhausted all retries - 401 is a client error indicating
+                        # invalid credentials. After 42s of retries, this is NOT
+                        # a propagation delay; the token chain is genuinely broken.
+                        _LOGGER.error(
                             "Nova API async request to %s: 401 persists after %d retries "
-                            "(total wait: %.0fs). Treating as transient auth failure.",
+                            "(total wait: %.0fs). Authentication is invalid; re-auth required.",
                             api_scope,
                             max_auth_retries,
                             sum(_AUTH_RETRY_DELAYS),
                         )
-                        # Invalidate the AAS token so the next poll cycle can attempt
-                        # a fresh token chain (OAuth -> AAS -> ADM). This is critical
-                        # when the underlying AAS token is invalid but gpsoauth didn't
-                        # explicitly reject it with a recognizable error.
+                        # Invalidate the AAS token so re-auth can generate a fresh
+                        # token chain (OAuth -> AAS -> ADM).
                         await policy.async_invalidate_aas_token()
                         raise NovaAuthError(
                             status,
-                            "Unauthorized after token refresh (transient; may self-heal)",
-                            is_permanent=False,
+                            "Unauthorized after token refresh; re-authentication required",
+                            is_permanent=True,
                         )
 
                     if status in HTTP_RETRY_ELIGIBLE:

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -1092,9 +1092,11 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                     )
 
                     if status == HTTP_UNAUTHORIZED:
-                        # Exponential backoff delays for 401 retries after token refresh.
-                        # Google backends may take time to propagate refreshed tokens.
-                        _AUTH_RETRY_DELAYS = (6.0, 12.0, 24.0)
+                        # Progressive backoff delays for 401 retries after token refresh:
+                        # - 6s: Backend propagation delay (token sync across servers)
+                        # - 61s: Short cooldown (~1 min, odd to avoid boundary hits)
+                        # - 301s: Long cooldown (~5 min, Google's typical rate-limit window)
+                        _AUTH_RETRY_DELAYS = (6.0, 61.0, 301.0)
                         max_auth_retries = len(_AUTH_RETRY_DELAYS)
 
                         lvl = logging.INFO if not refreshed_once else logging.WARNING
@@ -1118,7 +1120,7 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                             delay = _AUTH_RETRY_DELAYS[auth_retries_used]
                             _LOGGER.info(
                                 "Nova API async request to %s: 401 after refresh. "
-                                "Waiting %.1fs before retry %d/%d (backend propagation delay).",
+                                "Waiting %.0fs before retry %d/%d.",
                                 api_scope,
                                 delay,
                                 auth_retries_used + 1,
@@ -1129,8 +1131,8 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                             continue
 
                         # Exhausted all retries - 401 is a client error indicating
-                        # invalid credentials. After 42s of retries, this is NOT
-                        # a propagation delay; the token chain is genuinely broken.
+                        # invalid credentials. After ~6 min of retries, this is NOT
+                        # a transient issue; the token chain is genuinely broken.
                         _LOGGER.error(
                             "Nova API async request to %s: 401 persists after %d retries "
                             "(total wait: %.0fs). Authentication is invalid; re-auth required.",

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -687,7 +687,16 @@ class TTLPolicy:
 
 
 class AsyncTTLPolicy(TTLPolicy):
-    """Native async version of the TTL policy (no blocking calls)."""
+    """Native async version of the TTL policy (no blocking calls).
+
+    This policy manages both ADM and AAS token TTL learning:
+    - ADM tokens: proactive refresh based on measured TTL
+    - AAS tokens: proactive refresh based on learned lifetime (when AAS+ADM chain fails)
+    """
+
+    # AAS token TTL learning constants
+    AAS_TTL_MARGIN_SEC = 300  # 5 min margin before expiry
+    AAS_DEFAULT_TTL_SEC = 7 * 24 * 3600  # 7 days default (conservative estimate)
 
     def __init__(  # noqa: PLR0913
         self,
@@ -713,13 +722,72 @@ class AsyncTTLPolicy(TTLPolicy):
         self._aset: Callable[[str, Any], Awaitable[None]] = set_value
         self._arefresh: Callable[[], Awaitable[str | None]] = refresh_fn
 
+    # --- AAS TTL learning cache keys ---
+    @property
+    def k_aas_issued(self) -> str:
+        """Cache key for AAS token issuance timestamp."""
+        return f"{self._ns}aas_token_issued_at_{self.username}"
+
+    @property
+    def k_aas_bestttl(self) -> str:
+        """Cache key for best known AAS token TTL."""
+        return f"{self._ns}aas_best_ttl_sec_{self.username}"
+
+    async def async_record_aas_issued(self) -> None:
+        """Record the issuance timestamp when a fresh AAS token is generated.
+
+        This enables TTL learning for AAS tokens by tracking how long they
+        remain valid before Google rejects them.
+        """
+        now = time.time()
+        for key in self._key_variants(f"aas_token_issued_at_{self.username}"):
+            try:
+                await self._aset(key, now)
+            except Exception:  # noqa: BLE001 - defensive cache write
+                pass
+
     async def async_invalidate_aas_token(self) -> None:
-        """Clear the cached AAS token so the next refresh generates a fresh one.
+        """Clear the cached AAS token and learn its actual TTL.
 
         This should be called when persistent 401 errors occur after a token
         refresh, as it indicates the underlying AAS token may be invalid even
         if gpsoauth didn't explicitly reject it.
+
+        TTL Learning: When invalidating, we record the observed lifetime to
+        enable proactive refresh before future tokens expire.
         """
+        now = time.time()
+
+        # Learn AAS TTL from observed lifetime
+        issued_raw = await self._aget(self.k_aas_issued)
+        if issued_raw is not None:
+            try:
+                issued_at = float(issued_raw)
+                observed_ttl = now - issued_at
+                observed_ttl_hours = observed_ttl / 3600
+                self.log.info(
+                    "AAS token for %s lived %.1f hours before invalidation.",
+                    self.username,
+                    observed_ttl_hours,
+                )
+                # Update best known TTL (conservative: take the shorter one)
+                best_raw = await self._aget(self.k_aas_bestttl)
+                if best_raw is None or observed_ttl < float(best_raw):
+                    # Apply 5% safety margin
+                    safe_ttl = observed_ttl * 0.95
+                    for key in self._key_variants(f"aas_best_ttl_sec_{self.username}"):
+                        try:
+                            await self._aset(key, safe_ttl)
+                        except Exception:  # noqa: BLE001 - defensive cache write
+                            pass
+                    self.log.info(
+                        "Updated AAS best TTL for %s to %.1f hours (with 5%% margin).",
+                        self.username,
+                        safe_ttl / 3600,
+                    )
+            except (TypeError, ValueError) as e:
+                self.log.debug("Failed to learn AAS TTL: %s", e)
+
         self.log.warning(
             "Invalidating cached AAS token for %s due to persistent 401 errors.",
             self.username,
@@ -729,6 +797,54 @@ class AsyncTTLPolicy(TTLPolicy):
                 await self._aset(key, None)
             except Exception:
                 pass
+        # Clear issued timestamp so next refresh records a fresh one
+        for key in self._key_variants(f"aas_token_issued_at_{self.username}"):
+            try:
+                await self._aset(key, None)
+            except Exception:
+                pass
+        # Also clear ADM issued timestamp to bypass stampede guard in async_on_401
+        # This ensures the subsequent refresh actually happens instead of being skipped
+        for key in self._key_variants(f"adm_token_issued_at_{self.username}"):
+            try:
+                await self._aset(key, None)
+            except Exception:
+                pass
+
+    async def async_check_aas_proactive_refresh(self) -> bool:
+        """Check if AAS token should be proactively refreshed based on learned TTL.
+
+        Returns:
+            True if AAS token was refreshed, False otherwise.
+        """
+        now = time.time()
+        issued_raw = await self._aget(self.k_aas_issued)
+        best_ttl_raw = await self._aget(self.k_aas_bestttl)
+
+        if issued_raw is None or best_ttl_raw is None:
+            return False
+
+        try:
+            issued_at = float(issued_raw)
+            best_ttl = float(best_ttl_raw)
+            age = now - issued_at
+            threshold = max(0.0, best_ttl - self.AAS_TTL_MARGIN_SEC)
+            threshold = self._jitter_sec(threshold, self.JITTER_SEC)
+
+            if age >= threshold:
+                self.log.info(
+                    "AAS token for %s reached measured threshold (%.1f hours) – "
+                    "proactively refreshing token chain.",
+                    self.username,
+                    best_ttl / 3600,
+                )
+                await self.async_invalidate_aas_token()
+                # The next ADM refresh will trigger a fresh AAS token generation
+                return True
+        except (TypeError, ValueError) as e:
+            self.log.debug("AAS proactive refresh check failed: %s", e)
+
+        return False
 
     async def _arm_probe_if_due_async(self, now: float) -> bool:
         startup_left = await self._aget(self.k_startleft)
@@ -808,6 +924,16 @@ class AsyncTTLPolicy(TTLPolicy):
         return tok
 
     async def async_pre_request(self) -> None:
+        """Perform proactive token refresh checks for both AAS and ADM tokens.
+
+        This method checks:
+        1. AAS token: if approaching learned TTL, invalidate to trigger fresh generation
+        2. ADM token: if approaching measured TTL, proactively refresh
+        """
+        # Check AAS token proactive refresh first (longer-lived, less frequent)
+        await self.async_check_aas_proactive_refresh()
+
+        # Then check ADM token proactive refresh (shorter-lived, more frequent)
         now = time.time()
         issued_at = await self._aget(self.k_issued)
         best_ttl = await self._aget(self.k_bestttl)
@@ -1064,7 +1190,6 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
             ephemeral_session = True
 
     try:
-        refreshed_once = False
         retries_used = 0
         auth_retries_used = 0  # Counter for 401 retries after token refresh
         while True:
@@ -1092,57 +1217,106 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                     )
 
                     if status == HTTP_UNAUTHORIZED:
-                        # Progressive backoff delays for 401 retries after token refresh:
-                        # - 6s: Backend propagation delay (token sync across servers)
-                        # - 61s: Short cooldown (~1 min, odd to avoid boundary hits)
-                        # - 301s: Long cooldown (~5 min, Google's typical rate-limit window)
-                        _AUTH_RETRY_DELAYS = (6.0, 61.0, 301.0)
-                        max_auth_retries = len(_AUTH_RETRY_DELAYS)
+                        # 401 Retry Sequence (OAuth → AAS → ADM token chain):
+                        # ----------------------------------------------------------
+                        # Step 0 (initial): Request fails with 401
+                        # Step 1: Refresh ADM only → wait 6s (propagation) → retry
+                        # Step 2: If 401: wait 61s → invalidate AAS, refresh AAS+ADM → wait 6s → retry
+                        # Step 3: If 401: wait 501s (long cooldown) → retry
+                        # Step 4: If 401: permanent error, re-auth required
+                        #
+                        # Delays use odd numbers to avoid hitting rate-limit boundaries.
+                        # The 6s propagation delay allows Google's backend to sync new tokens.
+                        _PROPAGATION_DELAY_S = 6.0
+                        _SHORT_COOLDOWN_S = 61.0  # ~1 min
+                        _LONG_COOLDOWN_S = 501.0  # ~8 min
+                        # Auth retry step constants
+                        _AUTH_STEP_ADM_REFRESH = 0
+                        _AUTH_STEP_AAS_ADM_REFRESH = 1
+                        _AUTH_STEP_LONG_COOLDOWN = 2
+                        max_auth_retries = 4
 
-                        lvl = logging.INFO if not refreshed_once else logging.WARNING
+                        lvl = (
+                            logging.INFO
+                            if auth_retries_used == _AUTH_STEP_ADM_REFRESH
+                            else logging.WARNING
+                        )
                         _LOGGER.log(
                             lvl,
-                            "Nova API async request to %s: 401 Unauthorized. Refreshing token.",
+                            "Nova API async request to %s: 401 Unauthorized (attempt %d/%d).",
                             api_scope,
+                            auth_retries_used + 1,
+                            max_auth_retries,
                         )
 
-                        # Only refresh token on first 401; subsequent retries use the
-                        # already-refreshed token with increasing backoff delays.
-                        if not refreshed_once:
+                        if auth_retries_used == _AUTH_STEP_ADM_REFRESH:
+                            # Step 1: First 401 - refresh ADM token only, wait for propagation
+                            _LOGGER.info(
+                                "Nova API: refreshing ADM token (AAS unchanged)."
+                            )
                             try:
                                 await policy.async_on_401()
                             except NovaAuthPermanentError:
-                                # AAS token invalid - no point retrying, re-auth required
+                                # AAS token explicitly rejected - no point retrying
                                 raise
-                            refreshed_once = True
-
-                        if auth_retries_used < max_auth_retries:
-                            delay = _AUTH_RETRY_DELAYS[auth_retries_used]
                             _LOGGER.info(
-                                "Nova API async request to %s: 401 after refresh. "
-                                "Waiting %.0fs before retry %d/%d.",
-                                api_scope,
-                                delay,
-                                auth_retries_used + 1,
-                                max_auth_retries,
+                                "Nova API: waiting %.0fs for token propagation.",
+                                _PROPAGATION_DELAY_S,
                             )
+                            await asyncio.sleep(_PROPAGATION_DELAY_S)
                             auth_retries_used += 1
-                            await asyncio.sleep(delay)
                             continue
 
-                        # Exhausted all retries - 401 is a client error indicating
-                        # invalid credentials. After ~6 min of retries, this is NOT
-                        # a transient issue; the token chain is genuinely broken.
+                        if auth_retries_used == _AUTH_STEP_AAS_ADM_REFRESH:
+                            # Step 2: Second 401 - ADM refresh didn't help
+                            # Wait cooldown, then invalidate AAS and refresh entire chain
+                            _LOGGER.warning(
+                                "Nova API: ADM refresh failed. Waiting %.0fs before "
+                                "refreshing entire token chain (AAS+ADM).",
+                                _SHORT_COOLDOWN_S,
+                            )
+                            await asyncio.sleep(_SHORT_COOLDOWN_S)
+                            await policy.async_invalidate_aas_token()
+                            _LOGGER.info("Nova API: refreshing AAS+ADM token chain.")
+                            try:
+                                await policy.async_on_401()
+                            except NovaAuthPermanentError:
+                                raise
+                            _LOGGER.info(
+                                "Nova API: waiting %.0fs for token propagation.",
+                                _PROPAGATION_DELAY_S,
+                            )
+                            await asyncio.sleep(_PROPAGATION_DELAY_S)
+                            auth_retries_used += 1
+                            continue
+
+                        if auth_retries_used == _AUTH_STEP_LONG_COOLDOWN:
+                            # Step 3: Third 401 - even fresh AAS+ADM didn't help
+                            # Wait long cooldown, then retry once more
+                            _LOGGER.warning(
+                                "Nova API: AAS+ADM refresh failed. Waiting %.0fs "
+                                "(long cooldown) before final retry.",
+                                _LONG_COOLDOWN_S,
+                            )
+                            await asyncio.sleep(_LONG_COOLDOWN_S)
+                            auth_retries_used += 1
+                            continue
+
+                        # Step 4: Fourth 401 - all retries exhausted
+                        # Total wait: 6s + 61s + 6s + 501s = 574s (~9.5 min)
+                        total_wait = (
+                            _PROPAGATION_DELAY_S
+                            + _SHORT_COOLDOWN_S
+                            + _PROPAGATION_DELAY_S
+                            + _LONG_COOLDOWN_S
+                        )
                         _LOGGER.error(
                             "Nova API async request to %s: 401 persists after %d retries "
                             "(total wait: %.0fs). Authentication is invalid; re-auth required.",
                             api_scope,
                             max_auth_retries,
-                            sum(_AUTH_RETRY_DELAYS),
+                            total_wait,
                         )
-                        # Invalidate the AAS token so re-auth can generate a fresh
-                        # token chain (OAuth -> AAS -> ADM).
-                        await policy.async_invalidate_aas_token()
                         raise NovaAuthError(
                             status,
                             "Unauthorized after token refresh; re-authentication required",

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -44,6 +44,7 @@ from .const import (
     DEFAULT_GOOGLE_HOME_FILTER_KEYWORDS,
     DEFAULT_LOCATION_POLL_INTERVAL,
     DEFAULT_MAP_VIEW_TOKEN_EXPIRATION,
+    DEFAULT_MIN_POLL_INTERVAL,
     DOMAIN,
     OPT_DEVICE_POLL_DELAY,
     OPT_ENABLE_STATS_ENTITIES,
@@ -53,6 +54,7 @@ from .const import (
     # user-facing options (non-secret)
     OPT_LOCATION_POLL_INTERVAL,
     OPT_MAP_VIEW_TOKEN_EXPIRATION,
+    OPT_MIN_POLL_INTERVAL,
 )
 from .ha_typing import callback
 
@@ -523,6 +525,10 @@ async def async_get_config_entry_diagnostics(
                 OPT_LOCATION_POLL_INTERVAL, DEFAULT_LOCATION_POLL_INTERVAL
             ),
             DEFAULT_LOCATION_POLL_INTERVAL,
+        ),
+        "min_poll_interval": _coerce_pos_int(
+            effective_config.get(OPT_MIN_POLL_INTERVAL, DEFAULT_MIN_POLL_INTERVAL),
+            DEFAULT_MIN_POLL_INTERVAL,
         ),
         "device_poll_delay": _coerce_pos_int(
             effective_config.get(OPT_DEVICE_POLL_DELAY, DEFAULT_DEVICE_POLL_DELAY),

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -926,16 +926,18 @@ def test_async_nova_request_invalidates_aas_token_after_exhausted_401_retries(
 ) -> None:
     """Persistent 401 errors after token refresh must invalidate the AAS token.
 
-    When all auth_retries (3 attempts with backoff) are exhausted and 401
-    still persists, the AAS token should be cleared so subsequent poll cycles
-    can generate a fresh token chain (OAuth -> AAS -> ADM).
+    With the new retry sequence:
+    - Step 1: First 401 → refresh ADM → 6s → retry
+    - Step 2: Second 401 → 61s → invalidate AAS, refresh AAS+ADM → 6s → retry
+    - Step 3: Third 401 → 501s → retry
+    - Step 4: Fourth 401 → permanent error
 
-    This regression test covers the bug where an invalid AAS token would remain
-    cached indefinitely, causing a loop of failed token refreshes.
+    The AAS token is invalidated in step 2, enabling fresh token generation
+    in subsequent poll cycles.
     """
 
     cache = _StubCache()
-    # Need 4 responses: 1 initial 401 + 3 retries all returning 401
+    # Need 4 responses: 4 consecutive 401s to exhaust all retry steps
     session = _DummySession(
         [
             _DummyResponse(401, b"Unauthorized"),
@@ -963,7 +965,7 @@ def test_async_nova_request_invalidates_aas_token_after_exhausted_401_retries(
         async def _refresh() -> str:
             return "refreshed-adm"
 
-        # Mock asyncio.sleep to skip the 6s+12s+24s backoff delays
+        # Mock asyncio.sleep to skip delays
         async def _instant_sleep(_: float) -> None:
             pass
 
@@ -998,11 +1000,11 @@ def test_async_nova_request_invalidates_aas_token_after_exhausted_401_retries(
     with pytest.raises(NovaAuthError) as err:
         asyncio.run(_exercise())
 
-    # Verify the error is transient (not permanent)
+    # After all retries exhausted, error is permanent (requires re-auth)
     assert err.value.status == 401
-    assert not err.value.is_permanent
+    assert err.value.is_permanent is True
 
-    # Verify async_invalidate_aas_token was called
+    # AAS invalidation happens in step 2 (after second 401)
     assert len(aas_invalidation_calls) == 1
     assert aas_invalidation_calls[0] == "user@example.com"
 
@@ -1374,3 +1376,519 @@ def test_async_nova_request_loop_prevention_across_multiple_cycles(
     assert aas_states_at_cycle_start[1][1] is None  # Cycle 2 sees None
     assert aas_states_at_cycle_start[2][1] is None  # Cycle 3 sees None
     assert aas_states_at_cycle_start[3][1] is None  # Cycle 4 sees None
+
+
+def test_async_nova_request_adm_only_failure_recovers_on_second_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADM refresh alone should fix most 401 errors without invalidating AAS.
+
+    This test verifies the new retry sequence:
+    - Step 1: First 401 → refresh ADM only → 6s propagation → retry
+    - Success on second request proves ADM-only refresh was sufficient
+
+    The AAS token should NOT be invalidated in this scenario.
+    """
+
+    cache = _StubCache()
+    # First request: 401, second request after ADM refresh: success
+    session = _DummySession(
+        [
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(200, b"\xca\xfe\xba\xbe"),
+        ]
+    )
+
+    aas_invalidation_calls: list[str] = []
+    adm_refresh_calls: list[str] = []
+    sleep_delays: list[float] = []
+
+    async def _exercise() -> tuple[str, str | None]:
+        await cache.set(DATA_AAS_TOKEN, "valid-aas")
+        await cache.set(username_string, "user@example.com")
+
+        async def _fake_get_adm_token(
+            username: str | None = None,
+            *,
+            retries: int = 2,
+            backoff: float = 1.0,
+            cache: Any,
+        ) -> str:
+            return "initial-adm"
+
+        async def _refresh() -> str:
+            adm_refresh_calls.append("refresh")
+            return "refreshed-adm"
+
+        async def _tracking_sleep(delay: float) -> None:
+            sleep_delays.append(delay)
+
+        original_invalidate = AsyncTTLPolicy.async_invalidate_aas_token
+
+        async def _spy_invalidate(self: AsyncTTLPolicy) -> None:
+            aas_invalidation_calls.append(self.username)
+            await original_invalidate(self)
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+            _fake_get_adm_token,
+        )
+        monkeypatch.setattr("asyncio.sleep", _tracking_sleep)
+        monkeypatch.setattr(
+            AsyncTTLPolicy,
+            "async_invalidate_aas_token",
+            _spy_invalidate,
+        )
+
+        result = await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+            refresh_override=_refresh,
+        )
+
+        final_aas = await cache.get(DATA_AAS_TOKEN)
+        return result, final_aas
+
+    result, final_aas = asyncio.run(_exercise())
+
+    # Request should succeed
+    assert result == "cafebabe"
+
+    # ADM refresh should have been called once
+    assert len(adm_refresh_calls) == 1
+
+    # AAS token should NOT be invalidated (ADM refresh was sufficient)
+    assert len(aas_invalidation_calls) == 0
+    assert final_aas == "valid-aas"
+
+    # Should have waited 6s for propagation delay
+    assert 6.0 in sleep_delays
+
+
+def test_async_nova_request_aas_adm_failure_requires_full_chain_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ADM-only refresh fails, the entire AAS+ADM chain must be refreshed.
+
+    This test verifies the new retry sequence:
+    - Step 1: First 401 → refresh ADM only → 6s → retry
+    - Step 2: Second 401 → 61s cooldown → invalidate AAS → refresh AAS+ADM → 6s → retry
+    - Success on third request proves full chain refresh was needed
+
+    The AAS token should be invalidated after the second 401.
+    """
+
+    cache = _StubCache()
+    # Two 401s (ADM-only fails), then success after full chain refresh
+    session = _DummySession(
+        [
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(200, b"\xde\xad\xbe\xef"),
+        ]
+    )
+
+    aas_invalidation_calls: list[str] = []
+    adm_refresh_calls: list[str] = []
+    sleep_delays: list[float] = []
+
+    async def _exercise() -> tuple[str, str | None]:
+        await cache.set(DATA_AAS_TOKEN, "stale-aas")
+        await cache.set(username_string, "user@example.com")
+
+        async def _fake_get_adm_token(
+            username: str | None = None,
+            *,
+            retries: int = 2,
+            backoff: float = 1.0,
+            cache: Any,
+        ) -> str:
+            return "initial-adm"
+
+        async def _refresh() -> str:
+            adm_refresh_calls.append("refresh")
+            # After AAS invalidation, this simulates generating fresh tokens
+            return "refreshed-adm"
+
+        async def _tracking_sleep(delay: float) -> None:
+            sleep_delays.append(delay)
+
+        original_invalidate = AsyncTTLPolicy.async_invalidate_aas_token
+
+        async def _spy_invalidate(self: AsyncTTLPolicy) -> None:
+            aas_invalidation_calls.append(self.username)
+            await original_invalidate(self)
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+            _fake_get_adm_token,
+        )
+        monkeypatch.setattr("asyncio.sleep", _tracking_sleep)
+        monkeypatch.setattr(
+            AsyncTTLPolicy,
+            "async_invalidate_aas_token",
+            _spy_invalidate,
+        )
+
+        result = await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+            refresh_override=_refresh,
+        )
+
+        final_aas = await cache.get(DATA_AAS_TOKEN)
+        return result, final_aas
+
+    result, final_aas = asyncio.run(_exercise())
+
+    # Request should succeed
+    assert result == "deadbeef"
+
+    # ADM refresh should have been called twice (once for step 1, once for step 2)
+    assert len(adm_refresh_calls) == 2
+
+    # AAS token should be invalidated exactly once (in step 2)
+    assert len(aas_invalidation_calls) == 1
+    assert aas_invalidation_calls[0] == "user@example.com"
+
+    # AAS should be None after invalidation
+    assert final_aas is None
+
+    # Verify the delay sequence: 6s (step 1) + 61s (step 2 cooldown) + 6s (step 2 propagation)
+    assert sleep_delays == [6.0, 61.0, 6.0]
+
+
+def test_async_nova_request_full_retry_sequence_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When all 4 retry steps fail, a permanent auth error must be raised.
+
+    This test verifies the complete retry sequence:
+    - Step 1: First 401 → refresh ADM → 6s → retry
+    - Step 2: Second 401 → 61s → invalidate AAS, refresh AAS+ADM → 6s → retry
+    - Step 3: Third 401 → 501s long cooldown → retry
+    - Step 4: Fourth 401 → permanent error (re-auth required)
+
+    Total wait: 6s + 61s + 6s + 501s = 574s (~9.5 min)
+    """
+
+    cache = _StubCache()
+    # Four consecutive 401s to exhaust all retries
+    session = _DummySession(
+        [
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+        ]
+    )
+
+    aas_invalidation_calls: list[str] = []
+    adm_refresh_calls: list[str] = []
+    sleep_delays: list[float] = []
+
+    async def _exercise() -> None:
+        await cache.set(DATA_AAS_TOKEN, "stale-aas")
+        await cache.set(username_string, "user@example.com")
+
+        async def _fake_get_adm_token(
+            username: str | None = None,
+            *,
+            retries: int = 2,
+            backoff: float = 1.0,
+            cache: Any,
+        ) -> str:
+            return "initial-adm"
+
+        async def _refresh() -> str:
+            adm_refresh_calls.append("refresh")
+            return "refreshed-adm"
+
+        async def _tracking_sleep(delay: float) -> None:
+            sleep_delays.append(delay)
+
+        original_invalidate = AsyncTTLPolicy.async_invalidate_aas_token
+
+        async def _spy_invalidate(self: AsyncTTLPolicy) -> None:
+            aas_invalidation_calls.append(self.username)
+            await original_invalidate(self)
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+            _fake_get_adm_token,
+        )
+        monkeypatch.setattr("asyncio.sleep", _tracking_sleep)
+        monkeypatch.setattr(
+            AsyncTTLPolicy,
+            "async_invalidate_aas_token",
+            _spy_invalidate,
+        )
+
+        await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+            refresh_override=_refresh,
+        )
+
+    with pytest.raises(NovaAuthError) as err:
+        asyncio.run(_exercise())
+
+    # Should be a permanent error requiring re-authentication
+    assert err.value.status == 401
+    assert err.value.is_permanent is True
+    assert "re-authentication required" in str(err.value).lower()
+
+    # ADM refresh should have been called twice (step 1 and step 2)
+    assert len(adm_refresh_calls) == 2
+
+    # AAS invalidation should have been called once (step 2)
+    assert len(aas_invalidation_calls) == 1
+
+    # Verify the complete delay sequence: 6s + 61s + 6s + 501s
+    assert sleep_delays == [6.0, 61.0, 6.0, 501.0]
+
+
+def test_async_nova_request_recovers_on_long_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recovery on step 3 (after 501s long cooldown) should succeed.
+
+    This test verifies that even if ADM-only and AAS+ADM refresh both fail,
+    success after the long cooldown period should work.
+
+    Sequence: 401 → ADM → 401 → AAS+ADM → 401 → 501s → success
+    """
+
+    cache = _StubCache()
+    # Three 401s, then success after long cooldown
+    session = _DummySession(
+        [
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(401, b"Unauthorized"),
+            _DummyResponse(200, b"\xfe\xed\xfa\xce"),
+        ]
+    )
+
+    sleep_delays: list[float] = []
+
+    async def _exercise() -> str:
+        await cache.set(DATA_AAS_TOKEN, "stale-aas")
+        await cache.set(username_string, "user@example.com")
+
+        async def _fake_get_adm_token(
+            username: str | None = None,
+            *,
+            retries: int = 2,
+            backoff: float = 1.0,
+            cache: Any,
+        ) -> str:
+            return "initial-adm"
+
+        async def _refresh() -> str:
+            return "refreshed-adm"
+
+        async def _tracking_sleep(delay: float) -> None:
+            sleep_delays.append(delay)
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.NovaApi.nova_request.async_get_adm_token_api",
+            _fake_get_adm_token,
+        )
+        monkeypatch.setattr("asyncio.sleep", _tracking_sleep)
+
+        return await async_nova_request(
+            "testScope",
+            "00",
+            username="user@example.com",
+            cache=cache,
+            session=session,
+            refresh_override=_refresh,
+        )
+
+    result = asyncio.run(_exercise())
+
+    # Should succeed after long cooldown
+    assert result == "feedface"
+
+    # Verify delays: 6s + 61s + 6s + 501s
+    assert sleep_delays == [6.0, 61.0, 6.0, 501.0]
+
+
+def test_async_ttl_policy_aas_ttl_learning_records_observed_lifetime() -> None:
+    """AAS TTL learning should record the observed token lifetime when invalidated.
+
+    This test verifies that when an AAS token is invalidated:
+    1. The observed lifetime is calculated from the issued timestamp
+    2. The best TTL is updated with a 5% safety margin
+    """
+
+    async def _run() -> None:
+        hass = _FakeHass()
+        cache = await TokenCache.create(hass, "entry-aas-ttl")
+        try:
+            namespace = "entry-aas-ttl"
+            username = "user@example.com"
+
+            async def _cache_get(key: str) -> Any:
+                return await cache.get(key)
+
+            async def _cache_set(key: str, value: Any) -> None:
+                await cache.set(key, value)
+
+            async def _refresh() -> str:
+                return "fresh-token"
+
+            policy = AsyncTTLPolicy(
+                username=username,
+                logger=logging.getLogger("test_aas_ttl_learning"),
+                get_value=_cache_get,
+                set_value=_cache_set,
+                refresh_fn=_refresh,
+                set_auth_header_fn=lambda _: None,
+                ns_prefix=namespace,
+            )
+
+            # Simulate AAS token issued 24 hours ago
+            issued_time = time.time() - (24 * 3600)  # 24 hours ago
+            await cache.set(policy.k_aas_issued, issued_time)
+            await cache.set(DATA_AAS_TOKEN, "old-aas")
+
+            # Invalidate the AAS token
+            await policy.async_invalidate_aas_token()
+
+            # Verify AAS token is cleared
+            assert await cache.get(DATA_AAS_TOKEN) is None
+
+            # Verify best TTL was learned (24 hours * 0.95 = ~82080 seconds)
+            best_ttl = await cache.get(policy.k_aas_bestttl)
+            assert best_ttl is not None
+            expected_ttl = 24 * 3600 * 0.95
+            assert abs(float(best_ttl) - expected_ttl) < 60  # Allow 1 min tolerance
+
+        finally:
+            await cache.close()
+
+    asyncio.run(_run())
+
+
+def test_async_ttl_policy_aas_proactive_refresh_triggers_near_expiry() -> None:
+    """AAS proactive refresh should trigger when approaching learned TTL.
+
+    When the AAS token age approaches the learned TTL minus margin,
+    async_check_aas_proactive_refresh should return True and invalidate the token.
+    """
+
+    async def _run() -> None:
+        hass = _FakeHass()
+        cache = await TokenCache.create(hass, "entry-aas-proactive")
+        try:
+            namespace = "entry-aas-proactive"
+            username = "user@example.com"
+
+            async def _cache_get(key: str) -> Any:
+                return await cache.get(key)
+
+            async def _cache_set(key: str, value: Any) -> None:
+                await cache.set(key, value)
+
+            async def _refresh() -> str:
+                return "fresh-token"
+
+            policy = AsyncTTLPolicy(
+                username=username,
+                logger=logging.getLogger("test_aas_proactive"),
+                get_value=_cache_get,
+                set_value=_cache_set,
+                refresh_fn=_refresh,
+                set_auth_header_fn=lambda _: None,
+                ns_prefix=namespace,
+            )
+
+            # Set best TTL to 1 hour (3600 seconds)
+            await cache.set(policy.k_aas_bestttl, 3600.0)
+
+            # AAS token issued 57 minutes ago (past the threshold + max jitter)
+            # Threshold = 3600 - 300 = 3300s, jitter = ±90s, so max threshold = 3390s
+            # 57 min = 3420s > 3390s, so it will always trigger
+            issued_time = time.time() - (57 * 60)  # 57 minutes ago
+            await cache.set(policy.k_aas_issued, issued_time)
+            await cache.set(DATA_AAS_TOKEN, "old-aas")
+
+            # Check proactive refresh - should trigger
+            result = await policy.async_check_aas_proactive_refresh()
+
+            # Should have triggered proactive refresh
+            assert result is True
+
+            # AAS token should be invalidated
+            assert await cache.get(DATA_AAS_TOKEN) is None
+
+        finally:
+            await cache.close()
+
+    asyncio.run(_run())
+
+
+def test_async_ttl_policy_aas_proactive_refresh_skips_when_fresh() -> None:
+    """AAS proactive refresh should NOT trigger when token is still fresh.
+
+    When the AAS token is well within its TTL, proactive refresh should skip.
+    """
+
+    async def _run() -> None:
+        hass = _FakeHass()
+        cache = await TokenCache.create(hass, "entry-aas-fresh")
+        try:
+            namespace = "entry-aas-fresh"
+            username = "user@example.com"
+
+            async def _cache_get(key: str) -> Any:
+                return await cache.get(key)
+
+            async def _cache_set(key: str, value: Any) -> None:
+                await cache.set(key, value)
+
+            async def _refresh() -> str:
+                return "fresh-token"
+
+            policy = AsyncTTLPolicy(
+                username=username,
+                logger=logging.getLogger("test_aas_fresh"),
+                get_value=_cache_get,
+                set_value=_cache_set,
+                refresh_fn=_refresh,
+                set_auth_header_fn=lambda _: None,
+                ns_prefix=namespace,
+            )
+
+            # Set best TTL to 24 hours
+            await cache.set(policy.k_aas_bestttl, 24 * 3600.0)
+
+            # AAS token issued 1 hour ago (well within 24 hour TTL)
+            issued_time = time.time() - 3600  # 1 hour ago
+            await cache.set(policy.k_aas_issued, issued_time)
+            await cache.set(DATA_AAS_TOKEN, "fresh-aas")
+
+            # Check proactive refresh - should NOT trigger
+            result = await policy.async_check_aas_proactive_refresh()
+
+            # Should NOT have triggered proactive refresh
+            assert result is False
+
+            # AAS token should still exist
+            assert await cache.get(DATA_AAS_TOKEN) == "fresh-aas"
+
+        finally:
+            await cache.close()
+
+    asyncio.run(_run())


### PR DESCRIPTION
Changes Made
1. nova_request.py - Step-based 401 retry sequence:

Step 1 (First 401): Refresh ADM token only, wait 6s propagation delay
Step 2 (Second 401): Wait 61s cooldown, invalidate AAS, refresh full chain, wait 6s
Step 3 (Third 401): Long 501s cooldown (rate-limit recovery)
Step 4 (Fourth 401): Raise permanent NovaAuthError for re-authentication
2. nova_request.py - AAS TTL Learning:

Added k_aas_issued, k_aas_bestttl cache key properties
async_record_aas_issued() - Records AAS token issuance timestamp
async_invalidate_aas_token() - Learns observed TTL with 5% safety margin
async_check_aas_proactive_refresh() - Proactive refresh based on learned TTL
Clears ADM issued timestamp when invalidating AAS to bypass stampede guard
3. aas_token_retrieval.py:

Records AAS issuance timestamp when fresh token is generated
4. tests/test_nova_request.py - 7 new tests:

ADM-only failure recovery
AAS+ADM failure requiring full chain refresh
Full retry sequence exhausted (permanent error)
Long cooldown recovery
AAS TTL learning records observed lifetime
AAS proactive refresh triggers near expiry
AAS proactive refresh skips when fresh
Quality Checks Passed
✓ ruff format
✓ ruff check --fix
✓ mypy --strict
✓ All 26 tests pass