### PR TITLE
docs: add geo-consistency warning to auth repair issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,11 @@ The integration provides a couple of Home Assistant Actions for use with automat
 - Check firewall settings for Firebase Cloud Messaging
 - Review FCM debug logs for connection details
 
+### Authentication Expires Repeatedly
+- Google may revoke tokens when API requests originate from a different IP address or geographic region than where the token was originally created.
+- **Common scenario:** `secrets.json` generated on a laptop at home, but Home Assistant runs on a cloud VPS or a server in another country.
+- **Fix:** Run the authentication script on the same network (same public IP) where your Home Assistant instance is located, then re-import the credentials.
+
 ### Rate Limiting
 The integration respects Google's rate limits by:
 - Sequential device polling (one device at a time)

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "Reauthentication required",
-      "description": "Authentication for Google Find My Device is invalid or has expired for this entry.\n\n**Entry:** {entry_title}\n**Account:** {email}\n\nSelect **Reconfigure** on the integration card to sign in again. If you recently changed your Google password or revoked tokens, you must re-authenticate here to restore functionality."
+      "description": "Authentication for Google Find My Device is invalid or has expired for this entry.\n\n**Entry:** {entry_title}\n**Account:** {email}\n\nSelect **Reconfigure** on the integration card to sign in again. If you recently changed your Google password or revoked tokens, you must re-authenticate here to restore functionality.\n\n**Tip:** Google may revoke tokens when requests come from a different IP address or region than where the token was created (e.g. token generated on a laptop but used from a server or VPS in another country). Generate your `secrets.json` on the same network where Home Assistant runs, or use the same public IP address."
     },
     "fcm_connection_stuck": {
       "title": "FCM Push Connection Failed",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "Erneute Anmeldung erforderlich",
-      "description": "Die Anmeldung für Google Find My Device ist ungültig oder abgelaufen.\n\n**Eintrag:** {entry_title}\n**Konto:** {email}\n\nWähle auf der Integrationskarte **Neu konfigurieren**, um dich erneut anzumelden. Wenn du kürzlich dein Google-Passwort geändert oder Tokens widerrufen hast, musst du dich hier neu authentifizieren, um die Funktionalität wiederherzustellen."
+      "description": "Die Anmeldung für Google Find My Device ist ungültig oder abgelaufen.\n\n**Eintrag:** {entry_title}\n**Konto:** {email}\n\nWähle auf der Integrationskarte **Neu konfigurieren**, um dich erneut anzumelden. Wenn du kürzlich dein Google-Passwort geändert oder Tokens widerrufen hast, musst du dich hier neu authentifizieren, um die Funktionalität wiederherzustellen.\n\n**Tipp:** Google kann Tokens widerrufen, wenn Anfragen von einer anderen IP-Adresse oder Region kommen als bei der Token-Erstellung (z.\u00a0B. Token auf einem Laptop erstellt, aber von einem Server oder VPS in einem anderen Land genutzt). Erstelle deine `secrets.json` im selben Netzwerk, in dem Home Assistant läuft, oder verwende dieselbe öffentliche IP-Adresse."
     },
     "fcm_connection_stuck": {
       "title": "FCM Push-Verbindung fehlgeschlagen",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "Reauthentication required",
-      "description": "Authentication for Google Find My Device is invalid or has expired for this entry.\n\n**Entry:** {entry_title}\n**Account:** {email}\n\nSelect **Reconfigure** on the integration card to sign in again. If you recently changed your Google password or revoked tokens, you must re-authenticate here to restore functionality."
+      "description": "Authentication for Google Find My Device is invalid or has expired for this entry.\n\n**Entry:** {entry_title}\n**Account:** {email}\n\nSelect **Reconfigure** on the integration card to sign in again. If you recently changed your Google password or revoked tokens, you must re-authenticate here to restore functionality.\n\n**Tip:** Google may revoke tokens when requests come from a different IP address or region than where the token was created (e.g. token generated on a laptop but used from a server or VPS in another country). Generate your `secrets.json` on the same network where Home Assistant runs, or use the same public IP address."
     },
     "fcm_connection_stuck": {
       "title": "FCM Push Connection Failed",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "Se requiere volver a iniciar sesión",
-      "description": "La autenticación de Google Find My Device no es válida o ha caducado.\n\n**Entrada:** {entry_title}\n**Cuenta:** {email}\n\nEn la tarjeta de la integración, elige **Reconfigurar** para volver a autenticarte. Si recientemente cambiaste tu contraseña de Google o revocaste tokens, tendrás que iniciar sesión aquí para restablecer la funcionalidad."
+      "description": "La autenticación de Google Find My Device no es válida o ha caducado.\n\n**Entrada:** {entry_title}\n**Cuenta:** {email}\n\nEn la tarjeta de la integración, elige **Reconfigurar** para volver a autenticarte. Si recientemente cambiaste tu contraseña de Google o revocaste tokens, tendrás que iniciar sesión aquí para restablecer la funcionalidad.\n\n**Consejo:** Google puede revocar tokens cuando las solicitudes provienen de una dirección IP o región diferente a la que se usó al crear el token (p. ej. token generado en un portátil pero utilizado desde un servidor o VPS en otro país). Genera tu `secrets.json` en la misma red donde se ejecuta Home Assistant o utiliza la misma dirección IP pública."
     },
     "fcm_connection_stuck": {
       "title": "Conexión push de FCM fallida",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "Une réauthentification est requise",
-      "description": "L’authentification de Google Find My Device n’est plus valide ou a expiré.\n\n**Entrée :** {entry_title}\n**Compte :** {email}\n\nDans la carte de l’intégration, choisissez **Reconfigurer** pour vous réauthentifier. Si vous avez récemment changé votre mot de passe Google ou révoqué des jetons, vous devrez vous reconnecter ici pour rétablir le fonctionnement."
+      "description": "L'authentification de Google Find My Device n'est plus valide ou a expiré.\n\n**Entrée :** {entry_title}\n**Compte :** {email}\n\nDans la carte de l'intégration, choisissez **Reconfigurer** pour vous réauthentifier. Si vous avez récemment changé votre mot de passe Google ou révoqué des jetons, vous devrez vous reconnecter ici pour rétablir le fonctionnement.\n\n**Conseil :** Google peut révoquer les jetons lorsque les requêtes proviennent d'une adresse IP ou d'une région différente de celle où le jeton a été créé (par ex. jeton généré sur un ordinateur portable mais utilisé depuis un serveur ou un VPS dans un autre pays). Générez votre `secrets.json` sur le même réseau que Home Assistant, ou utilisez la même adresse IP publique."
     },
     "fcm_connection_stuck": {
       "title": "Échec de la connexion push FCM",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "È necessaria una nuova autenticazione",
-      "description": "L’autenticazione di Google Find My Device non è più valida o è scaduta.\n\n**Voce:** {entry_title}\n**Account:** {email}\n\nNella scheda dell’integrazione, scegli **Riconfigura** per riautenticarti. Se di recente hai cambiato la password di Google o hai revocato dei token, dovrai accedere di nuovo qui per ripristinare il funzionamento."
+      "description": "L'autenticazione di Google Find My Device non è più valida o è scaduta.\n\n**Voce:** {entry_title}\n**Account:** {email}\n\nNella scheda dell'integrazione, scegli **Riconfigura** per riautenticarti. Se di recente hai cambiato la password di Google o hai revocato dei token, dovrai accedere di nuovo qui per ripristinare il funzionamento.\n\n**Suggerimento:** Google potrebbe revocare i token quando le richieste provengono da un indirizzo IP o una regione diversi da quelli usati per creare il token (ad es. token generato su un laptop ma utilizzato da un server o VPS in un altro paese). Genera il file `secrets.json` sulla stessa rete in cui è in esecuzione Home Assistant oppure utilizza lo stesso indirizzo IP pubblico."
     },
     "fcm_connection_stuck": {
       "title": "Connessione push FCM non riuscita",

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "Herauthenticatie vereist",
-      "description": "Authenticatie voor Google Find My Device is ongeldig of verlopen voor dit item.\n\n**Item:** {entry_title}\n**Account:** {email}\n\nSelecteer **Opnieuw configureren** op de integratiekaart om opnieuw aan te melden. Als je onlangs je Google-wachtwoord hebt gewijzigd of tokens hebt ingetrokken, moet je hier opnieuw authenticeren om de functionaliteit te herstellen."
+      "description": "Authenticatie voor Google Find My Device is ongeldig of verlopen voor dit item.\n\n**Item:** {entry_title}\n**Account:** {email}\n\nSelecteer **Opnieuw configureren** op de integratiekaart om opnieuw aan te melden. Als je onlangs je Google-wachtwoord hebt gewijzigd of tokens hebt ingetrokken, moet je hier opnieuw authenticeren om de functionaliteit te herstellen.\n\n**Tip:** Google kan tokens intrekken wanneer verzoeken afkomstig zijn van een ander IP-adres of een andere regio dan waar het token is aangemaakt (bijv. token gegenereerd op een laptop maar gebruikt vanaf een server of VPS in een ander land). Genereer je `secrets.json` op hetzelfde netwerk waar Home Assistant draait, of gebruik hetzelfde openbare IP-adres."
     },
     "fcm_connection_stuck": {
       "title": "FCM push-verbinding mislukt",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "Wymagane ponowne uwierzytelnienie",
-      "description": "Uwierzytelnienie Google Find My Device jest nieprawidłowe lub wygasło.\n\n**Wpis:** {entry_title}\n**Konto:** {email}\n\nNa karcie integracji wybierz **Skonfiguruj ponownie**, aby przejść proces ponownego logowania. Jeśli niedawno zmieniono hasło do Google lub cofnięto tokeny, musisz zalogować się tutaj ponownie, aby przywrócić działanie."
+      "description": "Uwierzytelnienie Google Find My Device jest nieprawidłowe lub wygasło.\n\n**Wpis:** {entry_title}\n**Konto:** {email}\n\nNa karcie integracji wybierz **Skonfiguruj ponownie**, aby przejść proces ponownego logowania. Jeśli niedawno zmieniono hasło do Google lub cofnięto tokeny, musisz zalogować się tutaj ponownie, aby przywrócić działanie.\n\n**Wskazówka:** Google może unieważnić tokeny, gdy żądania pochodzą z innego adresu IP lub regionu niż ten, w którym token został utworzony (np. token wygenerowany na laptopie, ale używany z serwera lub VPS w innym kraju). Wygeneruj plik `secrets.json` w tej samej sieci, w której działa Home Assistant, lub użyj tego samego publicznego adresu IP."
     },
     "fcm_connection_stuck": {
       "title": "Połączenie push FCM nie powiodło się",

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "Reautenticação necessária",
-      "description": "A autenticação do Google Find My Device é inválida ou expirou para esta entrada.\n\n**Entrada:** {entry_title}\n**Conta:** {email}\n\nSelecione **Reconfigurar** no cartão da integração para entrar novamente. Se você alterou recentemente sua senha do Google ou revogou tokens, é necessário se autenticar novamente aqui para restaurar a funcionalidade."
+      "description": "A autenticação do Google Find My Device é inválida ou expirou para esta entrada.\n\n**Entrada:** {entry_title}\n**Conta:** {email}\n\nSelecione **Reconfigurar** no cartão da integração para entrar novamente. Se você alterou recentemente sua senha do Google ou revogou tokens, é necessário se autenticar novamente aqui para restaurar a funcionalidade.\n\n**Dica:** O Google pode revogar tokens quando as solicitações vêm de um endereço IP ou região diferente de onde o token foi criado (por ex. token gerado em um laptop mas usado a partir de um servidor ou VPS em outro país). Gere o arquivo `secrets.json` na mesma rede onde o Home Assistant está rodando, ou use o mesmo endereço IP público."
     },
     "fcm_connection_stuck": {
       "title": "Falha na conexão push do FCM",

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -628,7 +628,7 @@
   "issues": {
     "auth_expired": {
       "title": "Reautenticação necessária",
-      "description": "A autenticação do Google Find My Device é inválida ou expirou para esta entrada.\n\n**Entrada:** {entry_title}\n**Conta:** {email}\n\nSelecione **Reconfigurar** no cartão da integração para entrar novamente. Se você alterou recentemente sua senha do Google ou revogou tokens, é necessário se autenticar novamente aqui para restaurar a funcionalidade."
+      "description": "A autenticação do Google Find My Device é inválida ou expirou para esta entrada.\n\n**Entrada:** {entry_title}\n**Conta:** {email}\n\nSelecione **Reconfigurar** no cartão da integração para entrar novamente. Se você alterou recentemente sua senha do Google ou revogou tokens, é necessário se autenticar novamente aqui para restaurar a funcionalidade.\n\n**Dica:** O Google pode revogar tokens quando as solicitações vêm de um endereço IP ou região diferente de onde o token foi criado (por ex. token gerado num portátil mas utilizado a partir de um servidor ou VPS noutro país). Gere o ficheiro `secrets.json` na mesma rede onde o Home Assistant está a funcionar ou utilize o mesmo endereço IP público."
     },
     "fcm_connection_stuck": {
       "title": "Falha na conexão push do FCM",


### PR DESCRIPTION
Google may revoke tokens when API requests come from a different IP
address or region than where the token was created (e.g. secrets.json
generated on a laptop but used from a VPS in another country).  This
is a frequent cause of repeated BadAuthentication errors reported
upstream (https://github.com/leonboe1/GoogleFindMyTools/issues/78).

- Add a **Tip** paragraph to the auth_expired repair issue description
  in strings.json and all 8 translation files (de, en, es, fr, it,
  nl, pl, pt, pt-BR)
- Add "Authentication Expires Repeatedly" section to README
  troubleshooting

https://claude.ai/code/session_01FEYCWFKPqPSFqRS857YYB7
