### PR TITLE
docs: BLE battery sensor architecture & lessons learned

### DIFF
--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -2307,11 +2307,16 @@ class GoogleFindMyEIDResolver:
         """Decode the FMDN hashed-flags byte and store battery state.
 
         Extracts the optional flags byte from the BLE payload, XOR-decodes
-        it, and persists a :class:`BLEBatteryState` for **every** matched
-        device_id (shared-device propagation).
+        it, and persists a :class:`BLEBatteryState` keyed by
+        ``canonical_id`` (the Google API device identifier) for **every**
+        matched device (shared-device propagation).
 
-        On first successful decode per device a DEBUG-level
-        ``FMDN_FLAGS_PROBE`` log is emitted; subsequent updates also log at
+        The canonical_id key must match the ``device["id"]`` used by the
+        coordinator snapshot and :class:`GoogleFindMyBLEBatterySensor` so
+        that :meth:`get_ble_battery_state` lookups succeed.
+
+        On first successful decode per device an INFO-level
+        ``FMDN_FLAGS_PROBE`` log is emitted; subsequent updates log at
         DEBUG level only when the battery level changes.
         """
         if not matches:
@@ -2356,19 +2361,25 @@ class GoogleFindMyEIDResolver:
                 battery_raw, f"UNKNOWN({battery_raw})"
             )
 
-            # Store for ALL matches (shared-device propagation)
+            # Store for ALL matches (shared-device propagation).
+            # Key by canonical_id (Google API device ID) — this is the same
+            # identifier used by the coordinator snapshot (device["id"]) and
+            # by GoogleFindMyBLEBatterySensor._device_id so that
+            # get_ble_battery_state() lookups succeed.
             for match in matches:
-                prev = self._ble_battery_state.get(match.device_id)
-                self._ble_battery_state[match.device_id] = state
+                storage_key = match.canonical_id or match.device_id
+                prev = self._ble_battery_state.get(storage_key)
+                self._ble_battery_state[storage_key] = state
 
-                # First decode per device → diagnostic probe log
-                if match.device_id not in self._flags_logged_devices:
-                    _LOGGER.debug(
-                        "FMDN_FLAGS_PROBE device=%s flags_byte=0x%02x "
-                        "xor_mask=0x%02x decoded=0x%02x battery=%s(%d) "
-                        "battery_pct=%d uwt_mode=%s observed_frame=%s "
-                        "payload_len=%d",
+                # First decode per device → INFO probe log (once per device)
+                if storage_key not in self._flags_logged_devices:
+                    _LOGGER.info(
+                        "FMDN_FLAGS_PROBE device=%s canonical=%s "
+                        "flags_byte=0x%02x xor_mask=0x%02x decoded=0x%02x "
+                        "battery=%s(%d) battery_pct=%d uwt_mode=%s "
+                        "observed_frame=%s payload_len=%d",
                         match.device_id,
+                        match.canonical_id,
                         flags_byte,
                         xor_mask,
                         decoded,
@@ -2381,12 +2392,12 @@ class GoogleFindMyEIDResolver:
                         else None,
                         length,
                     )
-                    self._flags_logged_devices.add(match.device_id)
+                    self._flags_logged_devices.add(storage_key)
                 elif prev is not None and prev.battery_level != battery_raw:
                     # Battery level changed → DEBUG log
                     _LOGGER.debug(
                         "BLE battery changed device=%s %s(%d)→%s(%d)",
-                        match.device_id,
+                        storage_key,
                         battery_labels.get(prev.battery_level, "?"),
                         prev.battery_level,
                         battery_label,
@@ -2395,7 +2406,8 @@ class GoogleFindMyEIDResolver:
         else:
             # Cannot decode — log once per device at DEBUG for diagnostics
             for match in matches:
-                if match.device_id not in self._flags_logged_devices:
+                storage_key = match.canonical_id or match.device_id
+                if storage_key not in self._flags_logged_devices:
                     _max_hex = 40  # noqa: PLR2004
                     raw_hex = (
                         raw.hex()
@@ -2403,10 +2415,11 @@ class GoogleFindMyEIDResolver:
                         else raw[:_max_hex].hex() + "..."
                     )
                     _LOGGER.debug(
-                        "FMDN_FLAGS_PROBE device=%s CANNOT_DECODE "
-                        "observed_frame=%s payload_len=%d "
+                        "FMDN_FLAGS_PROBE device=%s canonical=%s "
+                        "CANNOT_DECODE observed_frame=%s payload_len=%d "
                         "has_xor_mask=%s flags_byte_found=%s raw_hex=%s",
                         match.device_id,
+                        match.canonical_id,
                         f"0x{observed_frame:02x}"
                         if observed_frame is not None
                         else None,
@@ -2415,13 +2428,18 @@ class GoogleFindMyEIDResolver:
                         flags_byte is not None,
                         raw_hex,
                     )
-                    self._flags_logged_devices.add(match.device_id)
+                    self._flags_logged_devices.add(storage_key)
 
     # ------------------------------------------------------------------
     # Public BLE battery API
     # ------------------------------------------------------------------
     def get_ble_battery_state(self, device_id: str) -> BLEBatteryState | None:
-        """Return the last observed BLE battery state for a device, or None."""
+        """Return the last observed BLE battery state for a device, or None.
+
+        The *device_id* parameter is the **canonical_id** (Google API device
+        identifier, i.e. ``device["id"]`` from the coordinator snapshot),
+        not the HA device-registry ID.
+        """
         return self._ble_battery_state.get(device_id)
 
     def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:  # noqa: PLR0911, PLR0912, PLR0915

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -559,6 +559,12 @@ async def async_setup_entry(
                             added_unique_ids.add(bat_uid)
                             known_battery_ids.add(dev_id)
                             entities.append(battery_entity)
+                            _LOGGER.info(
+                                "BLE battery sensor created for device=%s "
+                                "(battery=%s%%)",
+                                dev_id,
+                                battery_state.battery_percentage,
+                            )
 
             return entities
 

--- a/docs/BLE_BATTERY_SENSOR.md
+++ b/docs/BLE_BATTERY_SENSOR.md
@@ -1,0 +1,259 @@
+# BLE Battery Sensor — Architecture & Lessons Learned
+
+This document describes the **BLE battery sensor** feature: how battery
+state flows from a Bluetooth Low Energy advertisement all the way to a
+Home Assistant sensor entity.  It also records the lessons learned during
+development so that future contributors avoid the same pitfalls.
+
+---
+
+## 1. High-level data flow
+
+```
+┌─────────────┐   BLE advert    ┌──────────┐  resolve_eid()  ┌─────────────────────┐
+│  Tracker    │ ──────────────► │ Bermuda  │ ──────────────► │  EID Resolver       │
+│  (FMDN)    │   0x40|EID|flags│ (scanner) │  raw payload    │  (googlefindmy)     │
+└─────────────┘                 └──────────┘                 │                     │
+                                                             │  _resolve_eid_…()   │
+                                                             │  ↓                  │
+                                                             │  _update_ble_battery│
+                                                             │  ↓                  │
+                                                             │  _ble_battery_state │
+                                                             │  [canonical_id]     │
+                                                             └────────┬────────────┘
+                                                                      │
+              ┌───────────────────────────────────────────────────────┘
+              │ get_ble_battery_state(canonical_id)
+              ▼
+┌───────────────────────────┐   _build_entities()    ┌────────────────────────────┐
+│  sensor.py                │ ◄────────────────────  │  Coordinator update loop   │
+│  GoogleFindMyBLEBattery-  │                        │  (_add_new_devices listener)│
+│  Sensor                   │                        └────────────────────────────┘
+│  ._device_id = canonical  │
+│  .native_value → battery% │
+└───────────────────────────┘
+```
+
+### Step-by-step
+
+| # | Where | What happens |
+|---|-------|-------------|
+| 1 | **Tracker** | Broadcasts a BLE advertisement with Frame Type `0x40`, a 20-byte EID, and an optional 1-byte hashed-flags field. |
+| 2 | **Bermuda** (`fmdn/extraction.py`) | `extract_raw_fmdn_payloads()` extracts the **unmodified** service-data bytes (including the hashed-flags byte). |
+| 3 | **Bermuda** (`fmdn/integration.py`) | `normalize_eid_bytes()` converts the type to `bytes` (no content stripping), then calls `resolver.resolve_eid(payload)` or `resolver.resolve_eid_all(payload)`. |
+| 4 | **Resolver** (`eid_resolver.py`) | `_resolve_eid_internal()` looks up the EID in the precomputed cache. If found, returns `list[EIDMatch]` plus the raw payload and frame metadata. |
+| 5 | **Resolver** (`_update_ble_battery()`) | Locates the hashed-flags byte by frame format, XOR-decodes it with `compute_flags_xor_mask()`, extracts 2-bit battery level (bits 5-6) and UWT mode (bit 7). Stores a `BLEBatteryState` keyed by **`canonical_id`**. |
+| 6 | **Sensor** (`sensor.py` → `_build_entities()`) | On every coordinator update, iterates devices and calls `resolver.get_ble_battery_state(dev_id)` where `dev_id = device["id"]` (the canonical_id). If non-None, creates a `GoogleFindMyBLEBatterySensor`. |
+| 7 | **Sensor** (`native_value` property) | On each HA state poll, reads the latest `BLEBatteryState` from the resolver and returns `battery_pct`. |
+
+---
+
+## 2. Identity model — the three device IDs
+
+Understanding the identity model is **critical** for this feature.
+Three identifiers coexist in the system:
+
+| Identifier | Source | Example | Used where |
+|---|---|---|---|
+| **`canonical_id`** | Google API (`device["id"]` in coordinator snapshot, `DeviceIdentity.canonical_id`) | `01KBBxxx:aaaaaaaa-…-bbbbbbbb` | Coordinator snapshots, sensor `_device_id`, `_ble_battery_state` key |
+| **`registry_id`** | HA device registry (`device.id`, `DeviceIdentity.registry_id`) | `11b2838b4bb2ba2eb5f4f4b2c742cbf9` | `EIDMatch.device_id`, internal HA references |
+| **`config_entry_id`** | HA config entry | `abcdef1234567890` | `EIDMatch.config_entry_id` |
+
+The mapping lives in `coordinator/identity.py`:
+
+```python
+registry_map[canonical_id] = (device.id, None)
+#            ^^^^^^^^^^^^     ^^^^^^^^^
+#            Google API ID    HA registry ID
+```
+
+### Key rule
+
+> **`_ble_battery_state` MUST be keyed by `canonical_id`** because
+> the sensor entity queries it with `device["id"]` from the coordinator
+> snapshot, which is always the canonical_id.
+
+The storage key is computed as:
+```python
+storage_key = match.canonical_id or match.device_id
+```
+
+The `or match.device_id` fallback handles the (theoretical) case where
+`canonical_id` is empty, but in practice it is always set.
+
+---
+
+## 3. Hashed-flags byte — decoding
+
+The FMDN hashed-flags byte is XOR-obfuscated per rotation window.
+The resolver computes the XOR mask during EID precomputation
+(`compute_flags_xor_mask()` in `FMDNCrypto/eid_generator.py`).
+
+```
+Raw flags byte:    0xAB
+XOR mask:          0x73   (derived from EIK + time counter)
+Decoded:           0xAB ^ 0x73 = 0xD8
+
+Bit layout (decoded):
+  Bits 0-4:   Reserved / implementation-specific
+  Bits 5-6:   Battery level (2-bit enum)
+  Bit  7:     UWT mode (Unwanted Tracking protection active)
+
+Battery mapping:
+  0 → GOOD       → 100%
+  1 → LOW        →  25%
+  2 → CRITICAL   →   5%
+  3 → RESERVED   →   0%
+```
+
+The XOR mask is computed for **all** EID windows (previous, current,
+next) so the resolver can decode the flags regardless of which rotation
+window the tracker is currently broadcasting.
+
+---
+
+## 4. Lazy sensor creation
+
+The battery sensor is **not** created at integration startup.  It is
+created **lazily** when the first BLE battery state arrives:
+
+1. `_build_entities()` runs on every coordinator data update.
+2. It checks `resolver.get_ble_battery_state(dev_id)`.
+3. If the result is `None` (no BLE data yet), no sensor is created.
+4. Once Bermuda resolves a BLE advertisement and the resolver stores the
+   battery state, the next coordinator update detects non-None state and
+   creates the sensor entity.
+5. After creation, the sensor is tracked in `known_battery_ids` to avoid
+   duplicate creation.
+
+This means the sensor only appears after Bermuda (or another BLE
+scanner) has resolved at least one advertisement for the device.
+
+---
+
+## 5. Logging strategy
+
+| Log | Level | When | Purpose |
+|---|---|---|---|
+| `FMDN_FLAGS_PROBE` (first decode) | **INFO** | Once per device (lifetime of resolver instance) | Confirms the BLE battery pipeline works end-to-end |
+| `FMDN_FLAGS_PROBE CANNOT_DECODE` | DEBUG | Once per device when decode fails | Diagnostics for missing XOR mask or truncated payload |
+| `BLE battery changed` | DEBUG | On every battery level change | Track battery transitions |
+| `BLE battery sensor created` | **INFO** | Once per device when entity is created | Confirms sensor appeared in HA |
+
+The first-decode `FMDN_FLAGS_PROBE` is at **INFO** level intentionally.
+It fires exactly once per device per HA session, so it is not spammy.
+Users need to see this in default HA logs to confirm the pipeline works.
+
+---
+
+## 6. Lessons Learned
+
+### 6.1  Device ID mismatch (root cause bug)
+
+**Symptom:** Battery sensor never appeared despite Bermuda correctly
+resolving EIDs and `_update_ble_battery()` being called.
+
+**Root cause:** `_ble_battery_state` was keyed by `match.device_id`
+(HA device registry ID), but `get_ble_battery_state()` was called with
+`device["id"]` from the coordinator snapshot (Google API canonical_id).
+These are **always** different identifiers.
+
+```
+Resolver stored:  _ble_battery_state["11b2838b4bb2ba2eb5…"]  ← registry_id
+Sensor queried:   get_ble_battery_state("01KBBxxx:aaaa…")    ← canonical_id
+→ NEVER equal → lookup ALWAYS returned None → sensor NEVER created
+```
+
+**Fix:** Key `_ble_battery_state` by `match.canonical_id` (with
+fallback to `match.device_id`).
+
+**Lesson:** When multiple identifier namespaces coexist, document and
+test the keying contract explicitly.  The `EIDMatch` dataclass carries
+both `device_id` (registry) and `canonical_id` (Google API), and it is
+easy to pick the wrong one.
+
+### 6.2  Log level demotion hides diagnostics
+
+**Symptom:** User demoted `FMDN_FLAGS_PROBE` from INFO to DEBUG.
+Afterward, the log message disappeared entirely from the HA log viewer
+(which defaults to INFO level).  User concluded the code was broken.
+
+**Root cause:** Not a code bug — HA's default log level filters out
+DEBUG messages.  The demotion was structurally correct but made the
+one-time diagnostic probe invisible.
+
+**Fix:** Reverted the first-decode `FMDN_FLAGS_PROBE` to INFO.  It
+fires once per device per session, so it is acceptable at INFO.  All
+subsequent/repeated logs remain at DEBUG.
+
+**Lesson:** One-time-per-device diagnostic logs should stay at INFO.
+They are essential for confirming end-to-end functionality and do not
+create log noise.  Only repeated / per-advertisement logs should be
+demoted to DEBUG.
+
+### 6.3  `resolve_eid()` is a public API with no internal callers
+
+**Symptom:** During initial debugging, it looked like `resolve_eid()`
+was never called because no callers existed within the googlefindmy
+codebase.
+
+**Root cause:** `resolve_eid()` is intentionally a **public API** for
+external consumers (e.g., Bermuda).  The integration itself never calls
+it.  The EID resolution path is driven entirely by the external BLE
+scanner.
+
+**Lesson:** When tracing a data path, check external consumers (other
+integrations) in addition to internal callers.  The
+`Ephemeral_Identifier_Resolver_API.md` documents this contract.
+
+### 6.4  Google API `battery_level` is always None
+
+The `battery_level` field in the coordinator data model (from
+`ProtoDecoders/decoder.py`) is always `None` — Google's API does not
+populate it for FMDN trackers.  Battery data is only available via the
+BLE hashed-flags byte decoded locally.  Do not confuse
+`device["battery_level"]` (always None) with
+`BLEBatteryState.battery_level` (from BLE).
+
+### 6.5  Bermuda passes full raw payloads
+
+Bermuda's `extract_raw_fmdn_payloads()` returns the **unmodified**
+payload bytes including the hashed-flags byte.  The
+`normalize_eid_bytes()` helper only normalizes the Python type
+(`bytearray`/`memoryview`/`str` → `bytes`) without stripping content.
+This is correct and expected — the resolver needs the full payload to
+extract the flags byte.
+
+---
+
+## 7. Test coverage
+
+Tests live in `tests/test_ble_battery_sensor.py` and cover:
+
+- Battery state storage and retrieval via canonical_id
+- All battery levels (GOOD, LOW, CRITICAL, RESERVED)
+- UWT mode detection
+- Sensor creation, availability, and restore behavior
+- Shared-device propagation (multiple matches per advertisement)
+- XOR mask computation and flags byte decoding
+- Frame format detection (service-data vs raw-header)
+
+The `_match()` test helper defaults `canonical_id` to `device_id` so
+that the storage key matches the lookup key in test scenarios.
+
+---
+
+## 8. File reference
+
+| File | Role |
+|---|---|
+| `eid_resolver.py:2300–2443` | `_update_ble_battery()`, `get_ble_battery_state()` |
+| `eid_resolver.py:150–173` | `BLEBatteryState` dataclass, `FMDN_BATTERY_PCT` mapping |
+| `eid_resolver.py:132–139` | `EIDMatch` (carries both `device_id` and `canonical_id`) |
+| `sensor.py:500–567` | `_build_entities()` — lazy battery sensor creation |
+| `sensor.py:1270–1400` | `GoogleFindMyBLEBatterySensor` class |
+| `coordinator/identity.py:457` | `registry_map[canonical_id] = (device.id, None)` |
+| `coordinator/main.py:505–520` | `DeviceIdentity` dataclass |
+| `FMDNCrypto/eid_generator.py:256` | `compute_flags_xor_mask()` |
+| `ProtoDecoders/decoder.py:334` | `"id": canonic_id` in device stub |
+| `tests/test_ble_battery_sensor.py` | Full test suite |

--- a/docs/Ephemeral_Identifier_Resolver_API.md
+++ b/docs/Ephemeral_Identifier_Resolver_API.md
@@ -129,6 +129,68 @@ async def async_process_eid(hass, eid_bytes: bytes) -> dict[str, Any] | None:
 
 ---
 
+## BLE Battery State API
+
+When a BLE advertisement contains the optional **hashed-flags byte**
+(the byte immediately after the 20-byte EID), the resolver automatically
+decodes the battery level and stores it.  External integrations do not
+need to decode flags themselves.
+
+### Reading battery state
+
+```python
+from custom_components.googlefindmy.eid_resolver import BLEBatteryState
+
+if resolver:
+    # IMPORTANT: device_id must be the canonical_id (Google API device ID),
+    # i.e. device["id"] from the coordinator snapshot.
+    # This is NOT the HA device registry ID (match.device_id).
+    state: BLEBatteryState | None = resolver.get_ble_battery_state(canonical_id)
+    if state:
+        _LOGGER.info(
+            "Battery: %d%% (raw=%d, uwt=%s, observed=%.0f)",
+            state.battery_pct,
+            state.battery_level,
+            state.uwt_mode,
+            state.observed_at_wall,
+        )
+```
+
+### `BLEBatteryState` fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `battery_level` | `int` | Raw FMDN 2-bit value: 0=GOOD, 1=LOW, 2=CRITICAL, 3=RESERVED |
+| `battery_pct` | `int` | Mapped percentage: 100, 25, 5, or 0 |
+| `uwt_mode` | `bool` | `True` if Unwanted Tracking protection is active (bit 7) |
+| `decoded_flags` | `int` | Fully decoded flags byte (after XOR) |
+| `observed_at_wall` | `float` | Wall-clock `time.time()` of the BLE observation |
+
+### Identity model — which ID to use
+
+The resolver stores battery state keyed by **`canonical_id`** (the Google
+API device identifier, e.g. `01KBBxxx:aaaaaaaa-…-bbbbbbbb`).  This is
+the same value as `device["id"]` in the coordinator snapshot.
+
+**Do not** use `EIDMatch.device_id` (the HA device registry ID) as the
+lookup key — it is a different identifier and the lookup will return
+`None`.
+
+See `docs/BLE_BATTERY_SENSOR.md` for a detailed architecture description
+and lessons learned.
+
+### Payload requirements for battery decoding
+
+For battery decoding to work, the BLE scanner must pass the **full raw
+payload** (including the hashed-flags byte) to `resolve_eid()`.  If only
+the bare 20-byte EID is passed, EID resolution will succeed but the
+battery state will not be decoded.
+
+Bermuda's `extract_raw_fmdn_payloads()` already preserves the full
+payload.  Other scanners should ensure they do not strip trailing bytes.
+
+---
+
 ## Technical Specification
 
 This section details the cryptographic construction and frame layout of the EIDs handled by the resolver. This information is critical for BLE scanner implementations to correctly extract the payload before calling the resolver.

--- a/tests/test_ble_battery_sensor.py
+++ b/tests/test_ble_battery_sensor.py
@@ -82,12 +82,16 @@ def _make_resolver() -> GoogleFindMyEIDResolver:
     return resolver
 
 
-def _match(device_id: str = "dev-1") -> EIDMatch:
-    """Create a test EIDMatch."""
+def _match(device_id: str = "dev-1", canonical_id: str | None = None) -> EIDMatch:
+    """Create a test EIDMatch.
+
+    *canonical_id* defaults to *device_id* so that the battery-state
+    storage key (``canonical_id``) matches the test lookup key.
+    """
     return EIDMatch(
         device_id=device_id,
         config_entry_id="entry-1",
-        canonical_id="canonical-1",
+        canonical_id=canonical_id if canonical_id is not None else device_id,
         time_offset=0,
         is_reversed=False,
     )


### PR DESCRIPTION
[fix: use canonical_id as battery state storage key (device ID mismatch)](https://github.com/jleinenbach/GoogleFindMy-HA/commit/a14c6a603a134124dac268b49f862a49321810fe) 

The BLE battery state was stored keyed by match.device_id (HA device
registry ID) but queried via device["id"] (Google API canonical_id).
These are different identifiers, so get_ble_battery_state() always
returned None and the battery sensor was never created.

- Key _ble_battery_state by canonical_id (match.canonical_id or
  match.device_id as fallback) to match the coordinator snapshot ID
- Revert first-decode FMDN_FLAGS_PROBE back to INFO (one-time per
  device, not spammy) so users can see it with default log levels
- Add canonical=%s to FMDN_FLAGS_PROBE log format for diagnostics
- Add INFO log in sensor.py when BLE battery sensor entity is created
- Update docstrings to document canonical_id keying contract
- Update _match() test helper to default canonical_id to device_id

https://claude.ai/code/session_01FEYCWFKPqPSFqRS857YYB7
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 10 minutes ago
[docs: BLE battery sensor architecture & lessons learned](https://github.com/jleinenbach/GoogleFindMy-HA/commit/6bda88843ad7d3ac1f2ef2aae692f86b5d9e3efd) 

- New docs/BLE_BATTERY_SENSOR.md: full data flow diagram (Tracker →
  Bermuda → Resolver → Sensor), identity model (canonical_id vs
  registry_id vs config_entry_id), hashed-flags decoding, lazy sensor
  creation, logging strategy, and five lessons learned from the
  device-ID mismatch bug.
- Updated docs/Ephemeral_Identifier_Resolver_API.md: added BLE Battery
  State API section with code examples, BLEBatteryState field reference,
  identity model warning, and payload requirements.

https://claude.ai/code/session_01FEYCWFKPqPSFqRS857YYB7