### PR TITLE
fix: sync all language files with en.json as canonical reference

### DIFF
--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -256,10 +256,12 @@
       },
       "settings": {
         "title": "Options",
-        "description": "Adjust location settings:\n• Location poll interval: How often to poll for locations (60–3600 seconds)\n• Device poll delay: Delay between device polls (1–60 seconds)\n\nGoogle Home Filter:\n• Enable to associate detections from Google Home devices with the Home zone\n• Keywords support partial matching (comma-separated)\n• Example: “nest” matches “Kitchen Nest Mini”",
+        "description": "Adjust location settings:\n• Location poll interval: How often to poll for locations (60–3600 seconds)\n• Device poll delay: Delay between device polls (1–60 seconds)\n• Stale threshold: After this time without updates, tracker state becomes unknown\n\nGoogle Home Filter:\n• Enable to associate detections from Google Home devices with the Home zone\n• Keywords support partial matching (comma-separated)\n• Example: nest matches Kitchen Nest Mini",
         "data": {
           "location_poll_interval": "Location poll interval (s)",
           "device_poll_delay": "Device poll delay (s)",
+          "stale_threshold_enabled": "Enable stale threshold",
+          "stale_threshold": "Stale threshold (s)",
           "google_home_filter_enabled": "Filter Google Home devices",
           "google_home_filter_keywords": "Filter keywords (comma-separated)",
           "enable_stats_entities": "Create statistics entities",
@@ -269,6 +271,8 @@
           "subentry": "Feature group"
         },
         "data_description": {
+          "stale_threshold_enabled": "When enabled, the tracker state becomes unknown after the stale threshold time without updates. When disabled, the tracker always shows the last known location.",
+          "stale_threshold": "After this many seconds without a location update, the tracker state becomes unknown. Last known coordinates remain available in attributes. Default: 7200 (2 hours).",
           "delete_caches_on_remove": "Remove cached tokens and device metadata when this entry is deleted.",
           "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire.",
           "contributor_mode": "Choose how your device contributes to Google's network (High-traffic areas by default, or All areas for crowdsourced reporting).",
@@ -308,15 +312,6 @@
         "data": {
           "delete_subentry": "Subentry to delete",
           "fallback_subentry": "Fallback feature group"
-        }
-      },
-      "credentials": {
-        "title": "Update Credentials for {account_email}",
-        "description": "⚠️ This will update credentials for the current account only.\n\nTo add a different account, cancel this and use '+ Add Integration' from the Integrations page instead.",
-        "data": {
-          "new_secrets_json": "New secrets.json content (optional)",
-          "new_oauth_token": "New OAuth Token (optional)",
-          "new_google_email": "New Google Email (optional)"
         }
       }
     },
@@ -429,6 +424,28 @@
       },
       "reset_statistics": {
         "name": "Reset Statistics"
+      },
+      "regenerate_aas_token": {
+        "name": "Regenerate AAS Token",
+        "state_attributes": {
+          "cooldown_seconds": {
+            "name": "Cooldown period (s)"
+          },
+          "cooldown_remaining": {
+            "name": "Cooldown remaining (s)"
+          }
+        }
+      },
+      "regenerate_adm_token": {
+        "name": "Regenerate ADM Token",
+        "state_attributes": {
+          "cooldown_seconds": {
+            "name": "Cooldown period (s)"
+          },
+          "cooldown_remaining": {
+            "name": "Cooldown remaining (s)"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -486,11 +503,11 @@
           "status": {
             "name": "Status"
           },
-        "semantic_name": {
-          "name": "Semantic label"
-        },
-        "battery_level": {
-          "name": "Battery level"
+          "semantic_name": {
+            "name": "Semantic label"
+          },
+          "battery_level": {
+            "name": "Battery level"
           },
           "last_seen": {
             "name": "Last seen (reported)"
@@ -518,6 +535,18 @@
           },
           "altitude_m": {
             "name": "Altitude (m)"
+          },
+          "location_age": {
+            "name": "Location age (s)"
+          },
+          "location_status": {
+            "name": "Location status"
+          },
+          "last_latitude": {
+            "name": "Last known latitude"
+          },
+          "last_longitude": {
+            "name": "Last known longitude"
           }
         }
       }

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -256,7 +256,7 @@
       },
       "settings": {
         "title": "Optionen",
-        "description": "Einstellungen für die Ortung anpassen:\n• Positionsabfrage-Intervall: Wie häufig Positionen abgefragt werden (60–3600 Sekunden)\n• Verzögerung zwischen Geräteabfragen: Abstand zwischen den Abfragen einzelner Geräte (1–60 Sekunden)\n• Veraltungsgrenze: Nach dieser Zeit ohne Update wird der Tracker-Status unbekannt\n\nGoogle-Home-Filter:\n• Aktivieren, um Ortungen durch Google-Home-Geräte der Zuhause-Zone zuzuordnen\n• Schlüsselwörter unterstützen Teilübereinstimmungen (kommagetrennt)\n• Beispiel: nest passt zu Küche Nest Mini",
+        "description": "Standorteinstellungen anpassen:\n• Standort-Abfrageintervall: Wie oft Standorte abgefragt werden (60–3600 Sekunden)\n• Geräte-Abfrageverzögerung: Verzögerung zwischen Geräteabfragen (1–60 Sekunden)\n• Veraltungsgrenze: Nach dieser Zeit ohne Update wird der Tracker-Status unbekannt\n\nGoogle Home-Filter:\n• Aktivieren, um Erkennungen von Google Home-Geräten mit der Heimzone zu verknüpfen\n• Schlüsselwörter unterstützen Teilübereinstimmungen (kommagetrennt)\n• Beispiel: „nest“ stimmt mit „Küche Nest Mini“ überein",
         "data": {
           "location_poll_interval": "Positionsabfrage-Intervall (s)",
           "device_poll_delay": "Verzögerung zwischen Geräteabfragen (s)",
@@ -620,9 +620,9 @@
       "stat_invalid_coords": {
         "name": "Ungültige Koordinaten"
       },
-        "stat_fused_updates": {
-            "name": "Fusionierte Standort-Updates"
-        }
+      "stat_fused_updates": {
+        "name": "Fusionierte Standort-Updates"
+      }
     }
   },
   "issues": {

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -163,26 +163,26 @@
           "credentials": "Actualizar credenciales",
           "settings": "Modificar ajustes",
           "visibility": "Visibilidad de dispositivos",
-          "semantic_locations": "Semantic locations",
+          "semantic_locations": "Ubicaciones semánticas",
           "repairs": "Reparaciones de grupos de funciones"
         }
       },
       "semantic_locations_menu": {
-        "title": "Semantic locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Ubicaciones semánticas",
+        "description": "Gestiona las anulaciones de ubicación semántica. Asignaciones existentes:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_location_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Agregar ubicación semántica",
+          "semantic_location_edit": "Editar ubicación semántica",
+          "semantic_locations_delete": "Eliminar ubicación semántica"
         }
       },
       "semantic_locations": {
-        "title": "Semantic Locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Ubicaciones semánticas",
+        "description": "Gestiona las anulaciones de ubicación semántica. Asignaciones existentes:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_locations_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Agregar ubicación semántica",
+          "semantic_locations_edit": "Editar ubicación semántica",
+          "semantic_locations_delete": "Eliminar ubicación semántica"
         }
       },
       "semantic_locations_add": {
@@ -199,10 +199,10 @@
         }
       },
       "semantic_locations_edit": {
-        "title": "Choose semantic location",
-        "description": "Select a semantic location to edit.",
+        "title": "Elegir ubicación semántica",
+        "description": "Selecciona una ubicación semántica para editar.",
         "data": {
-          "semantic_location": "Semantic location"
+          "semantic_location": "Ubicación semántica"
         }
       },
       "semantic_location_edit": {
@@ -232,10 +232,10 @@
         }
       },
       "semantic_locations_delete": {
-        "title": "Delete semantic locations",
-        "description": "Select semantic locations to delete.",
+        "title": "Eliminar ubicaciones semánticas",
+        "description": "Selecciona ubicaciones semánticas para eliminar.",
         "data": {
-          "semantic_locations": "Semantic locations"
+          "semantic_locations": "Ubicaciones semánticas"
         }
       },
       "credentials": {
@@ -256,7 +256,7 @@
       },
       "settings": {
         "title": "Opciones",
-        "description": "Ajustar la configuración de localización:\n• Intervalo de sondeo de ubicación: frecuencia con la que se consultan ubicaciones (60–3600 segundos)\n• Retardo entre sondeos de dispositivos: intervalo entre consultas por dispositivo (1–60 segundos)\n• Umbral de obsolescencia: tras este tiempo sin actualizaciones, el estado del rastreador pasa a desconocido\n\nFiltro de Google Home:\n• Activar para asociar las detecciones de Google Home con la zona «Hogar»\n• Las palabras clave admiten coincidencias parciales (separadas por comas)\n• Ejemplo: «nest» coincide con «Kitchen Nest Mini»",
+        "description": "Ajustar opciones de localización:\n• Intervalo de sondeo de ubicación: Con qué frecuencia sondear ubicaciones (60–3600 segundos)\n• Retraso de sondeo de dispositivos: Retraso entre sondeos de dispositivos (1–60 segundos)\n• Umbral de obsolescencia: Tras este tiempo sin actualizaciones, el estado del rastreador pasa a desconocido\n\nFiltro Google Home:\n• Activar para asociar detecciones de dispositivos Google Home con la zona Hogar\n• Las palabras clave admiten coincidencia parcial (separadas por comas)\n• Ejemplo: \"nest\" coincide con \"Kitchen Nest Mini\"",
         "data": {
           "location_poll_interval": "Intervalo de sondeo de ubicación (s)",
           "device_poll_delay": "Retardo entre sondeos de dispositivos (s)",
@@ -324,15 +324,15 @@
       "choose_one": "Proporciona exactamente un método de credenciales.",
       "required": "Este campo es obligatorio.",
       "invalid_token": "Credenciales no válidas (token/correo). Comprueba el formato y el contenido.",
-      "duplicate_name": "Semantic name already exists. Choose a different name.",
-      "duplicate_semantic_location": "Semantic name already exists. Choose a different name.",
+      "duplicate_name": "El nombre semántico ya existe. Elige un nombre diferente.",
+      "duplicate_semantic_location": "El nombre semántico ya existe. Elige un nombre diferente.",
       "unknown": "Error inesperado.",
       "invalid_subentry": "Elige un grupo de funciones válido."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguración correcta.",
       "no_ignored_devices": "No hay dispositivos ignorados para restaurar.",
-      "no_semantic_locations": "No semantic locations are configured.",
+      "no_semantic_locations": "No hay ubicaciones semánticas configuradas.",
       "repairs_no_subentries": "No hay grupos de funciones que reparar.",
       "repair_no_devices": "Selecciona al menos un dispositivo para mover.",
       "subentry_move_success": "Dispositivos asignados a **{subentry}** ({count} actualizados).",
@@ -620,9 +620,9 @@
       "stat_invalid_coords": {
         "name": "Coordenadas no válidas"
       },
-        "stat_fused_updates": {
-            "name": "Actualizaciones de ubicación fusionadas"
-        }
+      "stat_fused_updates": {
+        "name": "Actualizaciones de ubicación fusionadas"
+      }
     }
   },
   "issues": {

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -163,26 +163,26 @@
           "credentials": "Mettre à jour les identifiants",
           "settings": "Modifier les paramètres",
           "visibility": "Visibilité des appareils",
-          "semantic_locations": "Semantic locations",
+          "semantic_locations": "Emplacements sémantiques",
           "repairs": "Réparations des groupes de fonctionnalités"
         }
       },
       "semantic_locations_menu": {
-        "title": "Semantic locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Emplacements sémantiques",
+        "description": "Gérez les remplacements d’emplacements sémantiques. Correspondances existantes :\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_location_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Ajouter un emplacement sémantique",
+          "semantic_location_edit": "Modifier un emplacement sémantique",
+          "semantic_locations_delete": "Supprimer un emplacement sémantique"
         }
       },
       "semantic_locations": {
-        "title": "Semantic Locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Emplacements sémantiques",
+        "description": "Gérez les remplacements d’emplacements sémantiques. Correspondances existantes :\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_locations_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Ajouter un emplacement sémantique",
+          "semantic_locations_edit": "Modifier un emplacement sémantique",
+          "semantic_locations_delete": "Supprimer un emplacement sémantique"
         }
       },
       "semantic_locations_add": {
@@ -199,10 +199,10 @@
         }
       },
       "semantic_locations_edit": {
-        "title": "Choose semantic location",
-        "description": "Select a semantic location to edit.",
+        "title": "Choisir un emplacement sémantique",
+        "description": "Sélectionnez un emplacement sémantique à modifier.",
         "data": {
-          "semantic_location": "Semantic location"
+          "semantic_location": "Emplacement sémantique"
         }
       },
       "semantic_location_edit": {
@@ -232,10 +232,10 @@
         }
       },
       "semantic_locations_delete": {
-        "title": "Delete semantic locations",
-        "description": "Select semantic locations to delete.",
+        "title": "Supprimer des emplacements sémantiques",
+        "description": "Sélectionnez les emplacements sémantiques à supprimer.",
         "data": {
-          "semantic_locations": "Semantic locations"
+          "semantic_locations": "Emplacements sémantiques"
         }
       },
       "credentials": {
@@ -256,7 +256,7 @@
       },
       "settings": {
         "title": "Options",
-        "description": "Ajuster les paramètres de localisation :\n• Intervalle d'interrogation de localisation : fréquence des interrogations (60–3600 secondes)\n• Délai entre interrogations d'appareils : intervalle entre les requêtes par appareil (1–60 secondes)\n• Seuil d'obsolescence : au-delà de ce délai sans mise à jour, l'état du traceur passe à inconnu\n\nFiltre Google Home :\n• Activer pour associer les détections des appareils Google Home à la zone Domicile\n• Les mots-clés prennent en charge les correspondances partielles (séparés par des virgules)\n• Exemple : « nest » correspond à « Kitchen Nest Mini »",
+        "description": "Ajuster les paramètres de localisation :\n• Intervalle de sondage de localisation : Fréquence de sondage des localisations (60–3600 secondes)\n• Délai entre les sondages d’appareils : Délai entre les sondages d’appareils (1–60 secondes)\n• Seuil d’obsolescence : Au-delà de ce délai sans mise à jour, l’état du traceur passe à inconnu\n\nFiltre Google Home :\n• Activer pour associer les détections d’appareils Google Home à la zone Domicile\n• Les mots-clés prennent en charge la correspondance partielle (séparés par des virgules)\n• Exemple : « nest » correspond à « Kitchen Nest Mini »",
         "data": {
           "location_poll_interval": "Intervalle d'interrogation de position (s)",
           "device_poll_delay": "Délai entre les interrogations d'appareil (s)",
@@ -324,15 +324,15 @@
       "choose_one": "Veuillez fournir exactement une méthode d’authentification.",
       "required": "Ce champ est obligatoire.",
       "invalid_token": "Identifiants invalides (jeton/e-mail). Veuillez vérifier le format et le contenu.",
-      "duplicate_name": "Semantic name already exists. Choose a different name.",
-      "duplicate_semantic_location": "Semantic name already exists. Choose a different name.",
+      "duplicate_name": "Le nom sémantique existe déjà. Choisissez un autre nom.",
+      "duplicate_semantic_location": "Le nom sémantique existe déjà. Choisissez un autre nom.",
       "unknown": "Erreur inattendue.",
       "invalid_subentry": "Choisissez un groupe de fonctionnalités valide."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguration réussie.",
       "no_ignored_devices": "Aucun appareil ignoré à restaurer.",
-      "no_semantic_locations": "No semantic locations are configured.",
+      "no_semantic_locations": "Aucun emplacement sémantique n’est configuré.",
       "repairs_no_subentries": "Aucun groupe de fonctionnalités à réparer.",
       "repair_no_devices": "Sélectionnez au moins un appareil à déplacer.",
       "subentry_move_success": "Appareils attribués à **{subentry}** ({count} mis à jour).",
@@ -620,9 +620,9 @@
       "stat_invalid_coords": {
         "name": "Coordonnées invalides"
       },
-        "stat_fused_updates": {
-            "name": "Mises à jour de position fusionnées"
-        }
+      "stat_fused_updates": {
+        "name": "Mises à jour de position fusionnées"
+      }
     }
   },
   "issues": {

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -163,26 +163,26 @@
           "credentials": "Aggiorna credenziali",
           "settings": "Modifica impostazioni",
           "visibility": "Visibilità dei dispositivi",
-          "semantic_locations": "Semantic locations",
+          "semantic_locations": "Posizioni semantiche",
           "repairs": "Riparazioni dei gruppi di funzionalità"
         }
       },
       "semantic_locations_menu": {
-        "title": "Semantic locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Posizioni semantiche",
+        "description": "Gestisci le sostituzioni delle posizioni semantiche. Corrispondenze esistenti:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_location_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Aggiungi posizione semantica",
+          "semantic_location_edit": "Modifica posizione semantica",
+          "semantic_locations_delete": "Elimina posizione semantica"
         }
       },
       "semantic_locations": {
-        "title": "Semantic Locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Posizioni semantiche",
+        "description": "Gestisci le sostituzioni delle posizioni semantiche. Corrispondenze esistenti:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_locations_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Aggiungi posizione semantica",
+          "semantic_locations_edit": "Modifica posizione semantica",
+          "semantic_locations_delete": "Elimina posizione semantica"
         }
       },
       "semantic_locations_add": {
@@ -199,10 +199,10 @@
         }
       },
       "semantic_locations_edit": {
-        "title": "Choose semantic location",
-        "description": "Select a semantic location to edit.",
+        "title": "Scegli posizione semantica",
+        "description": "Seleziona una posizione semantica da modificare.",
         "data": {
-          "semantic_location": "Semantic location"
+          "semantic_location": "Posizione semantica"
         }
       },
       "semantic_location_edit": {
@@ -232,10 +232,10 @@
         }
       },
       "semantic_locations_delete": {
-        "title": "Delete semantic locations",
-        "description": "Select semantic locations to delete.",
+        "title": "Elimina posizioni semantiche",
+        "description": "Seleziona le posizioni semantiche da eliminare.",
         "data": {
-          "semantic_locations": "Semantic locations"
+          "semantic_locations": "Posizioni semantiche"
         }
       },
       "credentials": {
@@ -256,7 +256,7 @@
       },
       "settings": {
         "title": "Opzioni",
-        "description": "Regola le impostazioni di localizzazione:\n• Intervallo di polling posizione: frequenza con cui interrogare le posizioni (60–3600 secondi)\n• Ritardo tra i polling dei dispositivi: intervallo tra le richieste per dispositivo (1–60 secondi)\n• Soglia di obsolescenza: dopo questo tempo senza aggiornamenti, lo stato del tracker diventa sconosciuto\n\nFiltro Google Home:\n• Abilita per associare i rilevamenti dei dispositivi Google Home alla zona Casa\n• Le parole chiave supportano corrispondenze parziali (separate da virgole)\n• Esempio: \"nest\" corrisponde a \"Kitchen Nest Mini\"",
+        "description": "Regola le impostazioni di localizzazione:\n• Intervallo di polling della posizione: Frequenza di polling delle posizioni (60–3600 secondi)\n• Ritardo di polling dei dispositivi: Ritardo tra i polling dei dispositivi (1–60 secondi)\n• Soglia di obsolescenza: Dopo questo tempo senza aggiornamenti, lo stato del tracker diventa sconosciuto\n\nFiltro Google Home:\n• Attiva per associare i rilevamenti dei dispositivi Google Home alla zona Casa\n• Le parole chiave supportano la corrispondenza parziale (separate da virgola)\n• Esempio: \"nest\" corrisponde a \"Kitchen Nest Mini\"",
         "data": {
           "location_poll_interval": "Intervallo di polling posizione (s)",
           "device_poll_delay": "Ritardo tra interrogazioni dei dispositivi (s)",
@@ -324,15 +324,15 @@
       "choose_one": "Fornisci esattamente un solo metodo di autenticazione.",
       "required": "Questo campo è obbligatorio.",
       "invalid_token": "Credenziali non valide (token/e-mail). Verifica formato e contenuto.",
-      "duplicate_name": "Semantic name already exists. Choose a different name.",
-      "duplicate_semantic_location": "Semantic name already exists. Choose a different name.",
+      "duplicate_name": "Il nome semantico esiste già. Scegli un nome diverso.",
+      "duplicate_semantic_location": "Il nome semantico esiste già. Scegli un nome diverso.",
       "unknown": "Errore imprevisto.",
       "invalid_subentry": "Scegli un gruppo di funzionalità valido."
     },
     "abort": {
       "reconfigure_successful": "Riconfigurazione riuscita.",
       "no_ignored_devices": "Non ci sono dispositivi ignorati da ripristinare.",
-      "no_semantic_locations": "No semantic locations are configured.",
+      "no_semantic_locations": "Non sono configurate posizioni semantiche.",
       "repairs_no_subentries": "Non ci sono gruppi di funzionalità da riparare.",
       "repair_no_devices": "Seleziona almeno un dispositivo da spostare.",
       "subentry_move_success": "Dispositivi assegnati a **{subentry}** ({count} aggiornati).",
@@ -620,9 +620,9 @@
       "stat_invalid_coords": {
         "name": "Coordinate non valide"
       },
-        "stat_fused_updates": {
-            "name": "Aggiornamenti di posizione fusi"
-        }
+      "stat_fused_updates": {
+        "name": "Aggiornamenti di posizione fusi"
+      }
     }
   },
   "issues": {

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -256,7 +256,7 @@
       },
       "settings": {
         "title": "Opties",
-        "description": "Locatie-instellingen aanpassen:\n• Locatie-pollinginterval: Hoe vaak locaties worden gepolld (60–3600 seconden)\n• Apparaat-pollingvertraging: Vertraging tussen apparaat-polls (1–60 seconden)\n\nGoogle Home-filter:\n• Schakel in om detecties van Google Home-apparaten te koppelen aan de Thuiszone\n• Trefwoorden ondersteunen gedeeltelijke overeenkomsten (kommagescheiden)\n• Voorbeeld: \"nest\" komt overeen met \"Keuken Nest Mini\"",
+        "description": "Locatie-instellingen aanpassen:\n• Locatie-pollinginterval: Hoe vaak locaties worden gepolld (60–3600 seconden)\n• Apparaat-pollingvertraging: Vertraging tussen apparaat-polls (1–60 seconden)\n• Verouderingsdrempel: Na deze tijd zonder updates wordt de trackerstatus onbekend\n\nGoogle Home-filter:\n• Schakel in om detecties van Google Home-apparaten te koppelen aan de Thuiszone\n• Trefwoorden ondersteunen gedeeltelijke overeenkomsten (kommagescheiden)\n• Voorbeeld: \"nest\" komt overeen met \"Keuken Nest Mini\"",
         "data": {
           "location_poll_interval": "Locatie-pollinginterval (s)",
           "device_poll_delay": "Apparaat-pollingvertraging (s)",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -163,26 +163,26 @@
           "credentials": "Zaktualizuj poświadczenia",
           "settings": "Zmień ustawienia",
           "visibility": "Widoczność urządzeń",
-          "semantic_locations": "Semantic locations",
+          "semantic_locations": "Lokalizacje semantyczne",
           "repairs": "Naprawy grup funkcji"
         }
       },
       "semantic_locations_menu": {
-        "title": "Semantic locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Lokalizacje semantyczne",
+        "description": "Zarządzaj nadpisaniami lokalizacji semantycznych. Istniejące mapowania:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_location_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Dodaj lokalizację semantyczną",
+          "semantic_location_edit": "Edytuj lokalizację semantyczną",
+          "semantic_locations_delete": "Usuń lokalizację semantyczną"
         }
       },
       "semantic_locations": {
-        "title": "Semantic Locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Lokalizacje semantyczne",
+        "description": "Zarządzaj nadpisaniami lokalizacji semantycznych. Istniejące mapowania:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_locations_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Dodaj lokalizację semantyczną",
+          "semantic_locations_edit": "Edytuj lokalizację semantyczną",
+          "semantic_locations_delete": "Usuń lokalizację semantyczną"
         }
       },
       "semantic_locations_add": {
@@ -199,10 +199,10 @@
         }
       },
       "semantic_locations_edit": {
-        "title": "Choose semantic location",
-        "description": "Select a semantic location to edit.",
+        "title": "Wybierz lokalizację semantyczną",
+        "description": "Wybierz lokalizację semantyczną do edycji.",
         "data": {
-          "semantic_location": "Semantic location"
+          "semantic_location": "Lokalizacja semantyczna"
         }
       },
       "semantic_location_edit": {
@@ -232,10 +232,10 @@
         }
       },
       "semantic_locations_delete": {
-        "title": "Delete semantic locations",
-        "description": "Select semantic locations to delete.",
+        "title": "Usuń lokalizacje semantyczne",
+        "description": "Wybierz lokalizacje semantyczne do usunięcia.",
         "data": {
-          "semantic_locations": "Semantic locations"
+          "semantic_locations": "Lokalizacje semantyczne"
         }
       },
       "credentials": {
@@ -256,7 +256,7 @@
       },
       "settings": {
         "title": "Opcje",
-        "description": "Dostosuj ustawienia lokalizacji:\n• Interwał odpytywania lokalizacji: jak często pobierać lokalizacje (60–3600 sekund)\n• Opóźnienie między odpytywaniem urządzeń: przerwa między zapytaniami dla urządzeń (1–60 sekund)\n\nFiltr Google Home:\n• Włącz, aby powiązać wykrycia z urządzeń Google Home ze strefą Dom\n• Słowa kluczowe obsługują częściowe dopasowania (oddzielone przecinkami)\n• Przykład: „nest” pasuje do „Kitchen Nest Mini”",
+        "description": "Dostosuj ustawienia lokalizacji:\n• Interwał odpytywania lokalizacji: Jak często pobierać lokalizacje (60–3600 sekund)\n• Opóźnienie między odpytywaniem urządzeń: Przerwa między zapytaniami dla urządzeń (1–60 sekund)\n• Próg nieaktualności: Po tym czasie bez aktualizacji status trackera zmieni się na nieznany\n\nFiltr Google Home:\n• Włącz, aby powiązać wykrycia z urządzeń Google Home ze strefą Dom\n• Słowa kluczowe obsługują częściowe dopasowania (oddzielone przecinkami)\n• Przykład: „nest“ pasuje do „Kitchen Nest Mini“",
         "data": {
           "location_poll_interval": "Interwał odpytywania lokalizacji (s)",
           "device_poll_delay": "Opóźnienie między odpytywaniem urządzeń (s)",
@@ -324,15 +324,15 @@
       "choose_one": "Podaj dokładnie jedną metodę poświadczeń.",
       "required": "To pole jest wymagane.",
       "invalid_token": "Nieprawidłowe dane logowania (token/e-mail). Sprawdź format i zawartość.",
-      "duplicate_name": "Semantic name already exists. Choose a different name.",
-      "duplicate_semantic_location": "Semantic name already exists. Choose a different name.",
+      "duplicate_name": "Nazwa semantyczna już istnieje. Wybierz inną nazwę.",
+      "duplicate_semantic_location": "Nazwa semantyczna już istnieje. Wybierz inną nazwę.",
       "unknown": "Wystąpił nieoczekiwany błąd.",
       "invalid_subentry": "Wybierz prawidłową grupę funkcji."
     },
     "abort": {
       "reconfigure_successful": "Ponowna konfiguracja zakończona pomyślnie.",
       "no_ignored_devices": "Brak ignorowanych urządzeń do przywrócenia.",
-      "no_semantic_locations": "No semantic locations are configured.",
+      "no_semantic_locations": "Nie skonfigurowano lokalizacji semantycznych.",
       "repairs_no_subentries": "Brak grup funkcji do naprawy.",
       "repair_no_devices": "Wybierz co najmniej jedno urządzenie do przeniesienia.",
       "subentry_move_success": "Urządzenia przypisane do **{subentry}** ({count} zaktualizowano).",
@@ -620,9 +620,9 @@
       "stat_invalid_coords": {
         "name": "Nieprawidłowe współrzędne"
       },
-        "stat_fused_updates": {
-            "name": "Połączone aktualizacje lokalizacji"
-        }
+      "stat_fused_updates": {
+        "name": "Połączone aktualizacje lokalizacji"
+      }
     }
   },
   "issues": {

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -163,26 +163,26 @@
           "credentials": "Atualizar credenciais",
           "settings": "Modificar configurações",
           "visibility": "Visibilidade do dispositivo",
-          "semantic_locations": "Semantic locations",
+          "semantic_locations": "Localizações semânticas",
           "repairs": "Reparos de subentrada"
         }
       },
       "semantic_locations_menu": {
-        "title": "Semantic locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Localizações semânticas",
+        "description": "Gerenciar substituições de localização semântica. Mapeamentos existentes:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_location_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Adicionar localização semântica",
+          "semantic_location_edit": "Editar localização semântica",
+          "semantic_locations_delete": "Excluir localização semântica"
         }
       },
       "semantic_locations": {
-        "title": "Semantic Locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Localizações semânticas",
+        "description": "Gerenciar substituições de localização semântica. Mapeamentos existentes:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_locations_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Adicionar localização semântica",
+          "semantic_locations_edit": "Editar localização semântica",
+          "semantic_locations_delete": "Excluir localização semântica"
         }
       },
       "semantic_locations_add": {
@@ -199,10 +199,10 @@
         }
       },
       "semantic_locations_edit": {
-        "title": "Choose semantic location",
-        "description": "Select a semantic location to edit.",
+        "title": "Escolher localização semântica",
+        "description": "Selecione uma localização semântica para editar.",
         "data": {
-          "semantic_location": "Semantic location"
+          "semantic_location": "Localização semântica"
         }
       },
       "semantic_location_edit": {
@@ -232,10 +232,10 @@
         }
       },
       "semantic_locations_delete": {
-        "title": "Delete semantic locations",
-        "description": "Select semantic locations to delete.",
+        "title": "Excluir localizações semânticas",
+        "description": "Selecione as localizações semânticas para excluir.",
         "data": {
-          "semantic_locations": "Semantic locations"
+          "semantic_locations": "Localizações semânticas"
         }
       },
       "credentials": {
@@ -256,7 +256,7 @@
       },
       "settings": {
         "title": "Opções",
-        "description": "Ajuste as configurações de localização:\n• Intervalo de verificação de localização: com que frequência consultar as localizações (60–3600 segundos)\n• Atraso entre verificações de dispositivos: intervalo entre consultas por dispositivo (1–60 segundos)\n\nFiltro do Google Home:\n• Ative para associar detecções de dispositivos Google Home à zona Casa\n• Palavras-chave aceitam correspondências parciais (separadas por vírgulas)\n• Exemplo: “nest” corresponde a “Kitchen Nest Mini”",
+        "description": "Ajuste as configurações de localização:\n• Intervalo de verificação de localização: Com que frequência consultar as localizações (60–3600 segundos)\n• Atraso entre verificações de dispositivos: Intervalo entre consultas por dispositivo (1–60 segundos)\n• Limite de obsolescência: Após esse tempo sem atualizações, o status do rastreador muda para desconhecido\n\nFiltro do Google Home:\n• Ative para associar detecções de dispositivos Google Home à zona Casa\n• Palavras-chave aceitam correspondências parciais (separadas por vírgulas)\n• Exemplo: \"nest\" corresponde a \"Kitchen Nest Mini\"",
         "data": {
           "location_poll_interval": "Intervalo(s) de pesquisa de localização",
           "device_poll_delay": "Intervalo entre pesquisas do dispositivo",
@@ -324,15 +324,15 @@
       "choose_one": "Forneça exatamente um método de credencial.",
       "required": "Este campo é obrigatório.",
       "invalid_token": "Credenciais inválidas (token/e-mail). ",
-      "duplicate_name": "Semantic name already exists. Choose a different name.",
-      "duplicate_semantic_location": "Semantic name already exists. Choose a different name.",
+      "duplicate_name": "O nome semântico já existe. Escolha um nome diferente.",
+      "duplicate_semantic_location": "O nome semântico já existe. Escolha um nome diferente.",
       "unknown": "Ocorreu um erro inesperado.",
       "invalid_subentry": "Escolha um grupo de recursos válido."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguração bem-sucedida.",
       "no_ignored_devices": "Não há dispositivos ignorados para restaurar.",
-      "no_semantic_locations": "No semantic locations are configured.",
+      "no_semantic_locations": "Não há localizações semânticas configuradas.",
       "repairs_no_subentries": "Não há subentradas para reparar.",
       "repair_no_devices": "Selecione pelo menos um dispositivo para mover.",
       "subentry_move_success": "Dispositivos atribuídos a **{subentry}** ({count} atualizado).",

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -163,26 +163,26 @@
           "credentials": "Atualizar credenciais",
           "settings": "Modificar configurações",
           "visibility": "Visibilidade do dispositivo",
-          "semantic_locations": "Semantic locations",
+          "semantic_locations": "Localizações semânticas",
           "repairs": "Reparos de subentrada"
         }
       },
       "semantic_locations_menu": {
-        "title": "Semantic locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Localizações semânticas",
+        "description": "Gerir substituições de localização semântica. Mapeamentos existentes:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_location_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Adicionar localização semântica",
+          "semantic_location_edit": "Editar localização semântica",
+          "semantic_locations_delete": "Eliminar localização semântica"
         }
       },
       "semantic_locations": {
-        "title": "Semantic Locations",
-        "description": "Manage semantic location overrides. Existing mappings:\n{semantic_locations}",
+        "title": "Localizações semânticas",
+        "description": "Gerir substituições de localização semântica. Mapeamentos existentes:\n{semantic_locations}",
         "menu_options": {
-          "semantic_locations_add": "Add semantic location",
-          "semantic_locations_edit": "Edit semantic location",
-          "semantic_locations_delete": "Delete semantic location"
+          "semantic_locations_add": "Adicionar localização semântica",
+          "semantic_locations_edit": "Editar localização semântica",
+          "semantic_locations_delete": "Eliminar localização semântica"
         }
       },
       "semantic_locations_add": {
@@ -199,10 +199,10 @@
         }
       },
       "semantic_locations_edit": {
-        "title": "Choose semantic location",
-        "description": "Select a semantic location to edit.",
+        "title": "Escolher localização semântica",
+        "description": "Selecione uma localização semântica para editar.",
         "data": {
-          "semantic_location": "Semantic location"
+          "semantic_location": "Localização semântica"
         }
       },
       "semantic_location_edit": {
@@ -232,10 +232,10 @@
         }
       },
       "semantic_locations_delete": {
-        "title": "Delete semantic locations",
-        "description": "Select semantic locations to delete.",
+        "title": "Eliminar localizações semânticas",
+        "description": "Selecione as localizações semânticas a eliminar.",
         "data": {
-          "semantic_locations": "Semantic locations"
+          "semantic_locations": "Localizações semânticas"
         }
       },
       "credentials": {
@@ -256,7 +256,7 @@
       },
       "settings": {
         "title": "Opções",
-        "description": "Ajustar definições de localização:\n• Intervalo de sondagem de localização: frequência de consulta das localizações (60–3600 segundos)\n• Atraso entre sondagens de dispositivos: intervalo entre pedidos por dispositivo (1–60 segundos)\n\nFiltro Google Home:\n• Ativar para associar deteções de dispositivos Google Home à zona Casa\n• As palavras-chave suportam correspondências parciais (separadas por vírgulas)\n• Exemplo: “nest” corresponde a “Kitchen Nest Mini”",
+        "description": "Ajustar definições de localização:\n• Intervalo de sondagem de localização: Frequência de consulta das localizações (60–3600 segundos)\n• Atraso entre sondagens de dispositivos: Intervalo entre pedidos por dispositivo (1–60 segundos)\n• Limite de obsolescência: Após este tempo sem atualizações, o estado do rastreador muda para desconhecido\n\nFiltro Google Home:\n• Ativar para associar deteções de dispositivos Google Home à zona Casa\n• As palavras-chave suportam correspondências parciais (separadas por vírgulas)\n• Exemplo: \"nest\" corresponde a \"Kitchen Nest Mini\"",
         "data": {
           "location_poll_interval": "Intervalo(s) de pesquisa de localização",
           "device_poll_delay": "Intervalo entre pesquisas do dispositivo",
@@ -324,15 +324,15 @@
       "choose_one": "Forneça exatamente um método de credencial.",
       "required": "Este campo é obrigatório.",
       "invalid_token": "Credenciais inválidas (token/e-mail). ",
-      "duplicate_name": "Semantic name already exists. Choose a different name.",
-      "duplicate_semantic_location": "Semantic name already exists. Choose a different name.",
+      "duplicate_name": "O nome semântico já existe. Escolha um nome diferente.",
+      "duplicate_semantic_location": "O nome semântico já existe. Escolha um nome diferente.",
       "unknown": "Ocorreu um erro inesperado.",
       "invalid_subentry": "Escolha um grupo de recursos válido."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguração bem-sucedida.",
       "no_ignored_devices": "Não há dispositivos ignorados para restaurar.",
-      "no_semantic_locations": "No semantic locations are configured.",
+      "no_semantic_locations": "Não estão configuradas localizações semânticas.",
       "repairs_no_subentries": "Não há subentradas para reparar.",
       "repair_no_devices": "Selecione pelo menos um dispositivo para mover.",
       "subentry_move_success": "Dispositivos atribuídos a **{subentry}** ({count} atualizado).",


### PR DESCRIPTION
- Sync strings.json with en.json to include missing keys: regenerate_aas_token/adm_token buttons, location_age/status/ last_latitude/last_longitude device_tracker attributes, stale_threshold settings fields
- Remove duplicate credentials block from strings.json
- Fix consistent indentation across all files via sync script
- Add stale threshold bullet to settings description in de, es, fr, it, nl, pl, pt, pt-BR
- Translate untranslated semantic location strings in es, fr, it, pl, pt, pt-BR (menu, edit, delete, errors, abort)
- All 9 language files now share identical key structure

https://claude.ai/code/session_01Rh1ndvsECvtmsDgV56Sy8V

