### PR TITLE
refactor: review pytest imports for Home Assistant compatibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2059,3 +2059,51 @@ components_pkg.__path__ = [str(ROOT / "custom_components")]
 
 gf_pkg = importlib.import_module("custom_components.googlefindmy")
 setattr(components_pkg, "googlefindmy", gf_pkg)
+
+
+@pytest.fixture
+def use_real_homeassistant_modules() -> Iterable[None]:
+    """Temporarily replace the stubbed Home Assistant modules with the real ones.
+
+    Use this fixture in tests that require the real Home Assistant implementation
+    provided by pytest-homeassistant-custom-component instead of the lightweight
+    stubs installed by conftest.py.
+
+    Example:
+        @pytest.mark.asyncio
+        async def test_integration_flow(
+            hass: HomeAssistant,
+            use_real_homeassistant_modules: None,
+        ) -> None:
+            # Test runs with real HA modules
+            ...
+    """
+    saved_modules = {
+        name: module for name, module in sys.modules.items() if name.startswith("homeassistant")
+    }
+    for name in list(sys.modules):
+        if name.startswith("homeassistant"):
+            del sys.modules[name]
+
+    import homeassistant  # noqa: F401 - ensure the real package is loaded
+    from homeassistant.helpers import aiohttp_client as _aiohttp_client
+    from homeassistant.util import dt as dt_util
+
+    # Ensure timezone is set for HA fixtures
+    dt_util.DEFAULT_TIME_ZONE = dt_util.UTC
+
+    # Some pytest-homeassistant-custom-component versions require this shim
+    if not hasattr(_aiohttp_client, "_async_make_resolver"):
+
+        async def _async_make_resolver(*args: Any, **kwargs: Any) -> None:  # pragma: no cover
+            return None
+
+        _aiohttp_client._async_make_resolver = _async_make_resolver  # type: ignore[attr-defined]
+
+    try:
+        yield
+    finally:
+        for name in list(sys.modules):
+            if name.startswith("homeassistant"):
+                del sys.modules[name]
+        sys.modules.update(saved_modules)

--- a/tests/test_entity_device_info_contract.py
+++ b/tests/test_entity_device_info_contract.py
@@ -35,35 +35,10 @@ from custom_components.googlefindmy.entity import GoogleFindMyDeviceEntity
 pytest_plugins = ("pytest_homeassistant_custom_component",)
 
 
-
 @pytest.fixture(autouse=True)
-def use_real_homeassistant_modules() -> Any:
-    """Temporarily replace the stubbed Home Assistant modules with the real ones."""
-
-    import sys
-
-    saved_modules = {
-        name: module for name, module in sys.modules.items() if name.startswith("homeassistant")
-    }
-    for name in list(sys.modules):
-        if name.startswith("homeassistant"):
-            del sys.modules[name]
-
-    import homeassistant  # noqa: F401  # ensure the real package is loaded
-    from homeassistant.helpers import aiohttp_client as _aiohttp_client
-
-    if not hasattr(_aiohttp_client, '_async_make_resolver'):
-        async def _async_make_resolver(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - plugin shim
-            return None
-
-        _aiohttp_client._async_make_resolver = _async_make_resolver  # type: ignore[attr-defined]
-
-    yield
-
-    for name in list(sys.modules):
-        if name.startswith("homeassistant"):
-            del sys.modules[name]
-    sys.modules.update(saved_modules)
+def _use_real_ha_modules(use_real_homeassistant_modules: None) -> None:
+    """Activate real Home Assistant modules from the central conftest fixture."""
+    pass
 
 
 class _DummyTokenCache:

--- a/tests/test_entity_recovery_manager.py
+++ b/tests/test_entity_recovery_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 from collections import defaultdict
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Sequence
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
@@ -25,35 +25,9 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture(autouse=True)
-def use_real_homeassistant_modules() -> Iterator[None]:
-    """Temporarily replace the stubbed Home Assistant modules with the real ones."""
-
-    import sys
-
-    saved_modules = {
-        name: module for name, module in sys.modules.items() if name.startswith("homeassistant")
-    }
-    for name in list(sys.modules):
-        if name.startswith("homeassistant"):
-            del sys.modules[name]
-
-    import homeassistant  # noqa: F401  # ensure the real package is loaded
-    from homeassistant.helpers import aiohttp_client as _aiohttp_client
-
-    if not hasattr(_aiohttp_client, "_async_make_resolver"):
-
-        async def _async_make_resolver(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - plugin shim
-            return None
-
-        _aiohttp_client._async_make_resolver = _async_make_resolver  # type: ignore[attr-defined]
-
-    try:
-        yield
-    finally:
-        for name in list(sys.modules):
-            if name.startswith("homeassistant"):
-                del sys.modules[name]
-        sys.modules.update(saved_modules)
+def _use_real_ha_modules(use_real_homeassistant_modules: None) -> None:
+    """Activate real Home Assistant modules from the central conftest fixture."""
+    pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Move the use_real_homeassistant_modules fixture from individual test files to conftest.py to eliminate code duplication. Tests that require real Home Assistant modules from pytest-homeassistant-custom-component can now simply depend on this central fixture.

- Add use_real_homeassistant_modules fixture to conftest.py
- Update test_entity_recovery_manager.py to use central fixture
- Update test_entity_device_info_contract.py to use central fixture
- Remove duplicate Iterator import

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
