### PR TITLE
fix: compatibility bugs, deprecations, warnings

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver.py
@@ -155,9 +155,9 @@ class FcmReceiver:  # pragma: no cover - legacy surface kept for compatibility
         try:
             if self._cache is not None:
                 if creds is None:
-                    self._cache._data.pop("fcm_credentials", None)
+                    self._cache.sync_pop("fcm_credentials")
                 else:
-                    self._cache._data["fcm_credentials"] = creds
+                    self._cache.sync_set("fcm_credentials", creds)
             else:
                 set_cached_value("fcm_credentials", creds)
             self._creds = creds
@@ -203,5 +203,5 @@ class FcmReceiver:  # pragma: no cover - legacy surface kept for compatibility
         """Return credentials from the selected cache without raising."""
 
         if self._cache is not None:
-            return self._cache._data.get("fcm_credentials")
+            return self._cache.sync_get("fcm_credentials")
         return get_cached_value("fcm_credentials")

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1668,12 +1668,18 @@ class FcmReceiverHA:
         token = self.get_fcm_token(entry_id)
         if token:
             self._update_token_routing(token, {entry_id})
-            asyncio.create_task(self._persist_routing_token(entry_id, token))
+            self._dispatch_to_hass_loop(
+                self._persist_routing_token(entry_id, token),
+                label=f"persist_routing_token_{entry_id}",
+            )
         self._clear_fatal_error_for_entry(
             entry_id, reason="Credentials updated for entry"
         )
 
-        asyncio.create_task(self._async_save_credentials_for_entry(entry_id))
+        self._dispatch_to_hass_loop(
+            self._async_save_credentials_for_entry(entry_id),
+            label=f"save_credentials_{entry_id}",
+        )
         _LOGGER.info("[entry=%s] FCM credentials updated", entry_id)
 
     async def _async_save_credentials_for_entry(self, entry_id: str) -> None:
@@ -1755,7 +1761,7 @@ class FcmReceiverHA:
                     eid,
                     timeout,
                 )
-            except (ConnectionError, TimeoutError) as err:
+            except ConnectionError as err:
                 _LOGGER.debug("[entry=%s] FCM client stop network error: %s", eid, err)
             except Exception as err:  # noqa: BLE001
                 _LOGGER.debug(

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -985,7 +985,10 @@ class FcmReceiverHA:
 
             pending_creds = self._pending_creds.pop(entry.entry_id, None)
             if pending_creds is not None:
-                asyncio.create_task(cache.set("fcm_credentials", pending_creds))
+                self._dispatch_to_hass_loop(
+                    cache.set("fcm_credentials", pending_creds),
+                    label=f"set_pending_creds_{entry.entry_id}",
+                )
 
             pending_tokens = self._pending_routing_tokens.pop(entry.entry_id, set())
 
@@ -1007,13 +1010,19 @@ class FcmReceiverHA:
                             err,
                         )
 
-                asyncio.create_task(_flush_tokens())
+                self._dispatch_to_hass_loop(
+                    _flush_tokens(),
+                    label=f"flush_pending_tokens_{entry.entry_id}",
+                )
 
         # Mirror any known credentials to this entry cache
         try:
             creds = self.creds.get(entry.entry_id)
             if creds and cache is not None:
-                asyncio.create_task(cache.set("fcm_credentials", creds))
+                self._dispatch_to_hass_loop(
+                    cache.set("fcm_credentials", creds),
+                    label=f"mirror_creds_{entry.entry_id}",
+                )
         except Exception as err:
             _LOGGER.debug("Entry-scoped credentials persistence skipped: %s", err)
 
@@ -1021,7 +1030,10 @@ class FcmReceiverHA:
         token = self.get_fcm_token(entry.entry_id)
         if token:
             self._update_token_routing(token, {entry.entry_id})
-            asyncio.create_task(self._persist_routing_token(entry.entry_id, token))
+            self._dispatch_to_hass_loop(
+                self._persist_routing_token(entry.entry_id, token),
+                label=f"persist_routing_token_{entry.entry_id}",
+            )
 
         # Load persisted routing tokens for this entry and map them as well
         if cache is not None:
@@ -1040,10 +1052,16 @@ class FcmReceiverHA:
                         err,
                     )
 
-            asyncio.create_task(_load_tokens())
+            self._dispatch_to_hass_loop(
+                _load_tokens(),
+                label=f"load_persisted_tokens_{entry.entry_id}",
+            )
 
         # Start supervisor for this entry
-        asyncio.create_task(self._start_supervisor_for_entry(entry.entry_id, cache))
+        self._dispatch_to_hass_loop(
+            self._start_supervisor_for_entry(entry.entry_id, cache),
+            label=f"start_supervisor_{entry.entry_id}",
+        )
 
     def unregister_coordinator(self, coordinator: Any) -> None:
         """Unregister a coordinator (sync; safe for async_on_unload)."""

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -43,7 +43,6 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
 
 from aiohttp import ClientSession
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_der_private_key
 
 import http_ece
@@ -449,9 +448,7 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
 
         der_data = urlsafe_b64decode(private_value.encode("ascii") + b"========")
         secret = urlsafe_b64decode(secret_value.encode("ascii") + b"========")
-        privkey = load_der_private_key(
-            der_data, password=None, backend=default_backend()
-        )
+        privkey = load_der_private_key(der_data, password=None)
         decrypted = http_decrypt(
             raw_data,
             salt=salt,

--- a/custom_components/googlefindmy/Auth/token_cache.py
+++ b/custom_components/googlefindmy/Auth/token_cache.py
@@ -558,15 +558,14 @@ def set_cached_value(name: str, value: Any | None) -> None:
         RuntimeError: If called inside the event loop (use async variant instead).
     """
     try:
-        loop = asyncio.get_running_loop()
-        if loop.is_running():
-            raise RuntimeError(
-                f"Sync `set_cached_value({name!r})` used inside event loop. "
-                "Use `async_set_cached_value` instead."
-            )
+        asyncio.get_running_loop()  # raises RuntimeError if no running loop
     except RuntimeError:
-        # No running loop; proceed synchronously
-        pass
+        pass  # No running loop; proceed synchronously
+    else:
+        raise RuntimeError(
+            f"Sync `set_cached_value({name!r})` used inside event loop. "
+            "Use `async_set_cached_value` instead."
+        )
 
     if not _INSTANCES:
         _LOGGER.warning("Cache not initialized; cannot set '%s'", name)
@@ -593,15 +592,14 @@ def get_cached_value_or_set(name: str, generator: Callable[[], Any]) -> Any:
     """
     # Prevent usage in the event loop
     try:
-        loop = asyncio.get_running_loop()
-        if loop.is_running():
-            raise RuntimeError(
-                f"Sync `get_cached_value_or_set({name!r})` used inside event loop. "
-                "Use `async_get_cached_value_or_set` instead."
-            )
+        asyncio.get_running_loop()  # raises RuntimeError if no running loop
     except RuntimeError:
-        # No running loop -> safe to proceed
-        pass
+        pass  # No running loop -> safe to proceed
+    else:
+        raise RuntimeError(
+            f"Sync `get_cached_value_or_set({name!r})` used inside event loop. "
+            "Use `async_get_cached_value_or_set` instead."
+        )
 
     if not _INSTANCES:
         _LOGGER.warning(

--- a/custom_components/googlefindmy/Auth/token_cache.py
+++ b/custom_components/googlefindmy/Auth/token_cache.py
@@ -200,6 +200,29 @@ class TokenCache:
 
     # ------------------------------- Get/Set ---------------------------------
 
+    def sync_get(self, name: str) -> Any:
+        """Return a value from the in-memory cache (sync, no lock).
+
+        Use from synchronous code paths that cannot await.
+        """
+        return self._data.get(name)
+
+    def sync_pop(self, name: str, default: Any = None) -> Any:
+        """Remove and return a value from the in-memory cache (sync, no lock).
+
+        Use from synchronous code paths that cannot await.
+        """
+        return self._data.pop(name, default)
+
+    def sync_set(self, name: str, value: Any) -> None:
+        """Set a value in the in-memory cache (sync, no lock, no persist).
+
+        Use from synchronous code paths that cannot await.
+        Note: does not trigger deferred save; call ``set()`` from async code
+        when persistence is required.
+        """
+        self._data[name] = value
+
     async def get(self, name: str) -> Any:
         """Return a value from the in-memory cache (non-blocking)."""
         return self._data.get(name)

--- a/custom_components/googlefindmy/FMDNCrypto/foreign_tracker_cryptor.py
+++ b/custom_components/googlefindmy/FMDNCrypto/foreign_tracker_cryptor.py
@@ -42,7 +42,7 @@ from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
     FHNA_K,
     EidVariant,
     build_table10_prf_input,
-    generate_eid,
+    generate_eid_variant,
     prf_aes_256_ecb,
 )
 
@@ -345,10 +345,10 @@ def decrypt(
     r = calculate_r(identity_key, beacon_time_counter) % order
 
     # R and S points
-    Rx = generate_eid(
+    Rx = generate_eid_variant(
         identity_key,
         beacon_time_counter,
-        variant=EidVariant.LEGACY_SECP160R1_X20_BE,
+        EidVariant.LEGACY_SECP160R1_X20_BE,
     )
     R = int.from_bytes(Rx, byteorder="big")
     _ = rx_to_ry(R, curve.curve)
@@ -393,12 +393,12 @@ def _get_random_bytes(length: int) -> bytes:
 
 
 def _create_random_eid(identity_key: bytes) -> bytes:
-    # Uses generate_eid to create a random EID
+    # Uses generate_eid_variant to create a random EID
     beacon_time_counter: int = int.from_bytes(_get_random_bytes(4), byteorder="big")
-    return generate_eid(
+    return generate_eid_variant(
         identity_key,
         beacon_time_counter,
-        variant=EidVariant.LEGACY_SECP160R1_X20_BE,
+        EidVariant.LEGACY_SECP160R1_X20_BE,
     )
 
 

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import warnings
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, cast, runtime_checkable
@@ -565,11 +566,8 @@ class GoogleFindMyAPI:
         """Return the event loop the sync helpers should execute on."""
 
         if self._session is not None:
-            session_loop = cast(
-                asyncio.AbstractEventLoop | None,
-                getattr(self._session, "_loop", None),
-            )
-            if session_loop is None:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
                 session_loop = cast(
                     asyncio.AbstractEventLoop | None,
                     getattr(self._session, "loop", None),

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -31,6 +31,7 @@ Methods moved here:
 from __future__ import annotations
 
 import asyncio
+import functools
 import inspect
 import logging
 import time
@@ -211,7 +212,10 @@ class PollingOperations:
           return the callable's result to the caller. Only use with functions that
           **return None** and are safe to run on the HA loop.
         """
-        self.hass.loop.call_soon_threadsafe(func, *args, **kwargs)
+        if kwargs:
+            self.hass.loop.call_soon_threadsafe(functools.partial(func, *args, **kwargs))
+        else:
+            self.hass.loop.call_soon_threadsafe(func, *args)
 
     def _dispatch_async_request_refresh(
         self: GoogleFindMyCoordinator, *, task_name: str, log_context: str

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -1067,11 +1067,8 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         return data.get("longitude")
 
     @property
-    def location_accuracy(self) -> int | None:
-        """Return accuracy of location in meters as an integer.
-
-        Coordinator stores accuracy as a float; HA's device_tracker expects
-        an integer for the `gps_accuracy` attribute, so we coerce here.
+    def location_accuracy(self) -> float | None:
+        """Return accuracy of location in meters.
 
         Returns None if location data is stale (older than stale_threshold),
         mirroring the behaviour of latitude/longitude for consistency.
@@ -1085,7 +1082,7 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         if acc is None:
             return None
         try:
-            return int(round(float(acc)))
+            return float(acc)
         except (TypeError, ValueError):
             return None
 

--- a/custom_components/googlefindmy/entity.py
+++ b/custom_components/googlefindmy/entity.py
@@ -225,9 +225,6 @@ def _default_async_run_hass_job(hass: HomeAssistant) -> Callable[..., Any]:
                     return loop.create_task(coroutine)
                 return asyncio.create_task(coroutine)
 
-            if loop is not None:
-                return asyncio.ensure_future(awaitable_result, loop=loop)
-
             return asyncio.ensure_future(awaitable_result)
 
         return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,10 +135,12 @@ if _PYTEST_HOMEASSISTANT_PLUGIN_AVAILABLE:
             loop = request.getfixturevalue("event_loop")
         except pytest.FixtureLookupError:
             try:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
             except RuntimeError:
                 loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
+                # pytest-homeassistant-custom-component calls get_event_loop()
+                # internally, so we must register the loop for compatibility.
+                asyncio.set_event_loop(loop)  # noqa: ASYNC110
                 created_loop = True
         loop.set_debug(True)
         try:
@@ -147,7 +149,7 @@ if _PYTEST_HOMEASSISTANT_PLUGIN_AVAILABLE:
             loop.set_debug(False)
             if created_loop:
                 loop.close()
-                asyncio.set_event_loop(None)
+                asyncio.set_event_loop(None)  # noqa: ASYNC110
 
 
 class _FakeIssueRegistry:
@@ -480,7 +482,6 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
 
     loop = asyncio.new_event_loop()
     try:
-        asyncio.set_event_loop(loop)
         argnames = getattr(pyfuncitem._fixtureinfo, "argnames", ())  # noqa: SLF001 - pytest internals
         if any(
             param.kind is inspect.Parameter.VAR_KEYWORD
@@ -495,7 +496,6 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
             }
         loop.run_until_complete(pyfuncitem.obj(**call_kwargs))
     finally:
-        asyncio.set_event_loop(None)
         loop.close()
     return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -475,7 +475,7 @@ def pytest_pyfunc_call(pyfuncitem: pytest.Function) -> bool | None:
     """Execute asyncio-marked coroutine tests without requiring pytest-asyncio."""
 
     marker = pyfuncitem.get_closest_marker("asyncio")
-    if marker is None or not asyncio.iscoroutinefunction(pyfuncitem.obj):
+    if marker is None or not inspect.iscoroutinefunction(pyfuncitem.obj):
         return None
 
     loop = asyncio.new_event_loop()

--- a/tests/helpers/asyncio.py
+++ b/tests/helpers/asyncio.py
@@ -13,11 +13,6 @@ def drain_loop(loop: asyncio.AbstractEventLoop) -> None:
     if loop.is_closed():
         return
 
-    try:
-        current_loop = asyncio.get_event_loop()
-    except RuntimeError:
-        current_loop = None
-
     pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
     for task in pending:
         task.cancel()
@@ -26,6 +21,3 @@ def drain_loop(loop: asyncio.AbstractEventLoop) -> None:
 
     loop.run_until_complete(asyncio.sleep(0))
     loop.close()
-
-    if current_loop is loop:
-        asyncio.set_event_loop(None)

--- a/tests/test_button_service_registration.py
+++ b/tests/test_button_service_registration.py
@@ -107,13 +107,7 @@ def test_button_setup_skips_service_registration_when_platform_missing(
         ) -> bool:
             return True
 
-    try:
-        original_loop = asyncio.get_event_loop()
-    except RuntimeError:
-        original_loop = None
-
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     hass = _StubHass(loop, button_module.DOMAIN)
     config_entry = GoogleFindMyConfigEntryStub()
@@ -156,7 +150,6 @@ def test_button_setup_skips_service_registration_when_platform_missing(
     finally:
         loop.run_until_complete(loop.shutdown_asyncgens())
         drain_loop(loop)
-        asyncio.set_event_loop(original_loop)
 
     assert [entity.entity_description.translation_key for entity in added_entities] == [
         "play_sound",

--- a/tests/test_config_flow_initial_auth.py
+++ b/tests/test_config_flow_initial_auth.py
@@ -181,7 +181,7 @@ def _prepare_reconfigure_flow(
                 frame_module=frame,
             )
             self.tasks: list[asyncio.Task[Any]] = []
-            self.loop = asyncio.get_event_loop()
+            self.loop = asyncio.get_running_loop()
 
         def async_create_task(self, coro: Any) -> asyncio.Task[Any]:
             task = asyncio.create_task(coro)

--- a/tests/test_coordinator_owner_index.py
+++ b/tests/test_coordinator_owner_index.py
@@ -41,7 +41,6 @@ def owner_index_coordinator(
         _factory,
     )
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     hass = _DummyHass(loop)
     hass.data.setdefault(DOMAIN, {})["device_owner_index"] = {}
 
@@ -101,7 +100,6 @@ def test_fcm_owner_index_fallback_routes_entry(
     """Owner-index mapping enables FCM routing when token context is missing."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     try:
         receiver = FcmReceiverHA()
         hass = SimpleNamespace(

--- a/tests/test_coordinator_short_retry.py
+++ b/tests/test_coordinator_short_retry.py
@@ -67,7 +67,6 @@ def fresh_loop() -> asyncio.AbstractEventLoop:
     """Yield a fresh event loop for isolation in scheduler tests."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     try:
         yield loop
     finally:

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -149,7 +149,6 @@ def coordinator(
     """Instantiate a coordinator with lightweight stubs for hass/cache."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     hass = _DummyHass(loop)
     monkeypatch.setattr(
         "custom_components.googlefindmy.coordinator.GoogleFindMyCoordinator._async_load_stats",

--- a/tests/test_coordinator_timeout.py
+++ b/tests/test_coordinator_timeout.py
@@ -87,7 +87,6 @@ def test_poll_timeout_sets_update_error(monkeypatch: pytest.MonkeyPatch) -> None
     """Timeouts should propagate as update errors and mark the cycle as failed."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     hass = _DummyHass(loop)
 
     monkeypatch.setattr(
@@ -139,7 +138,6 @@ def test_poll_auth_failure_raises_auth_failed(monkeypatch: pytest.MonkeyPatch) -
     """Auth failures should translate to ConfigEntryAuthFailed and mark the cycle failed."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     hass = _DummyHass(loop)
 
     monkeypatch.setattr(
@@ -193,7 +191,6 @@ def test_poll_timeout_still_processes_other_devices(
     """A timeout for one device should not prevent polling of the rest."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     hass = _DummyHass(loop)
 
     monkeypatch.setattr(

--- a/tests/test_diagnostics_buffer_summary.py
+++ b/tests/test_diagnostics_buffer_summary.py
@@ -116,7 +116,6 @@ def _run(coro):
 
     loop = asyncio.new_event_loop()
     try:
-        asyncio.set_event_loop(loop)
         return loop.run_until_complete(coro)
     finally:
         drain_loop(loop)

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 
-import custom_components.googlefindmy.Auth.fcm_receiver_ha as fcm_receiver_module
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
 from custom_components.googlefindmy.const import DOMAIN
 
@@ -339,18 +338,6 @@ async def test_credentials_update_clears_latched_fatal_error(
     receiver._fatal_errors[entry_id] = "BadAuthentication"
     receiver._fatal_error = "BadAuthentication"
 
-    loop = asyncio.get_running_loop()
-    captured_tasks: list[asyncio.Task[object]] = []
-
-    def _capture_task(
-        coro: Awaitable[object], *, name: str | None = None
-    ) -> asyncio.Task[object]:
-        task = loop.create_task(coro, name=name)
-        captured_tasks.append(task)
-        return task
-
-    monkeypatch.setattr(fcm_receiver_module.asyncio, "create_task", _capture_task)
-
     token_routes: list[tuple[str, set[str]]] = []
     monkeypatch.setattr(
         receiver,
@@ -372,7 +359,9 @@ async def test_credentials_update_clears_latched_fatal_error(
         entry_id, {"fcm": {"registration": {"token": "token-abc"}}}
     )
 
-    await asyncio.gather(*captured_tasks)
+    # _dispatch_to_hass_loop tracks tasks in _active_tasks; gather them
+    if receiver._active_tasks:
+        await asyncio.gather(*list(receiver._active_tasks))
 
     assert entry_id not in receiver._fatal_errors
     assert receiver._fatal_error is None

--- a/tests/test_fcm_receiver_guard.py
+++ b/tests/test_fcm_receiver_guard.py
@@ -216,7 +216,6 @@ def test_unregister_prunes_token_routing(monkeypatch: pytest.MonkeyPatch) -> Non
     """Removing a coordinator clears its tokens and blocks future fan-out."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         receiver = FcmReceiverHA()

--- a/tests/test_fcm_receiver_shim.py
+++ b/tests/test_fcm_receiver_shim.py
@@ -11,11 +11,20 @@ from custom_components.googlefindmy.Auth import fcm_receiver, token_cache
 
 
 class _StubCache:
-    """Minimal TokenCache stand-in exposing the `_data` attribute."""
+    """Minimal TokenCache stand-in exposing sync accessors."""
 
     def __init__(self, entry_id: str, initial: dict | None = None) -> None:
         self.entry_id = entry_id
         self._data = copy.deepcopy(initial) if initial is not None else {}
+
+    def sync_get(self, name: str) -> object:
+        return self._data.get(name)
+
+    def sync_pop(self, name: str, default: object = None) -> object:
+        return self._data.pop(name, default)
+
+    def sync_set(self, name: str, value: object) -> None:
+        self._data[name] = value
 
 
 @pytest.fixture

--- a/tests/test_hass_data_layout.py
+++ b/tests/test_hass_data_layout.py
@@ -571,7 +571,6 @@ def test_service_stats_unique_id_migration_prefers_service_subentry(
     """Tracker-prefixed stats sensor IDs collapse to the service identifier."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -696,7 +695,6 @@ def test_unique_id_migration_rewrites_legacy_tracker_entities(
     """Legacy tracker IDs are namespaced and scoped to subentries without collisions."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -855,7 +853,6 @@ def test_hass_data_layout(
     """The integration stores runtime state only under hass.data[DOMAIN]["entries"]."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         if "homeassistant.components.button" not in sys.modules:
@@ -1194,7 +1191,6 @@ def test_setup_entry_reactivates_disabled_button_entities(
     """Disabled button entities are re-enabled during setup."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -1650,7 +1646,6 @@ def test_setup_entry_failure_does_not_register_cache(
     """Setup failures must not leave a TokenCache registered in the facade."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -1719,7 +1714,6 @@ def test_duplicate_account_issue_translated(monkeypatch: pytest.MonkeyPatch) -> 
     """A duplicate-account repair issue renders with translated placeholders."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -1804,7 +1798,6 @@ def test_duplicate_account_issue_translated(monkeypatch: pytest.MonkeyPatch) -> 
         assert "Primary Account" in rendered
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_duplicate_account_issue_cleanup_on_success(
@@ -1813,7 +1806,6 @@ def test_duplicate_account_issue_cleanup_on_success(
     """Resolved duplicate-account issues are cleared during normal setup."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -1865,7 +1857,6 @@ def test_duplicate_account_issue_cleanup_on_success(
         assert create_calls == []
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_duplicate_account_mixed_states_prefer_loaded(
@@ -1874,7 +1865,6 @@ def test_duplicate_account_mixed_states_prefer_loaded(
     """Loaded duplicates remain authoritative; others auto-disable and clean up."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -1975,7 +1965,6 @@ def test_duplicate_account_mixed_states_prefer_loaded(
         )
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_duplicate_account_auto_disables_duplicates(
@@ -1984,7 +1973,6 @@ def test_duplicate_account_auto_disables_duplicates(
     """Non-authoritative entries are disabled, unloaded, and cleaned up."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -2073,7 +2061,6 @@ def test_duplicate_account_auto_disables_duplicates(
         assert not create_calls
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_duplicate_account_legacy_core_disable_fallback(
@@ -2083,7 +2070,6 @@ def test_duplicate_account_legacy_core_disable_fallback(
     """Legacy cores raise TypeError but still unload and raise repair issues."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -2183,7 +2169,6 @@ def test_duplicate_account_legacy_core_disable_fallback(
         ), "Legacy duplicate issues should remain open for manual action"
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_duplicate_account_all_not_loaded_prefers_newest_timestamp() -> None:
@@ -2238,7 +2223,6 @@ def test_duplicate_account_clear_stale_issues_for_all() -> None:
     """When duplicates are gone, all related issues are purged."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -2273,7 +2257,6 @@ def test_duplicate_account_clear_stale_issues_for_all() -> None:
         )
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_duplicate_account_cleanup_keeps_active_tuple_key_issues(
@@ -2282,7 +2265,6 @@ def test_duplicate_account_cleanup_keeps_active_tuple_key_issues(
     """Only stale duplicate-account issues are removed for tuple-key registries."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -2352,7 +2334,6 @@ def test_duplicate_account_cleanup_keeps_active_tuple_key_issues(
         assert authoritative.entry_id in str(placeholders.get("entries", ""))
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_duplicate_account_cleanup_respects_string_key_issue_registries(
@@ -2361,7 +2342,6 @@ def test_duplicate_account_cleanup_respects_string_key_issue_registries(
     """Stale cleanup handles registries that expose string-key issue mappings."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -2479,14 +2459,12 @@ def test_duplicate_account_cleanup_respects_string_key_issue_registries(
         assert authoritative.entry_id in str(placeholders.get("entries", ""))
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_issue_exists_helper_is_synchronous() -> None:
     """_issue_exists interacts with the registry helpers without awaiting."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -2519,7 +2497,6 @@ def test_issue_exists_helper_is_synchronous() -> None:
         )
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_duplicate_account_issue_log_level_downgrades_when_existing(
@@ -2528,7 +2505,6 @@ def test_duplicate_account_issue_log_level_downgrades_when_existing(
     """Existing repair issues cause duplicate detection logs to drop to DEBUG."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         integration = importlib.import_module("custom_components.googlefindmy")
@@ -2575,7 +2551,6 @@ def test_duplicate_account_issue_log_level_downgrades_when_existing(
         assert debug_records[-1].levelno == logging.DEBUG
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def test_service_no_active_entry_placeholders(
@@ -2584,7 +2559,6 @@ def test_service_no_active_entry_placeholders(
     """Service validation exposes counts/list placeholders for inactive setups."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         services_module = importlib.import_module(
@@ -2680,7 +2654,6 @@ def test_service_no_active_entry_placeholders(
         assert "Account One" in rendered
     finally:
         loop.close()
-        asyncio.set_event_loop(None)
 
 
 def _platform_names(platforms: tuple[object, ...]) -> tuple[str, ...]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,7 +47,7 @@ class TestListDevices:
     """list_devices() dispatches to _async_cli_main and handles errors."""
 
     @mock.patch("custom_components.googlefindmy.main.asyncio")
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main")
+    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
     def test_happy_path_with_entry_id(
         self, mock_cli: mock.MagicMock, mock_asyncio: mock.MagicMock
     ) -> None:
@@ -58,7 +58,7 @@ class TestListDevices:
         mock_asyncio.run.assert_called_once()
 
     @mock.patch("custom_components.googlefindmy.main.asyncio")
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main")
+    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
     def test_entry_id_from_env(
         self,
         mock_cli: mock.MagicMock,
@@ -73,7 +73,7 @@ class TestListDevices:
         mock_asyncio.run.assert_called_once()
 
     @mock.patch("custom_components.googlefindmy.main.asyncio")
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main")
+    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
     def test_no_entry_id(
         self,
         mock_cli: mock.MagicMock,
@@ -87,7 +87,7 @@ class TestListDevices:
         mock_cli.assert_called_once_with(None)
         mock_asyncio.run.assert_called_once()
 
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main")
+    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
     def test_keyboard_interrupt(
         self, mock_cli: mock.MagicMock, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -99,7 +99,7 @@ class TestListDevices:
 
         assert "Exiting." in capsys.readouterr().out
 
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main")
+    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
     def test_generic_exception(
         self, mock_cli: mock.MagicMock, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/test_multi_account_end_to_end.py
+++ b/tests/test_multi_account_end_to_end.py
@@ -293,7 +293,6 @@ def test_multi_account_end_to_end(
     """Two entries can coexist with isolated caches, services, and FCM tokens."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         if "homeassistant.loader" not in sys.modules:

--- a/tests/test_spot_grpc_client.py
+++ b/tests/test_spot_grpc_client.py
@@ -409,7 +409,6 @@ def test_poll_spot_auth_error_triggers_config_entry_auth_failed(
     """SpotAuthPermanentError should propagate as ConfigEntryAuthFailed in polling."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     hass_coordinator = _prepare_coordinator(loop)
     hass_coordinator.api = _AuthErrorAPI()
 

--- a/tests/test_spot_grpc_resilience.py
+++ b/tests/test_spot_grpc_resilience.py
@@ -239,7 +239,6 @@ def test_polling_path_translates_auth_error(monkeypatch: pytest.MonkeyPatch) -> 
     """SpotAuthPermanentError from the API should surface as ConfigEntryAuthFailed."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
     hass_coordinator = _prepare_coordinator(loop)
     hass_coordinator.api = _AuthErrorAPI()
 

--- a/tests/test_stats_sensor_updates.py
+++ b/tests/test_stats_sensor_updates.py
@@ -218,7 +218,6 @@ def test_increment_stat_notifies_registered_stats_sensor(
     """Stats increments must notify listeners so CoordinatorEntity state updates."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         hass = _StubHass(loop)
@@ -272,7 +271,6 @@ def test_increment_stat_persists_stats(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stats increments must trigger persistence via the debounced writer."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         hass = _StubHass(loop)
@@ -308,7 +306,6 @@ def test_history_fallback_increments_history_stat(
     """Recorder fallback should increment the history counter and surface via sensors."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         hass = _StubHass(loop)
@@ -396,7 +393,6 @@ def test_stats_sensor_device_info_uses_service_identifiers() -> None:
     """Stats sensors attach the hub device identifier set with subentry metadata."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         hass = _StubHass(loop)
@@ -435,7 +431,6 @@ def test_semantic_label_sensor_exposes_observations() -> None:
     """Semantic label sensor should surface cached labels and device IDs."""
 
     loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
     try:
         hass = _StubHass(loop)


### PR DESCRIPTION
[fix: Python 3.13 and HA 2026.x compatibility bugs](https://github.com/jleinenbach/GoogleFindMy-HA/commit/503f5c2e69abf77d709889a9c3cd72a8f71aad50) 

- Fix call_soon_threadsafe passing **kwargs (TypeError crash): use
  functools.partial when kwargs are present (coordinator/polling.py)
- Fix asyncio.ensure_future(loop=loop) removed in Python 3.10: drop
  the unreachable loop= branch (entity.py)
- Fix self-defeating safety check in set_cached_value and
  get_cached_value_or_set: RuntimeError raised inside try was caught
  by its own except clause, silently allowing event-loop usage. Use
  try/except/else pattern matching get_cached_value (token_cache.py)
- Fix unreachable TimeoutError in duplicate except clause: first
  except already catches TimeoutError, making the second branch dead
  code (fcm_receiver_ha.py)
- Fix _on_credentials_updated_for_entry using asyncio.create_task from
  potentially non-event-loop thread: use _dispatch_to_hass_loop for
  thread-safe task creation (fcm_receiver_ha.py)
- Fix location_accuracy returning int instead of float to match HA
  2026.1+ TrackerEntity type change (device_tracker.py)
- Fix asyncio.iscoroutinefunction deprecated in Python 3.13: use
  inspect.iscoroutinefunction instead (tests/conftest.py)

https://claude.ai/code/session_012Bd1cxydBXQdKwUiAUghS1
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 53 minutes ago
[fix: remaining deprecations and code quality issues](https://github.com/jleinenbach/GoogleFindMy-HA/commit/f8197f6d92e00a299448a6ff5c140f0cbbf35d95) 

Production code:
- Remove deprecated default_backend() from cryptography lib
  (fcmpushclient.py)
- Replace deprecated generate_eid() with generate_eid_variant()
  (foreign_tracker_cryptor.py)
- Fix fragile _session._loop private attribute access: use public
  .loop with DeprecationWarning suppression (api.py)
- Replace fire-and-forget asyncio.create_task() in
  register_coordinator() with tracked _dispatch_to_hass_loop()
  (fcm_receiver_ha.py)
- Add sync_get/sync_set/sync_pop to TokenCache for safe sync access;
  replace direct _data dict access in fcm_receiver.py

Test code:
- Remove deprecated asyncio.set_event_loop() calls across 15 test
  files (Python 3.12+ DeprecationWarning)
- Replace asyncio.get_event_loop() with get_running_loop() or
  new_event_loop() where appropriate
- Keep set_event_loop only in conftest _ensure_event_loop fixture
  (required by pytest-homeassistant-custom-component plugin)

https://claude.ai/code/session_012Bd1cxydBXQdKwUiAUghS1
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 12 minutes ago
[fix: suppress RuntimeWarning for unawaited coroutines in test_main.py](https://github.com/jleinenbach/GoogleFindMy-HA/commit/3a50461bcbeef6405fa66a45eb1edea09c98891b) 

Use new_callable=mock.MagicMock for _async_cli_main patches to prevent
AsyncMock auto-detection creating coroutines that are never awaited
(asyncio.run is also mocked in these tests).

Test suite now runs with 0 warnings (previously 2).

https://claude.ai/code/session_012Bd1cxydBXQdKwUiAUghS1