### PR TITLE
Fix tracker location fallback distance strategy

### DIFF
--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -785,13 +785,13 @@ class CacheOperations:
             Modern dual-frequency GNSS (L1+L5) can achieve sub-meter accuracy under
             ideal conditions, so valid values like 0.5m or 0.01m are preserved.
 
-            The fallback (DEFAULT_ACCURACY_FALLBACK = 2000m) is conservative for
-            "unknown" accuracy. This ensures:
-              - Error codes get very low weight in fusion (1/2000² ≈ 0)
-              - Any real measurement easily overrides the error code
+            The fallback (PRIVACY_ACCURACY_FALLBACK = 200m) is based on Bluetooth
+            tracker physics (max Bluetooth range + GPS error margin). This ensures:
+              - Error codes get lower weight in fusion than real GPS (200²/20² = 100x)
+              - The fallback is still useful for finding a tracker (unlike 2km)
 
             SELF-HEALING: If the cache contains a corrupted value (0.0),
-            treating it as 2000m allows new valid data to properly override it.
+            treating it as 200m allows new valid data to properly override it.
             """
             if value is None or not math.isfinite(value):
                 return DEFAULT_ACCURACY_FALLBACK_M

--- a/custom_components/googlefindmy/coordinator/helpers/geo.py
+++ b/custom_components/googlefindmy/coordinator/helpers/geo.py
@@ -32,9 +32,14 @@ EARTH_RADIUS_M = 6371000.0
 MIN_VALID_ACCURACY = 0.001  # 1 millimeter
 
 # Default fallback for invalid/missing GPS accuracy.
-# Conservative value for "unknown" - high enough to lose against any real measurement
-# in weighted fusion, but not so high as to cause map rendering issues.
-DEFAULT_ACCURACY_FALLBACK = 2000.0  # 2 kilometers
+# Based on Bluetooth tracker physics: max Bluetooth range (~100m) + GPS error margin.
+# 200m is large enough to lose against any real GPS measurement (typically 20-50m)
+# in weighted fusion (200²/20² = 100x lower weight), yet small enough to be
+# useful for actually finding a tracker on a map (unlike 2km which is useless).
+PRIVACY_ACCURACY_FALLBACK = 200.0  # 200 meters
+
+# Legacy alias for backward compatibility
+DEFAULT_ACCURACY_FALLBACK = PRIVACY_ACCURACY_FALLBACK
 
 # Legacy aliases for backward compatibility
 MIN_PHYSICAL_ACCURACY_M = MIN_VALID_ACCURACY
@@ -127,7 +132,7 @@ def safe_accuracy(value: Any, *, fallback: float | None = None) -> float:
     Args:
         value: Any value that might represent GPS accuracy. Handles None,
                strings, floats, ints, and any other type gracefully.
-        fallback: Custom fallback value. Defaults to DEFAULT_ACCURACY_FALLBACK (2000m).
+        fallback: Custom fallback value. Defaults to PRIVACY_ACCURACY_FALLBACK (200m).
 
     Returns:
         A finite float >= MIN_VALID_ACCURACY representing accuracy in meters,
@@ -141,13 +146,13 @@ def safe_accuracy(value: Any, *, fallback: float | None = None) -> float:
         >>> safe_accuracy(0.01)  # Valid centimeter accuracy
         0.01
         >>> safe_accuracy(None)
-        2000.0
+        200.0
         >>> safe_accuracy(0.0)  # Error code
-        2000.0
+        200.0
         >>> safe_accuracy(-5.0)
-        2000.0
+        200.0
         >>> safe_accuracy("invalid")  # Non-numeric
-        2000.0
+        200.0
     """
     if fallback is None:
         fallback = DEFAULT_ACCURACY_FALLBACK

--- a/tests/test_coordinator_geo.py
+++ b/tests/test_coordinator_geo.py
@@ -177,7 +177,7 @@ class TestCoerceFloat:
 class TestSafeAccuracy:
     """Tests for safe_accuracy function."""
 
-    # Default fallback value used in the function (2000m for unknown accuracy)
+    # Default fallback value used in the function (200m for unknown accuracy)
     DEFAULT_FALLBACK = DEFAULT_ACCURACY_FALLBACK_M
 
     def test_valid_positive_accuracy(self) -> None:

--- a/tests/test_fusion_robustness.py
+++ b/tests/test_fusion_robustness.py
@@ -56,27 +56,36 @@ class TestGeoConstants:
             f"{'=' * 70}"
         )
 
-    def test_default_fallback_is_two_kilometers(self) -> None:
-        """DEFAULT_ACCURACY_FALLBACK must be 2000.0m (conservative unknown).
+    def test_default_fallback_is_two_hundred_meters(self) -> None:
+        """PRIVACY_ACCURACY_FALLBACK must be 200.0m (Bluetooth range + GPS error).
 
-        A high fallback ensures error codes (0.0) have minimal weight in
-        fusion calculations and lose to any real measurement.
+        The fallback is based on Bluetooth tracker physics:
+        - Max Bluetooth range: ~100m
+        - GPS error margin: ~100m
+        - Total: 200m
+
+        This ensures:
+        - Error codes (0.0) have lower weight in fusion than real GPS (20-50m)
+        - The fallback is still useful for finding a tracker (unlike 2km)
         """
         from custom_components.googlefindmy.coordinator.helpers.geo import (
             DEFAULT_ACCURACY_FALLBACK,
+            PRIVACY_ACCURACY_FALLBACK,
         )
 
-        assert DEFAULT_ACCURACY_FALLBACK == 2000.0, (
+        assert PRIVACY_ACCURACY_FALLBACK == 200.0, (
             f"\n"
             f"{'=' * 70}\n"
-            f"CRITICAL: DEFAULT_ACCURACY_FALLBACK is not 2000.0m!\n"
+            f"CRITICAL: PRIVACY_ACCURACY_FALLBACK is not 200.0m!\n"
             f"{'=' * 70}\n"
-            f"Current value: {DEFAULT_ACCURACY_FALLBACK}\n"
-            f"Expected: 2000.0 (conservative for unknown accuracy)\n"
+            f"Current value: {PRIVACY_ACCURACY_FALLBACK}\n"
+            f"Expected: 200.0 (Bluetooth range + GPS error margin)\n"
             f"\n"
             f"FIX LOCATION: helpers/geo.py\n"
             f"{'=' * 70}"
         )
+        # Ensure legacy alias is also correct
+        assert DEFAULT_ACCURACY_FALLBACK == PRIVACY_ACCURACY_FALLBACK
 
     def test_safe_accuracy_rejects_error_code(self) -> None:
         """safe_accuracy() must reject 0.0m (error code) as invalid."""

--- a/tests/test_logic_safeguards.py
+++ b/tests/test_logic_safeguards.py
@@ -15,7 +15,7 @@ These tests verify three critical invariants:
 
 CONSTANTS:
 - MIN_VALID_ACCURACY = 0.001 (1mm threshold for error code detection)
-- DEFAULT_ACCURACY_FALLBACK = 2000.0 (conservative fallback for unknown)
+- PRIVACY_ACCURACY_FALLBACK = 200.0 (200m - Bluetooth range + GPS error margin)
 """
 
 from __future__ import annotations
@@ -444,19 +444,21 @@ class TestFusionSelfHealing:
         assert safe_accuracy(50.0) == 50.0
 
     def test_fusion_weight_calculation(self) -> None:
-        """Corrupted accuracy (0.0) should have near-zero weight in fusion."""
+        """Corrupted accuracy (0.0) should have much lower weight in fusion."""
         # Weight is 1/accuracy² - smaller accuracy = higher weight
-        # 0.0 → fallback (2000m) → weight = 1/2000² = 0.00000025
-        # 50m → weight = 1/50² = 0.0004
+        # 0.0 → fallback (200m) → weight = 1/200² = 0.000025
+        # 50m → weight = 1/50² = 0.0004 → 16x higher weight
+        # 20m → weight = 1/20² = 0.0025 → 100x higher weight
 
         fallback_weight = 1 / (DEFAULT_ACCURACY_FALLBACK**2)
         real_weight = 1 / (50.0**2)
 
-        # Real data should have ~1600x more weight than fallback
+        # Real data (50m) should have 16x more weight than fallback (200m)
+        # 200²/50² = 40000/2500 = 16
         weight_ratio = real_weight / fallback_weight
 
-        assert weight_ratio > 1000, (
-            f"Real data (50m) should have >1000x more weight than fallback.\n"
+        assert weight_ratio > 10, (
+            f"Real data (50m) should have >10x more weight than fallback.\n"
             f"Ratio: {weight_ratio:.1f}x\n"
             f"This ensures corrupted values (0.0) are quickly overwritten."
         )
@@ -548,7 +550,7 @@ class TestZeroAccuracyRetention:
 
         Chain:
         1. Decoder: Sees 0.0 -> removes key (for ranking purposes)
-        2. Cache: Sees missing key -> sets fallback 2000.0
+        2. Cache: Sees missing key -> sets fallback 200.0
         3. Result: Location preserved, marked as "inaccurate"
         """
         from custom_components.googlefindmy.coordinator.cache import CacheOperations
@@ -583,15 +585,15 @@ class TestZeroAccuracyRetention:
         assert final_acc is not None, "Accuracy must NOT be None"
 
     def test_downgraded_report_loses_to_real_gps(self) -> None:
-        """A downgraded report (2000m) must lose to real GPS (20m) in ranking.
+        """A downgraded report (200m) must lose to real GPS (20m) in ranking.
 
         This ensures the "honest uncertainty" marking actually works.
         """
-        # Downgraded report (was 0.0, now 2000.0)
+        # Downgraded report (was 0.0, now 200.0)
         downgraded_report: dict[str, Any] = {
             "latitude": 48.100,
             "longitude": 11.100,
-            "accuracy": DEFAULT_ACCURACY_FALLBACK,  # 2000m (was 0.0)
+            "accuracy": DEFAULT_ACCURACY_FALLBACK,  # 200m (was 0.0)
             "last_seen": 1700000100,
             "is_own_report": False,
         }
@@ -610,9 +612,9 @@ class TestZeroAccuracyRetention:
         assert best is not None
         best_acc = best.get("accuracy")
 
-        # Real GPS (20m) must win against downgraded (2000m)
+        # Real GPS (20m) must win against downgraded (200m)
         assert best_acc == 20.0, (
-            f"Real GPS (20m) should beat downgraded report (2000m).\n"
+            f"Real GPS (20m) should beat downgraded report (200m).\n"
             f"Got: {best_acc}m\n"
             f"Ranking: smaller accuracy = better precision = wins"
         )
@@ -624,7 +626,7 @@ class TestZeroAccuracyRetention:
         1. Input: accuracy=0.0
         2. Decoder: removes key (< MIN_VALID_ACCURACY)
         3. Cache: sets fallback
-        4. Output: valid location with 2000m accuracy
+        4. Output: valid location with 200m accuracy
         """
         # Step 1: Simulate decoder behavior
         from custom_components.googlefindmy.ProtoDecoders.decoder import (


### PR DESCRIPTION
…ation

User feedback: A 2km fallback radius is useless for finding a tracker. Since trackers use Bluetooth (~100m range) + GPS error margin (~100m), 200m is physically plausible and still useful for map navigation.

Math validation: 200m fallback loses to real GPS (20-50m) in fusion:
- Weight ratio: 200²/20² = 100x lower weight for fallback data
- Self-healing: Real GPS data quickly overrides corrupted values

Changes:
- PRIVACY_ACCURACY_FALLBACK = 200.0m (new canonical constant)
- DEFAULT_ACCURACY_FALLBACK = alias for backward compatibility
- Updated docstrings and test assertions to reflect 200m value

<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
