### PR TITLE
fix: improve InvalidTag error handling in decrypt_locations.py

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -15,6 +15,8 @@ from importlib import import_module
 from itertools import zip_longest
 from typing import TYPE_CHECKING, Any, cast
 
+from cryptography.exceptions import InvalidTag
+
 from custom_components.googlefindmy import get_proto_decoder
 from custom_components.googlefindmy.Auth.username_provider import username_string
 from custom_components.googlefindmy.const import MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S
@@ -1036,6 +1038,19 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             _LOGGER.warning(
                 "Failed to process one location report (malformed data): %s",
                 expected_exc,
+            )
+        except InvalidTag:
+            # InvalidTag means AES-GCM authentication failed during decryption.
+            # This is usually NOT a bug - common causes include:
+            # - Google authentication expired (user needs to re-auth in Google app)
+            # - Shared device where the sharing account's auth is stale
+            # - Tracker offline/dead battery causing stale encrypted data
+            # Log as warning (not error) since user action typically resolves this.
+            _LOGGER.warning(
+                "Decryption failed (InvalidTag): The location report could not be "
+                "authenticated. This often happens when Google authentication is "
+                "stale - try re-authenticating the account in the Google app. "
+                "For shared devices, the sharing account may need to re-authenticate."
             )
         except Exception as unexpected_exc:
             # Unexpected errors indicate bugs or API changes - log with stack trace


### PR DESCRIPTION
Handle cryptography.exceptions.InvalidTag explicitly instead of letting it fall into the generic Exception handler. This provides users with a helpful warning message explaining common causes:

- Google authentication expired (needs re-auth in Google app)
- Shared device where the sharing account's auth is stale
- Tracker offline/dead battery causing stale encrypted data

Previously, InvalidTag errors showed as ERROR with full stack trace, which was alarming to users. Now logged as WARNING with actionable guidance, since re-authenticating the Google account typically resolves the issue.

Addresses user report where shared device auth became stale and was resolved by re-authenticating the sharing account in the Google app.
