### PR TITLE
Fix tracker data missing in integration

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -977,8 +977,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         try:
             ts = _parse_epoch_seconds(time_ts, now_wall)
             if ts is None:
-                _LOGGER.debug(
-                    "Dropping one location report due to invalid or missing timestamp."
+                _LOGGER.warning(
+                    "Dropping one location report due to invalid or missing timestamp (raw=%r).",
+                    time_ts,
                 )
                 continue
 
@@ -1014,8 +1015,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
 
             decrypted_location = _ensure_bytes(decrypted_location_raw)
             if decrypted_location is None:
-                _LOGGER.debug(
-                    "Decrypted location payload is not bytes; dropping one report"
+                _LOGGER.warning(
+                    "Decrypted location payload is not bytes (type=%s); dropping one report",
+                    type(decrypted_location_raw).__name__,
                 )
                 continue
 
@@ -1029,12 +1031,22 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     name="",
                 )
             )
-        except Exception as one_exc:
-            # Continue with other reports (per-item resilience; avoid warn spam)
-            _LOGGER.debug("Failed to process one location report: %s", one_exc)
+        except (AttributeError, KeyError, TypeError, ValueError) as expected_exc:
+            # Expected errors from malformed protobuf data - log at warning level
+            _LOGGER.warning(
+                "Failed to process one location report (malformed data): %s",
+                expected_exc,
+            )
+        except Exception as unexpected_exc:
+            # Unexpected errors indicate bugs or API changes - log with stack trace
+            _LOGGER.error(
+                "Unexpected error processing location report: %s",
+                unexpected_exc,
+                exc_info=True,
+            )
 
     if not wrapped:
-        _LOGGER.debug("[DecryptLocations] No locations found.")
+        _LOGGER.info("[DecryptLocations] No locations found.")
         # FIX: Merge metadata_update into the returned payload even when no locations.
         # This ensures encrypted_identity_key, secrets_creation_date, owner_key_version,
         # identity_key, etc. are returned for devices (like phones) that have these
@@ -1094,7 +1106,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     # Protobuf parsing is relatively cheap → inline
                     proto_loc.ParseFromString(loc.decrypted_location)
                 except DecodeError as de:
-                    _LOGGER.debug(
+                    _LOGGER.warning(
                         "Failed to parse Location protobuf; dropping one report: %s", de
                     )
                     continue
@@ -1105,7 +1117,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 longitude = proto_loc.longitude / 1e7
                 if not _is_valid_latlon(latitude, longitude):
                     # Keep the message non-sensitive: do not print raw coordinates.
-                    _LOGGER.debug(
+                    _LOGGER.warning(
                         "Dropping invalid/out-of-bounds coordinates from one report"
                     )
                     continue

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -21,6 +21,7 @@ import time
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+from aiohttp import ClientConnectionError, ClientError
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
 from ..const import DEFAULT_MIN_POLL_INTERVAL
@@ -562,9 +563,21 @@ class LocateOperations:
             except Exception:
                 pass
             return False
+        except (asyncio.TimeoutError, TimeoutError, ClientConnectionError, ClientError) as conn_err:
+            _LOGGER.warning(
+                "Connection failed during play_sound for %s: %s",
+                device_id,
+                conn_err,
+            )
+            self.note_error(conn_err, where="async_play_sound", device=device_id)
+            self._note_push_transport_problem()
+            return False
         except Exception as err:
-            _LOGGER.debug(
-                "async_play_sound raised for %s: %s; entering cooldown", device_id, err
+            _LOGGER.error(
+                "Unexpected error during play_sound for %s: %s",
+                device_id,
+                err,
+                exc_info=True,
             )
             self.note_error(err, where="async_play_sound", device=device_id)
             self._note_push_transport_problem()
@@ -633,9 +646,21 @@ class LocateOperations:
             except Exception:
                 pass
             return False
+        except (asyncio.TimeoutError, TimeoutError, ClientConnectionError, ClientError) as conn_err:
+            _LOGGER.warning(
+                "Connection failed during stop_sound for %s: %s",
+                device_id,
+                conn_err,
+            )
+            self.note_error(conn_err, where="async_stop_sound", device=device_id)
+            self._note_push_transport_problem()
+            return False
         except Exception as err:
-            _LOGGER.debug(
-                "async_stop_sound raised for %s: %s; entering cooldown", device_id, err
+            _LOGGER.error(
+                "Unexpected error during stop_sound for %s: %s",
+                device_id,
+                err,
+                exc_info=True,
             )
             self.note_error(err, where="async_stop_sound", device=device_id)
             self._note_push_transport_problem()

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -563,7 +563,7 @@ class LocateOperations:
             except Exception:
                 pass
             return False
-        except (asyncio.TimeoutError, TimeoutError, ClientConnectionError, ClientError) as conn_err:
+        except (TimeoutError, ClientConnectionError, ClientError) as conn_err:
             _LOGGER.warning(
                 "Connection failed during play_sound for %s: %s",
                 device_id,
@@ -646,7 +646,7 @@ class LocateOperations:
             except Exception:
                 pass
             return False
-        except (asyncio.TimeoutError, TimeoutError, ClientConnectionError, ClientError) as conn_err:
+        except (TimeoutError, ClientConnectionError, ClientError) as conn_err:
             _LOGGER.warning(
                 "Connection failed during stop_sound for %s: %s",
                 device_id,

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1118,7 +1118,7 @@ class PollingOperations:
                                 )
                             else:
                                 if should_filter:
-                                    _LOGGER.debug(
+                                    _LOGGER.warning(
                                         "Filtering out Google Home spam detection for %s",
                                         dev_name,
                                     )
@@ -1209,7 +1209,7 @@ class PollingOperations:
                         )
                         if not self._normalize_coords(location, device_label=dev_name):
                             if not location.get("semantic_name"):
-                                _LOGGER.debug(
+                                _LOGGER.warning(
                                     "No location data (coordinates or semantic name) available for %s in this update.",
                                     dev_name,
                                 )


### PR DESCRIPTION
<!--
This is the operational checklist for PRs in this repository.
It implements the spirit of AGENTS.md without blocking urgent fixes.

Notes for AI/automation:
- You MAY pre-check boxes you have satisfied in this PR.
- Only mark items you have actually performed or verified.
-->

# Summary
<!-- 1–3 sentences: What changed and why it matters for users/reviewers. -->

- Type: ☐ fix ☐ feat ☐ refactor ☐ docs ☐ chore
- Scope/Area: …
- Linked issues: Fixes #…

## Motivation
<!-- Why are we doing this? Problem statement, user impact, context. Keep it crisp. -->

---

## Change Log (human-readable)
<!-- Keep this high-signal, mirroring your commit intent. -->

### Added
<!-- New behavior, services, entities, helpers, flags. -->
- …

### Changed
<!-- Modifications to existing behavior; migrations; clarified guarantees. -->
- …

### Fixed
<!-- Bugs/addressed regressions; include 1–2 bullets per root cause if known. -->
- …

### Removed
<!-- Deleted code/paths, legacy options; note if replacement exists. -->
- …

### Performance
<!-- Notable latency/CPU/memory reductions; micro-optimizations with rationale. -->
- …

### Security/Privacy
<!-- Redaction hardening, token handling, diagnostics safety, etc. -->
- …

### Compatibility
<!-- User-facing compatibility: breaking changes (expected none), migrations, deprecations. -->
- …

---

## Evidence (optional but helpful)
<!-- Logs, screenshots, sample diagnostics (redacted), before/after metrics, etc. -->
<details>
<summary>Expand for screenshots/logs</summary>

</details>

---

## Tests (MUST)
- ☐ `pytest -q` passes locally
- ☐ New/updated **unit/integration tests** cover the change
- ☐ For **bugfixes**: a **minimal regression test** is included that fails without the fix and passes with it
- Coverage targets:
  - ☐ `config_flow.py` remains **100%**
  - ☐ Total ≥ **95%**
    ☐ Temporary dip due to necessary code removal — **follow-up issue** opened: #___

### Expected areas (check all that apply)
- ☐ **Config flow**: user/invalid, duplicate abort (`async_set_unique_id` + `_abort_if_unique_id_configured`), connectivity pre-check, **reauth** (success/failure → reload), **reconfigure**
- ☐ **Lifecycle**: `async_setup_entry`, **reload**, `async_unload_entry` (no zombie listeners)
- ☐ **Coordinator & availability**: `UpdateFailed` on transient errors; entities flip to `unavailable`; single “down/back” log
- ☐ **Diagnostics**: strictly redacted (no tokens/emails/locations/IDs)
- ☐ **Services**: success/error paths with localized messages; rate limiting where applicable
- ☐ **Discovery & dynamic devices** (if supported)
- ☐ **Token cache**: expiry detection, refresh, failure propagation; **no hidden fallbacks**

---

## Token Cache Safety (MUST)
- ☐ Single **entry-scoped** `TokenCache` (no globals)
- ☐ `TokenCache` is **passed explicitly** through call chains (`__init__` → API/clients → coordinator → entities)
- ☐ Refresh is **synchronous** on the calling path or fails fast with a translatable error
- ☐ On refresh failure: raises `ConfigEntryAuthFailed`
- ☐ Regression tests for stale tokens / cross-account bleed / refresh races

---

## Docs & i18n
- ☐ No hard-coded UI strings in Python
- ☐ `translations/*.json` updated (services & exceptions via `translation_key`)
- ☐ README updated (only if user-visible behavior/options changed)
- ☐ Missing files are **non-blocking**; propose stub/follow-up if needed

---

## Quality Scale (lightweight, non-blocking)
- Touched rule IDs & evidence (file+line / test name / PR link):
  - e.g. `strict-typing`: attach mypy log or CI link
  - e.g. `diagnostics`: `tests/test_diagnostics.py::test_redaction`

---

## Deprecation Check (concise)
- Versions scanned: current HA ± 2 releases
- Notes found (links): …
- Impact here: …

---

## Risk & Rollback
- Risk level: ☐ low ☐ medium ☐ high
- Rollback plan: how to revert safely if needed (and whether data/entity IDs remain consistent)

---

## Local Verification (run before pushing)
### bash:
pre-commit run --all-files
python3 -m script.hassfest
pytest -q

---

## Reviewer Notes (optional)

* Edge cases to double-check:
* Follow-up tasks (if any):
