### PR TITLE
fix: reduce log level for transient FCM connection errors during retry

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -685,8 +685,10 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             self.logger.debug("Connected to MCS endpoint (%s,%s)", MCS_HOST, MCS_PORT)
             return True
         except OSError as oex:
-            self.logger.error(
-                "Could not connected to MCS endpoint (%s,%s): %s",
+            # Log at DEBUG level since _connect_with_retry() handles retries
+            # and will log ERROR if all attempts fail
+            self.logger.debug(
+                "Could not connect to MCS endpoint (%s,%s): %s",
                 MCS_HOST,
                 MCS_PORT,
                 oex,


### PR DESCRIPTION
Individual connection failures during retry attempts are now logged at DEBUG level instead of ERROR. The ERROR level is reserved for the final failure after all retry attempts are exhausted. This reduces log noise during transient network issues since the retry mechanism handles these cases gracefully.

Also fixed typo: "Could not connected" → "Could not connect"
