### PR TITLE
fix: add missing 'accuracy_sanitized_count' stat to coordinator initi…

### DIFF
--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -754,6 +754,7 @@ class GoogleFindMyCoordinator(
             "future_ts_drop_count": 0,  # timestamps too far in the future
             "drop_reason_invalid_ts": 0,  # invalid/stale timestamps (detail bucket)
             "fused_updates": 0,  # overlapping fixes fused to stabilize coordinates
+            "accuracy_sanitized_count": 0,  # accuracy values clamped to valid range
         }
         _LOGGER.debug("Initialized stats: %s", self.stats)
 


### PR DESCRIPTION
…alization

The stat was being incremented in cache.py but was never registered in the stats dictionary, causing repeated warnings in logs: "Tried to increment unknown stat 'accuracy_sanitized_count'"

