### PR TITLE
fix: relax pycares constraint from >=4.4.0,<5 to >=4.4.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7591,4 +7591,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13.2"
-content-hash = "f65801b8f429b614988edc444c54577e4d8d9e480dc31c90b0116a707dfe10e1"
+content-hash = "e2065374d627f066523d806729c05bdcb11bf409714be92263f45eca337672ec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ pip-audit = ">=2.6"
 # Additional dev tools
 pyyaml = ">=6.0.2"
 grpclib = ">=0.4.7"
-pycares = ">=4.4.0,<5"
+pycares = ">=4.4.0"
 certifi = ">=2024.7.4"
 
 # Release automation


### PR DESCRIPTION
HA 2026.2 requires pycares >=5.0.0, so the upper bound <5 must be removed to maintain compatibility.

https://claude.ai/code/session_01Ld3xcJSc7QdH5DAyAEaLkY
