### PR TITLE
fix: correct off-by-one in retry attempt count display

### DIFF
--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -1562,7 +1562,7 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                                 "Nova API request failed (Attempt %d/%d): HTTP %d for %s. "
                                 "Server response: %s. Retrying in %.2f seconds...",
                                 retries_used + 1,
-                                NOVA_MAX_RETRIES,
+                                NOVA_MAX_RETRIES + 1,
                                 status,
                                 api_scope,
                                 text_snippet,
@@ -1582,12 +1582,12 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                             )
                             if status == HTTP_TOO_MANY_REQUESTS:
                                 raise NovaRateLimitError(
-                                    f"Nova API rate limited after {NOVA_MAX_RETRIES} attempts. "
+                                    f"Nova API rate limited after {NOVA_MAX_RETRIES + 1} attempts. "
                                     f"Server response: {text_snippet}"
                                 )
                             raise NovaHTTPError(
                                 status,
-                                f"Nova API failed after {NOVA_MAX_RETRIES} attempts. "
+                                f"Nova API failed after {NOVA_MAX_RETRIES + 1} attempts. "
                                 f"Server response: {text_snippet}",
                             )
 
@@ -1606,7 +1606,7 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                     _LOGGER.warning(
                         "Nova API request failed (Attempt %d/%d): %s for %s. Retrying in %.2f seconds...",
                         retries_used + 1,
-                        NOVA_MAX_RETRIES,
+                        NOVA_MAX_RETRIES + 1,
                         type(e).__name__,
                         api_scope,
                         delay,


### PR DESCRIPTION
NOVA_MAX_RETRIES=6 means 6 retries, so total attempts = 7 (1 initial + 6 retries). The log messages and exception strings used NOVA_MAX_RETRIES as the denominator, showing "Attempt 1/6" instead of "Attempt 1/7". This made it appear as if retries never progressed past the first attempt, when in reality the second attempt was succeeding silently.

Fixed in all 4 affected locations:
- HTTP error retry warning (line 1565)
- Rate limit exhaustion error (line 1585)
- HTTP error exhaustion error (line 1590)
- Network error retry warning (line 1609)

https://claude.ai/code/session_01PsGnG9dtEfD4JGV7qWZbDg

