### PR TITLE
fix: "Phantom Update" Bug (Google FMDN accuracy=0.0)

### DIFF
--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -330,11 +330,15 @@ def _normalize_location_dict(loc: dict[str, Any]) -> dict[str, Any]:
 
     Validation rules:
         - NaN/Inf values are dropped for all numeric fields.
-        - accuracy <= 0 is dropped: GPS accuracy of 0.0m is physically impossible
-          (real GPS typically has 3-50m accuracy). Zero indicates missing data.
+        - accuracy < 1.0m is dropped: Consumer GPS cannot achieve sub-meter accuracy.
+          Values like 0.0 indicate "privacy masked" or "unknown" - the REPORT is kept,
+          but accuracy is treated as unmeasured (acc_rank = -inf in ranking).
         - "Null Island" coordinates (0.0, 0.0) are dropped: This location in the
           Atlantic Ocean is a common API default when no real location is available.
     """
+    # Minimum physically plausible GPS accuracy (consumer hardware floor)
+    _MIN_PLAUSIBLE_ACCURACY_M = 1.0
+
     out = dict(loc)
     for num_key in ("latitude", "longitude", "accuracy", "last_seen", "altitude"):
         val = out.get(num_key)
@@ -344,8 +348,11 @@ def _normalize_location_dict(loc: dict[str, Any]) -> dict[str, Any]:
             f = float(val)
             if not math.isfinite(f):
                 out.pop(num_key, None)
-            # accuracy <= 0 is physically impossible for GPS; treat as missing
-            elif num_key == "accuracy" and f <= 0.0:
+            # accuracy < 1.0m is physically impossible for consumer GPS.
+            # Values like 0.0 mean "unknown/masked", not "perfect".
+            # We KEEP the report but REMOVE the accuracy key so it doesn't
+            # corrupt ranking (acc_rank = -inf when accuracy is None).
+            elif num_key == "accuracy" and f < _MIN_PLAUSIBLE_ACCURACY_M:
                 out.pop(num_key, None)
             else:
                 out[num_key] = f
@@ -677,10 +684,17 @@ def _merge_semantics_if_near_ts(
 
     out = dict(best)
 
+    # Extract best candidate's timestamp FIRST - used for identity protection.
+    t_best = _extract_ts(out.get("last_seen"))
+
     # Track the freshest coordinate-bearing candidate so semantic-only entries can
     # still expose stable position data after the merge step.
+    #
+    # IDENTITY PROTECTION: Initialize to t_best (not -inf) so that lower-ranked
+    # candidates with the SAME timestamp cannot "steal" coordinates from the best.
+    # A lower-ranked entry must be STRICTLY newer to update coordinates.
     best_coordinate: dict[str, Any] | None = None
-    best_coordinate_ts = float("-inf")
+    best_coordinate_ts = t_best  # Protects against timestamp collision identity theft
 
     # Track the semantic label currently attached to the outgoing payload.
     semantic_label: str | None = None
@@ -688,8 +702,6 @@ def _merge_semantics_if_near_ts(
     if out.get("semantic_name"):
         semantic_label = str(out["semantic_name"])
         semantic_ts = _extract_ts(out.get("last_seen"))
-
-    t_best = _extract_ts(out.get("last_seen"))
 
     # Historical behaviour: borrow a semantic label very close to the coordinate
     # fix timestamp when none is present yet.

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -330,14 +330,17 @@ def _normalize_location_dict(loc: dict[str, Any]) -> dict[str, Any]:
 
     Validation rules:
         - NaN/Inf values are dropped for all numeric fields.
-        - accuracy < 1.0m is dropped: Consumer GPS cannot achieve sub-meter accuracy.
-          Values like 0.0 indicate "privacy masked" or "unknown" - the REPORT is kept,
-          but accuracy is treated as unmeasured (acc_rank = -inf in ranking).
+        - accuracy < 0.001m is dropped: The Android Location API uses 0.0 as an error
+          code meaning "no accuracy available". Modern dual-frequency GNSS can achieve
+          sub-meter accuracy, so only the error code (0.0) is filtered. The REPORT is
+          kept, but accuracy is treated as unmeasured (acc_rank = -inf in ranking).
         - "Null Island" coordinates (0.0, 0.0) are dropped: This location in the
           Atlantic Ocean is a common API default when no real location is available.
     """
-    # Minimum physically plausible GPS accuracy (consumer hardware floor)
-    _MIN_PLAUSIBLE_ACCURACY_M = 1.0
+    # Minimum valid accuracy threshold (1mm).
+    # Only the error code 0.0 (and negative values) are filtered.
+    # Modern dual-frequency GNSS can achieve sub-meter accuracy.
+    _MIN_VALID_ACCURACY = 0.001
 
     out = dict(loc)
     for num_key in ("latitude", "longitude", "accuracy", "last_seen", "altitude"):
@@ -348,11 +351,11 @@ def _normalize_location_dict(loc: dict[str, Any]) -> dict[str, Any]:
             f = float(val)
             if not math.isfinite(f):
                 out.pop(num_key, None)
-            # accuracy < 1.0m is physically impossible for consumer GPS.
-            # Values like 0.0 mean "unknown/masked", not "perfect".
+            # accuracy < 0.001m is the error code (0.0 = "no accuracy").
             # We KEEP the report but REMOVE the accuracy key so it doesn't
             # corrupt ranking (acc_rank = -inf when accuracy is None).
-            elif num_key == "accuracy" and f < _MIN_PLAUSIBLE_ACCURACY_M:
+            # Valid sub-meter values like 0.5m are preserved!
+            elif num_key == "accuracy" and f < _MIN_VALID_ACCURACY:
                 out.pop(num_key, None)
             else:
                 out[num_key] = f

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -53,8 +53,7 @@ class _DecryptLocationsCallable(Protocol):
         device_update_protobuf: DeviceUpdate_pb2.DeviceUpdate,
         *,
         cache: TokenCache,
-    ) -> list[dict[str, Any]] | None:
-        ...
+    ) -> list[dict[str, Any]] | None: ...
 
 
 # --------------------------------------------------------------------------------------
@@ -148,9 +147,7 @@ def custom_message_formatter(
                 nested_message = custom_message_formatter(
                     value, f"{indent}  ", _as_one_line
                 )
-                lines.append(
-                    f"{indent}{field.name} {{\n{nested_message}\n{indent}}}"
-                )
+                lines.append(f"{indent}{field.name} {{\n{nested_message}\n{indent}}}")
         else:
             lines.append(f"{indent}{field.name}: {value}")
     return "\n".join(lines)
@@ -394,7 +391,9 @@ def _normalize_timestamp(value: Any) -> int | None:
     return seconds if seconds > 0 else None
 
 
-def _merge_dict_preserve_left(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:
+def _merge_dict_preserve_left(
+    left: dict[str, Any], right: dict[str, Any]
+) -> dict[str, Any]:
     """Merge two dicts without overwriting keys from the left dict."""
 
     merged = dict(left)
@@ -404,7 +403,9 @@ def _merge_dict_preserve_left(left: dict[str, Any], right: dict[str, Any]) -> di
     return merged
 
 
-def _collect_anchor_metadata(location_candidates: list[dict[str, Any]]) -> dict[str, Any]:
+def _collect_anchor_metadata(
+    location_candidates: list[dict[str, Any]],
+) -> dict[str, Any]:
     """Union anchor/metadata keys across *all* candidates.
 
     This protects metadata-only candidates from being dropped when a different
@@ -427,7 +428,9 @@ def _collect_anchor_metadata(location_candidates: list[dict[str, Any]]) -> dict[
 
         # boolean
         if "metadata_only" in cand:
-            union["metadata_only"] = bool(union.get("metadata_only")) or bool(cand.get("metadata_only"))
+            union["metadata_only"] = bool(union.get("metadata_only")) or bool(
+                cand.get("metadata_only")
+            )
 
         for ts_key in ("pair_date", "secrets_creation_date"):
             if ts_key in cand:
@@ -458,7 +461,10 @@ def _collect_anchor_metadata(location_candidates: list[dict[str, Any]]) -> dict[
                 union["owner_key_version"] = okv
 
         # list unions
-        for list_key in ("identity_key_candidates", "encrypted_identity_key_candidates"):
+        for list_key in (
+            "identity_key_candidates",
+            "encrypted_identity_key_candidates",
+        ):
             lst = cand.get(list_key)
             if not isinstance(lst, list) or not lst:
                 continue
@@ -476,7 +482,11 @@ def _collect_anchor_metadata(location_candidates: list[dict[str, Any]]) -> dict[
             union[list_key] = existing
 
         # dict blobs (diagnostics)
-        for dict_key in ("device_registration", "device_type_information", "encrypted_user_secrets"):
+        for dict_key in (
+            "device_registration",
+            "device_type_information",
+            "encrypted_user_secrets",
+        ):
             if union.get(dict_key) is None:
                 d_val = cand.get(dict_key)
                 if isinstance(d_val, dict) and d_val:
@@ -487,7 +497,9 @@ def _collect_anchor_metadata(location_candidates: list[dict[str, Any]]) -> dict[
         if isinstance(dbg, dict) and dbg:
             existing_dbg = union.get("time_anchors_debug")
             if isinstance(existing_dbg, dict) and existing_dbg:
-                union["time_anchors_debug"] = _merge_dict_preserve_left(existing_dbg, dbg)
+                union["time_anchors_debug"] = _merge_dict_preserve_left(
+                    existing_dbg, dbg
+                )
             else:
                 union["time_anchors_debug"] = dbg
 
@@ -500,12 +512,28 @@ def _get_rank_tuple(n: dict[str, Any]) -> tuple[float, int, int, float, str]:
     Priority (high to low):
       1. Newer ``last_seen`` timestamp
       2. Source/Status: Owner > Crowdsourced > Aggregated > Unknown
+         (BUT: is_own_report only trusted if accuracy is valid)
       3. Presence of coordinates (tie-breaker when timestamps/status match)
       4. Better accuracy (smaller is better)
       5. Deterministic tie-breaker string
     """
-    # 1) Owner-Reports always take precedence
-    is_own = 1 if bool(n.get("is_own_report")) else 0
+    # Pre-compute accuracy validity for status ranking decisions.
+    # A report claiming is_own_report=True but with invalid/missing accuracy
+    # (after normalization strips accuracy <= 0) is suspicious and should NOT
+    # get the "own report" bonus. This prevents the January 2025 phantom bug.
+    acc = n.get("accuracy")
+    has_valid_accuracy = (
+        isinstance(acc, (int, float)) and math.isfinite(float(acc)) and float(acc) > 0
+    )
+
+    # 1) Owner-Reports take precedence ONLY if accuracy is trustworthy
+    is_own_flag = bool(n.get("is_own_report"))
+    # Own report bonus requires valid accuracy (or no coordinates = semantic only)
+    has_coords = isinstance(n.get("latitude"), (int, float)) and isinstance(
+        n.get("longitude"), (int, float)
+    )
+    # Trust is_own_report if: (1) accuracy is valid, OR (2) no coordinates (semantic)
+    is_own_trusted = is_own_flag and (has_valid_accuracy or not has_coords)
 
     # 2) Robustly determine status rank (String, Int, or via Hint)
     status_code = n.get("status_code")
@@ -531,7 +559,7 @@ def _get_rank_tuple(n: dict[str, Any]) -> tuple[float, int, int, float, str]:
     _MISSING = object()
     cs = getattr(Common_pb2.Status, "CROWDSOURCED", _MISSING)
     ag = getattr(Common_pb2.Status, "AGGREGATED", _MISSING)
-    if is_own:
+    if is_own_trusted:
         status_rank = 3
     elif (
         (cs is not _MISSING and status_code_int == cs)
@@ -550,26 +578,25 @@ def _get_rank_tuple(n: dict[str, Any]) -> tuple[float, int, int, float, str]:
     else:
         status_rank = 0  # SEMANTIC/Unknown/Default
 
-    has_coords = (
-        1
-        if isinstance(n.get("latitude"), (int, float))
-        and isinstance(n.get("longitude"), (int, float))
-        else 0
-    )
+    # has_coords already computed above as boolean; convert to int for tuple
+    has_coords_rank = 1 if has_coords else 0
+
     seen = n.get("last_seen")
     seen_rank = (
         float(seen)
         if isinstance(seen, (int, float)) and math.isfinite(float(seen))
         else float("-inf")
     )
-    acc = n.get("accuracy")
+
     # accuracy <= 0 is physically impossible for GPS; treat as missing/worst rank.
     # Defense in depth: even if _normalize_location_dict didn't filter it.
-    acc_rank = (
-        -float(acc)
-        if isinstance(acc, (int, float)) and math.isfinite(float(acc)) and float(acc) > 0
-        else float("-inf")
-    )
+    # (has_valid_accuracy already computed above; assert helps mypy)
+    if has_valid_accuracy:
+        assert acc is not None  # validated in has_valid_accuracy
+        acc_rank = -float(acc)
+    else:
+        acc_rank = float("-inf")
+
     # Deterministic final tiebreaker: canonical content key (string).
     stable_key = "|".join(
         str(x)
@@ -584,7 +611,7 @@ def _get_rank_tuple(n: dict[str, Any]) -> tuple[float, int, int, float, str]:
             n.get("semantic_name", ""),
         )
     )
-    return (seen_rank, status_rank, has_coords, acc_rank, stable_key)
+    return (seen_rank, status_rank, has_coords_rank, acc_rank, stable_key)
 
 
 def _select_best_location(
@@ -806,9 +833,7 @@ def get_devices_with_location(
                         f.name
                         for f, _ in device.information.locationInformation.ListFields()
                     ]
-                    _LOGGER.debug(
-                        "    -> locationInformation fields: %s", loc_fields
-                    )
+                    _LOGGER.debug("    -> locationInformation fields: %s", loc_fields)
 
             device_str = str(device)
             unknown_lines = [
@@ -930,7 +955,9 @@ def get_devices_with_location(
                         creation_date_obj, "seconds", None
                     )
             except (ValueError, AttributeError):
-                creation_date_obj = getattr(encrypted_user_secrets, "creationDate", None)
+                creation_date_obj = getattr(
+                    encrypted_user_secrets, "creationDate", None
+                )
                 raw_creation_date_seconds = (
                     getattr(creation_date_obj, "seconds", None)
                     if creation_date_obj is not None
@@ -1040,9 +1067,10 @@ def get_devices_with_location(
             if pair_date is not None:
                 dbg.setdefault("pair_date_source", "device_registration.proto")
             if secrets_creation_date is not None:
-                dbg.setdefault("secrets_creation_date_source", "encrypted_user_secrets.proto")
+                dbg.setdefault(
+                    "secrets_creation_date_source", "encrypted_user_secrets.proto"
+                )
             anchor_union["time_anchors_debug"] = dbg
-
 
         # Emit **exactly one** row per canonic ID.
         for canonic in canonic_ids:
@@ -1078,7 +1106,6 @@ def get_devices_with_location(
                 v = anchor_union.get(k)
                 if v is not None:
                     row[k] = v
-
 
             results.append(row)
 

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -327,9 +327,14 @@ def _build_device_stub(device_name: str, canonic_id: str) -> dict[str, Any]:
 
 
 def _normalize_location_dict(loc: dict[str, Any]) -> dict[str, Any]:
-    """Coerce numeric fields to floats (when present) and drop NaN/Inf.
+    """Coerce numeric fields to floats (when present) and drop invalid values.
 
     Only mutates a shallow copy. Unknown keys are preserved (e.g., `_report_hint`).
+
+    Validation rules:
+        - NaN/Inf values are dropped for all numeric fields.
+        - accuracy <= 0 is dropped: GPS accuracy of 0.0m is physically impossible
+          (real GPS typically has 3-50m accuracy). Zero indicates missing data.
     """
     out = dict(loc)
     for num_key in ("latitude", "longitude", "accuracy", "last_seen", "altitude"):
@@ -339,6 +344,9 @@ def _normalize_location_dict(loc: dict[str, Any]) -> dict[str, Any]:
         try:
             f = float(val)
             if not math.isfinite(f):
+                out.pop(num_key, None)
+            # accuracy <= 0 is physically impossible for GPS; treat as missing
+            elif num_key == "accuracy" and f <= 0.0:
                 out.pop(num_key, None)
             else:
                 out[num_key] = f
@@ -541,9 +549,11 @@ def _get_rank_tuple(n: dict[str, Any]) -> tuple[float, int, int, float, str]:
         else float("-inf")
     )
     acc = n.get("accuracy")
+    # accuracy <= 0 is physically impossible for GPS; treat as missing/worst rank.
+    # Defense in depth: even if _normalize_location_dict didn't filter it.
     acc_rank = (
         -float(acc)
-        if isinstance(acc, (int, float)) and math.isfinite(float(acc))
+        if isinstance(acc, (int, float)) and math.isfinite(float(acc)) and float(acc) > 0
         else float("-inf")
     )
     # Deterministic final tiebreaker: canonical content key (string).
@@ -670,10 +680,13 @@ def _merge_semantics_if_near_ts(
         ts = _extract_ts(n.get("last_seen"))
         latest_seen = max(latest_seen, ts)
 
+        # Use strict > to preserve sort order: when timestamps are equal,
+        # the first entry (already ranked higher by _get_rank_tuple) wins.
+        # Using >= would cause "last-write-wins" and prefer worse entries.
         if (
             isinstance(n.get("latitude"), (int, float))
             and isinstance(n.get("longitude"), (int, float))
-            and ts >= best_coordinate_ts
+            and ts > best_coordinate_ts
         ):
             best_coordinate = n
             best_coordinate_ts = ts

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -335,6 +335,8 @@ def _normalize_location_dict(loc: dict[str, Any]) -> dict[str, Any]:
         - NaN/Inf values are dropped for all numeric fields.
         - accuracy <= 0 is dropped: GPS accuracy of 0.0m is physically impossible
           (real GPS typically has 3-50m accuracy). Zero indicates missing data.
+        - "Null Island" coordinates (0.0, 0.0) are dropped: This location in the
+          Atlantic Ocean is a common API default when no real location is available.
     """
     out = dict(loc)
     for num_key in ("latitude", "longitude", "accuracy", "last_seen", "altitude"):
@@ -352,6 +354,18 @@ def _normalize_location_dict(loc: dict[str, Any]) -> dict[str, Any]:
                 out[num_key] = f
         except (TypeError, ValueError):
             out.pop(num_key, None)
+
+    # "Null Island" filter: Coordinates at (0.0, 0.0) are in the Atlantic Ocean
+    # and indicate a default/missing value from the API, not a real location.
+    lat = out.get("latitude")
+    lon = out.get("longitude")
+    if lat is not None and lon is not None:
+        # Use small epsilon for floating point comparison (covers 0.0 defaults)
+        if abs(lat) < 0.0001 and abs(lon) < 0.0001:
+            out.pop("latitude", None)
+            out.pop("longitude", None)
+            out.pop("accuracy", None)  # Without coordinates, accuracy is meaningless
+
     return out
 
 

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -4947,8 +4947,10 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
                 continue
 
             accuracy = self._coerce_float(payload.get("accuracy"))
-            if accuracy is None:
-                accuracy = 0.0
+            if accuracy is None or accuracy <= 0:
+                # Use default radius for semantic zones without explicit accuracy.
+                # Never use 0.0 as it's physically impossible for GPS.
+                accuracy = DEFAULT_SEMANTIC_DETECTION_RADIUS
 
             normalized[name] = {
                 "latitude": latitude,

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -161,6 +161,17 @@ DEFAULT_SEMANTIC_DETECTION_RADIUS: float = (
     50.0  # meters; soft floor for semantic locations
 )
 
+# GPS accuracy fallback for invalid/missing values.
+# When accuracy is reported as 0.0m, negative, NaN, or Inf, it indicates missing
+# or corrupted data (0.0m GPS accuracy is physically impossible - real GPS: 3-50m).
+# This fallback represents a conservative estimate based on:
+#   - Bluetooth range: ~40-80m (tracker could be anywhere within BLE range)
+#   - GPS error margin: ~10-30m (finder device uncertainty)
+# Using 50m prevents the "Fusion Lock-in" effect where 0.0m gets extreme weight
+# in weighted averaging (1/0² vs 1/20² = infinite vs 0.0025), while still being
+# easily overridden by real GPS fixes.
+DEFAULT_FALLBACK_ACCURACY_M: float = 50.0
+
 # Location timestamp acceptance window
 MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S: float = 24 * 60 * 60  # 24 hours
 

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -587,12 +587,16 @@ class CacheOperations:
         device_id: str,
         new_data: dict[str, Any],
     ) -> bool:
-        """Validate temporal ordering before committing cache updates.
+        """Validate temporal ordering and data quality before committing cache updates.
 
-        Weighted fusion now stabilizes coordinates earlier in the pipeline, so
-        this gate focuses on rejecting malformed or stale timestamps that would
-        regress cached locations. Callers run fusion before invoking this shim;
-        no additional coordinate logic belongs here.
+        This gate rejects:
+        1. Malformed payloads (not a dict)
+        2. Timestamps that are too old (pre-Y2K) or too far in the future
+        3. Timestamps that regress from the cached value
+        4. Physically impossible accuracy values (present but < 1.0m)
+
+        Note: Updates with no accuracy (semantic-only) are allowed. We only reject
+        updates that *claim* an accuracy that is physically impossible.
 
         Args:
             device_id: Canonical device identifier.
@@ -601,12 +605,43 @@ class CacheOperations:
         Returns:
             ``True`` when the caller should accept the payload.
         """
+        # Minimum plausible GPS accuracy for consumer hardware (meters).
+        # Anything below this is noise or API artifact, not a real measurement.
+        # Even best-case differential GPS rarely achieves < 1m accuracy.
+        MIN_PLAUSIBLE_ACCURACY_M = 1.0
+
         # Maximum accepted future drift in seconds (2 hours)
         MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S = 7200
 
         if not isinstance(new_data, dict):
             _LOGGER.debug("Rejecting update for %s: payload is not a dict", device_id)
             return False
+
+        # Quality gate: Reject physically impossible accuracy values.
+        # Note: We allow updates with no accuracy (semantic-only are valid).
+        # We only reject updates that claim an accuracy that's impossible.
+        new_acc = new_data.get("accuracy")
+        if new_acc is not None:
+            try:
+                acc_f = float(new_acc)
+                if not math.isfinite(acc_f) or acc_f < MIN_PLAUSIBLE_ACCURACY_M:
+                    self.increment_stat("invalid_accuracy_drop_count")
+                    _LOGGER.debug(
+                        "Rejecting update for %s: physically impossible accuracy (%s < %sm)",
+                        device_id,
+                        new_acc,
+                        MIN_PLAUSIBLE_ACCURACY_M,
+                    )
+                    return False
+            except (TypeError, ValueError):
+                # Non-numeric accuracy is also invalid
+                self.increment_stat("invalid_accuracy_drop_count")
+                _LOGGER.debug(
+                    "Rejecting update for %s: non-numeric accuracy (%r)",
+                    device_id,
+                    new_acc,
+                )
+                return False
 
         n_seen_norm = _normalize_epoch_seconds(new_data.get("last_seen"))
         if n_seen_norm is not None:
@@ -793,8 +828,23 @@ class CacheOperations:
         new_data["latitude"] = lat_fused
         new_data["longitude"] = lon_fused
 
-        # Select best accuracy, excluding physically impossible values (<= 0).
-        # GPS accuracy of 0.0m is impossible (real GPS: 3-50m typically).
+        # Calculate fused accuracy using inverse variance weighting.
+        #
+        # When fusing two measurements with variances σ₁² and σ₂², the optimal
+        # combined variance is: σ_fused² = 1 / (1/σ₁² + 1/σ₂²) = 1 / total_w
+        #
+        # Since accuracy ≈ standard deviation, the fused accuracy is:
+        #   accuracy_fused = sqrt(1 / total_w)
+        #
+        # This is statistically correct: combining two independent measurements
+        # should yield a MORE precise result than either alone.
+        #
+        # Safety bounds:
+        # - MIN_FUSED_ACCURACY_M: Physical limit (consumer GPS can't do better)
+        # - limit_best: Never claim worse than the best input (conservative)
+
+        MIN_FUSED_ACCURACY_M = 5.0  # Consumer GPS floor
+
         def _is_valid_accuracy(acc: float | None) -> bool:
             return (
                 acc is not None
@@ -808,8 +858,15 @@ class CacheOperations:
 
         best_accuracy: float | None
         if valid_existing and valid_new:
-            # Both valid: pick the smaller (more precise) one
-            best_accuracy = min(existing_acc_raw, new_acc_raw)  # type: ignore[arg-type]
+            # Both valid: use inverse variance formula
+            # accuracy_fused = sqrt(1 / total_w) where total_w = 1/acc₁² + 1/acc₂²
+            fused_accuracy = math.sqrt(1.0 / total_w)
+
+            # Safety bounds:
+            # - Never claim better than physics allows (MIN_FUSED_ACCURACY_M)
+            # - Never claim worse than the best individual measurement
+            limit_best = min(existing_acc_raw, new_acc_raw)  # type: ignore[arg-type]
+            best_accuracy = max(fused_accuracy, limit_best, MIN_FUSED_ACCURACY_M)
         elif valid_new:
             best_accuracy = new_acc_raw
         elif valid_existing:

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -622,31 +622,42 @@ class CacheOperations:
 
         # Sanitize error code accuracy values (0.0 in Android Location API).
         # The API uses 0.0 as "no accuracy available", not "perfect precision".
-        # We ACCEPT the update but REMOVE the invalid accuracy to prevent ranking corruption.
+        # We ACCEPT the update and REPLACE invalid accuracy with a conservative fallback.
+        # This ensures Home Assistant always gets a valid numeric gps_accuracy attribute.
         # Valid sub-meter values like 0.5m or 0.01m are preserved!
         new_acc = new_data.get("accuracy")
-        if new_acc is not None:
+        if new_acc is None:
+            # Missing accuracy: set conservative fallback for HA state machine
+            new_data["accuracy"] = DEFAULT_ACCURACY_FALLBACK_M
+            self.increment_stat("accuracy_sanitized_count")
+            _LOGGER.debug(
+                "Setting fallback accuracy for %s: key was missing, using %sm",
+                device_id,
+                DEFAULT_ACCURACY_FALLBACK_M,
+            )
+        else:
             try:
                 acc_f = float(new_acc)
                 if not math.isfinite(acc_f) or acc_f < MIN_PHYSICAL_ACCURACY_M:
-                    # Sanitize: remove error code (0.0) or negative, keep the report
-                    new_data.pop("accuracy", None)
+                    # Sanitize: replace error code with conservative fallback
+                    new_data["accuracy"] = DEFAULT_ACCURACY_FALLBACK_M
                     self.increment_stat("accuracy_sanitized_count")
                     _LOGGER.debug(
-                        "Sanitizing update for %s: error code accuracy (%s) removed (< %sm)",
+                        "Sanitizing update for %s: error code accuracy (%s) -> %sm",
                         device_id,
                         new_acc,
-                        MIN_PHYSICAL_ACCURACY_M,
+                        DEFAULT_ACCURACY_FALLBACK_M,
                     )
-                    # Continue processing - the update is valid, just without precision
+                    # Continue processing - the update is valid, with fallback precision
             except (TypeError, ValueError):
-                # Non-numeric accuracy: remove it, keep the report
-                new_data.pop("accuracy", None)
+                # Non-numeric accuracy: replace with fallback
+                new_data["accuracy"] = DEFAULT_ACCURACY_FALLBACK_M
                 self.increment_stat("accuracy_sanitized_count")
                 _LOGGER.debug(
-                    "Sanitizing update for %s: non-numeric accuracy (%r) removed",
+                    "Sanitizing update for %s: non-numeric accuracy (%r) -> %sm",
                     device_id,
                     new_acc,
+                    DEFAULT_ACCURACY_FALLBACK_M,
                 )
 
         n_seen_norm = _normalize_epoch_seconds(new_data.get("last_seen"))
@@ -884,14 +895,13 @@ class CacheOperations:
         elif valid_existing:
             best_accuracy = existing_acc_raw
         else:
-            # Neither is valid - leave accuracy unset
-            best_accuracy = None
+            # Neither is valid - use conservative fallback
+            # This ensures Home Assistant always gets a valid gps_accuracy attribute
+            best_accuracy = DEFAULT_ACCURACY_FALLBACK_M
 
-        if best_accuracy is not None:
-            new_data["accuracy"] = best_accuracy
-        else:
-            # Ensure invalid accuracy doesn't propagate
-            new_data.pop("accuracy", None)
+        # ALWAYS write back a valid accuracy - never leave it as None or missing
+        # Home Assistant requires a numeric gps_accuracy for the state machine
+        new_data["accuracy"] = best_accuracy
 
         new_data["status"] = "Fused (Weighted)"
         new_data["_fused_applied"] = True

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -23,7 +23,7 @@ from collections import deque
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-from ..const import DATA_EID_RESOLVER, DOMAIN
+from ..const import DATA_EID_RESOLVER, DEFAULT_FALLBACK_ACCURACY_M, DOMAIN
 from .helpers.cache import (
     merge_cache_row as _merge_cache_row_impl,
 )
@@ -728,13 +728,23 @@ class CacheOperations:
             """Convert raw accuracy to a safe value for fusion calculations.
 
             GPS accuracy of <= 0 is physically impossible (real GPS: 3-50m typically).
-            Such values indicate missing/corrupted data and should use fallback.
+            Such values indicate missing/corrupted data and should use the fallback.
+
+            The fallback (DEFAULT_FALLBACK_ACCURACY_M = 50m) is based on:
+              - Bluetooth range: ~40-80m (tracker position uncertainty)
+              - GPS error margin: ~10-30m (finder device uncertainty)
+
+            Using 50m instead of a huge value (e.g., 10000m) prevents the
+            "Fusion Lock-in" effect: with inverse-square weighting, 1/50² = 0.0004
+            is comparable to 1/20² = 0.0025, so real GPS fixes can override it.
+            With 1/10000² the poisoned value would have essentially zero weight
+            but still persist in the cache.
             """
             if value is None or not math.isfinite(value):
-                return 10000.0
+                return DEFAULT_FALLBACK_ACCURACY_M
             # <= 0 is physically impossible for GPS accuracy
             if value <= 0:
-                return 10000.0
+                return DEFAULT_FALLBACK_ACCURACY_M
             return value
 
         existing_acc = _safe_accuracy(existing_acc_raw)

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -619,31 +619,34 @@ class CacheOperations:
             _LOGGER.debug("Rejecting update for %s: payload is not a dict", device_id)
             return False
 
-        # Quality gate: Reject physically impossible accuracy values.
-        # Note: We allow updates with no accuracy (semantic-only are valid).
-        # We only reject updates that claim an accuracy that's impossible.
+        # Sanitize physically impossible accuracy values.
+        # Values like 0.0 mean "privacy masked" or "unknown", not "perfect precision".
+        # We ACCEPT the update but REMOVE the invalid accuracy to prevent ranking corruption.
+        # This allows reports with 0.0 accuracy to still provide location data.
         new_acc = new_data.get("accuracy")
         if new_acc is not None:
             try:
                 acc_f = float(new_acc)
                 if not math.isfinite(acc_f) or acc_f < MIN_PHYSICAL_ACCURACY_M:
-                    self.increment_stat("invalid_accuracy_drop_count")
+                    # Sanitize: remove invalid accuracy, keep the report
+                    new_data.pop("accuracy", None)
+                    self.increment_stat("accuracy_sanitized_count")
                     _LOGGER.debug(
-                        "Rejecting update for %s: physically impossible accuracy (%s < %sm)",
+                        "Sanitizing update for %s: invalid accuracy (%s) removed (< %sm)",
                         device_id,
                         new_acc,
                         MIN_PHYSICAL_ACCURACY_M,
                     )
-                    return False
+                    # Continue processing - the update is valid, just without precision
             except (TypeError, ValueError):
-                # Non-numeric accuracy is also invalid
-                self.increment_stat("invalid_accuracy_drop_count")
+                # Non-numeric accuracy: remove it, keep the report
+                new_data.pop("accuracy", None)
+                self.increment_stat("accuracy_sanitized_count")
                 _LOGGER.debug(
-                    "Rejecting update for %s: non-numeric accuracy (%r)",
+                    "Sanitizing update for %s: non-numeric accuracy (%r) removed",
                     device_id,
                     new_acc,
                 )
-                return False
 
         n_seen_norm = _normalize_epoch_seconds(new_data.get("last_seen"))
         if n_seen_norm is not None:

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -725,9 +725,15 @@ class CacheOperations:
         new_acc_raw = _coerce_float_impl(new_data.get("accuracy"))
 
         def _safe_accuracy(value: float | None) -> float:
+            """Convert raw accuracy to a safe value for fusion calculations.
+
+            GPS accuracy of <= 0 is physically impossible (real GPS: 3-50m typically).
+            Such values indicate missing/corrupted data and should use fallback.
+            """
             if value is None or not math.isfinite(value):
                 return 10000.0
-            if value < 0:
+            # <= 0 is physically impossible for GPS accuracy
+            if value <= 0:
                 return 10000.0
             return value
 
@@ -777,14 +783,36 @@ class CacheOperations:
         new_data["latitude"] = lat_fused
         new_data["longitude"] = lon_fused
 
+        # Select best accuracy, excluding physically impossible values (<= 0).
+        # GPS accuracy of 0.0m is impossible (real GPS: 3-50m typically).
+        def _is_valid_accuracy(acc: float | None) -> bool:
+            return (
+                acc is not None
+                and isinstance(acc, (int, float))
+                and math.isfinite(acc)
+                and acc > 0
+            )
+
+        valid_existing = _is_valid_accuracy(existing_acc_raw)
+        valid_new = _is_valid_accuracy(new_acc_raw)
+
         best_accuracy: float | None
-        if existing_acc_raw is not None and new_acc_raw is not None:
-            best_accuracy = min(existing_acc_raw, new_acc_raw)
+        if valid_existing and valid_new:
+            # Both valid: pick the smaller (more precise) one
+            best_accuracy = min(existing_acc_raw, new_acc_raw)  # type: ignore[arg-type]
+        elif valid_new:
+            best_accuracy = new_acc_raw
+        elif valid_existing:
+            best_accuracy = existing_acc_raw
         else:
-            best_accuracy = existing_acc_raw or new_acc_raw
+            # Neither is valid - leave accuracy unset
+            best_accuracy = None
 
         if best_accuracy is not None:
             new_data["accuracy"] = best_accuracy
+        else:
+            # Ensure invalid accuracy doesn't propagate
+            new_data.pop("accuracy", None)
 
         new_data["status"] = "Fused (Weighted)"
         new_data["_fused_applied"] = True

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -23,7 +23,7 @@ from collections import deque
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
-from ..const import DATA_EID_RESOLVER, DEFAULT_FALLBACK_ACCURACY_M, DOMAIN
+from ..const import DATA_EID_RESOLVER, DOMAIN
 from .helpers.cache import (
     merge_cache_row as _merge_cache_row_impl,
 )
@@ -37,6 +37,8 @@ from .helpers.cache import (
     should_clear_metadata_only_flag as _should_clear_metadata_only_flag_impl,
 )
 from .helpers.geo import (
+    DEFAULT_ACCURACY_FALLBACK_M,
+    MIN_PHYSICAL_ACCURACY_M,
     coerce_float as _coerce_float_impl,
 )
 from .helpers.geo import (
@@ -605,10 +607,8 @@ class CacheOperations:
         Returns:
             ``True`` when the caller should accept the payload.
         """
-        # Minimum plausible GPS accuracy for consumer hardware (meters).
-        # Anything below this is noise or API artifact, not a real measurement.
-        # Even best-case differential GPS rarely achieves < 1m accuracy.
-        MIN_PLAUSIBLE_ACCURACY_M = 1.0
+        # Use centralized constant from helpers/geo.py
+        # MIN_PHYSICAL_ACCURACY_M = 1.0m (consumer GPS floor)
 
         # Maximum accepted future drift in seconds (2 hours)
         MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S = 7200
@@ -624,13 +624,13 @@ class CacheOperations:
         if new_acc is not None:
             try:
                 acc_f = float(new_acc)
-                if not math.isfinite(acc_f) or acc_f < MIN_PLAUSIBLE_ACCURACY_M:
+                if not math.isfinite(acc_f) or acc_f < MIN_PHYSICAL_ACCURACY_M:
                     self.increment_stat("invalid_accuracy_drop_count")
                     _LOGGER.debug(
                         "Rejecting update for %s: physically impossible accuracy (%s < %sm)",
                         device_id,
                         new_acc,
-                        MIN_PLAUSIBLE_ACCURACY_M,
+                        MIN_PHYSICAL_ACCURACY_M,
                     )
                     return False
             except (TypeError, ValueError):
@@ -762,10 +762,10 @@ class CacheOperations:
         def _safe_accuracy(value: float | None) -> float:
             """Convert raw accuracy to a safe value for fusion calculations.
 
-            GPS accuracy of <= 0 is physically impossible (real GPS: 3-50m typically).
+            GPS accuracy < 1.0m is physically impossible for consumer hardware.
             Such values indicate missing/corrupted data and should use the fallback.
 
-            The fallback (DEFAULT_FALLBACK_ACCURACY_M = 50m) is based on:
+            The fallback (DEFAULT_ACCURACY_FALLBACK_M = 50m) is based on:
               - Bluetooth range: ~40-80m (tracker position uncertainty)
               - GPS error margin: ~10-30m (finder device uncertainty)
 
@@ -774,12 +774,16 @@ class CacheOperations:
             is comparable to 1/20² = 0.0025, so real GPS fixes can override it.
             With 1/10000² the poisoned value would have essentially zero weight
             but still persist in the cache.
+
+            SELF-HEALING: If the cache contains a poisoned value (< 1.0m),
+            treating it as 50m allows new valid data to properly override it.
             """
             if value is None or not math.isfinite(value):
-                return DEFAULT_FALLBACK_ACCURACY_M
-            # <= 0 is physically impossible for GPS accuracy
-            if value <= 0:
-                return DEFAULT_FALLBACK_ACCURACY_M
+                return DEFAULT_ACCURACY_FALLBACK_M
+            # < MIN_PHYSICAL_ACCURACY_M is physically impossible for GPS
+            # This also handles self-healing of corrupted cache entries
+            if value < MIN_PHYSICAL_ACCURACY_M:
+                return DEFAULT_ACCURACY_FALLBACK_M
             return value
 
         existing_acc = _safe_accuracy(existing_acc_raw)

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -597,10 +597,11 @@ class CacheOperations:
         1. Malformed payloads (not a dict)
         2. Timestamps that are too old (pre-Y2K) or too far in the future
         3. Timestamps that regress from the cached value
-        4. Physically impossible accuracy values (present but < 1.0m)
 
-        Note: Updates with no accuracy (semantic-only) are allowed. We only reject
-        updates that *claim* an accuracy that is physically impossible.
+        Accuracy sanitization (not rejection):
+        - Values < 0.001m (error code 0.0) are REMOVED from dict, not rejected
+        - Valid sub-meter accuracy (e.g., 0.5m) is preserved
+        - The report continues processing without precision data
 
         Args:
             device_id: Canonical device identifier.
@@ -610,7 +611,7 @@ class CacheOperations:
             ``True`` when the caller should accept the payload.
         """
         # Use centralized constant from helpers/geo.py
-        # MIN_PHYSICAL_ACCURACY_M = 1.0m (consumer GPS floor)
+        # MIN_PHYSICAL_ACCURACY_M = 0.001m (only error code 0.0 is filtered)
 
         # Maximum accepted future drift in seconds (2 hours)
         MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S = 7200
@@ -619,20 +620,20 @@ class CacheOperations:
             _LOGGER.debug("Rejecting update for %s: payload is not a dict", device_id)
             return False
 
-        # Sanitize physically impossible accuracy values.
-        # Values like 0.0 mean "privacy masked" or "unknown", not "perfect precision".
+        # Sanitize error code accuracy values (0.0 in Android Location API).
+        # The API uses 0.0 as "no accuracy available", not "perfect precision".
         # We ACCEPT the update but REMOVE the invalid accuracy to prevent ranking corruption.
-        # This allows reports with 0.0 accuracy to still provide location data.
+        # Valid sub-meter values like 0.5m or 0.01m are preserved!
         new_acc = new_data.get("accuracy")
         if new_acc is not None:
             try:
                 acc_f = float(new_acc)
                 if not math.isfinite(acc_f) or acc_f < MIN_PHYSICAL_ACCURACY_M:
-                    # Sanitize: remove invalid accuracy, keep the report
+                    # Sanitize: remove error code (0.0) or negative, keep the report
                     new_data.pop("accuracy", None)
                     self.increment_stat("accuracy_sanitized_count")
                     _LOGGER.debug(
-                        "Sanitizing update for %s: invalid accuracy (%s) removed (< %sm)",
+                        "Sanitizing update for %s: error code accuracy (%s) removed (< %sm)",
                         device_id,
                         new_acc,
                         MIN_PHYSICAL_ACCURACY_M,
@@ -767,25 +768,23 @@ class CacheOperations:
         def _safe_accuracy(value: float | None) -> float:
             """Convert raw accuracy to a safe value for fusion calculations.
 
-            GPS accuracy < 1.0m is physically impossible for consumer hardware.
-            Such values indicate missing/corrupted data and should use the fallback.
+            The Android Location API uses 0.0 as an error code meaning "no accuracy".
+            We treat values < MIN_VALID_ACCURACY (0.001m) as this error code.
 
-            The fallback (DEFAULT_ACCURACY_FALLBACK_M = 50m) is based on:
-              - Bluetooth range: ~40-80m (tracker position uncertainty)
-              - GPS error margin: ~10-30m (finder device uncertainty)
+            Modern dual-frequency GNSS (L1+L5) can achieve sub-meter accuracy under
+            ideal conditions, so valid values like 0.5m or 0.01m are preserved.
 
-            Using 50m instead of a huge value (e.g., 10000m) prevents the
-            "Fusion Lock-in" effect: with inverse-square weighting, 1/50² = 0.0004
-            is comparable to 1/20² = 0.0025, so real GPS fixes can override it.
-            With 1/10000² the poisoned value would have essentially zero weight
-            but still persist in the cache.
+            The fallback (DEFAULT_ACCURACY_FALLBACK = 2000m) is conservative for
+            "unknown" accuracy. This ensures:
+              - Error codes get very low weight in fusion (1/2000² ≈ 0)
+              - Any real measurement easily overrides the error code
 
-            SELF-HEALING: If the cache contains a poisoned value (< 1.0m),
-            treating it as 50m allows new valid data to properly override it.
+            SELF-HEALING: If the cache contains a corrupted value (0.0),
+            treating it as 2000m allows new valid data to properly override it.
             """
             if value is None or not math.isfinite(value):
                 return DEFAULT_ACCURACY_FALLBACK_M
-            # < MIN_PHYSICAL_ACCURACY_M is physically impossible for GPS
+            # < MIN_VALID_ACCURACY (0.001m) is the error code 0.0
             # This also handles self-healing of corrupted cache entries
             if value < MIN_PHYSICAL_ACCURACY_M:
                 return DEFAULT_ACCURACY_FALLBACK_M
@@ -825,8 +824,10 @@ class CacheOperations:
             return True
 
         # Overlapping accuracy circles: fuse with inverse-square weighting
-        w_old = 1 / (max(1.0, existing_acc) ** 2)
-        w_new = 1 / (max(1.0, new_acc) ** 2)
+        # Use MIN_PHYSICAL_ACCURACY_M (0.001m) as floor to preserve sub-meter weight
+        # and prevent division by zero. Valid sub-meter accuracy gets proper weight.
+        w_old = 1 / (max(MIN_PHYSICAL_ACCURACY_M, existing_acc) ** 2)
+        w_new = 1 / (max(MIN_PHYSICAL_ACCURACY_M, new_acc) ** 2)
         total_w = w_old + w_new
         if total_w == 0:
             return True

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -39,6 +39,8 @@ from .helpers.cache import (
 from .helpers.geo import (
     DEFAULT_ACCURACY_FALLBACK_M,
     MIN_PHYSICAL_ACCURACY_M,
+)
+from .helpers.geo import (
     coerce_float as _coerce_float_impl,
 )
 from .helpers.geo import (
@@ -869,7 +871,9 @@ class CacheOperations:
             # Safety bounds:
             # - Never claim better than physics allows (MIN_FUSED_ACCURACY_M)
             # - Never claim worse than the best individual measurement
-            limit_best = min(existing_acc_raw, new_acc_raw)  # type: ignore[arg-type]
+            # Note: assert helps mypy understand values are not None after validation
+            assert existing_acc_raw is not None and new_acc_raw is not None
+            limit_best = min(existing_acc_raw, new_acc_raw)
             best_accuracy = max(fused_accuracy, limit_best, MIN_FUSED_ACCURACY_M)
         elif valid_new:
             best_accuracy = new_acc_raw

--- a/custom_components/googlefindmy/coordinator/helpers/cache.py
+++ b/custom_components/googlefindmy/coordinator/helpers/cache.py
@@ -754,9 +754,7 @@ def sanitize_decoder_row(row: dict[str, Any]) -> dict[str, Any]:
     # 3. SEMANTIC status (status_code=0) is never an owner report by definition.
     if r.get("is_own_report"):
         has_invalid_accuracy = _is_invalid_accuracy(r.get("accuracy"))
-        has_no_coordinates = (
-            r.get("latitude") is None and r.get("longitude") is None
-        )
+        has_no_coordinates = r.get("latitude") is None and r.get("longitude") is None
         is_semantic_status = r.get("status_code") == 0
 
         if has_invalid_accuracy or has_no_coordinates or is_semantic_status:

--- a/custom_components/googlefindmy/coordinator/helpers/cache.py
+++ b/custom_components/googlefindmy/coordinator/helpers/cache.py
@@ -28,6 +28,7 @@ Refactoring additions:
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
@@ -709,13 +710,30 @@ def row_source_label(row: dict[str, Any]) -> tuple[int, str]:
     return 0, "semantic/unknown"
 
 
+def _is_invalid_accuracy(accuracy: Any) -> bool:
+    """Check if accuracy value is invalid (missing, non-positive, or non-finite).
+
+    GPS accuracy of <= 0 is physically impossible (real GPS: 3-50m typically).
+    Such values indicate missing/corrupted data from the API.
+    """
+    if accuracy is None:
+        return True
+    try:
+        f = float(accuracy)
+        # Non-finite (NaN/Inf) or non-positive values are invalid
+        return not (f > 0 and math.isfinite(f))
+    except (TypeError, ValueError):
+        return True
+
+
 def sanitize_decoder_row(row: dict[str, Any]) -> dict[str, Any]:
     """Enforce protocol invariants and prepare HA attributes.
 
     Notes:
         - Ensures timestamps are normalized and provides an ISO UTC mirror.
         - Derives a stable `source_label`/`source_rank` used for stats and UX.
-        - Zero-accuracy semantic entries are coerced to None to avoid noise.
+        - Detects and corrects spurious `is_own_report=True` flags from the API.
+        - Invalid accuracy (<=0, NaN, Inf) is coerced to None.
 
     Args:
         row: Raw decoder row dictionary.
@@ -724,11 +742,31 @@ def sanitize_decoder_row(row: dict[str, Any]) -> dict[str, Any]:
         Sanitized dictionary with normalized fields.
     """
     r = dict(row)
+
+    # --- Phase 1: Correct spurious is_own_report flags BEFORE label calculation ---
+    # Google's API sometimes returns is_own_report=True for reports that are clearly
+    # not from the owner's device. Detect and correct these cases:
+    #
+    # 1. accuracy <= 0 is physically impossible for real GPS (typical: 3-50m).
+    #    This indicates missing/corrupted data, not a precise fix.
+    # 2. No coordinates (lat/lon both None) means it's a semantic-only report
+    #    which cannot be an "own device" GPS report.
+    # 3. SEMANTIC status (status_code=0) is never an owner report by definition.
+    if r.get("is_own_report"):
+        has_invalid_accuracy = _is_invalid_accuracy(r.get("accuracy"))
+        has_no_coordinates = (
+            r.get("latitude") is None and r.get("longitude") is None
+        )
+        is_semantic_status = r.get("status_code") == 0
+
+        if has_invalid_accuracy or has_no_coordinates or is_semantic_status:
+            r["is_own_report"] = False
+
+    # --- Phase 2: Calculate source label/rank based on corrected data ---
     rank, label = row_source_label(r)
 
-    if label == "semantic/unknown" and r.get("is_own_report"):
-        r["is_own_report"] = False
-    if label == "semantic/unknown" and r.get("accuracy") in (0, 0.0):
+    # Coerce invalid accuracy to None for cleaner UX
+    if _is_invalid_accuracy(r.get("accuracy")):
         r["accuracy"] = None
 
     ts = normalize_epoch_seconds(r.get("last_seen"))

--- a/custom_components/googlefindmy/coordinator/helpers/geo.py
+++ b/custom_components/googlefindmy/coordinator/helpers/geo.py
@@ -24,7 +24,18 @@ from typing import Any
 # Earth radius in meters (WGS84 mean radius)
 EARTH_RADIUS_M = 6371000.0
 
-# Default fallback for invalid/missing GPS accuracy
+# Minimum physically plausible GPS accuracy (meters).
+# Consumer GPS hardware cannot achieve sub-meter accuracy.
+# Even differential GPS rarely achieves < 1m in practice.
+# Values below this indicate API artifacts, not real measurements.
+MIN_PHYSICAL_ACCURACY_M = 1.0
+
+# Default fallback for invalid/missing GPS accuracy.
+# Based on Bluetooth range (~40-80m) + GPS error (~10-30m).
+# Using 50m prevents "Fusion Lock-in" while allowing real fixes to override.
+DEFAULT_ACCURACY_FALLBACK_M = 50.0
+
+# Legacy constant (10km) for truly unknown locations
 DEFAULT_ACCURACY_FALLBACK = 10000.0
 
 
@@ -98,31 +109,79 @@ def coerce_float(value: Any) -> float | None:
 # ---------------------------------------------------------------------------
 
 
-def safe_accuracy(value: float | None) -> float:
-    """Normalize GPS accuracy to a safe, finite value.
+def safe_accuracy(value: float | None, *, fallback: float | None = None) -> float:
+    """Normalize GPS accuracy to a safe, finite, physically plausible value.
 
-    Invalid, missing, or negative accuracy values are replaced with
-    a large fallback (10km) to indicate low confidence.
+    GPS accuracy of < 1.0m is physically impossible for consumer hardware.
+    Such values indicate API artifacts or missing data, not real measurements.
+
+    Invalid, missing, or sub-meter accuracy values are replaced with
+    a fallback (default: 50m for Bluetooth range estimation).
 
     Args:
         value: GPS accuracy in meters, or None.
+        fallback: Custom fallback value. Defaults to DEFAULT_ACCURACY_FALLBACK_M (50m).
 
     Returns:
-        A non-negative finite float representing accuracy in meters.
+        A finite float >= MIN_PHYSICAL_ACCURACY_M representing accuracy in meters.
 
     Example:
         >>> safe_accuracy(50.0)
         50.0
         >>> safe_accuracy(None)
-        10000.0
+        50.0
+        >>> safe_accuracy(0.0)
+        50.0
+        >>> safe_accuracy(0.5)
+        50.0
         >>> safe_accuracy(-5.0)
-        10000.0
+        50.0
     """
+    if fallback is None:
+        fallback = DEFAULT_ACCURACY_FALLBACK_M
+
     if value is None or not math.isfinite(value):
-        return DEFAULT_ACCURACY_FALLBACK
-    if value < 0:
-        return DEFAULT_ACCURACY_FALLBACK
+        return fallback
+
+    # Values below MIN_PHYSICAL_ACCURACY_M are physically impossible
+    # for consumer GPS/Bluetooth hardware
+    if value < MIN_PHYSICAL_ACCURACY_M:
+        return fallback
+
     return value
+
+
+def is_valid_accuracy(value: float | None) -> bool:
+    """Check if an accuracy value is physically plausible.
+
+    GPS accuracy must be:
+    - Not None
+    - Finite (not NaN or Inf)
+    - >= MIN_PHYSICAL_ACCURACY_M (1.0m)
+
+    Args:
+        value: GPS accuracy in meters, or None.
+
+    Returns:
+        True if the value represents a valid GPS measurement.
+
+    Example:
+        >>> is_valid_accuracy(20.0)
+        True
+        >>> is_valid_accuracy(0.0)
+        False
+        >>> is_valid_accuracy(0.5)
+        False
+        >>> is_valid_accuracy(None)
+        False
+    """
+    if value is None:
+        return False
+    try:
+        v = float(value)
+        return math.isfinite(v) and v >= MIN_PHYSICAL_ACCURACY_M
+    except (TypeError, ValueError):
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/googlefindmy/coordinator/helpers/geo.py
+++ b/custom_components/googlefindmy/coordinator/helpers/geo.py
@@ -24,19 +24,21 @@ from typing import Any
 # Earth radius in meters (WGS84 mean radius)
 EARTH_RADIUS_M = 6371000.0
 
-# Minimum physically plausible GPS accuracy (meters).
-# Consumer GPS hardware cannot achieve sub-meter accuracy.
-# Even differential GPS rarely achieves < 1m in practice.
-# Values below this indicate API artifacts, not real measurements.
-MIN_PHYSICAL_ACCURACY_M = 1.0
+# Minimum valid accuracy threshold (meters).
+# The Android Location API uses 0.0 as an error code meaning "no accuracy available".
+# Modern dual-frequency GNSS chips (L1+L5) can achieve sub-meter accuracy under
+# ideal conditions (Open Sky), so we use 1mm as the floor to catch only the
+# error code (0.0) and negative values, NOT valid high-precision measurements.
+MIN_VALID_ACCURACY = 0.001  # 1 millimeter
 
 # Default fallback for invalid/missing GPS accuracy.
-# Based on Bluetooth range (~40-80m) + GPS error (~10-30m).
-# Using 50m prevents "Fusion Lock-in" while allowing real fixes to override.
-DEFAULT_ACCURACY_FALLBACK_M = 50.0
+# Conservative value for "unknown" - high enough to lose against any real measurement
+# in weighted fusion, but not so high as to cause map rendering issues.
+DEFAULT_ACCURACY_FALLBACK = 2000.0  # 2 kilometers
 
-# Legacy constant (10km) for truly unknown locations
-DEFAULT_ACCURACY_FALLBACK = 10000.0
+# Legacy aliases for backward compatibility
+MIN_PHYSICAL_ACCURACY_M = MIN_VALID_ACCURACY
+DEFAULT_ACCURACY_FALLBACK_M = DEFAULT_ACCURACY_FALLBACK
 
 
 # ---------------------------------------------------------------------------
@@ -110,54 +112,60 @@ def coerce_float(value: Any) -> float | None:
 
 
 def safe_accuracy(value: float | None, *, fallback: float | None = None) -> float:
-    """Normalize GPS accuracy to a safe, finite, physically plausible value.
+    """Normalize GPS accuracy to a safe, finite value.
 
-    GPS accuracy of < 1.0m is physically impossible for consumer hardware.
-    Such values indicate API artifacts or missing data, not real measurements.
+    The Android Location API uses 0.0 as an error code meaning "no accuracy".
+    We treat values < MIN_VALID_ACCURACY (0.001m) as this error code.
 
-    Invalid, missing, or sub-meter accuracy values are replaced with
-    a fallback (default: 50m for Bluetooth range estimation).
+    Modern dual-frequency GNSS can achieve sub-meter accuracy, so values like
+    0.01m (1cm) or 0.5m are valid and preserved unchanged.
 
     Args:
         value: GPS accuracy in meters, or None.
-        fallback: Custom fallback value. Defaults to DEFAULT_ACCURACY_FALLBACK_M (50m).
+        fallback: Custom fallback value. Defaults to DEFAULT_ACCURACY_FALLBACK (2000m).
 
     Returns:
-        A finite float >= MIN_PHYSICAL_ACCURACY_M representing accuracy in meters.
+        A finite float >= MIN_VALID_ACCURACY representing accuracy in meters,
+        or the fallback value if input is invalid.
 
     Example:
         >>> safe_accuracy(50.0)
         50.0
+        >>> safe_accuracy(0.5)  # Valid sub-meter accuracy
+        0.5
+        >>> safe_accuracy(0.01)  # Valid centimeter accuracy
+        0.01
         >>> safe_accuracy(None)
-        50.0
-        >>> safe_accuracy(0.0)
-        50.0
-        >>> safe_accuracy(0.5)
-        50.0
+        2000.0
+        >>> safe_accuracy(0.0)  # Error code
+        2000.0
         >>> safe_accuracy(-5.0)
-        50.0
+        2000.0
     """
     if fallback is None:
-        fallback = DEFAULT_ACCURACY_FALLBACK_M
+        fallback = DEFAULT_ACCURACY_FALLBACK
 
     if value is None or not math.isfinite(value):
         return fallback
 
-    # Values below MIN_PHYSICAL_ACCURACY_M are physically impossible
-    # for consumer GPS/Bluetooth hardware
-    if value < MIN_PHYSICAL_ACCURACY_M:
+    # Values below MIN_VALID_ACCURACY are the error code (0.0) or negative
+    # Modern GNSS can achieve sub-meter accuracy, so we only reject < 0.001m
+    if value < MIN_VALID_ACCURACY:
         return fallback
 
     return value
 
 
 def is_valid_accuracy(value: float | None) -> bool:
-    """Check if an accuracy value is physically plausible.
+    """Check if an accuracy value is valid (not an error code).
 
-    GPS accuracy must be:
+    Valid accuracy must be:
     - Not None
     - Finite (not NaN or Inf)
-    - >= MIN_PHYSICAL_ACCURACY_M (1.0m)
+    - >= MIN_VALID_ACCURACY (0.001m) - below this is the error code 0.0
+
+    Modern dual-frequency GNSS can achieve sub-meter accuracy, so values like
+    0.01m (1cm) or 0.5m are valid.
 
     Args:
         value: GPS accuracy in meters, or None.
@@ -168,9 +176,11 @@ def is_valid_accuracy(value: float | None) -> bool:
     Example:
         >>> is_valid_accuracy(20.0)
         True
-        >>> is_valid_accuracy(0.0)
-        False
-        >>> is_valid_accuracy(0.5)
+        >>> is_valid_accuracy(0.5)  # Valid sub-meter
+        True
+        >>> is_valid_accuracy(0.01)  # Valid centimeter
+        True
+        >>> is_valid_accuracy(0.0)  # Error code
         False
         >>> is_valid_accuracy(None)
         False
@@ -179,7 +189,7 @@ def is_valid_accuracy(value: float | None) -> bool:
         return False
     try:
         v = float(value)
-        return math.isfinite(v) and v >= MIN_PHYSICAL_ACCURACY_M
+        return math.isfinite(v) and v >= MIN_VALID_ACCURACY
     except (TypeError, ValueError):
         return False
 

--- a/custom_components/googlefindmy/coordinator/helpers/geo.py
+++ b/custom_components/googlefindmy/coordinator/helpers/geo.py
@@ -111,8 +111,12 @@ def coerce_float(value: Any) -> float | None:
 # ---------------------------------------------------------------------------
 
 
-def safe_accuracy(value: float | None, *, fallback: float | None = None) -> float:
+def safe_accuracy(value: Any, *, fallback: float | None = None) -> float:
     """Normalize GPS accuracy to a safe, finite value.
+
+    This function is EXTREMELY DEFENSIVE - it will never raise an exception
+    and always returns a valid numeric value suitable for Home Assistant's
+    gps_accuracy attribute.
 
     The Android Location API uses 0.0 as an error code meaning "no accuracy".
     We treat values < MIN_VALID_ACCURACY (0.001m) as this error code.
@@ -121,12 +125,13 @@ def safe_accuracy(value: float | None, *, fallback: float | None = None) -> floa
     0.01m (1cm) or 0.5m are valid and preserved unchanged.
 
     Args:
-        value: GPS accuracy in meters, or None.
+        value: Any value that might represent GPS accuracy. Handles None,
+               strings, floats, ints, and any other type gracefully.
         fallback: Custom fallback value. Defaults to DEFAULT_ACCURACY_FALLBACK (2000m).
 
     Returns:
         A finite float >= MIN_VALID_ACCURACY representing accuracy in meters,
-        or the fallback value if input is invalid.
+        or the fallback value if input is invalid. NEVER returns None.
 
     Example:
         >>> safe_accuracy(50.0)
@@ -141,19 +146,32 @@ def safe_accuracy(value: float | None, *, fallback: float | None = None) -> floa
         2000.0
         >>> safe_accuracy(-5.0)
         2000.0
+        >>> safe_accuracy("invalid")  # Non-numeric
+        2000.0
     """
     if fallback is None:
         fallback = DEFAULT_ACCURACY_FALLBACK
 
-    if value is None or not math.isfinite(value):
+    # Handle None explicitly
+    if value is None:
+        return fallback
+
+    # Try to convert to float - handle any type gracefully
+    try:
+        float_value = float(value)
+    except (TypeError, ValueError):
+        return fallback
+
+    # Check for NaN/Inf
+    if not math.isfinite(float_value):
         return fallback
 
     # Values below MIN_VALID_ACCURACY are the error code (0.0) or negative
     # Modern GNSS can achieve sub-meter accuracy, so we only reject < 0.001m
-    if value < MIN_VALID_ACCURACY:
+    if float_value < MIN_VALID_ACCURACY:
         return fallback
 
-    return value
+    return float_value
 
 
 def is_valid_accuracy(value: float | None) -> bool:

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -114,8 +114,9 @@ class LocateOperations:
         payload["longitude"] = lon_f
 
         # Best-effort normalize accuracy (if present).
-        # GPS accuracy < 1.0m is physically impossible for consumer hardware.
-        # Such values indicate missing/corrupted data from the API; remove them.
+        # The Android Location API uses 0.0 as an error code ("no accuracy").
+        # Modern dual-frequency GNSS can achieve sub-meter accuracy, so we only
+        # filter the error code (< 0.001m) and negative values.
         acc = payload.get("accuracy")
         if acc is not None:
             try:
@@ -123,7 +124,7 @@ class LocateOperations:
                 if math.isfinite(acc_f) and acc_f >= MIN_PHYSICAL_ACCURACY_M:
                     payload["accuracy"] = acc_f
                 else:
-                    # Invalid accuracy (< 1.0m, negative, NaN, Inf) - remove it
+                    # Error code (0.0), negative, NaN, Inf - remove it
                     payload.pop("accuracy", None)
             except (TypeError, ValueError):
                 # Accuracy malformed; remove it

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -25,6 +25,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
 from ..const import DEFAULT_MIN_POLL_INTERVAL
 from ..SpotApi.spot_request import SpotAuthPermanentError
+from .helpers.geo import MIN_PHYSICAL_ACCURACY_M
 
 if TYPE_CHECKING:
     from .main import GoogleFindMyCoordinator
@@ -113,16 +114,16 @@ class LocateOperations:
         payload["longitude"] = lon_f
 
         # Best-effort normalize accuracy (if present).
-        # GPS accuracy of <= 0 is physically impossible (real GPS: 3-50m typically).
+        # GPS accuracy < 1.0m is physically impossible for consumer hardware.
         # Such values indicate missing/corrupted data from the API; remove them.
         acc = payload.get("accuracy")
         if acc is not None:
             try:
                 acc_f = float(acc)
-                if math.isfinite(acc_f) and acc_f > 0:
+                if math.isfinite(acc_f) and acc_f >= MIN_PHYSICAL_ACCURACY_M:
                     payload["accuracy"] = acc_f
                 else:
-                    # Invalid accuracy (0.0, negative, NaN, Inf) - remove it
+                    # Invalid accuracy (< 1.0m, negative, NaN, Inf) - remove it
                     payload.pop("accuracy", None)
             except (TypeError, ValueError):
                 # Accuracy malformed; remove it

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -112,16 +112,21 @@ class LocateOperations:
         payload["latitude"] = lat_f
         payload["longitude"] = lon_f
 
-        # Best-effort normalize accuracy (if present)
+        # Best-effort normalize accuracy (if present).
+        # GPS accuracy of <= 0 is physically impossible (real GPS: 3-50m typically).
+        # Such values indicate missing/corrupted data from the API; remove them.
         acc = payload.get("accuracy")
         if acc is not None:
             try:
                 acc_f = float(acc)
-                if math.isfinite(acc_f):
+                if math.isfinite(acc_f) and acc_f > 0:
                     payload["accuracy"] = acc_f
+                else:
+                    # Invalid accuracy (0.0, negative, NaN, Inf) - remove it
+                    payload.pop("accuracy", None)
             except (TypeError, ValueError):
-                # Accuracy can be absent or malformed; not critical enough for a warning.
-                pass
+                # Accuracy malformed; remove it
+                payload.pop("accuracy", None)
 
         return True
 

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -140,6 +140,7 @@ from ..const import (
     # Core / options
     DEFAULT_MIN_POLL_INTERVAL,
     DEFAULT_OPTIONS,
+    DEFAULT_SEMANTIC_DETECTION_RADIUS,
     DOMAIN,
     # Required symbols provided by const.py (5.1-A)
     EVENT_AUTH_ERROR,
@@ -1164,8 +1165,10 @@ class GoogleFindMyCoordinator(
                 continue
 
             accuracy = self._coerce_float(coords.get("accuracy"))
-            if accuracy is None:
-                accuracy = 0.0
+            if accuracy is None or accuracy <= 0:
+                # Use default radius for semantic zones without explicit accuracy.
+                # Never use 0.0 as it's physically impossible for GPS.
+                accuracy = DEFAULT_SEMANTIC_DETECTION_RADIUS
 
             normalized[name.casefold()] = {
                 "latitude": latitude,

--- a/tests/test_coordinator_geo.py
+++ b/tests/test_coordinator_geo.py
@@ -177,7 +177,7 @@ class TestCoerceFloat:
 class TestSafeAccuracy:
     """Tests for safe_accuracy function."""
 
-    # Default fallback value used in the function (50m for Bluetooth range estimation)
+    # Default fallback value used in the function (2000m for unknown accuracy)
     DEFAULT_FALLBACK = DEFAULT_ACCURACY_FALLBACK_M
 
     def test_valid_positive_accuracy(self) -> None:
@@ -187,21 +187,29 @@ class TestSafeAccuracy:
         assert safe_accuracy(9999.0) == 9999.0
 
     def test_zero_accuracy_returns_fallback(self) -> None:
-        """Zero accuracy means 'unknown/masked', returns fallback.
+        """Zero accuracy is the Android API error code, returns fallback.
 
-        BACKGROUND: Google's API sometimes returns accuracy=0.0 as "privacy masking"
-        or "unknown precision", not as "perfect precision". We treat it as unmeasured.
+        BACKGROUND: The Android Location API uses 0.0 as an error code meaning
+        "no accuracy available", not "perfect precision". We treat it as unknown.
         """
         assert safe_accuracy(0.0) == self.DEFAULT_FALLBACK
 
-    def test_sub_meter_accuracy_returns_fallback(self) -> None:
-        """Sub-meter accuracy is physically implausible for consumer GPS, returns fallback.
+    def test_sub_meter_accuracy_is_valid(self) -> None:
+        """Sub-meter accuracy is valid for modern dual-frequency GNSS.
 
-        Consumer GPS hardware floor is ~1.0m. Values < 1.0 indicate data corruption
-        or API quirks, not actual precision.
+        Modern GNSS chips (L1+L5) can achieve sub-meter accuracy under ideal
+        conditions (Open Sky). Values like 0.5m or 0.01m are valid measurements.
         """
-        assert safe_accuracy(0.5) == self.DEFAULT_FALLBACK
-        assert safe_accuracy(0.99) == self.DEFAULT_FALLBACK
+        assert safe_accuracy(0.5) == 0.5
+        assert safe_accuracy(0.99) == 0.99
+        assert safe_accuracy(0.01) == 0.01
+        assert safe_accuracy(0.002) == 0.002  # 2mm - extreme but valid
+
+    def test_error_code_returns_fallback(self) -> None:
+        """Error codes (< 0.001m) return fallback."""
+        assert safe_accuracy(0.0) == self.DEFAULT_FALLBACK
+        assert safe_accuracy(0.0001) == self.DEFAULT_FALLBACK
+        assert safe_accuracy(0.0009) == self.DEFAULT_FALLBACK
 
     def test_none_returns_fallback(self) -> None:
         """None returns fallback value."""
@@ -222,13 +230,14 @@ class TestSafeAccuracy:
         assert safe_accuracy(float("-inf")) == self.DEFAULT_FALLBACK
 
     def test_boundary_accuracy_value(self) -> None:
-        """Boundary value: 1.0m is the minimum valid accuracy.
+        """Boundary value: 0.001m (1mm) is the minimum valid accuracy.
 
-        Consumer GPS cannot achieve sub-meter accuracy.
-        Exactly 1.0m is the threshold - valid and returned unchanged.
+        Modern GNSS can achieve sub-meter accuracy. The threshold is set at 1mm
+        to only catch the error code (0.0) and not valid high-precision data.
         """
-        assert safe_accuracy(1.0) == 1.0
-        assert safe_accuracy(1.001) == 1.001
+        assert safe_accuracy(0.001) == 0.001  # Exactly at threshold - valid
+        assert safe_accuracy(0.002) == 0.002  # Above threshold - valid
+        assert safe_accuracy(0.0009) == self.DEFAULT_FALLBACK  # Below - error
 
     def test_very_large_positive(self) -> None:
         """Very large positive values are valid."""

--- a/tests/test_coordinator_geo.py
+++ b/tests/test_coordinator_geo.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import math
 
 from custom_components.googlefindmy.coordinator.helpers.geo import (
+    DEFAULT_ACCURACY_FALLBACK_M,
     clamp,
     coerce_float,
     haversine_distance,
@@ -176,8 +177,8 @@ class TestCoerceFloat:
 class TestSafeAccuracy:
     """Tests for safe_accuracy function."""
 
-    # Default fallback value used in the function
-    DEFAULT_FALLBACK = 10000.0
+    # Default fallback value used in the function (50m for Bluetooth range estimation)
+    DEFAULT_FALLBACK = DEFAULT_ACCURACY_FALLBACK_M
 
     def test_valid_positive_accuracy(self) -> None:
         """Valid positive accuracy is returned unchanged."""
@@ -185,9 +186,22 @@ class TestSafeAccuracy:
         assert safe_accuracy(1.5) == 1.5
         assert safe_accuracy(9999.0) == 9999.0
 
-    def test_zero_accuracy(self) -> None:
-        """Zero is a valid accuracy."""
-        assert safe_accuracy(0.0) == 0.0
+    def test_zero_accuracy_returns_fallback(self) -> None:
+        """Zero accuracy means 'unknown/masked', returns fallback.
+
+        BACKGROUND: Google's API sometimes returns accuracy=0.0 as "privacy masking"
+        or "unknown precision", not as "perfect precision". We treat it as unmeasured.
+        """
+        assert safe_accuracy(0.0) == self.DEFAULT_FALLBACK
+
+    def test_sub_meter_accuracy_returns_fallback(self) -> None:
+        """Sub-meter accuracy is physically implausible for consumer GPS, returns fallback.
+
+        Consumer GPS hardware floor is ~1.0m. Values < 1.0 indicate data corruption
+        or API quirks, not actual precision.
+        """
+        assert safe_accuracy(0.5) == self.DEFAULT_FALLBACK
+        assert safe_accuracy(0.99) == self.DEFAULT_FALLBACK
 
     def test_none_returns_fallback(self) -> None:
         """None returns fallback value."""
@@ -207,10 +221,14 @@ class TestSafeAccuracy:
         assert safe_accuracy(float("inf")) == self.DEFAULT_FALLBACK
         assert safe_accuracy(float("-inf")) == self.DEFAULT_FALLBACK
 
-    def test_very_small_positive(self) -> None:
-        """Very small positive values are valid."""
-        assert safe_accuracy(0.001) == 0.001
-        assert safe_accuracy(1e-10) == 1e-10
+    def test_boundary_accuracy_value(self) -> None:
+        """Boundary value: 1.0m is the minimum valid accuracy.
+
+        Consumer GPS cannot achieve sub-meter accuracy.
+        Exactly 1.0m is the threshold - valid and returned unchanged.
+        """
+        assert safe_accuracy(1.0) == 1.0
+        assert safe_accuracy(1.001) == 1.001
 
     def test_very_large_positive(self) -> None:
         """Very large positive values are valid."""

--- a/tests/test_decoder_accuracy_regression.py
+++ b/tests/test_decoder_accuracy_regression.py
@@ -396,3 +396,514 @@ class TestDirtyDataHandling:
         best, rest = _select_best_location([])
         assert best is None
         assert rest == []
+
+    def test_null_island_coordinates_filtered(self) -> None:
+        """Coordinates at (0.0, 0.0) - 'Null Island' - must be filtered out.
+
+        The point (0.0, 0.0) is in the Atlantic Ocean off the coast of Africa.
+        This is a common API default when no real location data is available.
+        Such coordinates should never be accepted as valid device locations.
+        """
+        null_island_report: dict[str, Any] = {
+            "latitude": 0.0,
+            "longitude": 0.0,
+            "accuracy": 100.0,  # Valid accuracy, but invalid coordinates
+            "last_seen": 1700000200,
+            "is_own_report": True,
+        }
+
+        valid_report: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 50.0,
+            "last_seen": 1700000100,  # Older timestamp
+            "is_own_report": False,
+        }
+
+        # After normalization, Null Island should have no coordinates
+        normalized = _normalize_location_dict(null_island_report)
+        assert "latitude" not in normalized or "longitude" not in normalized, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: Null Island coordinates (0.0, 0.0) were NOT filtered!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"The point (0.0, 0.0) is in the Atlantic Ocean and indicates\n"
+            f"missing/default data from the API, not a real device location.\n"
+            f"\n"
+            f"FIX LOCATION: decoder.py :: _normalize_location_dict()\n"
+            f"Add filter: if abs(lat) < 0.0001 and abs(lon) < 0.0001: pop both\n"
+            f"{'=' * 70}"
+        )
+
+        # When selecting between Null Island and valid coords, valid must win
+        best, _rest = _select_best_location([null_island_report, valid_report])
+
+        if best is not None:
+            lat = best.get("latitude")
+            lon = best.get("longitude")
+            # Either no coords (filtered), or the valid location
+            if lat is not None and lon is not None:
+                assert not (abs(lat) < 0.0001 and abs(lon) < 0.0001), (
+                    f"\n"
+                    f"{'=' * 70}\n"
+                    f"CRITICAL: Null Island was selected as best location!\n"
+                    f"{'=' * 70}\n"
+                    f"Selected: ({lat}, {lon})\n"
+                    f"Expected: Valid coordinates (48.123, 11.456) or None\n"
+                    f"{'=' * 70}"
+                )
+
+
+# =============================================================================
+# SECTION 4: "Perfect Storm" - Ranking vs Recency
+# =============================================================================
+
+
+class TestPerfectStormScenario:
+    """Test the 'Perfect Storm' scenario where bad data has a newer timestamp.
+
+    This tests the critical case where:
+    - An is_own_report=True update with accuracy=0.0 arrives with a NEWER timestamp
+    - A valid crowdsourced update with accuracy=20.0 has an OLDER timestamp
+
+    The system MUST reject the invalid data even though it's "newer".
+    Recency cannot override physical impossibility.
+    """
+
+    def test_newer_invalid_data_loses_to_older_valid_data(self) -> None:
+        """CRITICAL: Newer timestamp cannot rescue physically impossible data.
+
+        This is the 'Perfect Storm' scenario: The bad report has every advantage
+        (is_own_report=True, newer timestamp) except valid accuracy.
+        It MUST still lose.
+        """
+        # The "bad" report: Everything looks good except accuracy is impossible
+        bad_newer_own: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 0.0,  # PHYSICALLY IMPOSSIBLE
+            "last_seen": 1700000200,  # NEWER timestamp (advantage!)
+            "is_own_report": True,  # Owner priority (advantage!)
+            "status": "LAST_KNOWN",
+            "status_code": 1,
+        }
+
+        # The "good" report: Older, crowdsourced, but VALID
+        good_older_crowd: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 20.0,  # Realistic GPS accuracy
+            "last_seen": 1700000100,  # OLDER timestamp (disadvantage)
+            "is_own_report": False,  # No owner priority (disadvantage)
+            "status": "CROWDSOURCED",
+            "status_code": 2,
+        }
+
+        best, _rest = _select_best_location([bad_newer_own, good_older_crowd])
+
+        # The system must not select the invalid report
+        if best is not None:
+            selected_acc = best.get("accuracy")
+            # Valid outcomes: good report wins, or accuracy is filtered to None
+            is_good_winner = selected_acc == pytest.approx(20.0)
+            is_filtered = selected_acc is None
+
+            assert is_good_winner or is_filtered, (
+                f"\n"
+                f"{'=' * 70}\n"
+                f"CRITICAL FAILURE: 'Perfect Storm' scenario broke the system!\n"
+                f"{'=' * 70}\n"
+                f"\n"
+                f"SCENARIO: A physically impossible report (accuracy=0.0m) with\n"
+                f"is_own_report=True and a NEWER timestamp was selected over\n"
+                f"a valid crowdsourced report with accuracy=20.0m.\n"
+                f"\n"
+                f"SELECTED: accuracy={selected_acc}m\n"
+                f"EXPECTED: accuracy=20.0m or None (filtered)\n"
+                f"\n"
+                f"ROOT CAUSE: The ranking algorithm or normalization failed to\n"
+                f"reject accuracy=0.0m as invalid. The 'newer is better' heuristic\n"
+                f"must NOT override physical constraints.\n"
+                f"\n"
+                f"PRINCIPLE: Physics > Recency\n"
+                f"A timestamp cannot make 0.0m GPS accuracy possible.\n"
+                f"\n"
+                f"FIX LOCATIONS (check in order):\n"
+                f"  1. decoder.py :: _normalize_location_dict() - must filter acc <= 0\n"
+                f"  2. decoder.py :: _get_rank_tuple() - must penalize acc <= 0\n"
+                f"  3. cache.py :: _is_significant_update() - must reject acc < 1.0m\n"
+                f"{'=' * 70}"
+            )
+
+    def test_edge_case_0_001m_still_wins_ranking(self) -> None:
+        """Edge case: Very small but positive accuracy (0.001m) may pass ranking.
+
+        While 0.001m is unrealistic for consumer GPS, it's technically positive.
+        The cache gate (_is_significant_update) should catch this at < 1.0m.
+        But in the decoder, we only filter <= 0.
+        """
+        tiny_accuracy: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 0.001,  # Positive but unrealistic
+            "last_seen": 1700000100,
+            "is_own_report": False,
+        }
+
+        normal_accuracy: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 20.0,
+            "last_seen": 1700000100,
+            "is_own_report": False,
+        }
+
+        # The decoder may pass 0.001m through (it's > 0)
+        normalized = _normalize_location_dict(tiny_accuracy)
+
+        # This is expected to pass decoder validation (0.001 > 0)
+        # The cache gate should catch it later (< 1.0m)
+        # For the decoder alone, this documents expected behavior
+        if "accuracy" in normalized:
+            # Document that decoder passes tiny positive values
+            assert normalized["accuracy"] == pytest.approx(0.001), (
+                "Decoder should preserve tiny positive accuracy (cache gate handles < 1.0m)"
+            )
+
+
+# =============================================================================
+# SECTION 5: Cache and Fusion Tests
+# =============================================================================
+
+
+class TestCacheFusionRobustness:
+    """Test cache fusion logic against dirty data.
+
+    These tests verify that the cache's weighted fusion algorithm and
+    quality gates correctly handle edge cases and malicious data.
+    """
+
+    def test_is_significant_update_rejects_zero_accuracy(self) -> None:
+        """_is_significant_update must reject accuracy=0.0 as physically impossible."""
+        from unittest.mock import MagicMock
+
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        # Create a minimal mock coordinator
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        # Bind the method to our mock
+        is_sig = CacheOperations._is_significant_update
+
+        bad_update = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,  # INVALID
+            "last_seen": 1700000100,
+        }
+
+        result = is_sig(mock_coord, "device-1", bad_update)
+
+        assert result is False, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: Cache accepted update with accuracy=0.0m!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"The cache gatekeeper (_is_significant_update) must reject\n"
+            f"any update with accuracy < 1.0m as physically impossible.\n"
+            f"\n"
+            f"FIX LOCATION: cache.py :: _is_significant_update()\n"
+            f"Add check: if acc_f < MIN_PLAUSIBLE_ACCURACY_M: return False\n"
+            f"{'=' * 70}"
+        )
+
+        # Verify the stat was incremented
+        mock_coord.increment_stat.assert_called_with("invalid_accuracy_drop_count")
+
+    def test_is_significant_update_rejects_sub_meter_accuracy(self) -> None:
+        """_is_significant_update must reject accuracy < 1.0m (consumer GPS floor)."""
+        from unittest.mock import MagicMock
+
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        # 0.5m is positive but impossible for consumer GPS
+        bad_update = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.5,  # Sub-meter = INVALID for consumer GPS
+            "last_seen": 1700000100,
+        }
+
+        result = is_sig(mock_coord, "device-1", bad_update)
+
+        assert result is False, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: Cache accepted sub-meter accuracy (0.5m)!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"Consumer GPS hardware cannot achieve sub-meter accuracy.\n"
+            f"Even differential GPS rarely achieves < 1m.\n"
+            f"Values like 0.5m indicate API artifacts, not real measurements.\n"
+            f"\n"
+            f"The cache MUST reject accuracy < 1.0m to prevent:\n"
+            f"- 'Fusion Lock-in' where bad data gets extreme weight\n"
+            f"- Incorrect 'Own Device' reports poisoning the cache\n"
+            f"\n"
+            f"FIX LOCATION: cache.py :: _is_significant_update()\n"
+            f"Ensure MIN_PLAUSIBLE_ACCURACY_M = 1.0 and check is enforced.\n"
+            f"{'=' * 70}"
+        )
+
+    def test_is_significant_update_allows_valid_accuracy(self) -> None:
+        """_is_significant_update must allow valid accuracy values (>= 1.0m)."""
+        from unittest.mock import MagicMock
+
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        good_update = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 5.0,  # Valid GPS accuracy
+            "last_seen": 1700000100,
+        }
+
+        result = is_sig(mock_coord, "device-1", good_update)
+
+        assert result is True, (
+            "Valid accuracy (5.0m) should be accepted by the cache gate"
+        )
+
+    def test_is_significant_update_allows_no_accuracy(self) -> None:
+        """_is_significant_update must allow updates without accuracy (semantic-only)."""
+        from unittest.mock import MagicMock
+
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        # Semantic-only update: no accuracy is fine
+        semantic_update = {
+            "semantic_name": "Home",
+            "last_seen": 1700000100,
+            # No accuracy - this is valid for semantic locations
+        }
+
+        result = is_sig(mock_coord, "device-1", semantic_update)
+
+        assert result is True, (
+            "Semantic-only updates (no accuracy) should be accepted.\n"
+            "Only updates that CLAIM an impossible accuracy should be rejected."
+        )
+
+
+# =============================================================================
+# SECTION 6: Fusion Lock-in Prevention
+# =============================================================================
+
+
+class TestFusionLockInPrevention:
+    """Test that the fusion algorithm cannot be 'locked in' by bad data.
+
+    The 'Fusion Lock-in' effect occurs when:
+    1. A bad accuracy value (e.g., 0.1m) gets into the cache
+    2. Due to inverse-square weighting (1/acc²), this value gets extreme weight
+    3. Subsequent valid updates (e.g., 20m) cannot move the position
+       because their weight is negligible compared to the 'poisoned' cache
+
+    Prevention strategy:
+    - Layer 1: Decoder filters accuracy <= 0
+    - Layer 2: Cache gate rejects accuracy < 1.0m
+    - Layer 3: Fusion uses 50m fallback for invalid values
+    - Layer 4: Fusion math uses proper inverse variance formula
+    """
+
+    def test_fusion_weight_ratio_is_reasonable(self) -> None:
+        """Verify fusion weights don't become astronomically skewed.
+
+        With proper fallback (50m for invalid), the weight ratio between
+        any two valid measurements should be reasonable (not > 100:1).
+        """
+        import math
+
+        # Worst realistic case: 5m vs 100m
+        acc_good = 5.0
+        acc_poor = 100.0
+
+        w_good = 1 / (acc_good ** 2)  # 1/25 = 0.04
+        w_poor = 1 / (acc_poor ** 2)  # 1/10000 = 0.0001
+
+        ratio = w_good / w_poor  # 400:1 - this is acceptable
+
+        # But if bad data (0.1m) got through, the ratio would be insane
+        acc_poison = 0.1
+        w_poison = 1 / (acc_poison ** 2)  # 1/0.01 = 100
+
+        poison_ratio = w_poison / w_poor  # 100 / 0.0001 = 1,000,000:1
+
+        assert poison_ratio > 10000, (
+            f"Sanity check: Poison ratio should be extreme ({poison_ratio})"
+        )
+
+        # This test documents WHY we need the cache gate
+        # If 0.1m gets through, it dominates with 1,000,000:1 weight ratio
+
+    def test_fusion_fallback_prevents_lockin(self) -> None:
+        """The 50m fallback should prevent extreme weight ratios.
+
+        When invalid accuracy (0.0, None) uses the 50m fallback instead of
+        a tiny value, the weight ratio stays reasonable.
+        """
+        from custom_components.googlefindmy.const import DEFAULT_FALLBACK_ACCURACY_M
+
+        # Fallback should be 50m (defined in const.py)
+        assert DEFAULT_FALLBACK_ACCURACY_M == 50.0, (
+            f"Expected DEFAULT_FALLBACK_ACCURACY_M = 50.0, got {DEFAULT_FALLBACK_ACCURACY_M}\n"
+            f"This value prevents Fusion Lock-in by ensuring invalid accuracy\n"
+            f"doesn't get extreme weight in the fusion formula."
+        )
+
+        # With 50m fallback, ratio to a 20m fix is reasonable
+        w_fallback = 1 / (50.0 ** 2)  # 1/2500 = 0.0004
+        w_valid = 1 / (20.0 ** 2)  # 1/400 = 0.0025
+
+        ratio = w_valid / w_fallback  # 6.25:1
+
+        assert ratio < 10, (
+            f"With 50m fallback, weight ratio should be < 10:1 (got {ratio:.2f}:1)\n"
+            f"This ensures valid GPS fixes can 'rescue' the cache from bad data."
+        )
+
+    def test_inverse_variance_formula_documented(self) -> None:
+        """Document the inverse variance fusion formula.
+
+        When fusing two measurements with accuracies σ₁ and σ₂:
+        - Weights: w₁ = 1/σ₁², w₂ = 1/σ₂²
+        - Fused position: (x₁*w₁ + x₂*w₂) / (w₁ + w₂)
+        - Fused variance: σ_fused² = 1 / (w₁ + w₂)
+        - Fused accuracy: σ_fused = sqrt(1 / (w₁ + w₂))
+
+        The fused accuracy should be BETTER than both inputs when valid.
+        """
+        import math
+
+        acc1 = 20.0  # First measurement: 20m accuracy
+        acc2 = 30.0  # Second measurement: 30m accuracy
+
+        w1 = 1 / (acc1 ** 2)  # 0.0025
+        w2 = 1 / (acc2 ** 2)  # 0.00111
+        total_w = w1 + w2  # 0.00361
+
+        fused_acc = math.sqrt(1 / total_w)  # ~16.6m
+
+        assert fused_acc < acc1, (
+            f"Fused accuracy ({fused_acc:.1f}m) should be better than first ({acc1}m)\n"
+            f"Combining measurements improves precision (inverse variance weighting)."
+        )
+
+        assert fused_acc < acc2, (
+            f"Fused accuracy ({fused_acc:.1f}m) should be better than second ({acc2}m)"
+        )
+
+        # With safety floor (5m), we clamp but don't go below physics limit
+        MIN_FUSED = 5.0
+        clamped = max(fused_acc, MIN_FUSED)
+        assert clamped >= MIN_FUSED, "Fused accuracy must respect physics floor (5m)"
+
+
+# =============================================================================
+# SECTION 7: Integration Scenario Tests
+# =============================================================================
+
+
+class TestIntegrationScenarios:
+    """End-to-end scenario tests combining multiple components."""
+
+    def test_full_pipeline_rejects_poisoned_own_report(self) -> None:
+        """Complete pipeline test: poisoned 'Own Device' report must be rejected.
+
+        This test simulates the full flow:
+        1. Raw data comes from Google's API (is_own_report=True, accuracy=0.0)
+        2. Decoder normalization should filter the accuracy
+        3. Ranking should penalize the report
+        4. Cache gate should reject it entirely
+        """
+        # Simulate the poisoned report exactly as it comes from the API
+        poisoned_api_response: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 0.0,
+            "last_seen": 1700000200,
+            "is_own_report": True,
+            "status_code": 1,
+        }
+
+        # Step 1: Decoder normalization
+        normalized = _normalize_location_dict(poisoned_api_response)
+
+        # Accuracy should be filtered out
+        assert "accuracy" not in normalized, (
+            "Decoder must filter accuracy=0.0 at normalization stage"
+        )
+
+        # Step 2: Ranking (if it somehow got through)
+        rank = _get_rank_tuple(poisoned_api_response)
+        acc_rank = rank[3]
+
+        assert math.isinf(acc_rank) and acc_rank < 0, (
+            "Ranking must penalize accuracy=0.0 with -inf rank"
+        )
+
+        # Step 3: If normalized (accuracy removed), verify ranking still works
+        rank_after_norm = _get_rank_tuple(normalized)
+        acc_rank_after = rank_after_norm[3]
+
+        assert math.isinf(acc_rank_after) and acc_rank_after < 0, (
+            "After normalization removes accuracy, rank should still be -inf (None = worst)"
+        )
+
+    def test_valid_crowdsourced_survives_pipeline(self) -> None:
+        """Verify that valid crowdsourced reports pass through unchanged."""
+        valid_report: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 25.0,
+            "last_seen": 1700000100,
+            "is_own_report": False,
+            "status_code": 2,
+        }
+
+        # Normalization preserves valid data
+        normalized = _normalize_location_dict(valid_report)
+        assert normalized.get("accuracy") == pytest.approx(25.0)
+        assert normalized.get("latitude") == pytest.approx(48.200)
+        assert normalized.get("longitude") == pytest.approx(11.200)
+
+        # Ranking assigns proper (non-worst) rank
+        rank = _get_rank_tuple(normalized)
+        acc_rank = rank[3]
+
+        assert acc_rank == pytest.approx(-25.0), (
+            f"Valid accuracy 25.0m should get rank -25.0 (got {acc_rank})"
+        )
+        assert not math.isinf(acc_rank), "Valid accuracy should not get -inf rank"

--- a/tests/test_decoder_accuracy_regression.py
+++ b/tests/test_decoder_accuracy_regression.py
@@ -32,7 +32,6 @@ from custom_components.googlefindmy.ProtoDecoders.decoder import (
     _select_best_location,
 )
 
-
 # =============================================================================
 # SECTION 1: Physics Validation Tests (accuracy must be > 0)
 # =============================================================================
@@ -206,7 +205,9 @@ class TestSelectBestLocationRegression:
             "status_code": 2,
         }
 
-        best, _rest = _select_best_location([spurious_own_report, legitimate_crowdsourced])
+        best, _rest = _select_best_location(
+            [spurious_own_report, legitimate_crowdsourced]
+        )
 
         assert best is not None, "Should select a location"
 
@@ -353,34 +354,59 @@ class TestDirtyDataHandling:
     """Test handling of malformed or missing data."""
 
     def test_missing_coordinates_not_selected(self) -> None:
-        """Reports without coordinates should not be selected as best location."""
+        """Reports without coordinates should not beat reports WITH coordinates.
+
+        When timestamp and status are equal, coordinates become the tie-breaker.
+        The algorithm's priority is:
+          1. Newer timestamp
+          2. Status (owner > crowdsourced > aggregated)
+          3. Has coordinates (tie-breaker)
+          4. Better accuracy
+        """
+        # Semantic-only: no lat/lon - should lose as tie-breaker
         no_coords: dict[str, Any] = {
             "accuracy": 5.0,
-            "last_seen": 1700000200,
-            "is_own_report": True,
+            "last_seen": 1700000100,  # Same timestamp
+            "is_own_report": False,  # Same status
             "semantic_name": "Home",
+            "status": "CROWDSOURCED",
+            "status_code": 2,
         }
 
+        # Has coordinates - should win as tie-breaker
         with_coords: dict[str, Any] = {
             "latitude": 48.200,
             "longitude": 11.200,
-            "accuracy": 50.0,
-            "last_seen": 1700000100,
-            "is_own_report": False,
+            "accuracy": 50.0,  # Worse accuracy, but has coords
+            "last_seen": 1700000100,  # Same timestamp
+            "is_own_report": False,  # Same status
+            "status": "CROWDSOURCED",
+            "status_code": 2,
         }
 
         best, _rest = _select_best_location([no_coords, with_coords])
 
         assert best is not None
         assert "latitude" in best and "longitude" in best, (
-            "Should select the report with actual coordinates"
+            "When timestamps match, report with coordinates should win over "
+            "semantic-only report as a tie-breaker"
         )
 
     def test_all_invalid_returns_none_or_filters(self) -> None:
         """If all reports have invalid accuracy, result should be filtered/empty."""
         all_bad = [
-            {"latitude": 48.1, "longitude": 11.1, "accuracy": 0.0, "last_seen": 1700000100},
-            {"latitude": 48.2, "longitude": 11.2, "accuracy": -5.0, "last_seen": 1700000100},
+            {
+                "latitude": 48.1,
+                "longitude": 11.1,
+                "accuracy": 0.0,
+                "last_seen": 1700000100,
+            },
+            {
+                "latitude": 48.2,
+                "longitude": 11.2,
+                "accuracy": -5.0,
+                "last_seen": 1700000100,
+            },
         ]
 
         best, _rest = _select_best_location(all_bad)
@@ -547,14 +573,6 @@ class TestPerfectStormScenario:
             "latitude": 48.100,
             "longitude": 11.100,
             "accuracy": 0.001,  # Positive but unrealistic
-            "last_seen": 1700000100,
-            "is_own_report": False,
-        }
-
-        normal_accuracy: dict[str, Any] = {
-            "latitude": 48.200,
-            "longitude": 11.200,
-            "accuracy": 20.0,
             "last_seen": 1700000100,
             "is_own_report": False,
         }
@@ -744,20 +762,20 @@ class TestFusionLockInPrevention:
         With proper fallback (50m for invalid), the weight ratio between
         any two valid measurements should be reasonable (not > 100:1).
         """
-        import math
 
         # Worst realistic case: 5m vs 100m
         acc_good = 5.0
         acc_poor = 100.0
 
-        w_good = 1 / (acc_good ** 2)  # 1/25 = 0.04
-        w_poor = 1 / (acc_poor ** 2)  # 1/10000 = 0.0001
+        w_good = 1 / (acc_good**2)  # 1/25 = 0.04
+        w_poor = 1 / (acc_poor**2)  # 1/10000 = 0.0001
 
         ratio = w_good / w_poor  # 400:1 - this is acceptable
+        assert ratio < 1000, f"Normal weight ratio should be < 1000:1 (got {ratio}:1)"
 
         # But if bad data (0.1m) got through, the ratio would be insane
         acc_poison = 0.1
-        w_poison = 1 / (acc_poison ** 2)  # 1/0.01 = 100
+        w_poison = 1 / (acc_poison**2)  # 1/0.01 = 100
 
         poison_ratio = w_poison / w_poor  # 100 / 0.0001 = 1,000,000:1
 
@@ -784,8 +802,8 @@ class TestFusionLockInPrevention:
         )
 
         # With 50m fallback, ratio to a 20m fix is reasonable
-        w_fallback = 1 / (50.0 ** 2)  # 1/2500 = 0.0004
-        w_valid = 1 / (20.0 ** 2)  # 1/400 = 0.0025
+        w_fallback = 1 / (50.0**2)  # 1/2500 = 0.0004
+        w_valid = 1 / (20.0**2)  # 1/400 = 0.0025
 
         ratio = w_valid / w_fallback  # 6.25:1
 
@@ -810,8 +828,8 @@ class TestFusionLockInPrevention:
         acc1 = 20.0  # First measurement: 20m accuracy
         acc2 = 30.0  # Second measurement: 30m accuracy
 
-        w1 = 1 / (acc1 ** 2)  # 0.0025
-        w2 = 1 / (acc2 ** 2)  # 0.00111
+        w1 = 1 / (acc1**2)  # 0.0025
+        w2 = 1 / (acc2**2)  # 0.00111
         total_w = w1 + w2  # 0.00361
 
         fused_acc = math.sqrt(1 / total_w)  # ~16.6m

--- a/tests/test_decoder_accuracy_regression.py
+++ b/tests/test_decoder_accuracy_regression.py
@@ -48,15 +48,18 @@ class TestAccuracyPhysicsValidation:
     @pytest.mark.parametrize(
         ("input_accuracy", "should_be_removed", "scenario"),
         [
-            # Valid accuracy values - should be preserved (>= 1.0m)
-            (1.0, False, "minimum_valid_accuracy"),
+            # Valid accuracy values - should be preserved (>= 0.001m)
+            # Modern dual-frequency GNSS can achieve sub-meter accuracy
+            (0.001, False, "minimum_valid_accuracy_1mm"),
+            (0.002, False, "micro_precision_2mm"),
+            (0.5, False, "sub_meter_valid"),
+            (1.0, False, "one_meter_valid"),
             (5.0, False, "typical_gps_accuracy"),
             (20.0, False, "moderate_gps_accuracy"),
             (100.0, False, "poor_gps_accuracy"),
-            # Invalid accuracy values - MUST be removed (< 1.0m is physically impossible)
-            (0.0, True, "zero_accuracy_means_unknown"),
-            (0.5, True, "sub_meter_accuracy_impossible"),
-            (0.99, True, "just_under_threshold_invalid"),
+            # Invalid accuracy values - MUST be removed (< 0.001m is error code)
+            (0.0, True, "zero_accuracy_error_code"),
+            (0.0001, True, "below_threshold_error_code"),
             (-1.0, True, "negative_accuracy_impossible"),
             (-100.0, True, "large_negative_impossible"),
             (float("nan"), True, "nan_is_invalid"),
@@ -71,11 +74,12 @@ class TestAccuracyPhysicsValidation:
         should_be_removed: bool,
         scenario: str,
     ) -> None:
-        """_normalize_location_dict must remove physically impossible accuracy values.
+        """_normalize_location_dict must filter error codes, preserve valid data.
 
-        GPS accuracy of <= 0 meters is physically impossible. Real GPS systems
-        report accuracy in the range of 3-50m (good conditions) to 100m+ (poor).
-        Values of 0.0, negative, NaN, or Inf indicate missing/corrupted data.
+        The Android Location API uses 0.0 as an error code meaning "no accuracy".
+        Modern dual-frequency GNSS can achieve sub-meter accuracy, so values like
+        0.5m or 0.01m are valid and must be preserved.
+        Only the error code (< 0.001m) and invalid values (negative, NaN, Inf) are filtered.
         """
         loc = {
             "latitude": 48.123,
@@ -90,18 +94,16 @@ class TestAccuracyPhysicsValidation:
             assert "accuracy" not in result, (
                 f"\n"
                 f"{'=' * 70}\n"
-                f"REGRESSION DETECTED: Invalid accuracy was NOT filtered!\n"
+                f"REGRESSION DETECTED: Error code accuracy was NOT filtered!\n"
                 f"{'=' * 70}\n"
                 f"Scenario: {scenario}\n"
                 f"Input accuracy: {input_accuracy}\n"
                 f"\n"
-                f"PHYSICS VIOLATION: GPS accuracy of {input_accuracy}m is invalid.\n"
-                f"Consumer GPS cannot achieve sub-meter accuracy (< 1.0m).\n"
-                f"Values < 1.0 indicate API artifacts or 'unknown', not precision.\n"
+                f"The Android Location API uses 0.0 as an error code.\n"
+                f"Values < 0.001m should be filtered as error codes.\n"
                 f"\n"
                 f"FIX LOCATION: decoder.py :: _normalize_location_dict()\n"
-                f"The function must filter out accuracy < 1.0m before returning.\n"
-                f"Look for: 'elif num_key == \"accuracy\" and f < _MIN_PLAUSIBLE_ACCURACY_M'\n"
+                f"Look for: 'elif num_key == \"accuracy\" and f < _MIN_VALID_ACCURACY'\n"
                 f"{'=' * 70}"
             )
         else:
@@ -655,12 +657,11 @@ class TestCacheFusionRobustness:
         # Verify sanitization was counted
         mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
 
-    def test_is_significant_update_sanitizes_sub_meter_accuracy(self) -> None:
-        """_is_significant_update must ACCEPT but SANITIZE accuracy < 1.0m.
+    def test_is_significant_update_preserves_sub_meter_accuracy(self) -> None:
+        """_is_significant_update must PRESERVE valid sub-meter accuracy.
 
-        Consumer GPS cannot achieve sub-meter accuracy. Values like 0.5m
-        indicate API artifacts, not real measurements. We ACCEPT the update
-        but REMOVE the invalid accuracy from the dict.
+        Modern dual-frequency GNSS (L1+L5) can achieve sub-meter accuracy.
+        Values like 0.5m are valid measurements and must be preserved.
         """
         from unittest.mock import MagicMock
 
@@ -672,31 +673,27 @@ class TestCacheFusionRobustness:
 
         is_sig = CacheOperations._is_significant_update
 
-        # 0.5m is positive but impossible for consumer GPS - will be sanitized
+        # 0.5m is valid sub-meter accuracy for modern GNSS
         update_with_sub_meter = {
             "latitude": 48.123,
             "longitude": 11.456,
-            "accuracy": 0.5,  # Sub-meter = will be sanitized (removed)
+            "accuracy": 0.5,  # Valid sub-meter - MUST be preserved
             "last_seen": 1700000100,
         }
 
         result = is_sig(mock_coord, "device-1", update_with_sub_meter)
 
         # Update must be ACCEPTED
-        assert result is True, (
-            "Update with sub-meter accuracy should be ACCEPTED (sanitized)"
-        )
+        assert result is True, "Update with valid sub-meter accuracy should be ACCEPTED"
 
-        # Accuracy should have been removed
-        assert "accuracy" not in update_with_sub_meter, (
-            "Sub-meter accuracy should be removed from update dict"
+        # Accuracy must be PRESERVED (not sanitized)
+        assert update_with_sub_meter.get("accuracy") == 0.5, (
+            "Valid sub-meter accuracy (0.5m) should be PRESERVED, not removed.\n"
+            "Modern GNSS can achieve sub-meter accuracy."
         )
-
-        # Verify sanitization was counted
-        mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
 
     def test_is_significant_update_allows_valid_accuracy(self) -> None:
-        """_is_significant_update must allow valid accuracy values (>= 1.0m)."""
+        """_is_significant_update must allow valid accuracy values (>= 0.001m)."""
         from unittest.mock import MagicMock
 
         from custom_components.googlefindmy.coordinator.cache import CacheOperations

--- a/tests/test_decoder_accuracy_regression.py
+++ b/tests/test_decoder_accuracy_regression.py
@@ -649,9 +649,14 @@ class TestCacheFusionRobustness:
             f"{'=' * 70}"
         )
 
-        # Accuracy should have been removed from the update dict
-        assert "accuracy" not in update_with_zero_acc, (
-            "Invalid accuracy should be removed from update dict"
+        # Accuracy should have been SET to fallback (not removed)
+        # Home Assistant requires a numeric gps_accuracy attribute
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            DEFAULT_ACCURACY_FALLBACK,
+        )
+
+        assert update_with_zero_acc.get("accuracy") == DEFAULT_ACCURACY_FALLBACK, (
+            f"Invalid accuracy should be set to fallback ({DEFAULT_ACCURACY_FALLBACK}m)"
         )
 
         # Verify sanitization was counted
@@ -1260,9 +1265,14 @@ class TestZeroAccuracyGhostPrevention:
             "Zero accuracy update should be ACCEPTED (with accuracy sanitized)"
         )
 
-        # Accuracy must have been removed
-        assert "accuracy" not in ghost_update, (
-            "Zero accuracy should be removed from update dict"
+        # Accuracy must have been SET to fallback (not removed)
+        # Home Assistant requires a numeric gps_accuracy attribute
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            DEFAULT_ACCURACY_FALLBACK,
+        )
+
+        assert ghost_update.get("accuracy") == DEFAULT_ACCURACY_FALLBACK, (
+            f"Zero accuracy should be set to fallback ({DEFAULT_ACCURACY_FALLBACK}m)"
         )
 
         # Verify the sanitization was counted

--- a/tests/test_decoder_accuracy_regression.py
+++ b/tests/test_decoder_accuracy_regression.py
@@ -48,13 +48,15 @@ class TestAccuracyPhysicsValidation:
     @pytest.mark.parametrize(
         ("input_accuracy", "should_be_removed", "scenario"),
         [
-            # Valid accuracy values - should be preserved
+            # Valid accuracy values - should be preserved (>= 1.0m)
+            (1.0, False, "minimum_valid_accuracy"),
             (5.0, False, "typical_gps_accuracy"),
             (20.0, False, "moderate_gps_accuracy"),
             (100.0, False, "poor_gps_accuracy"),
-            (0.001, False, "very_precise_but_positive"),
-            # Invalid accuracy values - MUST be removed
-            (0.0, True, "zero_accuracy_impossible"),
+            # Invalid accuracy values - MUST be removed (< 1.0m is physically impossible)
+            (0.0, True, "zero_accuracy_means_unknown"),
+            (0.5, True, "sub_meter_accuracy_impossible"),
+            (0.99, True, "just_under_threshold_invalid"),
             (-1.0, True, "negative_accuracy_impossible"),
             (-100.0, True, "large_negative_impossible"),
             (float("nan"), True, "nan_is_invalid"),
@@ -93,12 +95,13 @@ class TestAccuracyPhysicsValidation:
                 f"Scenario: {scenario}\n"
                 f"Input accuracy: {input_accuracy}\n"
                 f"\n"
-                f"PHYSICS VIOLATION: GPS accuracy of {input_accuracy}m is impossible.\n"
-                f"Real GPS accuracy is typically 3-50m, never <= 0.\n"
+                f"PHYSICS VIOLATION: GPS accuracy of {input_accuracy}m is invalid.\n"
+                f"Consumer GPS cannot achieve sub-meter accuracy (< 1.0m).\n"
+                f"Values < 1.0 indicate API artifacts or 'unknown', not precision.\n"
                 f"\n"
                 f"FIX LOCATION: decoder.py :: _normalize_location_dict()\n"
-                f"The function must filter out accuracy <= 0 before returning.\n"
-                f"Look for: 'elif num_key == \"accuracy\" and f <= 0.0'\n"
+                f"The function must filter out accuracy < 1.0m before returning.\n"
+                f"Look for: 'elif num_key == \"accuracy\" and f < _MIN_PLAUSIBLE_ACCURACY_M'\n"
                 f"{'=' * 70}"
             )
         else:
@@ -603,8 +606,13 @@ class TestCacheFusionRobustness:
     quality gates correctly handle edge cases and malicious data.
     """
 
-    def test_is_significant_update_rejects_zero_accuracy(self) -> None:
-        """_is_significant_update must reject accuracy=0.0 as physically impossible."""
+    def test_is_significant_update_sanitizes_zero_accuracy(self) -> None:
+        """_is_significant_update must ACCEPT but SANITIZE accuracy=0.0.
+
+        BACKGROUND: 0.0 means 'unknown/masked', not 'perfect precision'.
+        The update contains valid location data - only accuracy is invalid.
+        We ACCEPT the update but REMOVE the invalid accuracy from the dict.
+        """
         from unittest.mock import MagicMock
 
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
@@ -617,34 +625,43 @@ class TestCacheFusionRobustness:
         # Bind the method to our mock
         is_sig = CacheOperations._is_significant_update
 
-        bad_update = {
+        update_with_zero_acc = {
             "latitude": 48.123,
             "longitude": 11.456,
-            "accuracy": 0.0,  # INVALID
+            "accuracy": 0.0,  # Will be sanitized (removed)
             "last_seen": 1700000100,
         }
 
-        result = is_sig(mock_coord, "device-1", bad_update)
+        result = is_sig(mock_coord, "device-1", update_with_zero_acc)
 
-        assert result is False, (
+        # Update must be ACCEPTED (not rejected)
+        assert result is True, (
             f"\n"
             f"{'=' * 70}\n"
-            f"CRITICAL: Cache accepted update with accuracy=0.0m!\n"
+            f"CACHE REJECTED VALID UPDATE!\n"
             f"{'=' * 70}\n"
             f"\n"
-            f"The cache gatekeeper (_is_significant_update) must reject\n"
-            f"any update with accuracy < 1.0m as physically impossible.\n"
-            f"\n"
-            f"FIX LOCATION: cache.py :: _is_significant_update()\n"
-            f"Add check: if acc_f < MIN_PLAUSIBLE_ACCURACY_M: return False\n"
+            f"An update with accuracy=0.0 was REJECTED instead of SANITIZED.\n"
+            f"The report contains valid location data. Only the accuracy\n"
+            f"is invalid and should be removed, not the entire update.\n"
             f"{'=' * 70}"
         )
 
-        # Verify the stat was incremented
-        mock_coord.increment_stat.assert_called_with("invalid_accuracy_drop_count")
+        # Accuracy should have been removed from the update dict
+        assert "accuracy" not in update_with_zero_acc, (
+            "Invalid accuracy should be removed from update dict"
+        )
 
-    def test_is_significant_update_rejects_sub_meter_accuracy(self) -> None:
-        """_is_significant_update must reject accuracy < 1.0m (consumer GPS floor)."""
+        # Verify sanitization was counted
+        mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
+
+    def test_is_significant_update_sanitizes_sub_meter_accuracy(self) -> None:
+        """_is_significant_update must ACCEPT but SANITIZE accuracy < 1.0m.
+
+        Consumer GPS cannot achieve sub-meter accuracy. Values like 0.5m
+        indicate API artifacts, not real measurements. We ACCEPT the update
+        but REMOVE the invalid accuracy from the dict.
+        """
         from unittest.mock import MagicMock
 
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
@@ -655,34 +672,28 @@ class TestCacheFusionRobustness:
 
         is_sig = CacheOperations._is_significant_update
 
-        # 0.5m is positive but impossible for consumer GPS
-        bad_update = {
+        # 0.5m is positive but impossible for consumer GPS - will be sanitized
+        update_with_sub_meter = {
             "latitude": 48.123,
             "longitude": 11.456,
-            "accuracy": 0.5,  # Sub-meter = INVALID for consumer GPS
+            "accuracy": 0.5,  # Sub-meter = will be sanitized (removed)
             "last_seen": 1700000100,
         }
 
-        result = is_sig(mock_coord, "device-1", bad_update)
+        result = is_sig(mock_coord, "device-1", update_with_sub_meter)
 
-        assert result is False, (
-            f"\n"
-            f"{'=' * 70}\n"
-            f"CRITICAL: Cache accepted sub-meter accuracy (0.5m)!\n"
-            f"{'=' * 70}\n"
-            f"\n"
-            f"Consumer GPS hardware cannot achieve sub-meter accuracy.\n"
-            f"Even differential GPS rarely achieves < 1m.\n"
-            f"Values like 0.5m indicate API artifacts, not real measurements.\n"
-            f"\n"
-            f"The cache MUST reject accuracy < 1.0m to prevent:\n"
-            f"- 'Fusion Lock-in' where bad data gets extreme weight\n"
-            f"- Incorrect 'Own Device' reports poisoning the cache\n"
-            f"\n"
-            f"FIX LOCATION: cache.py :: _is_significant_update()\n"
-            f"Ensure MIN_PLAUSIBLE_ACCURACY_M = 1.0 and check is enforced.\n"
-            f"{'=' * 70}"
+        # Update must be ACCEPTED
+        assert result is True, (
+            "Update with sub-meter accuracy should be ACCEPTED (sanitized)"
         )
+
+        # Accuracy should have been removed
+        assert "accuracy" not in update_with_sub_meter, (
+            "Sub-meter accuracy should be removed from update dict"
+        )
+
+        # Verify sanitization was counted
+        mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
 
     def test_is_significant_update_allows_valid_accuracy(self) -> None:
         """_is_significant_update must allow valid accuracy values (>= 1.0m)."""
@@ -1221,8 +1232,13 @@ class TestZeroAccuracyGhostPrevention:
             f"{'=' * 70}"
         )
 
-    def test_cache_gate_rejects_zero_accuracy(self) -> None:
-        """cache.py _is_significant_update must reject accuracy=0.0."""
+    def test_cache_gate_sanitizes_zero_accuracy(self) -> None:
+        """cache.py _is_significant_update must SANITIZE accuracy=0.0.
+
+        Zero accuracy means 'unknown/masked', not 'perfect precision'.
+        We ACCEPT the update but REMOVE the invalid accuracy to prevent
+        ranking corruption.
+        """
         from unittest.mock import MagicMock
 
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
@@ -1236,28 +1252,21 @@ class TestZeroAccuracyGhostPrevention:
         ghost_update = {
             "latitude": 48.123,
             "longitude": 11.456,
-            "accuracy": 0.0,  # THE GHOST
+            "accuracy": 0.0,  # Will be sanitized (removed)
             "last_seen": 1700000100,
         }
 
         result = is_sig(mock_coord, "device-1", ghost_update)
 
-        assert result is False, (
-            f"\n"
-            f"{'=' * 70}\n"
-            f"CACHE ACCEPTED ZERO-ACCURACY GHOST!\n"
-            f"{'=' * 70}\n"
-            f"\n"
-            f"The cache gatekeeper (_is_significant_update) accepted an\n"
-            f"update with accuracy=0.0m. This will poison the cache.\n"
-            f"\n"
-            f"Expected: False (rejected)\n"
-            f"Actual: True (accepted)\n"
-            f"\n"
-            f"FIX: cache.py :: _is_significant_update()\n"
-            f"Add: if acc_f < MIN_PHYSICAL_ACCURACY_M: return False\n"
-            f"{'=' * 70}"
+        # Update must be ACCEPTED (sanitized, not rejected)
+        assert result is True, (
+            "Zero accuracy update should be ACCEPTED (with accuracy sanitized)"
         )
 
-        # Verify the rejection was counted
-        mock_coord.increment_stat.assert_called_with("invalid_accuracy_drop_count")
+        # Accuracy must have been removed
+        assert "accuracy" not in ghost_update, (
+            "Zero accuracy should be removed from update dict"
+        )
+
+        # Verify the sanitization was counted
+        mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")

--- a/tests/test_decoder_accuracy_regression.py
+++ b/tests/test_decoder_accuracy_regression.py
@@ -1,0 +1,398 @@
+# tests/test_decoder_accuracy_regression.py
+"""Regression tests for accuracy validation in decoder.py.
+
+These tests ensure that physically impossible accuracy values (0.0m, negative,
+NaN, Inf) are correctly rejected and never win the ranking algorithm.
+
+BACKGROUND (January 2025):
+Google's API sometimes returns `isOwnReport=True` with `accuracy=0.0m`. This is
+physically impossible - real GPS accuracy is typically 3-50m. The algorithm
+previously treated 0.0m as "perfect precision" due to the ranking formula:
+    acc_rank = -float(acc)  # 0.0 -> -0.0 > -20.0 (oops!)
+
+This caused spurious "Own Device" reports with invalid data to win over
+legitimate crowdsourced reports with real GPS coordinates.
+
+These tests are designed to:
+1. Prevent regression if someone refactors the validation logic
+2. Provide clear, actionable error messages pointing to the fix location
+3. Document the physics constraints that the code must enforce
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.ProtoDecoders.decoder import (
+    _get_rank_tuple,
+    _normalize_location_dict,
+    _select_best_location,
+)
+
+
+# =============================================================================
+# SECTION 1: Physics Validation Tests (accuracy must be > 0)
+# =============================================================================
+
+
+class TestAccuracyPhysicsValidation:
+    """Test that physically impossible accuracy values are rejected."""
+
+    # -------------------------------------------------------------------------
+    # Test: _normalize_location_dict must filter invalid accuracy
+    # -------------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("input_accuracy", "should_be_removed", "scenario"),
+        [
+            # Valid accuracy values - should be preserved
+            (5.0, False, "typical_gps_accuracy"),
+            (20.0, False, "moderate_gps_accuracy"),
+            (100.0, False, "poor_gps_accuracy"),
+            (0.001, False, "very_precise_but_positive"),
+            # Invalid accuracy values - MUST be removed
+            (0.0, True, "zero_accuracy_impossible"),
+            (-1.0, True, "negative_accuracy_impossible"),
+            (-100.0, True, "large_negative_impossible"),
+            (float("nan"), True, "nan_is_invalid"),
+            (float("inf"), True, "positive_infinity_invalid"),
+            (float("-inf"), True, "negative_infinity_invalid"),
+        ],
+        ids=lambda x: str(x) if not isinstance(x, str) else x,
+    )
+    def test_normalize_filters_invalid_accuracy(
+        self,
+        input_accuracy: float,
+        should_be_removed: bool,
+        scenario: str,
+    ) -> None:
+        """_normalize_location_dict must remove physically impossible accuracy values.
+
+        GPS accuracy of <= 0 meters is physically impossible. Real GPS systems
+        report accuracy in the range of 3-50m (good conditions) to 100m+ (poor).
+        Values of 0.0, negative, NaN, or Inf indicate missing/corrupted data.
+        """
+        loc = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": input_accuracy,
+            "last_seen": 1700000000,
+        }
+
+        result = _normalize_location_dict(loc)
+
+        if should_be_removed:
+            assert "accuracy" not in result, (
+                f"\n"
+                f"{'=' * 70}\n"
+                f"REGRESSION DETECTED: Invalid accuracy was NOT filtered!\n"
+                f"{'=' * 70}\n"
+                f"Scenario: {scenario}\n"
+                f"Input accuracy: {input_accuracy}\n"
+                f"\n"
+                f"PHYSICS VIOLATION: GPS accuracy of {input_accuracy}m is impossible.\n"
+                f"Real GPS accuracy is typically 3-50m, never <= 0.\n"
+                f"\n"
+                f"FIX LOCATION: decoder.py :: _normalize_location_dict()\n"
+                f"The function must filter out accuracy <= 0 before returning.\n"
+                f"Look for: 'elif num_key == \"accuracy\" and f <= 0.0'\n"
+                f"{'=' * 70}"
+            )
+        else:
+            assert "accuracy" in result, (
+                f"Valid accuracy {input_accuracy} should be preserved"
+            )
+            assert result["accuracy"] == pytest.approx(input_accuracy, nan_ok=False)
+
+    # -------------------------------------------------------------------------
+    # Test: _get_rank_tuple must penalize invalid accuracy
+    # -------------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        ("accuracy", "expected_rank", "scenario"),
+        [
+            # Valid: smaller accuracy = better (more negative rank = higher priority)
+            (5.0, -5.0, "good_accuracy_ranked_high"),
+            (50.0, -50.0, "moderate_accuracy_ranked_lower"),
+            # Invalid: must get worst possible rank (float("-inf"))
+            (0.0, float("-inf"), "zero_gets_worst_rank"),
+            (-10.0, float("-inf"), "negative_gets_worst_rank"),
+            (None, float("-inf"), "missing_gets_worst_rank"),
+        ],
+    )
+    def test_get_rank_tuple_penalizes_invalid_accuracy(
+        self,
+        accuracy: float | None,
+        expected_rank: float,
+        scenario: str,
+    ) -> None:
+        """_get_rank_tuple must assign worst rank to invalid accuracy values.
+
+        Defense in depth: even if _normalize_location_dict fails to filter,
+        the ranking function must not treat 0.0m as "perfect precision".
+        """
+        loc: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "last_seen": 1700000000,
+            "is_own_report": False,
+        }
+        if accuracy is not None:
+            loc["accuracy"] = accuracy
+
+        rank_tuple = _get_rank_tuple(loc)
+        acc_rank = rank_tuple[3]  # Index 3 is accuracy rank
+
+        if math.isinf(expected_rank) and expected_rank < 0:
+            assert math.isinf(acc_rank) and acc_rank < 0, (
+                f"\n"
+                f"{'=' * 70}\n"
+                f"REGRESSION DETECTED: Invalid accuracy got non-worst rank!\n"
+                f"{'=' * 70}\n"
+                f"Scenario: {scenario}\n"
+                f"Input accuracy: {accuracy}\n"
+                f"Actual acc_rank: {acc_rank}\n"
+                f"Expected: float('-inf') (worst possible rank)\n"
+                f"\n"
+                f"PROBLEM: The ranking algorithm is treating invalid accuracy\n"
+                f"as if it were valid data. This causes 0.0m to win over real GPS.\n"
+                f"\n"
+                f"FIX LOCATION: decoder.py :: _get_rank_tuple()\n"
+                f"The acc_rank calculation must check: float(acc) > 0\n"
+                f"Look for the line with 'acc_rank = ('\n"
+                f"{'=' * 70}"
+            )
+        else:
+            assert acc_rank == pytest.approx(expected_rank)
+
+
+# =============================================================================
+# SECTION 2: Ranking Algorithm Regression Tests
+# =============================================================================
+
+
+class TestSelectBestLocationRegression:
+    """Test that _select_best_location correctly handles accuracy conflicts."""
+
+    def test_crowdsourced_beats_own_report_with_zero_accuracy(self) -> None:
+        """CRITICAL: A real GPS fix must beat a spurious 'Own Device' with 0.0m.
+
+        This is the core regression test for the January 2025 bug where
+        Google's API returned isOwnReport=True with accuracy=0.0m, and
+        the algorithm incorrectly prioritized it over real crowdsourced data.
+        """
+        # The "bad" report: Own device flag but physically impossible accuracy
+        spurious_own_report: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 0.0,  # IMPOSSIBLE - this should be rejected
+            "last_seen": 1700000100,
+            "is_own_report": True,
+            "status": "LAST_KNOWN",
+            "status_code": 1,
+        }
+
+        # The "good" report: Real GPS data from the network
+        legitimate_crowdsourced: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 20.0,  # Realistic GPS accuracy
+            "last_seen": 1700000100,  # Same timestamp
+            "is_own_report": False,
+            "status": "CROWDSOURCED",
+            "status_code": 2,
+        }
+
+        best, _rest = _select_best_location([spurious_own_report, legitimate_crowdsourced])
+
+        assert best is not None, "Should select a location"
+
+        # The legitimate report MUST win
+        assert best.get("accuracy") == pytest.approx(20.0), (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL REGRESSION: Zero-accuracy 'Own Device' won the ranking!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"THE BUG: Google's API returned isOwnReport=True with accuracy=0.0m.\n"
+            f"This is physically impossible (GPS is never 0.0m accurate).\n"
+            f"The algorithm incorrectly treated 0.0 as 'perfect precision'.\n"
+            f"\n"
+            f"EXPECTED: Crowdsourced report (accuracy=20.0m) should win.\n"
+            f"ACTUAL: Selected accuracy={best.get('accuracy')}m\n"
+            f"\n"
+            f"ROOT CAUSE: The ranking formula was:\n"
+            f"    acc_rank = -float(acc)  # 0.0 -> -0.0 > -20.0 (WRONG!)\n"
+            f"\n"
+            f"FIX LOCATIONS (check both):\n"
+            f"  1. decoder.py :: _normalize_location_dict() - filter accuracy <= 0\n"
+            f"  2. decoder.py :: _get_rank_tuple() - penalize accuracy <= 0\n"
+            f"{'=' * 70}"
+        )
+
+        assert best.get("is_own_report") is False, (
+            "The legitimate crowdsourced report should be selected, not the spurious own report"
+        )
+
+    @pytest.mark.parametrize(
+        ("bad_accuracy", "good_accuracy", "scenario"),
+        [
+            (0.0, 20.0, "zero_vs_normal"),
+            (-5.0, 50.0, "negative_vs_poor"),
+            (float("nan"), 100.0, "nan_vs_very_poor"),
+            (float("inf"), 30.0, "inf_vs_normal"),
+        ],
+        ids=["zero_vs_normal", "negative_vs_poor", "nan_vs_very_poor", "inf_vs_normal"],
+    )
+    def test_invalid_accuracy_never_wins(
+        self,
+        bad_accuracy: float,
+        good_accuracy: float,
+        scenario: str,
+    ) -> None:
+        """Reports with invalid accuracy must never win, regardless of other factors."""
+        bad_report: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": bad_accuracy,
+            "last_seen": 1700000200,  # Even newer timestamp!
+            "is_own_report": True,  # Even with owner priority!
+            "status": "LAST_KNOWN",
+            "status_code": 1,
+        }
+
+        good_report: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": good_accuracy,
+            "last_seen": 1700000100,  # Older
+            "is_own_report": False,  # No owner priority
+            "status": "CROWDSOURCED",
+            "status_code": 2,
+        }
+
+        best, _rest = _select_best_location([bad_report, good_report])
+
+        assert best is not None
+        selected_accuracy = best.get("accuracy")
+
+        # The good report must win (or accuracy should be None if filtered)
+        valid_outcomes = (
+            selected_accuracy == pytest.approx(good_accuracy)
+            or selected_accuracy is None  # Filtered out entirely is also acceptable
+        )
+
+        assert valid_outcomes, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"REGRESSION: Invalid accuracy report won the ranking!\n"
+            f"{'=' * 70}\n"
+            f"Scenario: {scenario}\n"
+            f"Bad accuracy: {bad_accuracy} (should lose)\n"
+            f"Good accuracy: {good_accuracy} (should win)\n"
+            f"Selected: {selected_accuracy}\n"
+            f"\n"
+            f"FIX: Ensure _normalize_location_dict filters accuracy <= 0, NaN, Inf\n"
+            f"{'=' * 70}"
+        )
+
+    def test_timestamp_tiebreaker_preserves_sort_order(self) -> None:
+        """When timestamps are equal, the pre-sorted order must be preserved.
+
+        This tests the fix for the 'Last-Write-Wins' bug where >= was used
+        instead of > in _merge_semantics_if_near_ts.
+        """
+        # Both have same timestamp, but first one has better accuracy
+        better_report: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 5.0,  # Better
+            "last_seen": 1700000100,
+            "is_own_report": False,
+            "status": "CROWDSOURCED",
+            "status_code": 2,
+        }
+
+        worse_report: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 50.0,  # Worse
+            "last_seen": 1700000100,  # Same timestamp
+            "is_own_report": False,
+            "status": "CROWDSOURCED",
+            "status_code": 2,
+        }
+
+        # Order matters: better_report should win even if worse_report comes later
+        best, _rest = _select_best_location([better_report, worse_report])
+
+        assert best is not None
+        assert best.get("accuracy") == pytest.approx(5.0), (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"REGRESSION: Last-Write-Wins bug detected!\n"
+            f"{'=' * 70}\n"
+            f"When timestamps are equal, the better-ranked entry should win.\n"
+            f"Selected accuracy: {best.get('accuracy')}m (expected 5.0m)\n"
+            f"\n"
+            f"FIX LOCATION: decoder.py :: _merge_semantics_if_near_ts()\n"
+            f"Change 'ts >= best_coordinate_ts' to 'ts > best_coordinate_ts'\n"
+            f"{'=' * 70}"
+        )
+
+
+# =============================================================================
+# SECTION 3: Edge Cases and Dirty Data
+# =============================================================================
+
+
+class TestDirtyDataHandling:
+    """Test handling of malformed or missing data."""
+
+    def test_missing_coordinates_not_selected(self) -> None:
+        """Reports without coordinates should not be selected as best location."""
+        no_coords: dict[str, Any] = {
+            "accuracy": 5.0,
+            "last_seen": 1700000200,
+            "is_own_report": True,
+            "semantic_name": "Home",
+        }
+
+        with_coords: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 50.0,
+            "last_seen": 1700000100,
+            "is_own_report": False,
+        }
+
+        best, _rest = _select_best_location([no_coords, with_coords])
+
+        assert best is not None
+        assert "latitude" in best and "longitude" in best, (
+            "Should select the report with actual coordinates"
+        )
+
+    def test_all_invalid_returns_none_or_filters(self) -> None:
+        """If all reports have invalid accuracy, result should be filtered/empty."""
+        all_bad = [
+            {"latitude": 48.1, "longitude": 11.1, "accuracy": 0.0, "last_seen": 1700000100},
+            {"latitude": 48.2, "longitude": 11.2, "accuracy": -5.0, "last_seen": 1700000100},
+        ]
+
+        best, _rest = _select_best_location(all_bad)
+
+        # Either no selection, or accuracy is filtered to None
+        if best is not None:
+            assert best.get("accuracy") is None, (
+                "If a location is selected, its invalid accuracy should be filtered to None"
+            )
+
+    def test_empty_list_returns_none(self) -> None:
+        """Empty input should return None."""
+        best, rest = _select_best_location([])
+        assert best is None
+        assert rest == []

--- a/tests/test_decoder_accuracy_regression.py
+++ b/tests/test_decoder_accuracy_regression.py
@@ -28,6 +28,7 @@ import pytest
 
 from custom_components.googlefindmy.ProtoDecoders.decoder import (
     _get_rank_tuple,
+    _merge_semantics_if_near_ts,
     _normalize_location_dict,
     _select_best_location,
 )
@@ -925,3 +926,338 @@ class TestIntegrationScenarios:
             f"Valid accuracy 25.0m should get rank -25.0 (got {acc_rank})"
         )
         assert not math.isinf(acc_rank), "Valid accuracy should not get -inf rank"
+
+
+# =============================================================================
+# SECTION 8: Timestamp Collision Identity Theft Protection
+# =============================================================================
+
+
+class TestTimestampCollisionIdentityTheft:
+    """Test that identical timestamps don't cause lower-ranked entries to win.
+
+    CONTEXT: Google sends batch updates where multiple reports have the exact
+    same timestamp. Without proper protection, "last-write-wins" semantics
+    could let a lower-ranked (crowdsourced) report overwrite coordinates
+    from a higher-ranked (own device) report.
+
+    INVARIANT: In _merge_semantics_if_near_ts, when timestamps are equal,
+    the first (higher-ranked) entry must preserve its coordinates.
+    This is achieved by using `>` instead of `>=` in the comparison.
+    """
+
+    def test_identical_timestamp_preserves_best_rank_coordinates(self) -> None:
+        """When timestamps collide, higher-ranked coordinates must NOT be overwritten.
+
+        SCENARIO:
+        - Candidate 1 (High Rank): is_own_report=True, coords=(48.1, 11.1), ts=1000
+        - Candidate 2 (Low Rank): is_own_report=False, coords=(50.0, 10.0), ts=1000
+
+        Since Candidate 1 is ranked higher (own_report), its coordinates must
+        be preserved even though Candidate 2 has the same timestamp.
+        """
+        # High-ranked candidate with coordinates
+        high_rank: dict[str, Any] = {
+            "latitude": 48.1,
+            "longitude": 11.1,
+            "accuracy": 20.0,
+            "last_seen": 1000,
+            "is_own_report": True,
+            "status": "LAST_KNOWN",
+            "status_code": 1,
+        }
+
+        # Low-ranked candidate with DIFFERENT coordinates, SAME timestamp
+        low_rank: dict[str, Any] = {
+            "latitude": 50.0,  # Different!
+            "longitude": 10.0,  # Different!
+            "accuracy": 15.0,
+            "last_seen": 1000,  # SAME timestamp
+            "is_own_report": False,
+            "status": "CROWDSOURCED",
+            "status_code": 2,
+        }
+
+        # Normalize candidates (simulating the decoder pipeline)
+        normed_high = _normalize_location_dict(high_rank)
+        normed_low = _normalize_location_dict(low_rank)
+
+        # Verify ranking: high_rank should come first
+        rank_high = _get_rank_tuple(normed_high)
+        rank_low = _get_rank_tuple(normed_low)
+        assert rank_high > rank_low, (
+            f"Own report should rank higher than crowdsourced.\n"
+            f"High rank: {rank_high}\n"
+            f"Low rank: {rank_low}"
+        )
+
+        # Simulate _merge_semantics_if_near_ts with high_rank as "best"
+        # The normed_cands list is sorted by rank (high first)
+        normed_cands = [normed_high, normed_low]
+        result = _merge_semantics_if_near_ts(dict(normed_high), normed_cands)
+
+        # CRITICAL: The coordinates must be from high_rank, not low_rank
+        assert result.get("latitude") == pytest.approx(48.1), (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"IDENTITY THEFT DETECTED!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"Lower-ranked report (crowdsourced) overwrote coordinates from\n"
+            f"higher-ranked report (own device) due to timestamp collision.\n"
+            f"\n"
+            f"Expected latitude: 48.1 (from own device report)\n"
+            f"Actual latitude: {result.get('latitude')} (from crowdsourced)\n"
+            f"\n"
+            f"ROOT CAUSE: _merge_semantics_if_near_ts uses >= instead of >\n"
+            f"for timestamp comparison, causing 'last-write-wins' behavior.\n"
+            f"\n"
+            f"FIX: Change 'if ts >= best_coordinate_ts' to 'if ts > best_coordinate_ts'\n"
+            f"in decoder.py :: _merge_semantics_if_near_ts()\n"
+            f"{'=' * 70}"
+        )
+        assert result.get("longitude") == pytest.approx(11.1), (
+            "Longitude must also be from the higher-ranked report"
+        )
+
+    def test_semantic_only_best_borrows_coords_from_any_timestamp(self) -> None:
+        """When best candidate has no coordinates, it can borrow from others.
+
+        This is EXPECTED behavior - a semantic-only "own report" should borrow
+        coordinates from a nearby crowdsourced report. The identity theft
+        protection only prevents OVERWRITING existing coordinates.
+        """
+        # High-ranked semantic-only report (no coordinates)
+        semantic_own: dict[str, Any] = {
+            "semantic_name": "Home",
+            "last_seen": 1000,
+            "is_own_report": True,
+            "status": "LAST_KNOWN",
+            "status_code": 1,
+            # No latitude/longitude!
+        }
+
+        # Low-ranked report with coordinates
+        coords_crowdsourced: dict[str, Any] = {
+            "latitude": 50.0,
+            "longitude": 10.0,
+            "accuracy": 15.0,
+            "last_seen": 1000,  # Same timestamp
+            "is_own_report": False,
+            "status": "CROWDSOURCED",
+            "status_code": 2,
+        }
+
+        normed_semantic = _normalize_location_dict(semantic_own)
+        normed_coords = _normalize_location_dict(coords_crowdsourced)
+        normed_cands = [normed_semantic, normed_coords]
+
+        result = _merge_semantics_if_near_ts(dict(normed_semantic), normed_cands)
+
+        # EXPECTED: semantic report borrows coordinates (this is OK)
+        # The key is that it ADDS coordinates, not OVERWRITES existing ones.
+        assert result.get("semantic_name") == "Home", (
+            "Semantic label should be preserved from the best candidate"
+        )
+        # Coordinates are borrowed - this is valid behavior
+        if "latitude" in result and "longitude" in result:
+            # Document that borrowing happened (not a failure)
+            assert result.get("latitude") == pytest.approx(50.0)
+            assert result.get("longitude") == pytest.approx(10.0)
+
+    def test_newer_timestamp_can_update_coordinates(self) -> None:
+        """A report with a STRICTLY newer timestamp CAN update coordinates.
+
+        This ensures the protection doesn't prevent legitimate updates.
+        Only EQUAL timestamps should preserve the first entry's coordinates.
+        """
+        # Older report
+        older: dict[str, Any] = {
+            "latitude": 48.1,
+            "longitude": 11.1,
+            "accuracy": 20.0,
+            "last_seen": 1000,
+            "is_own_report": True,
+        }
+
+        # Newer report with different coordinates
+        newer: dict[str, Any] = {
+            "latitude": 50.0,
+            "longitude": 10.0,
+            "accuracy": 15.0,
+            "last_seen": 2000,  # NEWER timestamp
+            "is_own_report": False,
+        }
+
+        normed_older = _normalize_location_dict(older)
+        normed_newer = _normalize_location_dict(newer)
+
+        # Even though older is "best" by ranking, we pass it as best
+        # and the newer timestamp should be able to update coordinates
+        normed_cands = [normed_older, normed_newer]
+        result = _merge_semantics_if_near_ts(dict(normed_older), normed_cands)
+
+        # The newer report's coordinates should be used (ts=2000 > ts=1000)
+        assert result.get("latitude") == pytest.approx(50.0), (
+            "Strictly newer timestamp should update coordinates"
+        )
+        assert result.get("longitude") == pytest.approx(10.0)
+
+
+# =============================================================================
+# SECTION 9: Zero-Accuracy Ghost Prevention
+# =============================================================================
+
+
+class TestZeroAccuracyGhostPrevention:
+    """Test that accuracy=0.0 is never stored or used for ranking.
+
+    CONTEXT: API errors can return accuracy=0.0, which is physically impossible.
+    Real GPS accuracy is typically 3-50m. A 0.0 value indicates missing data.
+
+    INVARIANT: The system must either:
+    1. Discard the accuracy (set to None), OR
+    2. Reject the update entirely
+    It must NEVER store accuracy=0.0 in any cache or ranking.
+    """
+
+    def test_zero_accuracy_is_discarded_by_decoder(self) -> None:
+        """decoder.py must remove accuracy=0.0 during normalization."""
+        ghost_report: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,  # THE GHOST
+            "last_seen": 1700000100,
+            "is_own_report": True,
+        }
+
+        normalized = _normalize_location_dict(ghost_report)
+
+        assert "accuracy" not in normalized or normalized.get("accuracy") is None, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"ZERO-ACCURACY GHOST DETECTED!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"accuracy=0.0 was NOT discarded during normalization.\n"
+            f"This value will cause ranking corruption (0.0 -> 'perfect precision').\n"
+            f"\n"
+            f"Stored accuracy: {normalized.get('accuracy')}\n"
+            f"Expected: None (discarded)\n"
+            f"\n"
+            f"FIX: decoder.py :: _normalize_location_dict()\n"
+            f"Add check: if num_key == 'accuracy' and f <= 0.0: out.pop(num_key, None)\n"
+            f"{'=' * 70}"
+        )
+
+    def test_zero_accuracy_gets_worst_ranking(self) -> None:
+        """_get_rank_tuple must assign -inf rank to accuracy=0.0."""
+        ghost_report: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,  # THE GHOST
+            "last_seen": 1700000100,
+            "is_own_report": True,
+        }
+
+        rank = _get_rank_tuple(ghost_report)
+        acc_rank = rank[3]
+
+        assert math.isinf(acc_rank) and acc_rank < 0, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"RANKING BUG: accuracy=0.0 got non-worst rank!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"accuracy=0.0 received acc_rank={acc_rank}\n"
+            f"Expected: -inf (worst possible rank)\n"
+            f"\n"
+            f"Without -inf, the formula '-float(0.0) = -0.0' causes\n"
+            f"the ghost to rank BETTER than valid entries like -20.0.\n"
+            f"\n"
+            f"FIX: decoder.py :: _get_rank_tuple()\n"
+            f"Add check: if acc <= 0: return -inf for acc_rank\n"
+            f"{'=' * 70}"
+        )
+
+    def test_zero_accuracy_never_wins_selection(self) -> None:
+        """_select_best_location must never choose a 0.0 accuracy report."""
+        ghost: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 0.0,  # GHOST - should lose
+            "last_seen": 1700000200,  # Even newer!
+            "is_own_report": True,  # Even with owner priority!
+        }
+
+        valid: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 50.0,  # Valid (even if poor)
+            "last_seen": 1700000100,
+            "is_own_report": False,
+        }
+
+        best, _rest = _select_best_location([ghost, valid])
+
+        assert best is not None
+        # The valid report should win despite being older/crowdsourced
+        # because the ghost's accuracy=0.0 is invalid
+        best_acc = best.get("accuracy")
+        assert best_acc is None or best_acc == pytest.approx(50.0), (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"ZERO-ACCURACY GHOST WON THE SELECTION!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"A report with accuracy=0.0m was selected as best.\n"
+            f"This is physically impossible and indicates a regression.\n"
+            f"\n"
+            f"Selected accuracy: {best_acc}\n"
+            f"Expected: 50.0 (from valid report) or None (filtered)\n"
+            f"\n"
+            f"The ghost had every advantage (newer timestamp, is_own_report)\n"
+            f"but must still lose because 0.0m is invalid data.\n"
+            f"{'=' * 70}"
+        )
+
+    def test_cache_gate_rejects_zero_accuracy(self) -> None:
+        """cache.py _is_significant_update must reject accuracy=0.0."""
+        from unittest.mock import MagicMock
+
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        ghost_update = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,  # THE GHOST
+            "last_seen": 1700000100,
+        }
+
+        result = is_sig(mock_coord, "device-1", ghost_update)
+
+        assert result is False, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CACHE ACCEPTED ZERO-ACCURACY GHOST!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"The cache gatekeeper (_is_significant_update) accepted an\n"
+            f"update with accuracy=0.0m. This will poison the cache.\n"
+            f"\n"
+            f"Expected: False (rejected)\n"
+            f"Actual: True (accepted)\n"
+            f"\n"
+            f"FIX: cache.py :: _is_significant_update()\n"
+            f"Add: if acc_f < MIN_PHYSICAL_ACCURACY_M: return False\n"
+            f"{'=' * 70}"
+        )
+
+        # Verify the rejection was counted
+        mock_coord.increment_stat.assert_called_with("invalid_accuracy_drop_count")

--- a/tests/test_fusion_robustness.py
+++ b/tests/test_fusion_robustness.py
@@ -25,7 +25,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 # =============================================================================
 # SECTION 1: Central Constants Tests (helpers/geo.py)
 # =============================================================================
@@ -394,8 +393,8 @@ class TestCacheSelfHealing:
 
         # New valid data has reasonable weight ratio against fallback
         new_acc = 25.0
-        w_cached = 1 / (cached_acc ** 2)  # 1/50² = 0.0004
-        w_new = 1 / (new_acc ** 2)  # 1/25² = 0.0016
+        w_cached = 1 / (cached_acc**2)  # 1/50² = 0.0004
+        w_new = 1 / (new_acc**2)  # 1/25² = 0.0016
 
         ratio = w_new / w_cached  # 4:1 - new data wins with 80% weight
 
@@ -408,15 +407,16 @@ class TestCacheSelfHealing:
     def test_fusion_weight_ratio_reasonable_after_healing(self) -> None:
         """After healing, fusion weights should allow valid data to dominate."""
         # Simulate the fusion weight calculation
-        poisoned_acc = 0.0  # Would be infinite weight without healing
-        healed_acc = 50.0  # What safe_accuracy returns
+        # poisoned_acc = 0.0 would cause infinite weight (1/0² = infinity)
+        # After healing via safe_accuracy(), it becomes:
+        healed_acc = 50.0  # What safe_accuracy(0.0) returns
 
         new_valid_acc = 25.0
 
         # Without healing: infinite weight ratio
         # With healing: reasonable ratio
-        w_healed = 1 / (healed_acc ** 2)
-        w_new = 1 / (new_valid_acc ** 2)
+        w_healed = 1 / (healed_acc**2)
+        w_new = 1 / (new_valid_acc**2)
 
         total_w = w_healed + w_new
         new_weight_fraction = w_new / total_w
@@ -457,7 +457,7 @@ class TestManualLocateSanity:
         )
 
         assert MIN_PHYSICAL_ACCURACY_M == 1.0, (
-            f"locate.py should use MIN_PHYSICAL_ACCURACY_M = 1.0m"
+            "locate.py should use MIN_PHYSICAL_ACCURACY_M = 1.0m"
         )
 
 
@@ -522,9 +522,7 @@ class TestCacheGatekeeper:
 
             result = is_sig(mock_coord, "device-1", bad_update)
 
-            assert result is False, (
-                f"Gatekeeper should reject accuracy={invalid_acc}m"
-            )
+            assert result is False, f"Gatekeeper should reject accuracy={invalid_acc}m"
 
     def test_gatekeeper_accepts_valid_accuracy(self) -> None:
         """_is_significant_update must accept accuracy >= 1.0m."""
@@ -585,8 +583,8 @@ class TestFusionMath:
         acc1 = 20.0
         acc2 = 30.0
 
-        w1 = 1 / (acc1 ** 2)
-        w2 = 1 / (acc2 ** 2)
+        w1 = 1 / (acc1**2)
+        w2 = 1 / (acc2**2)
         total_w = w1 + w2
 
         fused = math.sqrt(1 / total_w)  # ~16.6m
@@ -602,8 +600,8 @@ class TestFusionMath:
         acc1 = 5.0
         acc2 = 5.0
 
-        w1 = 1 / (acc1 ** 2)
-        w2 = 1 / (acc2 ** 2)
+        w1 = 1 / (acc1**2)
+        w2 = 1 / (acc2**2)
         total_w = w1 + w2
 
         raw_fused = math.sqrt(1 / total_w)  # ~3.5m

--- a/tests/test_fusion_robustness.py
+++ b/tests/test_fusion_robustness.py
@@ -569,7 +569,9 @@ class TestCacheGatekeeper:
 
             result = is_sig(mock_coord, "device-1", update)
 
-            assert result is True, f"Update with accuracy={error_code}m should be ACCEPTED"
+            assert result is True, (
+                f"Update with accuracy={error_code}m should be ACCEPTED"
+            )
             assert update.get("accuracy") == DEFAULT_ACCURACY_FALLBACK, (
                 f"Error code {error_code}m should be set to fallback ({DEFAULT_ACCURACY_FALLBACK}m)"
             )
@@ -599,7 +601,9 @@ class TestCacheGatekeeper:
 
             result = is_sig(mock_coord, "device-1", update)
 
-            assert result is True, f"Update with accuracy={valid_acc}m should be accepted"
+            assert result is True, (
+                f"Update with accuracy={valid_acc}m should be accepted"
+            )
             assert update.get("accuracy") == valid_acc, (
                 f"Valid accuracy {valid_acc}m should be PRESERVED, not sanitized"
             )

--- a/tests/test_fusion_robustness.py
+++ b/tests/test_fusion_robustness.py
@@ -504,12 +504,16 @@ class TestCacheGatekeeper:
     """
 
     def test_gatekeeper_sanitizes_zero_accuracy(self) -> None:
-        """_is_significant_update must SANITIZE accuracy=0.0 (not reject).
+        """_is_significant_update must SANITIZE accuracy=0.0 to fallback.
 
         Zero accuracy means 'unknown/masked', not 'perfect precision'.
-        We ACCEPT the update but REMOVE the invalid accuracy.
+        We ACCEPT the update and SET accuracy to conservative fallback.
+        Home Assistant requires a numeric gps_accuracy attribute.
         """
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            DEFAULT_ACCURACY_FALLBACK,
+        )
 
         mock_coord = MagicMock(spec=CacheOperations)
         mock_coord._device_location_data = {}
@@ -520,7 +524,7 @@ class TestCacheGatekeeper:
         update = {
             "latitude": 48.123,
             "longitude": 11.456,
-            "accuracy": 0.0,  # Will be sanitized
+            "accuracy": 0.0,  # Will be sanitized to fallback
             "last_seen": 1700000100,
         }
 
@@ -529,18 +533,24 @@ class TestCacheGatekeeper:
         # Must be ACCEPTED
         assert result is True, "Zero accuracy update should be ACCEPTED (sanitized)"
 
-        # Accuracy must be removed
-        assert "accuracy" not in update, "Zero accuracy should be removed from dict"
+        # Accuracy must be SET to fallback (not removed)
+        assert update.get("accuracy") == DEFAULT_ACCURACY_FALLBACK, (
+            f"Zero accuracy should be set to fallback ({DEFAULT_ACCURACY_FALLBACK}m)"
+        )
 
         mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
 
     def test_gatekeeper_sanitizes_error_codes(self) -> None:
-        """_is_significant_update must SANITIZE error codes (< 0.001m).
+        """_is_significant_update must SANITIZE error codes to fallback.
 
         The Android Location API uses 0.0 as "no accuracy available".
-        We ACCEPT the update but REMOVE the error code accuracy.
+        We ACCEPT the update and SET accuracy to conservative fallback.
+        Home Assistant requires a numeric gps_accuracy attribute.
         """
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            DEFAULT_ACCURACY_FALLBACK,
+        )
 
         mock_coord = MagicMock(spec=CacheOperations)
         mock_coord._device_location_data = {}
@@ -548,7 +558,7 @@ class TestCacheGatekeeper:
 
         is_sig = CacheOperations._is_significant_update
 
-        # Only error codes (< 0.001m) should be sanitized
+        # Error codes (< 0.001m) should be sanitized to fallback
         for error_code in [0.0, 0.0001, 0.0009]:
             update = {
                 "latitude": 48.123,
@@ -560,7 +570,9 @@ class TestCacheGatekeeper:
             result = is_sig(mock_coord, "device-1", update)
 
             assert result is True, f"Update with accuracy={error_code}m should be ACCEPTED"
-            assert "accuracy" not in update, f"Error code {error_code}m should be removed"
+            assert update.get("accuracy") == DEFAULT_ACCURACY_FALLBACK, (
+                f"Error code {error_code}m should be set to fallback ({DEFAULT_ACCURACY_FALLBACK}m)"
+            )
 
     def test_gatekeeper_preserves_sub_meter_accuracy(self) -> None:
         """_is_significant_update must PRESERVE valid sub-meter accuracy.

--- a/tests/test_fusion_robustness.py
+++ b/tests/test_fusion_robustness.py
@@ -1,0 +1,617 @@
+# tests/test_fusion_robustness.py
+"""Comprehensive robustness tests for location fusion and dirty data handling.
+
+These tests verify the Defense-in-Depth strategy against "Phantom Updates"
+(is_own_report=True with accuracy=0.0m) and other malformed data.
+
+Test Scenarios:
+1. "The 0.0m Ghost" - Spurious own-device reports with impossible accuracy
+2. "Null Island Attack" - Coordinates at (0.0, 0.0)
+3. "Cache Self-Healing" - Recovery from poisoned cache entries
+4. "Manual Locate Sanity" - Validation in locate.py
+
+Architecture under test:
+- Layer 1: helpers/geo.py - Central validation constants
+- Layer 2: decoder.py - Input filtering and ranking
+- Layer 3: locate.py - Manual locate validation
+- Layer 4: cache.py - Gatekeeper and fusion math
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# =============================================================================
+# SECTION 1: Central Constants Tests (helpers/geo.py)
+# =============================================================================
+
+
+class TestGeoConstants:
+    """Verify the central physics constants are correctly defined."""
+
+    def test_min_physical_accuracy_is_one_meter(self) -> None:
+        """MIN_PHYSICAL_ACCURACY_M must be 1.0m (consumer GPS floor)."""
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            MIN_PHYSICAL_ACCURACY_M,
+        )
+
+        assert MIN_PHYSICAL_ACCURACY_M == 1.0, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: MIN_PHYSICAL_ACCURACY_M is not 1.0m!\n"
+            f"{'=' * 70}\n"
+            f"Current value: {MIN_PHYSICAL_ACCURACY_M}\n"
+            f"Expected: 1.0 (consumer GPS cannot achieve sub-meter accuracy)\n"
+            f"\n"
+            f"FIX LOCATION: helpers/geo.py\n"
+            f"{'=' * 70}"
+        )
+
+    def test_default_fallback_is_fifty_meters(self) -> None:
+        """DEFAULT_ACCURACY_FALLBACK_M must be 50.0m (Bluetooth range)."""
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            DEFAULT_ACCURACY_FALLBACK_M,
+        )
+
+        assert DEFAULT_ACCURACY_FALLBACK_M == 50.0, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: DEFAULT_ACCURACY_FALLBACK_M is not 50.0m!\n"
+            f"{'=' * 70}\n"
+            f"Current value: {DEFAULT_ACCURACY_FALLBACK_M}\n"
+            f"Expected: 50.0 (based on Bluetooth range ~40-80m + GPS error)\n"
+            f"\n"
+            f"FIX LOCATION: helpers/geo.py\n"
+            f"{'=' * 70}"
+        )
+
+    def test_safe_accuracy_rejects_zero(self) -> None:
+        """safe_accuracy() must reject 0.0m as invalid."""
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            DEFAULT_ACCURACY_FALLBACK_M,
+            safe_accuracy,
+        )
+
+        result = safe_accuracy(0.0)
+
+        assert result == DEFAULT_ACCURACY_FALLBACK_M, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: safe_accuracy(0.0) did not return fallback!\n"
+            f"{'=' * 70}\n"
+            f"Input: 0.0m\n"
+            f"Output: {result}m\n"
+            f"Expected: {DEFAULT_ACCURACY_FALLBACK_M}m (fallback)\n"
+            f"\n"
+            f"0.0m GPS accuracy is physically impossible.\n"
+            f"FIX LOCATION: helpers/geo.py :: safe_accuracy()\n"
+            f"{'=' * 70}"
+        )
+
+    def test_safe_accuracy_rejects_sub_meter(self) -> None:
+        """safe_accuracy() must reject values < 1.0m."""
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            DEFAULT_ACCURACY_FALLBACK_M,
+            safe_accuracy,
+        )
+
+        for invalid in [0.0, 0.1, 0.5, 0.99, -1.0, -100.0]:
+            result = safe_accuracy(invalid)
+            assert result == DEFAULT_ACCURACY_FALLBACK_M, (
+                f"safe_accuracy({invalid}) should return fallback, got {result}"
+            )
+
+    def test_safe_accuracy_accepts_valid(self) -> None:
+        """safe_accuracy() must preserve valid accuracy values."""
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            safe_accuracy,
+        )
+
+        for valid in [1.0, 5.0, 20.0, 100.0, 1000.0]:
+            result = safe_accuracy(valid)
+            assert result == valid, (
+                f"safe_accuracy({valid}) should return {valid}, got {result}"
+            )
+
+    def test_is_valid_accuracy_function(self) -> None:
+        """is_valid_accuracy() must correctly classify values."""
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            is_valid_accuracy,
+        )
+
+        # Invalid cases
+        assert is_valid_accuracy(None) is False
+        assert is_valid_accuracy(0.0) is False
+        assert is_valid_accuracy(0.5) is False
+        assert is_valid_accuracy(-1.0) is False
+        assert is_valid_accuracy(float("nan")) is False
+        assert is_valid_accuracy(float("inf")) is False
+
+        # Valid cases
+        assert is_valid_accuracy(1.0) is True
+        assert is_valid_accuracy(20.0) is True
+        assert is_valid_accuracy(100.0) is True
+
+
+# =============================================================================
+# SECTION 2: "The 0.0m Ghost" - Decoder Filtering
+# =============================================================================
+
+
+class TestZeroMeterGhost:
+    """Test that 0.0m accuracy reports are correctly rejected.
+
+    The "0.0m Ghost" occurs when Google's API returns:
+    - is_own_report=True
+    - accuracy=0.0 (physically impossible)
+
+    This data must be filtered/rejected at multiple layers.
+    """
+
+    def test_decoder_filters_zero_accuracy(self) -> None:
+        """_normalize_location_dict must remove accuracy=0.0."""
+        from custom_components.googlefindmy.ProtoDecoders.decoder import (
+            _normalize_location_dict,
+        )
+
+        ghost_report: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,
+            "last_seen": 1700000000,
+            "is_own_report": True,
+        }
+
+        normalized = _normalize_location_dict(ghost_report)
+
+        assert "accuracy" not in normalized, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: 'The 0.0m Ghost' was NOT filtered by decoder!\n"
+            f"{'=' * 70}\n"
+            f"Input: accuracy=0.0m, is_own_report=True\n"
+            f"Output: accuracy still present in dict\n"
+            f"\n"
+            f"This 'Phantom Update' will poison the ranking and cache.\n"
+            f"GPS accuracy of 0.0m is physically impossible.\n"
+            f"\n"
+            f"FIX LOCATION: decoder.py :: _normalize_location_dict()\n"
+            f"Ensure: accuracy <= 0 is removed from the dict\n"
+            f"{'=' * 70}"
+        )
+
+    def test_ranking_penalizes_zero_accuracy(self) -> None:
+        """_get_rank_tuple must assign worst rank to accuracy=0.0."""
+        from custom_components.googlefindmy.ProtoDecoders.decoder import (
+            _get_rank_tuple,
+        )
+
+        ghost_report: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,  # Should trigger -inf rank
+            "last_seen": 1700000000,
+            "is_own_report": True,
+        }
+
+        rank = _get_rank_tuple(ghost_report)
+        acc_rank = rank[3]  # Index 3 is accuracy rank
+
+        assert math.isinf(acc_rank) and acc_rank < 0, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: 0.0m accuracy did NOT get worst rank!\n"
+            f"{'=' * 70}\n"
+            f"Input: accuracy=0.0m\n"
+            f"Acc Rank: {acc_rank}\n"
+            f"Expected: float('-inf') (worst possible)\n"
+            f"\n"
+            f"Without -inf rank, the ghost report may win over valid data.\n"
+            f"FIX LOCATION: decoder.py :: _get_rank_tuple()\n"
+            f"{'=' * 70}"
+        )
+
+    def test_valid_report_beats_ghost_in_ranking(self) -> None:
+        """A valid crowdsourced report MUST beat the 0.0m ghost."""
+        from custom_components.googlefindmy.ProtoDecoders.decoder import (
+            _select_best_location,
+        )
+
+        ghost: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 0.0,
+            "last_seen": 1700000200,  # Newer (advantage)
+            "is_own_report": True,  # Owner priority (advantage)
+            "status_code": 1,
+        }
+
+        valid: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 20.0,
+            "last_seen": 1700000100,  # Older
+            "is_own_report": False,
+            "status_code": 2,
+        }
+
+        best, _rest = _select_best_location([ghost, valid])
+
+        if best is not None:
+            selected_acc = best.get("accuracy")
+            # Either valid wins, or accuracy is filtered to None
+            is_valid_winner = selected_acc == pytest.approx(20.0)
+            is_filtered = selected_acc is None
+
+            assert is_valid_winner or is_filtered, (
+                f"\n"
+                f"{'=' * 70}\n"
+                f"CRITICAL: 'The 0.0m Ghost' won the ranking!\n"
+                f"{'=' * 70}\n"
+                f"Selected accuracy: {selected_acc}m\n"
+                f"Expected: 20.0m (valid) or None (filtered)\n"
+                f"\n"
+                f"The ghost had advantages (newer, owner priority) but MUST lose\n"
+                f"because 0.0m accuracy is physically impossible.\n"
+                f"\n"
+                f"PRINCIPLE: Physics > Recency > Priority\n"
+                f"{'=' * 70}"
+            )
+
+
+# =============================================================================
+# SECTION 3: "Null Island Attack"
+# =============================================================================
+
+
+class TestNullIslandAttack:
+    """Test that coordinates at (0.0, 0.0) are rejected.
+
+    "Null Island" is the point at 0°N 0°E in the Atlantic Ocean.
+    It's a common API default when no real location is available.
+    """
+
+    def test_decoder_filters_null_island(self) -> None:
+        """_normalize_location_dict must remove (0.0, 0.0) coordinates."""
+        from custom_components.googlefindmy.ProtoDecoders.decoder import (
+            _normalize_location_dict,
+        )
+
+        null_island: dict[str, Any] = {
+            "latitude": 0.0,
+            "longitude": 0.0,
+            "accuracy": 50.0,  # Valid accuracy
+            "last_seen": 1700000000,
+        }
+
+        normalized = _normalize_location_dict(null_island)
+
+        has_coords = "latitude" in normalized and "longitude" in normalized
+
+        assert not has_coords, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: Null Island coordinates were NOT filtered!\n"
+            f"{'=' * 70}\n"
+            f"Input: (0.0, 0.0) - The Atlantic Ocean\n"
+            f"Output: Coordinates still present\n"
+            f"\n"
+            f"(0.0, 0.0) is a common API default for 'no location'.\n"
+            f"It does not represent a real device position.\n"
+            f"\n"
+            f"FIX LOCATION: decoder.py :: _normalize_location_dict()\n"
+            f"Add: if abs(lat) < 0.0001 and abs(lon) < 0.0001: filter out\n"
+            f"{'=' * 70}"
+        )
+
+    def test_null_island_loses_to_valid_location(self) -> None:
+        """Null Island must lose to any valid location in ranking."""
+        from custom_components.googlefindmy.ProtoDecoders.decoder import (
+            _select_best_location,
+        )
+
+        null_island: dict[str, Any] = {
+            "latitude": 0.0,
+            "longitude": 0.0,
+            "accuracy": 10.0,  # Good accuracy (irrelevant, coords are bad)
+            "last_seen": 1700000200,  # Newer
+            "is_own_report": True,
+        }
+
+        valid: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 100.0,  # Poor accuracy
+            "last_seen": 1700000100,  # Older
+            "is_own_report": False,
+        }
+
+        best, _rest = _select_best_location([null_island, valid])
+
+        if best is not None:
+            lat = best.get("latitude")
+            lon = best.get("longitude")
+
+            # Must NOT be Null Island
+            if lat is not None and lon is not None:
+                is_null_island = abs(lat) < 0.0001 and abs(lon) < 0.0001
+                assert not is_null_island, (
+                    f"\n"
+                    f"{'=' * 70}\n"
+                    f"CRITICAL: Null Island won over valid coordinates!\n"
+                    f"{'=' * 70}\n"
+                    f"Selected: ({lat}, {lon})\n"
+                    f"Expected: (48.123, 11.456) or coordinates removed\n"
+                    f"{'=' * 70}"
+                )
+
+
+# =============================================================================
+# SECTION 4: "Cache Self-Healing"
+# =============================================================================
+
+
+class TestCacheSelfHealing:
+    """Test that poisoned cache entries can be overridden by valid data.
+
+    The "Cache Self-Healing" scenario:
+    1. Cache contains poisoned data (accuracy=0.0 from a past bug)
+    2. New valid data arrives (accuracy=25.0)
+    3. The valid data MUST be able to override the poisoned entry
+
+    Without self-healing, the poisoned 0.0m would have infinite weight
+    in fusion calculations (1/0² = infinity), locking in the bad position.
+    """
+
+    def test_safe_accuracy_heals_poisoned_cache(self) -> None:
+        """_safe_accuracy treats cached 0.0m as fallback, enabling override."""
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            DEFAULT_ACCURACY_FALLBACK_M,
+            safe_accuracy,
+        )
+
+        # Poisoned cache value
+        cached_acc = safe_accuracy(0.0)
+
+        assert cached_acc == DEFAULT_ACCURACY_FALLBACK_M, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: Poisoned cache accuracy not converted to fallback!\n"
+            f"{'=' * 70}\n"
+            f"Cached value: 0.0m (poisoned)\n"
+            f"safe_accuracy output: {cached_acc}m\n"
+            f"Expected: {DEFAULT_ACCURACY_FALLBACK_M}m (fallback)\n"
+            f"\n"
+            f"Without this conversion, 0.0m gets infinite fusion weight.\n"
+            f"FIX LOCATION: helpers/geo.py :: safe_accuracy()\n"
+            f"{'=' * 70}"
+        )
+
+        # New valid data has reasonable weight ratio against fallback
+        new_acc = 25.0
+        w_cached = 1 / (cached_acc ** 2)  # 1/50² = 0.0004
+        w_new = 1 / (new_acc ** 2)  # 1/25² = 0.0016
+
+        ratio = w_new / w_cached  # 4:1 - new data wins with 80% weight
+
+        assert ratio > 1, (
+            f"New valid data should have more weight than healed poisoned data.\n"
+            f"Weight ratio: {ratio:.2f}:1 (new:cached)\n"
+            f"This ensures valid data can 'rescue' a poisoned cache."
+        )
+
+    def test_fusion_weight_ratio_reasonable_after_healing(self) -> None:
+        """After healing, fusion weights should allow valid data to dominate."""
+        # Simulate the fusion weight calculation
+        poisoned_acc = 0.0  # Would be infinite weight without healing
+        healed_acc = 50.0  # What safe_accuracy returns
+
+        new_valid_acc = 25.0
+
+        # Without healing: infinite weight ratio
+        # With healing: reasonable ratio
+        w_healed = 1 / (healed_acc ** 2)
+        w_new = 1 / (new_valid_acc ** 2)
+
+        total_w = w_healed + w_new
+        new_weight_fraction = w_new / total_w
+
+        # New data should contribute significantly (> 50%)
+        assert new_weight_fraction > 0.5, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: New valid data has insufficient fusion weight!\n"
+            f"{'=' * 70}\n"
+            f"Healed cached accuracy: {healed_acc}m (was 0.0m)\n"
+            f"New valid accuracy: {new_valid_acc}m\n"
+            f"New data weight fraction: {new_weight_fraction:.1%}\n"
+            f"Expected: > 50% (new data should dominate)\n"
+            f"\n"
+            f"If new data has < 50% weight, poisoned cache 'locks in' position.\n"
+            f"{'=' * 70}"
+        )
+
+
+# =============================================================================
+# SECTION 5: "Manual Locate Sanity"
+# =============================================================================
+
+
+class TestManualLocateSanity:
+    """Test that locate.py properly validates accuracy values.
+
+    Manual locate requests bypass the decoder, so locate.py must
+    independently validate accuracy before writing to cache.
+    """
+
+    def test_locate_uses_min_physical_accuracy(self) -> None:
+        """locate.py must import and use MIN_PHYSICAL_ACCURACY_M."""
+        # Verify the import exists
+        from custom_components.googlefindmy.coordinator.locate import (
+            MIN_PHYSICAL_ACCURACY_M,
+        )
+
+        assert MIN_PHYSICAL_ACCURACY_M == 1.0, (
+            f"locate.py should use MIN_PHYSICAL_ACCURACY_M = 1.0m"
+        )
+
+
+# =============================================================================
+# SECTION 6: Cache Gatekeeper Tests
+# =============================================================================
+
+
+class TestCacheGatekeeper:
+    """Test the cache gatekeeper (_is_significant_update) rejects invalid data."""
+
+    def test_gatekeeper_rejects_zero_accuracy(self) -> None:
+        """_is_significant_update must reject accuracy=0.0."""
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        bad_update = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,
+            "last_seen": 1700000100,
+        }
+
+        result = is_sig(mock_coord, "device-1", bad_update)
+
+        assert result is False, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CRITICAL: Cache gatekeeper accepted accuracy=0.0m!\n"
+            f"{'=' * 70}\n"
+            f"This allows poisoned data to enter the cache.\n"
+            f"\n"
+            f"FIX LOCATION: cache.py :: _is_significant_update()\n"
+            f"Add: if acc_f < MIN_PHYSICAL_ACCURACY_M: return False\n"
+            f"{'=' * 70}"
+        )
+
+        mock_coord.increment_stat.assert_called_with("invalid_accuracy_drop_count")
+
+    def test_gatekeeper_rejects_sub_meter(self) -> None:
+        """_is_significant_update must reject accuracy < 1.0m."""
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        for invalid_acc in [0.0, 0.1, 0.5, 0.99]:
+            bad_update = {
+                "latitude": 48.123,
+                "longitude": 11.456,
+                "accuracy": invalid_acc,
+                "last_seen": 1700000100,
+            }
+
+            result = is_sig(mock_coord, "device-1", bad_update)
+
+            assert result is False, (
+                f"Gatekeeper should reject accuracy={invalid_acc}m"
+            )
+
+    def test_gatekeeper_accepts_valid_accuracy(self) -> None:
+        """_is_significant_update must accept accuracy >= 1.0m."""
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        good_update = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 5.0,  # Valid
+            "last_seen": 1700000100,
+        }
+
+        result = is_sig(mock_coord, "device-1", good_update)
+
+        assert result is True, "Gatekeeper should accept accuracy=5.0m"
+
+    def test_gatekeeper_allows_semantic_only(self) -> None:
+        """_is_significant_update must allow updates without accuracy."""
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        semantic_update = {
+            "semantic_name": "Home",
+            "last_seen": 1700000100,
+            # No accuracy field - valid for semantic locations
+        }
+
+        result = is_sig(mock_coord, "device-1", semantic_update)
+
+        assert result is True, (
+            "Gatekeeper should allow semantic updates without accuracy"
+        )
+
+
+# =============================================================================
+# SECTION 7: Fusion Math Verification
+# =============================================================================
+
+
+class TestFusionMath:
+    """Verify the inverse variance fusion formula is correctly implemented."""
+
+    def test_inverse_variance_improves_accuracy(self) -> None:
+        """Combining two measurements should yield better accuracy than either."""
+        import math
+
+        acc1 = 20.0
+        acc2 = 30.0
+
+        w1 = 1 / (acc1 ** 2)
+        w2 = 1 / (acc2 ** 2)
+        total_w = w1 + w2
+
+        fused = math.sqrt(1 / total_w)  # ~16.6m
+
+        assert fused < acc1, f"Fused ({fused:.1f}m) should be < {acc1}m"
+        assert fused < acc2, f"Fused ({fused:.1f}m) should be < {acc2}m"
+
+    def test_safety_floor_prevents_impossible_precision(self) -> None:
+        """Fused accuracy must not claim better than 5m (GPS floor)."""
+        import math
+
+        # Even if both inputs are excellent...
+        acc1 = 5.0
+        acc2 = 5.0
+
+        w1 = 1 / (acc1 ** 2)
+        w2 = 1 / (acc2 ** 2)
+        total_w = w1 + w2
+
+        raw_fused = math.sqrt(1 / total_w)  # ~3.5m
+
+        # The code should clamp to minimum 5m
+        MIN_FUSED = 5.0
+        clamped = max(raw_fused, MIN_FUSED)
+
+        assert clamped >= MIN_FUSED, (
+            f"Fused accuracy ({clamped:.1f}m) must be >= {MIN_FUSED}m (GPS floor)"
+        )

--- a/tests/test_fusion_robustness.py
+++ b/tests/test_fusion_robustness.py
@@ -467,10 +467,19 @@ class TestManualLocateSanity:
 
 
 class TestCacheGatekeeper:
-    """Test the cache gatekeeper (_is_significant_update) rejects invalid data."""
+    """Test the cache gatekeeper (_is_significant_update) handles invalid data.
 
-    def test_gatekeeper_rejects_zero_accuracy(self) -> None:
-        """_is_significant_update must reject accuracy=0.0."""
+    Invalid accuracy values (< 1.0m) are SANITIZED (removed from dict),
+    not rejected. This allows valid location data to pass through while
+    preventing invalid accuracy from corrupting rankings.
+    """
+
+    def test_gatekeeper_sanitizes_zero_accuracy(self) -> None:
+        """_is_significant_update must SANITIZE accuracy=0.0 (not reject).
+
+        Zero accuracy means 'unknown/masked', not 'perfect precision'.
+        We ACCEPT the update but REMOVE the invalid accuracy.
+        """
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
 
         mock_coord = MagicMock(spec=CacheOperations)
@@ -479,31 +488,29 @@ class TestCacheGatekeeper:
 
         is_sig = CacheOperations._is_significant_update
 
-        bad_update = {
+        update = {
             "latitude": 48.123,
             "longitude": 11.456,
-            "accuracy": 0.0,
+            "accuracy": 0.0,  # Will be sanitized
             "last_seen": 1700000100,
         }
 
-        result = is_sig(mock_coord, "device-1", bad_update)
+        result = is_sig(mock_coord, "device-1", update)
 
-        assert result is False, (
-            f"\n"
-            f"{'=' * 70}\n"
-            f"CRITICAL: Cache gatekeeper accepted accuracy=0.0m!\n"
-            f"{'=' * 70}\n"
-            f"This allows poisoned data to enter the cache.\n"
-            f"\n"
-            f"FIX LOCATION: cache.py :: _is_significant_update()\n"
-            f"Add: if acc_f < MIN_PHYSICAL_ACCURACY_M: return False\n"
-            f"{'=' * 70}"
-        )
+        # Must be ACCEPTED
+        assert result is True, "Zero accuracy update should be ACCEPTED (sanitized)"
 
-        mock_coord.increment_stat.assert_called_with("invalid_accuracy_drop_count")
+        # Accuracy must be removed
+        assert "accuracy" not in update, "Zero accuracy should be removed from dict"
 
-    def test_gatekeeper_rejects_sub_meter(self) -> None:
-        """_is_significant_update must reject accuracy < 1.0m."""
+        mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
+
+    def test_gatekeeper_sanitizes_sub_meter(self) -> None:
+        """_is_significant_update must SANITIZE accuracy < 1.0m (not reject).
+
+        Sub-meter accuracy is physically impossible for consumer GPS.
+        We ACCEPT the update but REMOVE the invalid accuracy.
+        """
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
 
         mock_coord = MagicMock(spec=CacheOperations)
@@ -513,16 +520,17 @@ class TestCacheGatekeeper:
         is_sig = CacheOperations._is_significant_update
 
         for invalid_acc in [0.0, 0.1, 0.5, 0.99]:
-            bad_update = {
+            update = {
                 "latitude": 48.123,
                 "longitude": 11.456,
                 "accuracy": invalid_acc,
                 "last_seen": 1700000100,
             }
 
-            result = is_sig(mock_coord, "device-1", bad_update)
+            result = is_sig(mock_coord, "device-1", update)
 
-            assert result is False, f"Gatekeeper should reject accuracy={invalid_acc}m"
+            assert result is True, f"Update with accuracy={invalid_acc}m should be ACCEPTED"
+            assert "accuracy" not in update, f"accuracy={invalid_acc}m should be removed"
 
     def test_gatekeeper_accepts_valid_accuracy(self) -> None:
         """_is_significant_update must accept accuracy >= 1.0m."""

--- a/tests/test_fusion_robustness.py
+++ b/tests/test_fusion_robustness.py
@@ -33,80 +33,106 @@ import pytest
 class TestGeoConstants:
     """Verify the central physics constants are correctly defined."""
 
-    def test_min_physical_accuracy_is_one_meter(self) -> None:
-        """MIN_PHYSICAL_ACCURACY_M must be 1.0m (consumer GPS floor)."""
+    def test_min_valid_accuracy_is_one_millimeter(self) -> None:
+        """MIN_VALID_ACCURACY must be 0.001m (1mm threshold for error code).
+
+        The Android Location API uses 0.0 as an error code meaning "no accuracy".
+        Modern dual-frequency GNSS can achieve sub-meter accuracy, so we use a
+        very low threshold (1mm) to only catch the error code.
+        """
         from custom_components.googlefindmy.coordinator.helpers.geo import (
-            MIN_PHYSICAL_ACCURACY_M,
+            MIN_VALID_ACCURACY,
         )
 
-        assert MIN_PHYSICAL_ACCURACY_M == 1.0, (
+        assert MIN_VALID_ACCURACY == 0.001, (
             f"\n"
             f"{'=' * 70}\n"
-            f"CRITICAL: MIN_PHYSICAL_ACCURACY_M is not 1.0m!\n"
+            f"CRITICAL: MIN_VALID_ACCURACY is not 0.001m!\n"
             f"{'=' * 70}\n"
-            f"Current value: {MIN_PHYSICAL_ACCURACY_M}\n"
-            f"Expected: 1.0 (consumer GPS cannot achieve sub-meter accuracy)\n"
+            f"Current value: {MIN_VALID_ACCURACY}\n"
+            f"Expected: 0.001 (1mm - only catch error code 0.0)\n"
             f"\n"
             f"FIX LOCATION: helpers/geo.py\n"
             f"{'=' * 70}"
         )
 
-    def test_default_fallback_is_fifty_meters(self) -> None:
-        """DEFAULT_ACCURACY_FALLBACK_M must be 50.0m (Bluetooth range)."""
+    def test_default_fallback_is_two_kilometers(self) -> None:
+        """DEFAULT_ACCURACY_FALLBACK must be 2000.0m (conservative unknown).
+
+        A high fallback ensures error codes (0.0) have minimal weight in
+        fusion calculations and lose to any real measurement.
+        """
         from custom_components.googlefindmy.coordinator.helpers.geo import (
-            DEFAULT_ACCURACY_FALLBACK_M,
+            DEFAULT_ACCURACY_FALLBACK,
         )
 
-        assert DEFAULT_ACCURACY_FALLBACK_M == 50.0, (
+        assert DEFAULT_ACCURACY_FALLBACK == 2000.0, (
             f"\n"
             f"{'=' * 70}\n"
-            f"CRITICAL: DEFAULT_ACCURACY_FALLBACK_M is not 50.0m!\n"
+            f"CRITICAL: DEFAULT_ACCURACY_FALLBACK is not 2000.0m!\n"
             f"{'=' * 70}\n"
-            f"Current value: {DEFAULT_ACCURACY_FALLBACK_M}\n"
-            f"Expected: 50.0 (based on Bluetooth range ~40-80m + GPS error)\n"
+            f"Current value: {DEFAULT_ACCURACY_FALLBACK}\n"
+            f"Expected: 2000.0 (conservative for unknown accuracy)\n"
             f"\n"
             f"FIX LOCATION: helpers/geo.py\n"
             f"{'=' * 70}"
         )
 
-    def test_safe_accuracy_rejects_zero(self) -> None:
-        """safe_accuracy() must reject 0.0m as invalid."""
+    def test_safe_accuracy_rejects_error_code(self) -> None:
+        """safe_accuracy() must reject 0.0m (error code) as invalid."""
         from custom_components.googlefindmy.coordinator.helpers.geo import (
-            DEFAULT_ACCURACY_FALLBACK_M,
+            DEFAULT_ACCURACY_FALLBACK,
             safe_accuracy,
         )
 
         result = safe_accuracy(0.0)
 
-        assert result == DEFAULT_ACCURACY_FALLBACK_M, (
+        assert result == DEFAULT_ACCURACY_FALLBACK, (
             f"\n"
             f"{'=' * 70}\n"
             f"CRITICAL: safe_accuracy(0.0) did not return fallback!\n"
             f"{'=' * 70}\n"
-            f"Input: 0.0m\n"
+            f"Input: 0.0m (Android API error code)\n"
             f"Output: {result}m\n"
-            f"Expected: {DEFAULT_ACCURACY_FALLBACK_M}m (fallback)\n"
+            f"Expected: {DEFAULT_ACCURACY_FALLBACK}m (fallback)\n"
             f"\n"
-            f"0.0m GPS accuracy is physically impossible.\n"
+            f"0.0 is the Android Location API error code for 'no accuracy'.\n"
             f"FIX LOCATION: helpers/geo.py :: safe_accuracy()\n"
             f"{'=' * 70}"
         )
 
-    def test_safe_accuracy_rejects_sub_meter(self) -> None:
-        """safe_accuracy() must reject values < 1.0m."""
+    def test_safe_accuracy_rejects_below_threshold(self) -> None:
+        """safe_accuracy() must reject values < 0.001m (error codes)."""
         from custom_components.googlefindmy.coordinator.helpers.geo import (
-            DEFAULT_ACCURACY_FALLBACK_M,
+            DEFAULT_ACCURACY_FALLBACK,
             safe_accuracy,
         )
 
-        for invalid in [0.0, 0.1, 0.5, 0.99, -1.0, -100.0]:
+        # Only error codes (< 0.001m) and negative should return fallback
+        for invalid in [0.0, 0.0001, 0.0009, -1.0, -100.0]:
             result = safe_accuracy(invalid)
-            assert result == DEFAULT_ACCURACY_FALLBACK_M, (
+            assert result == DEFAULT_ACCURACY_FALLBACK, (
                 f"safe_accuracy({invalid}) should return fallback, got {result}"
             )
 
-    def test_safe_accuracy_accepts_valid(self) -> None:
-        """safe_accuracy() must preserve valid accuracy values."""
+    def test_safe_accuracy_preserves_sub_meter(self) -> None:
+        """safe_accuracy() must PRESERVE valid sub-meter accuracy.
+
+        Modern dual-frequency GNSS can achieve sub-meter accuracy.
+        """
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            safe_accuracy,
+        )
+
+        # Valid sub-meter values should be preserved
+        for valid in [0.001, 0.002, 0.1, 0.5, 0.99]:
+            result = safe_accuracy(valid)
+            assert result == valid, (
+                f"safe_accuracy({valid}) should preserve {valid}, got {result}"
+            )
+
+    def test_safe_accuracy_preserves_standard_accuracy(self) -> None:
+        """safe_accuracy() must preserve standard accuracy values."""
         from custom_components.googlefindmy.coordinator.helpers.geo import (
             safe_accuracy,
         )
@@ -123,15 +149,18 @@ class TestGeoConstants:
             is_valid_accuracy,
         )
 
-        # Invalid cases
+        # Invalid cases: error codes and invalid values
         assert is_valid_accuracy(None) is False
-        assert is_valid_accuracy(0.0) is False
-        assert is_valid_accuracy(0.5) is False
-        assert is_valid_accuracy(-1.0) is False
+        assert is_valid_accuracy(0.0) is False, "0.0 is error code"
+        assert is_valid_accuracy(0.0001) is False, "< 0.001 is error"
+        assert is_valid_accuracy(-1.0) is False, "Negative is invalid"
         assert is_valid_accuracy(float("nan")) is False
         assert is_valid_accuracy(float("inf")) is False
 
-        # Valid cases
+        # Valid cases: sub-meter is now valid for modern GNSS
+        assert is_valid_accuracy(0.001) is True, "1mm is valid threshold"
+        assert is_valid_accuracy(0.002) is True, "2mm is valid"
+        assert is_valid_accuracy(0.5) is True, "50cm is valid"
         assert is_valid_accuracy(1.0) is True
         assert is_valid_accuracy(20.0) is True
         assert is_valid_accuracy(100.0) is True
@@ -449,15 +478,15 @@ class TestManualLocateSanity:
     independently validate accuracy before writing to cache.
     """
 
-    def test_locate_uses_min_physical_accuracy(self) -> None:
-        """locate.py must import and use MIN_PHYSICAL_ACCURACY_M."""
+    def test_locate_uses_min_valid_accuracy(self) -> None:
+        """locate.py must import and use MIN_PHYSICAL_ACCURACY_M (0.001m)."""
         # Verify the import exists
         from custom_components.googlefindmy.coordinator.locate import (
             MIN_PHYSICAL_ACCURACY_M,
         )
 
-        assert MIN_PHYSICAL_ACCURACY_M == 1.0, (
-            "locate.py should use MIN_PHYSICAL_ACCURACY_M = 1.0m"
+        assert MIN_PHYSICAL_ACCURACY_M == 0.001, (
+            "locate.py should use MIN_PHYSICAL_ACCURACY_M = 0.001m (1mm threshold)"
         )
 
 
@@ -469,9 +498,9 @@ class TestManualLocateSanity:
 class TestCacheGatekeeper:
     """Test the cache gatekeeper (_is_significant_update) handles invalid data.
 
-    Invalid accuracy values (< 1.0m) are SANITIZED (removed from dict),
-    not rejected. This allows valid location data to pass through while
-    preventing invalid accuracy from corrupting rankings.
+    Error code accuracy values (< 0.001m) are SANITIZED (removed from dict),
+    not rejected. Valid sub-meter accuracy is preserved. This allows valid
+    location data to pass through while preventing error codes from corrupting rankings.
     """
 
     def test_gatekeeper_sanitizes_zero_accuracy(self) -> None:
@@ -505,11 +534,11 @@ class TestCacheGatekeeper:
 
         mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
 
-    def test_gatekeeper_sanitizes_sub_meter(self) -> None:
-        """_is_significant_update must SANITIZE accuracy < 1.0m (not reject).
+    def test_gatekeeper_sanitizes_error_codes(self) -> None:
+        """_is_significant_update must SANITIZE error codes (< 0.001m).
 
-        Sub-meter accuracy is physically impossible for consumer GPS.
-        We ACCEPT the update but REMOVE the invalid accuracy.
+        The Android Location API uses 0.0 as "no accuracy available".
+        We ACCEPT the update but REMOVE the error code accuracy.
         """
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
 
@@ -519,21 +548,26 @@ class TestCacheGatekeeper:
 
         is_sig = CacheOperations._is_significant_update
 
-        for invalid_acc in [0.0, 0.1, 0.5, 0.99]:
+        # Only error codes (< 0.001m) should be sanitized
+        for error_code in [0.0, 0.0001, 0.0009]:
             update = {
                 "latitude": 48.123,
                 "longitude": 11.456,
-                "accuracy": invalid_acc,
+                "accuracy": error_code,
                 "last_seen": 1700000100,
             }
 
             result = is_sig(mock_coord, "device-1", update)
 
-            assert result is True, f"Update with accuracy={invalid_acc}m should be ACCEPTED"
-            assert "accuracy" not in update, f"accuracy={invalid_acc}m should be removed"
+            assert result is True, f"Update with accuracy={error_code}m should be ACCEPTED"
+            assert "accuracy" not in update, f"Error code {error_code}m should be removed"
 
-    def test_gatekeeper_accepts_valid_accuracy(self) -> None:
-        """_is_significant_update must accept accuracy >= 1.0m."""
+    def test_gatekeeper_preserves_sub_meter_accuracy(self) -> None:
+        """_is_significant_update must PRESERVE valid sub-meter accuracy.
+
+        Modern dual-frequency GNSS can achieve sub-meter accuracy.
+        Values like 0.5m or 0.01m are valid and must be preserved.
+        """
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
 
         mock_coord = MagicMock(spec=CacheOperations)
@@ -542,16 +576,21 @@ class TestCacheGatekeeper:
 
         is_sig = CacheOperations._is_significant_update
 
-        good_update = {
-            "latitude": 48.123,
-            "longitude": 11.456,
-            "accuracy": 5.0,  # Valid
-            "last_seen": 1700000100,
-        }
+        # Valid sub-meter values (>= 0.001m) should be preserved
+        for valid_acc in [0.001, 0.002, 0.5, 0.99, 1.0, 5.0]:
+            update = {
+                "latitude": 48.123,
+                "longitude": 11.456,
+                "accuracy": valid_acc,
+                "last_seen": 1700000100,
+            }
 
-        result = is_sig(mock_coord, "device-1", good_update)
+            result = is_sig(mock_coord, "device-1", update)
 
-        assert result is True, "Gatekeeper should accept accuracy=5.0m"
+            assert result is True, f"Update with accuracy={valid_acc}m should be accepted"
+            assert update.get("accuracy") == valid_acc, (
+                f"Valid accuracy {valid_acc}m should be PRESERVED, not sanitized"
+            )
 
     def test_gatekeeper_allows_semantic_only(self) -> None:
         """_is_significant_update must allow updates without accuracy."""

--- a/tests/test_logic_safeguards.py
+++ b/tests/test_logic_safeguards.py
@@ -1,0 +1,422 @@
+# tests/test_logic_safeguards.py
+"""Logic safeguard tests for data integrity and identity protection.
+
+These tests verify two critical invariants:
+1. Identity Integrity: Lower-ranked reports cannot "steal" a higher-ranked report's
+   identity by having the same timestamp.
+2. Zero Accuracy Handling: Reports with accuracy=0.0 are NOT rejected, but the
+   accuracy is sanitized (removed or replaced with fallback).
+
+BACKGROUND:
+- Google's API sometimes returns accuracy=0.0 as "privacy masking" or "unknown"
+- Batch updates often have identical timestamps for multiple reports
+- Without proper protection, these could corrupt the data integrity
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.ProtoDecoders.decoder import (
+    _get_rank_tuple,
+    _merge_semantics_if_near_ts,
+    _normalize_location_dict,
+    _select_best_location,
+)
+
+# =============================================================================
+# SECTION 1: Identity Integrity at Timestamp Collision
+# =============================================================================
+
+
+class TestIdentityIntegrityAtCollision:
+    """Test that timestamp collisions don't cause identity theft.
+
+    SCENARIO:
+    - Candidate A (Own Device): High rank, has or doesn't have coordinates
+    - Candidate B (Crowdsourced): Lower rank, has different coordinates
+    - Both have the SAME timestamp
+
+    INVARIANT: Candidate A must NOT inherit B's coordinates just because
+    B happens to be in the same batch update. Only if B is STRICTLY NEWER
+    should its coordinates be considered.
+    """
+
+    def test_own_device_without_coords_does_not_steal_crowdsourced_coords(
+        self,
+    ) -> None:
+        """When Own Device has no coords, it must NOT borrow from same-timestamp Crowdsourced.
+
+        This is the core "identity theft" scenario:
+        - Own Device (high rank) has semantic info but no coordinates
+        - Crowdsourced (lower rank) has coordinates, same timestamp
+        - Result must NOT have Crowdsourced coordinates attached to Own Device identity
+        """
+        # Own Device: High rank, semantic-only (no coordinates)
+        own_device: dict[str, Any] = {
+            "semantic_name": "Home",
+            "last_seen": 1700000100,
+            "is_own_report": True,
+            "status": "LAST_KNOWN",
+            "status_code": 1,
+            # NO latitude/longitude - this is a semantic-only report
+        }
+
+        # Crowdsourced: Lower rank, has coordinates, SAME timestamp
+        crowdsourced: dict[str, Any] = {
+            "latitude": 50.0,
+            "longitude": 10.0,
+            "accuracy": 20.0,
+            "last_seen": 1700000100,  # SAME timestamp as Own Device
+            "is_own_report": False,
+            "status": "CROWDSOURCED",
+            "status_code": 2,
+        }
+
+        # Normalize both
+        normed_own = _normalize_location_dict(own_device)
+        normed_crowd = _normalize_location_dict(crowdsourced)
+
+        # Verify ranking: Own Device should rank higher
+        rank_own = _get_rank_tuple(normed_own)
+        rank_crowd = _get_rank_tuple(normed_crowd)
+        assert rank_own > rank_crowd, (
+            f"Own Device should rank higher than Crowdsourced.\n"
+            f"Own: {rank_own}\nCrowd: {rank_crowd}"
+        )
+
+        # Run merge with Own Device as "best" (sorted by rank, highest first)
+        normed_cands = [normed_own, normed_crowd]
+        result = _merge_semantics_if_near_ts(dict(normed_own), normed_cands)
+
+        # CRITICAL: Result must NOT have Crowdsourced coordinates
+        # because Crowdsourced is not NEWER, only EQUAL timestamp
+        result_lat = result.get("latitude")
+        result_lon = result.get("longitude")
+
+        has_coords = result_lat is not None and result_lon is not None
+
+        assert not has_coords, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"IDENTITY THEFT DETECTED!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"Own Device (semantic-only) inherited Crowdsourced coordinates\n"
+            f"even though Crowdsourced has the SAME timestamp (not newer).\n"
+            f"\n"
+            f"Result coordinates: ({result_lat}, {result_lon})\n"
+            f"Expected: No coordinates (semantic-only should remain semantic-only)\n"
+            f"\n"
+            f"This is IDENTITY THEFT: attaching untrusted coordinates\n"
+            f"to a trusted 'Own Device' identity.\n"
+            f"\n"
+            f"FIX: In _merge_semantics_if_near_ts, initialize best_coordinate_ts\n"
+            f"to t_best (not -inf) to prevent same-timestamp stealing.\n"
+            f"{'=' * 70}"
+        )
+
+        # Verify semantic name is preserved
+        assert result.get("semantic_name") == "Home", (
+            "Own Device's semantic name should be preserved"
+        )
+
+    def test_own_device_with_coords_is_not_overwritten_by_crowdsourced(
+        self,
+    ) -> None:
+        """When Own Device HAS coordinates, they must not be overwritten by same-timestamp Crowdsourced."""
+        # Own Device: High rank, has coordinates
+        own_device: dict[str, Any] = {
+            "latitude": 48.1,
+            "longitude": 11.1,
+            "accuracy": 25.0,
+            "last_seen": 1700000100,
+            "is_own_report": True,
+            "status": "LAST_KNOWN",
+            "status_code": 1,
+        }
+
+        # Crowdsourced: Lower rank, DIFFERENT coordinates, SAME timestamp
+        crowdsourced: dict[str, Any] = {
+            "latitude": 50.0,  # Different!
+            "longitude": 10.0,  # Different!
+            "accuracy": 15.0,  # Better accuracy (but lower rank)
+            "last_seen": 1700000100,  # SAME timestamp
+            "is_own_report": False,
+            "status": "CROWDSOURCED",
+            "status_code": 2,
+        }
+
+        normed_own = _normalize_location_dict(own_device)
+        normed_crowd = _normalize_location_dict(crowdsourced)
+        normed_cands = [normed_own, normed_crowd]
+
+        result = _merge_semantics_if_near_ts(dict(normed_own), normed_cands)
+
+        # Own Device coordinates must be preserved
+        assert result.get("latitude") == pytest.approx(48.1), (
+            f"Own Device latitude should be preserved, got {result.get('latitude')}"
+        )
+        assert result.get("longitude") == pytest.approx(11.1), (
+            f"Own Device longitude should be preserved, got {result.get('longitude')}"
+        )
+
+    def test_strictly_newer_timestamp_can_update_coordinates(self) -> None:
+        """A STRICTLY newer report CAN update coordinates (this is valid behavior)."""
+        # Own Device: Has coordinates
+        own_device: dict[str, Any] = {
+            "latitude": 48.1,
+            "longitude": 11.1,
+            "accuracy": 25.0,
+            "last_seen": 1700000100,  # OLDER
+            "is_own_report": True,
+        }
+
+        # Crowdsourced: NEWER timestamp
+        crowdsourced: dict[str, Any] = {
+            "latitude": 50.0,
+            "longitude": 10.0,
+            "accuracy": 15.0,
+            "last_seen": 1700000200,  # STRICTLY NEWER (+100s)
+            "is_own_report": False,
+        }
+
+        normed_own = _normalize_location_dict(own_device)
+        normed_crowd = _normalize_location_dict(crowdsourced)
+        normed_cands = [normed_own, normed_crowd]
+
+        result = _merge_semantics_if_near_ts(dict(normed_own), normed_cands)
+
+        # Newer coordinates CAN be used (this is valid)
+        assert result.get("latitude") == pytest.approx(50.0), (
+            "Strictly newer timestamp should update coordinates"
+        )
+        assert result.get("longitude") == pytest.approx(10.0)
+
+
+# =============================================================================
+# SECTION 2: Zero Accuracy Handling (Downgrade, not Reject)
+# =============================================================================
+
+
+class TestZeroAccuracyDowngrade:
+    """Test that accuracy=0.0 is sanitized, not rejected.
+
+    PRINCIPLE: 0.0 means "unknown/masked", not "perfect precision".
+    The REPORT should be kept, but accuracy should be treated as unmeasured.
+
+    INVARIANT:
+    1. Reports with accuracy=0.0 are NOT rejected
+    2. The accuracy field is either removed or set to fallback
+    3. In fusion, such reports don't dominate (low weight due to fallback)
+    """
+
+    def test_zero_accuracy_report_is_accepted(self) -> None:
+        """A report with accuracy=0.0 must be ACCEPTED (not rejected)."""
+        report: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,  # This means "unknown", not "perfect"
+            "last_seen": 1700000100,
+            "is_own_report": True,
+        }
+
+        normalized = _normalize_location_dict(report)
+
+        # Report must still have coordinates (was not rejected)
+        assert normalized.get("latitude") == pytest.approx(48.123), (
+            "Report with 0.0 accuracy should be ACCEPTED, coordinates preserved"
+        )
+        assert normalized.get("longitude") == pytest.approx(11.456)
+
+    def test_zero_accuracy_is_sanitized_to_none(self) -> None:
+        """accuracy=0.0 must be REMOVED (not kept as 0.0)."""
+        report: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,
+            "last_seen": 1700000100,
+        }
+
+        normalized = _normalize_location_dict(report)
+
+        # Accuracy must be removed
+        assert "accuracy" not in normalized or normalized.get("accuracy") is None, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"ZERO ACCURACY NOT SANITIZED!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"accuracy=0.0 was kept instead of being removed.\n"
+            f"Stored accuracy: {normalized.get('accuracy')}\n"
+            f"Expected: None (key should not exist)\n"
+            f"\n"
+            f"This will corrupt ranking: 0.0 would get acc_rank = -0.0,\n"
+            f"which is BETTER than valid entries like -20.0.\n"
+            f"\n"
+            f"FIX: In _normalize_location_dict, remove accuracy if < 1.0m.\n"
+            f"{'=' * 70}"
+        )
+
+    def test_zero_accuracy_gets_worst_ranking(self) -> None:
+        """After sanitization, the report should get acc_rank = -inf."""
+        report: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,
+            "last_seen": 1700000100,
+        }
+
+        normalized = _normalize_location_dict(report)
+        rank = _get_rank_tuple(normalized)
+        acc_rank = rank[3]
+
+        assert math.isinf(acc_rank) and acc_rank < 0, (
+            f"After sanitization (accuracy removed), acc_rank should be -inf.\n"
+            f"Got: {acc_rank}"
+        )
+
+    def test_valid_report_beats_sanitized_zero_accuracy(self) -> None:
+        """A valid 20m report should beat a sanitized 0.0m report when other factors are equal.
+
+        IMPORTANT: The ranking tuple is (seen_rank, status_rank, has_coords_rank, acc_rank).
+        Timestamp and status are evaluated BEFORE accuracy. To test accuracy tiebreaker,
+        we must make timestamp and status EQUAL so only accuracy differs.
+        """
+        # Report with 0.0 accuracy (will be sanitized)
+        masked_report: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 0.0,  # This will be sanitized → acc_rank = -inf
+            "last_seen": 1700000100,  # SAME timestamp
+            "is_own_report": False,  # SAME status
+        }
+
+        # Valid report with real accuracy
+        valid_report: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 20.0,  # Valid GPS accuracy → acc_rank = -20.0
+            "last_seen": 1700000100,  # SAME timestamp
+            "is_own_report": False,  # SAME status
+        }
+
+        best, _rest = _select_best_location([masked_report, valid_report])
+
+        assert best is not None, "Should select a location"
+
+        # When timestamp and status are EQUAL, accuracy becomes the tiebreaker:
+        # - masked_report has accuracy=0.0 → sanitized to None → acc_rank = -inf
+        # - valid_report has accuracy=20.0 → acc_rank = -20.0 (better than -inf)
+        # Therefore valid_report should win.
+        best_acc = best.get("accuracy")
+        assert best_acc == pytest.approx(20.0), (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"MASKED REPORT INCORRECTLY WON!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"A report with accuracy=0.0 (now sanitized) beat a valid 20m report\n"
+            f"when timestamp and status were EQUAL.\n"
+            f"\n"
+            f"Selected accuracy: {best_acc}\n"
+            f"Expected: 20.0 (from valid report)\n"
+            f"\n"
+            f"This proves acc_rank = -inf is not being applied correctly.\n"
+            f"{'=' * 70}"
+        )
+
+    def test_cache_accepts_zero_accuracy_with_sanitization(self) -> None:
+        """cache.py must ACCEPT updates with accuracy=0.0 (sanitize, not reject)."""
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        # Update with 0.0 accuracy
+        update_with_zero_acc = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,
+            "last_seen": 1700000100,
+        }
+
+        result = is_sig(mock_coord, "device-1", update_with_zero_acc)
+
+        # Update must be ACCEPTED (not rejected)
+        assert result is True, (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"CACHE REJECTED VALID UPDATE!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"An update with accuracy=0.0 was REJECTED instead of SANITIZED.\n"
+            f"\n"
+            f"The report contains valid location data. Only the accuracy\n"
+            f"is invalid and should be removed, not the entire update.\n"
+            f"\n"
+            f"FIX: In _is_significant_update, sanitize invalid accuracy\n"
+            f"(remove from dict) instead of returning False.\n"
+            f"{'=' * 70}"
+        )
+
+        # Accuracy should have been removed from the update dict
+        assert "accuracy" not in update_with_zero_acc, (
+            "Invalid accuracy should be removed from update dict"
+        )
+
+        # Verify sanitization was counted
+        mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
+
+
+# =============================================================================
+# SECTION 3: Fusion Behavior with Sanitized Accuracy
+# =============================================================================
+
+
+class TestFusionWithSanitizedAccuracy:
+    """Test that fusion correctly handles sanitized (fallback) accuracy."""
+
+    def test_valid_accuracy_dominates_over_fallback(self) -> None:
+        """When fusing, a valid 20m accuracy should dominate over 50m fallback.
+
+        If a cached entry has accuracy=0.0 (now treated as 50m fallback),
+        a new entry with accuracy=20m should have MORE weight in fusion.
+        """
+        from custom_components.googlefindmy.coordinator.helpers.geo import (
+            DEFAULT_ACCURACY_FALLBACK_M,
+        )
+
+        # Fallback accuracy (used for sanitized 0.0)
+        fallback_acc = DEFAULT_ACCURACY_FALLBACK_M  # 50m
+
+        # Valid accuracy
+        valid_acc = 20.0
+
+        # Calculate weights
+        w_fallback = 1 / (fallback_acc**2)  # 1/2500 = 0.0004
+        w_valid = 1 / (valid_acc**2)  # 1/400 = 0.0025
+
+        total_w = w_fallback + w_valid
+        valid_weight_fraction = w_valid / total_w
+
+        # Valid accuracy should have > 50% weight
+        assert valid_weight_fraction > 0.5, (
+            f"Valid 20m accuracy should dominate over 50m fallback.\n"
+            f"Valid weight fraction: {valid_weight_fraction:.1%}\n"
+            f"Expected: > 50%"
+        )
+
+        # Specifically, 20m vs 50m → valid gets 6.25x more weight
+        weight_ratio = w_valid / w_fallback
+        assert weight_ratio > 6, (
+            f"20m accuracy should have ~6x weight of 50m fallback.\n"
+            f"Actual ratio: {weight_ratio:.2f}x"
+        )

--- a/tests/test_logic_safeguards.py
+++ b/tests/test_logic_safeguards.py
@@ -1,16 +1,21 @@
 # tests/test_logic_safeguards.py
 """Logic safeguard tests for data integrity and identity protection.
 
-These tests verify two critical invariants:
-1. Identity Integrity: Lower-ranked reports cannot "steal" a higher-ranked report's
-   identity by having the same timestamp.
-2. Zero Accuracy Handling: Reports with accuracy=0.0 are NOT rejected, but the
-   accuracy is sanitized (removed or replaced with fallback).
+These tests verify three critical invariants:
 
-BACKGROUND:
-- Google's API sometimes returns accuracy=0.0 as "privacy masking" or "unknown"
-- Batch updates often have identical timestamps for multiple reports
-- Without proper protection, these could corrupt the data integrity
+1. **Micro-Precision Survival**: Modern dual-frequency GNSS (L1+L5) can achieve
+   sub-meter accuracy. Values like 0.002m (2mm) must be preserved, NOT filtered.
+
+2. **Zero-Accuracy Downgrade**: The Android Location API uses 0.0 as an error code
+   meaning "no accuracy available". This must be sanitized (removed) but the report
+   itself must NOT be rejected.
+
+3. **Identity Integrity**: Lower-ranked reports cannot "steal" a higher-ranked
+   report's identity by having the same timestamp (First-Win Principle).
+
+CONSTANTS:
+- MIN_VALID_ACCURACY = 0.001 (1mm threshold for error code detection)
+- DEFAULT_ACCURACY_FALLBACK = 2000.0 (conservative fallback for unknown)
 """
 
 from __future__ import annotations
@@ -21,6 +26,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.googlefindmy.coordinator.helpers.geo import (
+    DEFAULT_ACCURACY_FALLBACK,
+    MIN_VALID_ACCURACY,
+    is_valid_accuracy,
+    safe_accuracy,
+)
 from custom_components.googlefindmy.ProtoDecoders.decoder import (
     _get_rank_tuple,
     _merge_semantics_if_near_ts,
@@ -28,310 +39,336 @@ from custom_components.googlefindmy.ProtoDecoders.decoder import (
     _select_best_location,
 )
 
+
 # =============================================================================
-# SECTION 1: Identity Integrity at Timestamp Collision
+# SECTION 1: Micro-Precision Survival (Sub-Meter Accuracy)
 # =============================================================================
 
 
-class TestIdentityIntegrityAtCollision:
+class TestMicroPrecisionSurvival:
+    """Test that valid sub-meter accuracy is preserved, not filtered.
+
+    Modern dual-frequency GNSS chips (L1+L5) can achieve accuracies like:
+    - 0.5m under ideal Open Sky conditions
+    - 0.01m (1cm) in theoretical edge cases
+    - 0.002m (2mm) as an extreme test case
+
+    These MUST be preserved because they represent real measurements from
+    high-end hardware, NOT error codes.
+    """
+
+    @pytest.mark.parametrize(
+        ("accuracy", "expected_preserved"),
+        [
+            (0.002, True),    # 2mm - extreme precision, MUST be preserved
+            (0.01, True),     # 1cm - centimeter precision, valid
+            (0.1, True),      # 10cm - sub-meter, valid
+            (0.5, True),      # 50cm - common sub-meter, valid
+            (1.0, True),      # 1m - valid
+            (5.0, True),      # 5m - typical GPS, valid
+            (50.0, True),     # 50m - moderate GPS, valid
+            (0.0, False),     # Error code - MUST be removed
+            (0.0001, False),  # Below threshold - error code
+            (-1.0, False),    # Negative - error code
+        ],
+        ids=[
+            "2mm_preserved",
+            "1cm_preserved",
+            "10cm_preserved",
+            "50cm_preserved",
+            "1m_preserved",
+            "5m_preserved",
+            "50m_preserved",
+            "0.0_removed",
+            "0.0001_removed",
+            "negative_removed",
+        ],
+    )
+    def test_normalize_preserves_valid_accuracy(
+        self, accuracy: float, expected_preserved: bool
+    ) -> None:
+        """_normalize_location_dict must preserve valid accuracy values."""
+        loc: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": accuracy,
+            "last_seen": 1700000000,
+        }
+
+        result = _normalize_location_dict(loc)
+
+        if expected_preserved:
+            assert "accuracy" in result, (
+                f"Valid accuracy {accuracy}m was incorrectly removed!\n"
+                f"Modern GNSS can achieve sub-meter accuracy.\n"
+                f"Only the error code (0.0) should be filtered."
+            )
+            assert result["accuracy"] == pytest.approx(accuracy)
+        else:
+            assert "accuracy" not in result, (
+                f"Error code accuracy {accuracy}m was NOT removed!\n"
+                f"Values < {MIN_VALID_ACCURACY}m should be filtered."
+            )
+
+    def test_micro_precision_beats_moderate_accuracy_in_ranking(self) -> None:
+        """A 2mm report must beat a 500mm report (smaller accuracy = better)."""
+        micro_precision: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 0.002,  # 2mm - extreme precision
+            "last_seen": 1700000100,
+            "is_own_report": False,
+        }
+
+        moderate_accuracy: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 0.5,  # 500mm - moderate
+            "last_seen": 1700000100,  # SAME timestamp
+            "is_own_report": False,   # SAME status
+        }
+
+        best, _rest = _select_best_location([micro_precision, moderate_accuracy])
+
+        assert best is not None, "Should select a location"
+        best_acc = best.get("accuracy")
+
+        # 0.002m should win because smaller = more precise = higher rank
+        assert best_acc == pytest.approx(0.002), (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"MICRO-PRECISION LOST TO MODERATE ACCURACY!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"Expected: 0.002m (2mm precision)\n"
+            f"Got: {best_acc}m\n"
+            f"\n"
+            f"Smaller accuracy = more precise = should win.\n"
+            f"Modern GNSS can achieve sub-meter accuracy.\n"
+            f"{'=' * 70}"
+        )
+
+
+# =============================================================================
+# SECTION 2: Zero-Accuracy Downgrade
+# =============================================================================
+
+
+class TestZeroAccuracyDowngrade:
+    """Test that accuracy=0.0 (error code) is sanitized but report is kept.
+
+    The Android Location API uses 0.0 as an error code meaning "no accuracy
+    available". This is NOT "perfect precision" but rather "unknown".
+
+    BEHAVIOR:
+    - The accuracy KEY is removed from the dict
+    - The REPORT is kept (location data is valid)
+    - In ranking, missing accuracy gets acc_rank = -inf (lowest priority)
+    """
+
+    def test_zero_accuracy_is_sanitized_not_rejected(self) -> None:
+        """accuracy=0.0 must be REMOVED from dict, not reject the report."""
+        loc: dict[str, Any] = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,  # Error code
+            "last_seen": 1700000000,
+        }
+
+        result = _normalize_location_dict(loc)
+
+        # Report must be kept (has valid coordinates)
+        assert result.get("latitude") == pytest.approx(48.123), (
+            "Report should be kept, only accuracy removed"
+        )
+        assert result.get("longitude") == pytest.approx(11.456), (
+            "Report should be kept, only accuracy removed"
+        )
+
+        # Accuracy must be removed
+        assert "accuracy" not in result, (
+            "accuracy=0.0 (error code) should be REMOVED from dict"
+        )
+
+    def test_zero_accuracy_loses_to_real_data_in_ranking(self) -> None:
+        """A report with sanitized 0.0 accuracy must lose to real data."""
+        zero_acc_report: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": 0.0,  # Will be sanitized → acc_rank = -inf
+            "last_seen": 1700000100,
+            "is_own_report": False,
+        }
+
+        real_data_report: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 50.0,  # Valid accuracy → acc_rank = -50.0
+            "last_seen": 1700000100,  # SAME timestamp
+            "is_own_report": False,   # SAME status
+        }
+
+        best, _rest = _select_best_location([zero_acc_report, real_data_report])
+
+        assert best is not None
+        best_acc = best.get("accuracy")
+
+        # Real data (50m) should win because 0.0 is sanitized to None → -inf
+        assert best_acc == pytest.approx(50.0), (
+            f"\n"
+            f"{'=' * 70}\n"
+            f"ZERO-ACCURACY REPORT WON!\n"
+            f"{'=' * 70}\n"
+            f"\n"
+            f"Expected: 50.0m (real data)\n"
+            f"Got: {best_acc}\n"
+            f"\n"
+            f"accuracy=0.0 means 'unknown', not 'perfect'.\n"
+            f"It should lose to any real measurement.\n"
+            f"{'=' * 70}"
+        )
+
+    def test_safe_accuracy_fallback_for_zero(self) -> None:
+        """safe_accuracy(0.0) must return DEFAULT_ACCURACY_FALLBACK."""
+        result = safe_accuracy(0.0)
+
+        assert result == DEFAULT_ACCURACY_FALLBACK, (
+            f"safe_accuracy(0.0) should return {DEFAULT_ACCURACY_FALLBACK}m, "
+            f"got {result}m"
+        )
+
+    def test_is_valid_accuracy_rejects_error_code(self) -> None:
+        """is_valid_accuracy must return False for error codes."""
+        assert is_valid_accuracy(0.0) is False, "0.0 is error code"
+        assert is_valid_accuracy(0.0001) is False, f"< {MIN_VALID_ACCURACY} is error"
+        assert is_valid_accuracy(-1.0) is False, "Negative is error"
+        assert is_valid_accuracy(None) is False, "None is invalid"
+
+    def test_is_valid_accuracy_accepts_sub_meter(self) -> None:
+        """is_valid_accuracy must return True for valid sub-meter values."""
+        assert is_valid_accuracy(0.002) is True, "2mm is valid GNSS"
+        assert is_valid_accuracy(0.5) is True, "50cm is valid GNSS"
+        assert is_valid_accuracy(1.0) is True, "1m is valid"
+        assert is_valid_accuracy(50.0) is True, "50m is valid"
+
+
+# =============================================================================
+# SECTION 3: Identity Integrity at Timestamp Collision
+# =============================================================================
+
+
+class TestIdentityIntegrity:
     """Test that timestamp collisions don't cause identity theft.
 
     SCENARIO:
-    - Candidate A (Own Device): High rank, has or doesn't have coordinates
-    - Candidate B (Crowdsourced): Lower rank, has different coordinates
+    - Candidate A: is_own_report=True, lat=10 (higher ranked, WINNER)
+    - Candidate B: is_own_report=False, lat=50 (lower ranked)
     - Both have the SAME timestamp
 
-    INVARIANT: Candidate A must NOT inherit B's coordinates just because
-    B happens to be in the same batch update. Only if B is STRICTLY NEWER
-    should its coordinates be considered.
+    INVARIANT: Result must be lat=10 (from A).
+    B must NOT steal A's identity by having the same timestamp.
     """
 
-    def test_own_device_without_coords_does_not_steal_crowdsourced_coords(
-        self,
-    ) -> None:
-        """When Own Device has no coords, it must NOT borrow from same-timestamp Crowdsourced.
-
-        This is the core "identity theft" scenario:
-        - Own Device (high rank) has semantic info but no coordinates
-        - Crowdsourced (lower rank) has coordinates, same timestamp
-        - Result must NOT have Crowdsourced coordinates attached to Own Device identity
-        """
-        # Own Device: High rank, semantic-only (no coordinates)
+    def test_own_device_wins_at_timestamp_collision(self) -> None:
+        """Own device report wins against crowdsourced at same timestamp."""
         own_device: dict[str, Any] = {
-            "semantic_name": "Home",
-            "last_seen": 1700000100,
-            "is_own_report": True,
-            "status": "LAST_KNOWN",
-            "status_code": 1,
-            # NO latitude/longitude - this is a semantic-only report
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "accuracy": 20.0,
+            "last_seen": 1700000100,  # SAME timestamp
+            "is_own_report": True,     # HIGHER status → WINNER
         }
 
-        # Crowdsourced: Lower rank, has coordinates, SAME timestamp
         crowdsourced: dict[str, Any] = {
             "latitude": 50.0,
-            "longitude": 10.0,
-            "accuracy": 20.0,
-            "last_seen": 1700000100,  # SAME timestamp as Own Device
-            "is_own_report": False,
-            "status": "CROWDSOURCED",
-            "status_code": 2,
+            "longitude": 60.0,
+            "accuracy": 15.0,  # Even better accuracy
+            "last_seen": 1700000100,  # SAME timestamp
+            "is_own_report": False,    # Lower status
         }
 
-        # Normalize both
-        normed_own = _normalize_location_dict(own_device)
-        normed_crowd = _normalize_location_dict(crowdsourced)
+        best, _rest = _select_best_location([own_device, crowdsourced])
 
-        # Verify ranking: Own Device should rank higher
-        rank_own = _get_rank_tuple(normed_own)
-        rank_crowd = _get_rank_tuple(normed_crowd)
-        assert rank_own > rank_crowd, (
-            f"Own Device should rank higher than Crowdsourced.\n"
-            f"Own: {rank_own}\nCrowd: {rank_crowd}"
-        )
-
-        # Run merge with Own Device as "best" (sorted by rank, highest first)
-        normed_cands = [normed_own, normed_crowd]
-        result = _merge_semantics_if_near_ts(dict(normed_own), normed_cands)
-
-        # CRITICAL: Result must NOT have Crowdsourced coordinates
-        # because Crowdsourced is not NEWER, only EQUAL timestamp
-        result_lat = result.get("latitude")
-        result_lon = result.get("longitude")
-
-        has_coords = result_lat is not None and result_lon is not None
-
-        assert not has_coords, (
+        assert best is not None
+        assert best.get("latitude") == pytest.approx(10.0), (
             f"\n"
             f"{'=' * 70}\n"
             f"IDENTITY THEFT DETECTED!\n"
             f"{'=' * 70}\n"
             f"\n"
-            f"Own Device (semantic-only) inherited Crowdsourced coordinates\n"
-            f"even though Crowdsourced has the SAME timestamp (not newer).\n"
+            f"Expected latitude: 10.0 (from own_device)\n"
+            f"Got latitude: {best.get('latitude')}\n"
             f"\n"
-            f"Result coordinates: ({result_lat}, {result_lon})\n"
-            f"Expected: No coordinates (semantic-only should remain semantic-only)\n"
-            f"\n"
-            f"This is IDENTITY THEFT: attaching untrusted coordinates\n"
-            f"to a trusted 'Own Device' identity.\n"
-            f"\n"
-            f"FIX: In _merge_semantics_if_near_ts, initialize best_coordinate_ts\n"
-            f"to t_best (not -inf) to prevent same-timestamp stealing.\n"
+            f"Own device (is_own_report=True) must win against crowdsourced\n"
+            f"even when they have the same timestamp.\n"
             f"{'=' * 70}"
         )
 
-        # Verify semantic name is preserved
-        assert result.get("semantic_name") == "Home", (
-            "Own Device's semantic name should be preserved"
-        )
-
-    def test_own_device_with_coords_is_not_overwritten_by_crowdsourced(
-        self,
-    ) -> None:
-        """When Own Device HAS coordinates, they must not be overwritten by same-timestamp Crowdsourced."""
-        # Own Device: High rank, has coordinates
-        own_device: dict[str, Any] = {
-            "latitude": 48.1,
-            "longitude": 11.1,
-            "accuracy": 25.0,
+    def test_merge_semantics_respects_best_coordinates(self) -> None:
+        """_merge_semantics_if_near_ts must not let B steal A's coordinates."""
+        best: dict[str, Any] = {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "accuracy": 20.0,
             "last_seen": 1700000100,
-            "is_own_report": True,
-            "status": "LAST_KNOWN",
-            "status_code": 1,
         }
 
-        # Crowdsourced: Lower rank, DIFFERENT coordinates, SAME timestamp
-        crowdsourced: dict[str, Any] = {
-            "latitude": 50.0,  # Different!
-            "longitude": 10.0,  # Different!
-            "accuracy": 15.0,  # Better accuracy (but lower rank)
-            "last_seen": 1700000100,  # SAME timestamp
-            "is_own_report": False,
-            "status": "CROWDSOURCED",
-            "status_code": 2,
+        # Candidate with SAME timestamp should NOT steal coordinates
+        same_ts_candidate: dict[str, Any] = {
+            "latitude": 50.0,  # Different coords
+            "longitude": 60.0,
+            "accuracy": 10.0,  # Better accuracy
+            "last_seen": 1700000100,  # SAME timestamp as best
         }
 
-        normed_own = _normalize_location_dict(own_device)
-        normed_crowd = _normalize_location_dict(crowdsourced)
-        normed_cands = [normed_own, normed_crowd]
+        result = _merge_semantics_if_near_ts(best, [same_ts_candidate])
 
-        result = _merge_semantics_if_near_ts(dict(normed_own), normed_cands)
-
-        # Own Device coordinates must be preserved
-        assert result.get("latitude") == pytest.approx(48.1), (
-            f"Own Device latitude should be preserved, got {result.get('latitude')}"
+        # Best's coordinates must be preserved
+        assert result.get("latitude") == pytest.approx(10.0), (
+            "Best's latitude must be preserved at timestamp collision"
         )
-        assert result.get("longitude") == pytest.approx(11.1), (
-            f"Own Device longitude should be preserved, got {result.get('longitude')}"
+        assert result.get("longitude") == pytest.approx(20.0), (
+            "Best's longitude must be preserved at timestamp collision"
         )
 
-    def test_strictly_newer_timestamp_can_update_coordinates(self) -> None:
-        """A STRICTLY newer report CAN update coordinates (this is valid behavior)."""
-        # Own Device: Has coordinates
-        own_device: dict[str, Any] = {
-            "latitude": 48.1,
-            "longitude": 11.1,
-            "accuracy": 25.0,
-            "last_seen": 1700000100,  # OLDER
-            "is_own_report": True,
+    def test_newer_timestamp_can_update_coordinates(self) -> None:
+        """A STRICTLY NEWER candidate CAN update coordinates (by design)."""
+        best: dict[str, Any] = {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "accuracy": 20.0,
+            "last_seen": 1700000100,
         }
 
-        # Crowdsourced: NEWER timestamp
-        crowdsourced: dict[str, Any] = {
+        # Candidate with NEWER timestamp CAN provide coordinates
+        newer_candidate: dict[str, Any] = {
             "latitude": 50.0,
-            "longitude": 10.0,
-            "accuracy": 15.0,
-            "last_seen": 1700000200,  # STRICTLY NEWER (+100s)
-            "is_own_report": False,
+            "longitude": 60.0,
+            "accuracy": 10.0,
+            "last_seen": 1700000200,  # NEWER than best
         }
 
-        normed_own = _normalize_location_dict(own_device)
-        normed_crowd = _normalize_location_dict(crowdsourced)
-        normed_cands = [normed_own, normed_crowd]
+        result = _merge_semantics_if_near_ts(best, [newer_candidate])
 
-        result = _merge_semantics_if_near_ts(dict(normed_own), normed_cands)
-
-        # Newer coordinates CAN be used (this is valid)
+        # Newer candidate's coordinates should be used
         assert result.get("latitude") == pytest.approx(50.0), (
-            "Strictly newer timestamp should update coordinates"
+            "Strictly newer candidate should provide coordinates"
         )
-        assert result.get("longitude") == pytest.approx(10.0)
+        assert result.get("longitude") == pytest.approx(60.0), (
+            "Strictly newer candidate should provide coordinates"
+        )
 
 
 # =============================================================================
-# SECTION 2: Zero Accuracy Handling (Downgrade, not Reject)
+# SECTION 4: Cache Gatekeeper Tests
 # =============================================================================
 
 
-class TestZeroAccuracyDowngrade:
-    """Test that accuracy=0.0 is sanitized, not rejected.
+class TestCacheGatekeeper:
+    """Test cache.py _is_significant_update with new thresholds."""
 
-    PRINCIPLE: 0.0 means "unknown/masked", not "perfect precision".
-    The REPORT should be kept, but accuracy should be treated as unmeasured.
-
-    INVARIANT:
-    1. Reports with accuracy=0.0 are NOT rejected
-    2. The accuracy field is either removed or set to fallback
-    3. In fusion, such reports don't dominate (low weight due to fallback)
-    """
-
-    def test_zero_accuracy_report_is_accepted(self) -> None:
-        """A report with accuracy=0.0 must be ACCEPTED (not rejected)."""
-        report: dict[str, Any] = {
-            "latitude": 48.123,
-            "longitude": 11.456,
-            "accuracy": 0.0,  # This means "unknown", not "perfect"
-            "last_seen": 1700000100,
-            "is_own_report": True,
-        }
-
-        normalized = _normalize_location_dict(report)
-
-        # Report must still have coordinates (was not rejected)
-        assert normalized.get("latitude") == pytest.approx(48.123), (
-            "Report with 0.0 accuracy should be ACCEPTED, coordinates preserved"
-        )
-        assert normalized.get("longitude") == pytest.approx(11.456)
-
-    def test_zero_accuracy_is_sanitized_to_none(self) -> None:
-        """accuracy=0.0 must be REMOVED (not kept as 0.0)."""
-        report: dict[str, Any] = {
-            "latitude": 48.123,
-            "longitude": 11.456,
-            "accuracy": 0.0,
-            "last_seen": 1700000100,
-        }
-
-        normalized = _normalize_location_dict(report)
-
-        # Accuracy must be removed
-        assert "accuracy" not in normalized or normalized.get("accuracy") is None, (
-            f"\n"
-            f"{'=' * 70}\n"
-            f"ZERO ACCURACY NOT SANITIZED!\n"
-            f"{'=' * 70}\n"
-            f"\n"
-            f"accuracy=0.0 was kept instead of being removed.\n"
-            f"Stored accuracy: {normalized.get('accuracy')}\n"
-            f"Expected: None (key should not exist)\n"
-            f"\n"
-            f"This will corrupt ranking: 0.0 would get acc_rank = -0.0,\n"
-            f"which is BETTER than valid entries like -20.0.\n"
-            f"\n"
-            f"FIX: In _normalize_location_dict, remove accuracy if < 1.0m.\n"
-            f"{'=' * 70}"
-        )
-
-    def test_zero_accuracy_gets_worst_ranking(self) -> None:
-        """After sanitization, the report should get acc_rank = -inf."""
-        report: dict[str, Any] = {
-            "latitude": 48.123,
-            "longitude": 11.456,
-            "accuracy": 0.0,
-            "last_seen": 1700000100,
-        }
-
-        normalized = _normalize_location_dict(report)
-        rank = _get_rank_tuple(normalized)
-        acc_rank = rank[3]
-
-        assert math.isinf(acc_rank) and acc_rank < 0, (
-            f"After sanitization (accuracy removed), acc_rank should be -inf.\n"
-            f"Got: {acc_rank}"
-        )
-
-    def test_valid_report_beats_sanitized_zero_accuracy(self) -> None:
-        """A valid 20m report should beat a sanitized 0.0m report when other factors are equal.
-
-        IMPORTANT: The ranking tuple is (seen_rank, status_rank, has_coords_rank, acc_rank).
-        Timestamp and status are evaluated BEFORE accuracy. To test accuracy tiebreaker,
-        we must make timestamp and status EQUAL so only accuracy differs.
-        """
-        # Report with 0.0 accuracy (will be sanitized)
-        masked_report: dict[str, Any] = {
-            "latitude": 48.100,
-            "longitude": 11.100,
-            "accuracy": 0.0,  # This will be sanitized → acc_rank = -inf
-            "last_seen": 1700000100,  # SAME timestamp
-            "is_own_report": False,  # SAME status
-        }
-
-        # Valid report with real accuracy
-        valid_report: dict[str, Any] = {
-            "latitude": 48.200,
-            "longitude": 11.200,
-            "accuracy": 20.0,  # Valid GPS accuracy → acc_rank = -20.0
-            "last_seen": 1700000100,  # SAME timestamp
-            "is_own_report": False,  # SAME status
-        }
-
-        best, _rest = _select_best_location([masked_report, valid_report])
-
-        assert best is not None, "Should select a location"
-
-        # When timestamp and status are EQUAL, accuracy becomes the tiebreaker:
-        # - masked_report has accuracy=0.0 → sanitized to None → acc_rank = -inf
-        # - valid_report has accuracy=20.0 → acc_rank = -20.0 (better than -inf)
-        # Therefore valid_report should win.
-        best_acc = best.get("accuracy")
-        assert best_acc == pytest.approx(20.0), (
-            f"\n"
-            f"{'=' * 70}\n"
-            f"MASKED REPORT INCORRECTLY WON!\n"
-            f"{'=' * 70}\n"
-            f"\n"
-            f"A report with accuracy=0.0 (now sanitized) beat a valid 20m report\n"
-            f"when timestamp and status were EQUAL.\n"
-            f"\n"
-            f"Selected accuracy: {best_acc}\n"
-            f"Expected: 20.0 (from valid report)\n"
-            f"\n"
-            f"This proves acc_rank = -inf is not being applied correctly.\n"
-            f"{'=' * 70}"
-        )
-
-    def test_cache_accepts_zero_accuracy_with_sanitization(self) -> None:
-        """cache.py must ACCEPT updates with accuracy=0.0 (sanitize, not reject)."""
+    def test_cache_sanitizes_zero_accuracy(self) -> None:
+        """_is_significant_update must SANITIZE 0.0, not reject."""
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
 
         mock_coord = MagicMock(spec=CacheOperations)
@@ -340,83 +377,87 @@ class TestZeroAccuracyDowngrade:
 
         is_sig = CacheOperations._is_significant_update
 
-        # Update with 0.0 accuracy
-        update_with_zero_acc = {
+        update = {
             "latitude": 48.123,
             "longitude": 11.456,
-            "accuracy": 0.0,
+            "accuracy": 0.0,  # Will be sanitized
             "last_seen": 1700000100,
         }
 
-        result = is_sig(mock_coord, "device-1", update_with_zero_acc)
+        result = is_sig(mock_coord, "device-1", update)
 
-        # Update must be ACCEPTED (not rejected)
-        assert result is True, (
-            f"\n"
-            f"{'=' * 70}\n"
-            f"CACHE REJECTED VALID UPDATE!\n"
-            f"{'=' * 70}\n"
-            f"\n"
-            f"An update with accuracy=0.0 was REJECTED instead of SANITIZED.\n"
-            f"\n"
-            f"The report contains valid location data. Only the accuracy\n"
-            f"is invalid and should be removed, not the entire update.\n"
-            f"\n"
-            f"FIX: In _is_significant_update, sanitize invalid accuracy\n"
-            f"(remove from dict) instead of returning False.\n"
-            f"{'=' * 70}"
-        )
+        # Must be ACCEPTED
+        assert result is True, "Update should be ACCEPTED (sanitized)"
 
-        # Accuracy should have been removed from the update dict
-        assert "accuracy" not in update_with_zero_acc, (
-            "Invalid accuracy should be removed from update dict"
-        )
+        # Accuracy must be removed
+        assert "accuracy" not in update, "0.0 accuracy should be removed"
 
-        # Verify sanitization was counted
+        # Stat must be incremented
         mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
 
+    def test_cache_preserves_sub_meter_accuracy(self) -> None:
+        """_is_significant_update must PRESERVE valid sub-meter accuracy."""
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        for valid_acc in [0.002, 0.5, 1.0, 50.0]:
+            update = {
+                "latitude": 48.123,
+                "longitude": 11.456,
+                "accuracy": valid_acc,
+                "last_seen": 1700000100,
+            }
+
+            result = is_sig(mock_coord, "device-1", update)
+
+            assert result is True, f"Update with {valid_acc}m should be accepted"
+            assert update.get("accuracy") == valid_acc, (
+                f"Valid accuracy {valid_acc}m should be PRESERVED"
+            )
+
 
 # =============================================================================
-# SECTION 3: Fusion Behavior with Sanitized Accuracy
+# SECTION 5: Fusion Self-Healing Tests
 # =============================================================================
 
 
-class TestFusionWithSanitizedAccuracy:
-    """Test that fusion correctly handles sanitized (fallback) accuracy."""
+class TestFusionSelfHealing:
+    """Test that cache fusion properly handles corrupted accuracy values."""
 
-    def test_valid_accuracy_dominates_over_fallback(self) -> None:
-        """When fusing, a valid 20m accuracy should dominate over 50m fallback.
+    def test_safe_accuracy_self_healing(self) -> None:
+        """safe_accuracy must replace corrupted values with fallback."""
+        # Error codes should get fallback
+        assert safe_accuracy(0.0) == DEFAULT_ACCURACY_FALLBACK
+        assert safe_accuracy(-1.0) == DEFAULT_ACCURACY_FALLBACK
+        assert safe_accuracy(0.0001) == DEFAULT_ACCURACY_FALLBACK
+        assert safe_accuracy(None) == DEFAULT_ACCURACY_FALLBACK
+        assert safe_accuracy(float("nan")) == DEFAULT_ACCURACY_FALLBACK
+        assert safe_accuracy(float("inf")) == DEFAULT_ACCURACY_FALLBACK
 
-        If a cached entry has accuracy=0.0 (now treated as 50m fallback),
-        a new entry with accuracy=20m should have MORE weight in fusion.
-        """
-        from custom_components.googlefindmy.coordinator.helpers.geo import (
-            DEFAULT_ACCURACY_FALLBACK_M,
-        )
+        # Valid values should be preserved
+        assert safe_accuracy(0.002) == 0.002
+        assert safe_accuracy(0.5) == 0.5
+        assert safe_accuracy(50.0) == 50.0
 
-        # Fallback accuracy (used for sanitized 0.0)
-        fallback_acc = DEFAULT_ACCURACY_FALLBACK_M  # 50m
+    def test_fusion_weight_calculation(self) -> None:
+        """Corrupted accuracy (0.0) should have near-zero weight in fusion."""
+        # Weight is 1/accuracy² - smaller accuracy = higher weight
+        # 0.0 → fallback (2000m) → weight = 1/2000² = 0.00000025
+        # 50m → weight = 1/50² = 0.0004
 
-        # Valid accuracy
-        valid_acc = 20.0
+        fallback_weight = 1 / (DEFAULT_ACCURACY_FALLBACK ** 2)
+        real_weight = 1 / (50.0 ** 2)
 
-        # Calculate weights
-        w_fallback = 1 / (fallback_acc**2)  # 1/2500 = 0.0004
-        w_valid = 1 / (valid_acc**2)  # 1/400 = 0.0025
+        # Real data should have ~1600x more weight than fallback
+        weight_ratio = real_weight / fallback_weight
 
-        total_w = w_fallback + w_valid
-        valid_weight_fraction = w_valid / total_w
-
-        # Valid accuracy should have > 50% weight
-        assert valid_weight_fraction > 0.5, (
-            f"Valid 20m accuracy should dominate over 50m fallback.\n"
-            f"Valid weight fraction: {valid_weight_fraction:.1%}\n"
-            f"Expected: > 50%"
-        )
-
-        # Specifically, 20m vs 50m → valid gets 6.25x more weight
-        weight_ratio = w_valid / w_fallback
-        assert weight_ratio > 6, (
-            f"20m accuracy should have ~6x weight of 50m fallback.\n"
-            f"Actual ratio: {weight_ratio:.2f}x"
+        assert weight_ratio > 1000, (
+            f"Real data (50m) should have >1000x more weight than fallback.\n"
+            f"Ratio: {weight_ratio:.1f}x\n"
+            f"This ensures corrupted values (0.0) are quickly overwritten."
         )

--- a/tests/test_logic_safeguards.py
+++ b/tests/test_logic_safeguards.py
@@ -20,7 +20,6 @@ CONSTANTS:
 
 from __future__ import annotations
 
-import math
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -33,12 +32,10 @@ from custom_components.googlefindmy.coordinator.helpers.geo import (
     safe_accuracy,
 )
 from custom_components.googlefindmy.ProtoDecoders.decoder import (
-    _get_rank_tuple,
     _merge_semantics_if_near_ts,
     _normalize_location_dict,
     _select_best_location,
 )
-
 
 # =============================================================================
 # SECTION 1: Micro-Precision Survival (Sub-Meter Accuracy)
@@ -60,16 +57,16 @@ class TestMicroPrecisionSurvival:
     @pytest.mark.parametrize(
         ("accuracy", "expected_preserved"),
         [
-            (0.002, True),    # 2mm - extreme precision, MUST be preserved
-            (0.01, True),     # 1cm - centimeter precision, valid
-            (0.1, True),      # 10cm - sub-meter, valid
-            (0.5, True),      # 50cm - common sub-meter, valid
-            (1.0, True),      # 1m - valid
-            (5.0, True),      # 5m - typical GPS, valid
-            (50.0, True),     # 50m - moderate GPS, valid
-            (0.0, False),     # Error code - MUST be removed
+            (0.002, True),  # 2mm - extreme precision, MUST be preserved
+            (0.01, True),  # 1cm - centimeter precision, valid
+            (0.1, True),  # 10cm - sub-meter, valid
+            (0.5, True),  # 50cm - common sub-meter, valid
+            (1.0, True),  # 1m - valid
+            (5.0, True),  # 5m - typical GPS, valid
+            (50.0, True),  # 50m - moderate GPS, valid
+            (0.0, False),  # Error code - MUST be removed
             (0.0001, False),  # Below threshold - error code
-            (-1.0, False),    # Negative - error code
+            (-1.0, False),  # Negative - error code
         ],
         ids=[
             "2mm_preserved",
@@ -125,7 +122,7 @@ class TestMicroPrecisionSurvival:
             "longitude": 11.200,
             "accuracy": 0.5,  # 500mm - moderate
             "last_seen": 1700000100,  # SAME timestamp
-            "is_own_report": False,   # SAME status
+            "is_own_report": False,  # SAME status
         }
 
         best, _rest = _select_best_location([micro_precision, moderate_accuracy])
@@ -205,7 +202,7 @@ class TestZeroAccuracyDowngrade:
             "longitude": 11.200,
             "accuracy": 50.0,  # Valid accuracy → acc_rank = -50.0
             "last_seen": 1700000100,  # SAME timestamp
-            "is_own_report": False,   # SAME status
+            "is_own_report": False,  # SAME status
         }
 
         best, _rest = _select_best_location([zero_acc_report, real_data_report])
@@ -276,7 +273,7 @@ class TestIdentityIntegrity:
             "longitude": 20.0,
             "accuracy": 20.0,
             "last_seen": 1700000100,  # SAME timestamp
-            "is_own_report": True,     # HIGHER status → WINNER
+            "is_own_report": True,  # HIGHER status → WINNER
         }
 
         crowdsourced: dict[str, Any] = {
@@ -284,7 +281,7 @@ class TestIdentityIntegrity:
             "longitude": 60.0,
             "accuracy": 15.0,  # Even better accuracy
             "last_seen": 1700000100,  # SAME timestamp
-            "is_own_report": False,    # Lower status
+            "is_own_report": False,  # Lower status
         }
 
         best, _rest = _select_best_location([own_device, crowdsourced])
@@ -452,8 +449,8 @@ class TestFusionSelfHealing:
         # 0.0 → fallback (2000m) → weight = 1/2000² = 0.00000025
         # 50m → weight = 1/50² = 0.0004
 
-        fallback_weight = 1 / (DEFAULT_ACCURACY_FALLBACK ** 2)
-        real_weight = 1 / (50.0 ** 2)
+        fallback_weight = 1 / (DEFAULT_ACCURACY_FALLBACK**2)
+        real_weight = 1 / (50.0**2)
 
         # Real data should have ~1600x more weight than fallback
         weight_ratio = real_weight / fallback_weight
@@ -605,7 +602,7 @@ class TestZeroAccuracyRetention:
             "longitude": 11.200,
             "accuracy": 20.0,  # Real GPS accuracy
             "last_seen": 1700000100,  # SAME timestamp
-            "is_own_report": False,   # SAME status
+            "is_own_report": False,  # SAME status
         }
 
         best, _rest = _select_best_location([downgraded_report, real_gps_report])

--- a/tests/test_logic_safeguards.py
+++ b/tests/test_logic_safeguards.py
@@ -368,7 +368,7 @@ class TestCacheGatekeeper:
     """Test cache.py _is_significant_update with new thresholds."""
 
     def test_cache_sanitizes_zero_accuracy(self) -> None:
-        """_is_significant_update must SANITIZE 0.0, not reject."""
+        """_is_significant_update must SANITIZE 0.0 to fallback value."""
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
 
         mock_coord = MagicMock(spec=CacheOperations)
@@ -380,7 +380,7 @@ class TestCacheGatekeeper:
         update = {
             "latitude": 48.123,
             "longitude": 11.456,
-            "accuracy": 0.0,  # Will be sanitized
+            "accuracy": 0.0,  # Will be sanitized to fallback
             "last_seen": 1700000100,
         }
 
@@ -389,8 +389,10 @@ class TestCacheGatekeeper:
         # Must be ACCEPTED
         assert result is True, "Update should be ACCEPTED (sanitized)"
 
-        # Accuracy must be removed
-        assert "accuracy" not in update, "0.0 accuracy should be removed"
+        # Accuracy must be SET to fallback (not None, not removed)
+        assert update.get("accuracy") == DEFAULT_ACCURACY_FALLBACK, (
+            f"0.0 accuracy should be set to fallback ({DEFAULT_ACCURACY_FALLBACK}m)"
+        )
 
         # Stat must be incremented
         mock_coord.increment_stat.assert_called_with("accuracy_sanitized_count")
@@ -461,3 +463,204 @@ class TestFusionSelfHealing:
             f"Ratio: {weight_ratio:.1f}x\n"
             f"This ensures corrupted values (0.0) are quickly overwritten."
         )
+
+
+# =============================================================================
+# SECTION 6: Missing Key Crash Test
+# =============================================================================
+
+
+class TestMissingKeyCrashPrevention:
+    """Test that missing accuracy key doesn't crash downstream code.
+
+    When the decoder strips the 'accuracy' key (because it was 0.0),
+    the cache must handle this gracefully and write back a fallback value.
+    Home Assistant requires a numeric gps_accuracy attribute.
+    """
+
+    def test_cache_handles_stripped_accuracy_gracefully(self) -> None:
+        """_is_significant_update must handle missing accuracy key without crash.
+
+        Scenario:
+        1. Decoder receives accuracy=0.0 and REMOVES the key
+        2. Cache receives dict WITHOUT accuracy key
+        3. Cache must NOT crash and must SET a fallback value
+        """
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        # Dict WITHOUT accuracy key (simulating decoder stripping it)
+        update_without_accuracy = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            # NO "accuracy" key!
+            "last_seen": 1700000100,
+        }
+
+        # This must NOT raise an exception
+        result = is_sig(mock_coord, "device-1", update_without_accuracy)
+
+        # Must be accepted
+        assert result is True, "Update should be accepted even without accuracy key"
+
+        # CRITICAL: Accuracy must be set to fallback (not None, not missing)
+        assert "accuracy" in update_without_accuracy, (
+            "Cache must SET accuracy key when it was missing"
+        )
+        assert update_without_accuracy["accuracy"] == DEFAULT_ACCURACY_FALLBACK, (
+            f"Missing accuracy should be set to fallback ({DEFAULT_ACCURACY_FALLBACK}m), "
+            f"got {update_without_accuracy.get('accuracy')}"
+        )
+
+    def test_safe_accuracy_handles_any_input(self) -> None:
+        """safe_accuracy must handle ANY input type without crashing."""
+        # All of these must return fallback without exception
+        assert safe_accuracy(None) == DEFAULT_ACCURACY_FALLBACK
+        assert safe_accuracy("invalid") == DEFAULT_ACCURACY_FALLBACK
+        assert safe_accuracy([1, 2, 3]) == DEFAULT_ACCURACY_FALLBACK
+        assert safe_accuracy({"key": "value"}) == DEFAULT_ACCURACY_FALLBACK
+        assert safe_accuracy(object()) == DEFAULT_ACCURACY_FALLBACK
+
+        # Valid inputs should be preserved
+        assert safe_accuracy(50.0) == 50.0
+        assert safe_accuracy(0.5) == 0.5
+        assert safe_accuracy("20.0") == 20.0  # String that can be converted
+
+
+# =============================================================================
+# SECTION 7: Retention Test (Zero Accuracy Data Preservation)
+# =============================================================================
+
+
+class TestZeroAccuracyRetention:
+    """Test that data with accuracy=0.0 is KEPT but downgraded.
+
+    The "Sanitize-not-Reject" strategy means:
+    - Coordinates are preserved (no data loss)
+    - Accuracy is set to fallback (honest about uncertainty)
+    - Report loses to real GPS data in ranking (correct prioritization)
+    """
+
+    def test_zero_accuracy_is_kept_but_downgraded(self) -> None:
+        """Data with accuracy=0.0 must be retained with downgraded accuracy.
+
+        Chain:
+        1. Decoder: Sees 0.0 -> removes key (for ranking purposes)
+        2. Cache: Sees missing key -> sets fallback 2000.0
+        3. Result: Location preserved, marked as "inaccurate"
+        """
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+
+        # Simulate: decoder already stripped the accuracy (was 0.0)
+        update_with_stripped_accuracy = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            # accuracy was 0.0, decoder removed it
+            "last_seen": 1700000100,
+        }
+
+        result = is_sig(mock_coord, "device-1", update_with_stripped_accuracy)
+
+        # Assert 1: No data loss - coordinates are preserved
+        assert result is True, "Update must be accepted (no data loss)"
+        assert update_with_stripped_accuracy.get("latitude") == 48.123
+        assert update_with_stripped_accuracy.get("longitude") == 11.456
+
+        # Assert 2: Accuracy is set to fallback (not None, not 0.0)
+        final_acc = update_with_stripped_accuracy.get("accuracy")
+        assert final_acc == DEFAULT_ACCURACY_FALLBACK, (
+            f"Accuracy should be fallback ({DEFAULT_ACCURACY_FALLBACK}m), got {final_acc}"
+        )
+        assert final_acc != 0.0, "Accuracy must NOT be 0.0"
+        assert final_acc is not None, "Accuracy must NOT be None"
+
+    def test_downgraded_report_loses_to_real_gps(self) -> None:
+        """A downgraded report (2000m) must lose to real GPS (20m) in ranking.
+
+        This ensures the "honest uncertainty" marking actually works.
+        """
+        # Downgraded report (was 0.0, now 2000.0)
+        downgraded_report: dict[str, Any] = {
+            "latitude": 48.100,
+            "longitude": 11.100,
+            "accuracy": DEFAULT_ACCURACY_FALLBACK,  # 2000m (was 0.0)
+            "last_seen": 1700000100,
+            "is_own_report": False,
+        }
+
+        # Real GPS report with actual measurement
+        real_gps_report: dict[str, Any] = {
+            "latitude": 48.200,
+            "longitude": 11.200,
+            "accuracy": 20.0,  # Real GPS accuracy
+            "last_seen": 1700000100,  # SAME timestamp
+            "is_own_report": False,   # SAME status
+        }
+
+        best, _rest = _select_best_location([downgraded_report, real_gps_report])
+
+        assert best is not None
+        best_acc = best.get("accuracy")
+
+        # Real GPS (20m) must win against downgraded (2000m)
+        assert best_acc == 20.0, (
+            f"Real GPS (20m) should beat downgraded report (2000m).\n"
+            f"Got: {best_acc}m\n"
+            f"Ranking: smaller accuracy = better precision = wins"
+        )
+
+    def test_end_to_end_zero_accuracy_handling(self) -> None:
+        """End-to-end test: 0.0 accuracy through decoder and into cache.
+
+        Full chain verification:
+        1. Input: accuracy=0.0
+        2. Decoder: removes key (< MIN_VALID_ACCURACY)
+        3. Cache: sets fallback
+        4. Output: valid location with 2000m accuracy
+        """
+        # Step 1: Simulate decoder behavior
+        from custom_components.googlefindmy.ProtoDecoders.decoder import (
+            _normalize_location_dict,
+        )
+
+        raw_location = {
+            "latitude": 48.123,
+            "longitude": 11.456,
+            "accuracy": 0.0,  # Error code
+            "last_seen": 1700000100,
+        }
+
+        # Decoder strips the accuracy key
+        decoded = _normalize_location_dict(raw_location)
+        assert "accuracy" not in decoded, "Decoder should remove 0.0 accuracy"
+        assert decoded.get("latitude") == 48.123, "Coordinates preserved"
+
+        # Step 2: Cache receives decoded data
+        from custom_components.googlefindmy.coordinator.cache import CacheOperations
+
+        mock_coord = MagicMock(spec=CacheOperations)
+        mock_coord._device_location_data = {}
+        mock_coord.increment_stat = MagicMock()
+
+        is_sig = CacheOperations._is_significant_update
+        result = is_sig(mock_coord, "device-1", decoded)
+
+        assert result is True, "Cache should accept the update"
+
+        # Step 3: Verify final state
+        assert decoded.get("accuracy") == DEFAULT_ACCURACY_FALLBACK, (
+            f"Final accuracy should be {DEFAULT_ACCURACY_FALLBACK}m"
+        )
+        assert decoded.get("latitude") == 48.123, "Latitude preserved"
+        assert decoded.get("longitude") == 11.456, "Longitude preserved"


### PR DESCRIPTION
## PR Summary: Fix "Phantom Update" Bug (Google FMDN accuracy=0.0)

### Problem
Google's Find My Device Network API occasionally returns spurious location reports with:
- `is_own_report=True` (high priority)
- `accuracy=0.0` (Android API error code for "no accuracy available")

These "Phantom Updates" won the ranking algorithm due to their owner-priority status, causing:
1. **Position Lock-in**: 0.0m accuracy = infinite fusion weight (1/0²), locking bad coordinates
2. **State Machine Corruption**: Home Assistant requires numeric `gps_accuracy` attribute

### Solution: Defense-in-Depth Strategy

**4 Protection Layers:**

| Layer | Location | Function |
|-------|----------|----------|
| 1 | `helpers/geo.py` | Central constants & `safe_accuracy()` |
| 2 | `decoder.py` | Input filtering, ranking penalty (-∞) |
| 3 | `locate.py` | Manual locate validation |
| 4 | `cache.py` | Gatekeeper & self-healing fusion |

### Key Constants
```python
MIN_VALID_ACCURACY = 0.001      # 1mm threshold (only catch error code 0.0)
DEFAULT_ACCURACY_FALLBACK = 2000.0  # Conservative fallback for HA state machine
