### PR TITLE
fix: battery_raw=3 maps to None (not 0%) and Bermuda event guard

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1147,6 +1147,18 @@ class FcmReceiverHA:
                 await self._run_callback_async(cb, canonic_id, hex_string)
                 return
 
+            # Log FCM pushes that have no registered callback (e.g. sound
+            # confirmations, device status updates).  This fires only in
+            # response to a user-initiated action (Play Sound button etc.)
+            # so it does not create log spam during normal operation.
+            _LOGGER.debug(
+                "FCM push for %s has no registered callback "
+                "(may be action confirmation): payload_len=%d, hex_prefix=%s",
+                canonic_id[:8],
+                len(hex_string),
+                hex_string[:120] if hex_string else "(empty)",
+            )
+
             tracked = [
                 c for c in target_coordinators if self._is_tracked(c, canonic_id)
             ]

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -8130,7 +8130,9 @@ async def _async_unload_parent_entry(hass: HomeAssistant, entry: MyConfigEntry) 
 
         # Unload BLE scanner (if registered)
         try:
-            from .fmdn_finder.ble_scanner import async_unload_ble_scanner  # noqa: PLC0415
+            from .fmdn_finder.ble_scanner import (
+                async_unload_ble_scanner,  # noqa: PLC0415
+            )
 
             await async_unload_ble_scanner(hass)
         except ImportError:

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -7377,13 +7377,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
         # devices across all loaded config entries via hass.data[DOMAIN][DATA_EID_RESOLVER].
         domain_bucket[DATA_EID_RESOLVER] = eid_resolver
 
-    # Setup FMDN Finder (Bermuda integration listener for location uploads)
-    # This allows Home Assistant to act as a "Finder" in Google's FMDN network,
-    # uploading encrypted location reports for detected FMDN beacons.
-    # Feature is disabled by default via FEATURE_FMDN_FINDER_ENABLED in const.py.
+    # ---- BLE Scanner: optional HA-Bluetooth FMDN advertisement listener ----
+    # Always attempted (independent of FEATURE_FMDN_FINDER_ENABLED).
+    # Collects MAC addresses and frame types for future BLE ringing (Phase 2).
+    # Silently skipped when the bluetooth integration is not loaded.
+    try:
+        from .fmdn_finder.ble_scanner import async_setup_ble_scanner  # noqa: PLC0415
+
+        await async_setup_ble_scanner(hass)
+    except ImportError:
+        _LOGGER.debug("BLE scanner module not available (optional)")
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("BLE scanner setup skipped: %s", err)
+
+    # ---- FMDN Finder: Bermuda listener for location uploads ----
+    # Disabled by default via FEATURE_FMDN_FINDER_ENABLED in const.py.
     if FEATURE_FMDN_FINDER_ENABLED:
         try:
-            from .fmdn_finder import async_setup_fmdn_finder
+            from .fmdn_finder import async_setup_fmdn_finder  # noqa: PLC0415
 
             fmdn_setup_success = await async_setup_fmdn_finder(hass)
             if fmdn_setup_success:
@@ -8117,9 +8128,19 @@ async def _async_unload_parent_entry(hass: HomeAssistant, entry: MyConfigEntry) 
         except Exception as err:
             _LOGGER.debug("FCM release during parent unload raised: %s", err)
 
+        # Unload BLE scanner (if registered)
+        try:
+            from .fmdn_finder.ble_scanner import async_unload_ble_scanner  # noqa: PLC0415
+
+            await async_unload_ble_scanner(hass)
+        except ImportError:
+            pass
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("BLE scanner unload raised: %s", err)
+
         # Unload FMDN Finder (if enabled)
         try:
-            from .fmdn_finder import async_unload_fmdn_finder
+            from .fmdn_finder import async_unload_fmdn_finder  # noqa: PLC0415
 
             await async_unload_fmdn_finder(hass)
             _LOGGER.debug("FMDN Finder unloaded successfully")

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -1535,8 +1535,15 @@ class GoogleFindMyAPI:
                 )
                 return (False, None)
 
-            _response_hex, request_uuid = result
+            response_hex, request_uuid = result
             _LOGGER.info("Play Sound (async) submitted successfully for %s", device_id)
+            _LOGGER.debug(
+                "Play Sound Nova response for %s (uuid=%s): %d bytes: %s",
+                device_id,
+                request_uuid[:8] if request_uuid else "none",
+                len(response_hex) // 2 if response_hex else 0,
+                response_hex[:200] if response_hex else "(empty)",
+            )
             return (True, request_uuid)
 
         except NovaAuthError as err:
@@ -1629,6 +1636,12 @@ class GoogleFindMyAPI:
             if ok:
                 _LOGGER.info(
                     "Stop Sound (async) submitted successfully for %s", device_id
+                )
+                _LOGGER.debug(
+                    "Stop Sound Nova response for %s: %d bytes: %s",
+                    device_id,
+                    len(result_hex) // 2 if result_hex else 0,
+                    result_hex[:200] if result_hex else "(empty)",
                 )
             else:
                 _LOGGER.error(

--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Iterable, Mapping
+from datetime import UTC, datetime
 from typing import Any, NamedTuple
 
 from homeassistant.components.binary_sensor import (
@@ -43,16 +44,20 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import EntityRecoveryManager
 from .const import (
+    DATA_EID_RESOLVER,
     DOMAIN,
     EVENT_AUTH_ERROR,
     EVENT_AUTH_OK,
     SERVICE_SUBENTRY_KEY,
     SUBENTRY_TYPE_SERVICE,
+    SUBENTRY_TYPE_TRACKER,
+    TRACKER_SUBENTRY_KEY,
     TRANSLATION_KEY_AUTH_STATUS,
     issue_id_for,
 )
 from .coordinator import GoogleFindMyCoordinator, format_epoch_utc
 from .entity import (
+    GoogleFindMyDeviceEntity,
     GoogleFindMyEntity,
     ensure_config_subentry_id,
     ensure_dispatcher_dependencies,
@@ -114,6 +119,12 @@ CONNECTIVITY_DESC = BinarySensorEntityDescription(
     key="connectivity",
     translation_key="connectivity",
     device_class=CONNECTIVITY_DEVICE_CLASS,
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+
+UWT_MODE_DESC = BinarySensorEntityDescription(
+    key="uwt_mode",
+    translation_key="uwt_mode",
     entity_category=EntityCategory.DIAGNOSTIC,
 )
 
@@ -337,6 +348,125 @@ async def async_setup_entry(  # noqa: PLR0915
         )
         _schedule_service_entities(deduped_entities, True)
 
+    # ---- Per-device tracker scope: UWT-Mode binary sensors ----
+    processed_tracker_identifiers: set[str] = set()
+    known_uwt_ids: set[str] = set()
+
+    def _get_ble_resolver() -> Any:
+        """Return the EID resolver from hass.data, or None."""
+        domain_data = hass.data.get(DOMAIN)
+        if not isinstance(domain_data, dict):
+            return None
+        return domain_data.get(DATA_EID_RESOLVER)
+
+    def _add_tracker_scope(  # noqa: PLR0915
+        tracker_key: str,
+        forwarded_config_id: str | None,
+    ) -> None:
+        """Create per-device UWT binary sensors for a tracker subentry."""
+        tracker_ids = _known_ids_for_type(SUBENTRY_TYPE_TRACKER)
+        sanitized_config_id = ensure_config_subentry_id(
+            entry,
+            "binary_sensor_tracker",
+            forwarded_config_id,
+            known_ids=tracker_ids,
+        )
+        if sanitized_config_id is None:
+            if tracker_ids:
+                return
+            sanitized_config_id = forwarded_config_id or tracker_key
+
+        tracker_identifier = sanitized_config_id or tracker_key
+        if tracker_identifier in processed_tracker_identifiers:
+            return
+        processed_tracker_identifiers.add(tracker_identifier)
+
+        def _schedule_tracker_entities(
+            new_entities: Iterable[BinarySensorEntity],
+            update_before_add: bool = True,
+        ) -> None:
+            schedule_add_entities(
+                coordinator.hass,
+                async_add_entities,
+                entities=new_entities,
+                update_before_add=update_before_add,
+                config_subentry_id=sanitized_config_id,
+                log_owner="Binary sensor setup (tracker)",
+                logger=_LOGGER,
+            )
+
+        def _build_uwt_entities() -> list[BinarySensorEntity]:
+            """Build UWT-Mode binary sensors for devices with BLE data."""
+            entities: list[BinarySensorEntity] = []
+            resolver = _get_ble_resolver()
+            if resolver is None:
+                return entities
+            for device in coordinator.get_subentry_snapshot(tracker_key):
+                dev_id = device.get("id") if isinstance(device, Mapping) else None
+                dev_name = device.get("name") if isinstance(device, Mapping) else None
+                if not dev_id or not dev_name:
+                    continue
+                if dev_id in known_uwt_ids:
+                    continue
+
+                visible = True
+                is_visible = getattr(
+                    coordinator, "is_device_visible_in_subentry", None
+                )
+                if callable(is_visible):
+                    try:
+                        visible = bool(is_visible(tracker_key, dev_id))
+                    except Exception:  # pragma: no cover
+                        visible = True
+                if not visible:
+                    continue
+
+                battery_state = None
+                try:
+                    battery_state = resolver.get_ble_battery_state(dev_id)
+                except Exception:  # noqa: BLE001
+                    pass
+                if battery_state is None:
+                    continue
+
+                uwt_entity = GoogleFindMyUWTModeSensor(
+                    coordinator,
+                    device,
+                    subentry_key=tracker_key,
+                    subentry_identifier=tracker_identifier,
+                )
+                uwt_uid = getattr(uwt_entity, "unique_id", None)
+                if isinstance(uwt_uid, str) and uwt_uid not in added_unique_ids:
+                    added_unique_ids.add(uwt_uid)
+                    known_uwt_ids.add(dev_id)
+                    entities.append(uwt_entity)
+                    _LOGGER.info(
+                        "UWT-Mode binary sensor created for device=%s "
+                        "(uwt_mode=%s)",
+                        dev_id,
+                        battery_state.uwt_mode,
+                    )
+            return entities
+
+        initial = _build_uwt_entities()
+        if initial:
+            _schedule_tracker_entities(initial, True)
+        else:
+            _schedule_tracker_entities([], True)
+
+        @callback
+        def _add_new_uwt_devices() -> None:
+            new_entities = _build_uwt_entities()
+            if new_entities:
+                _LOGGER.debug(
+                    "Binary sensor: dynamically adding %d UWT entity(ies)",
+                    len(new_entities),
+                )
+                _schedule_tracker_entities(new_entities, True)
+
+        unsub = coordinator.async_add_listener(_add_new_uwt_devices)
+        entry.async_on_unload(unsub)
+
     seen_subentries: set[str | None] = set()
 
     @callback
@@ -350,7 +480,7 @@ async def async_setup_entry(  # noqa: PLR0915
             )
 
         subentry_type = _subentry_type(subentry)
-        if subentry_type is not None and subentry_type != "service":
+        if subentry_type is not None and subentry_type not in ("service", "tracker"):
             _LOGGER.debug(
                 "Binary sensor setup skipped for unrelated subentry '%s' (type '%s')",
                 subentry_identifier,
@@ -362,10 +492,26 @@ async def async_setup_entry(  # noqa: PLR0915
             return
         seen_subentries.add(subentry_identifier)
 
-        for scope in _collect_service_scopes(
-            subentry_identifier, forwarded_config_id=subentry_identifier
-        ):
-            _add_scope(scope, subentry_identifier)
+        if subentry_type != "tracker":
+            for scope in _collect_service_scopes(
+                subentry_identifier, forwarded_config_id=subentry_identifier
+            ):
+                _add_scope(scope, subentry_identifier)
+
+        # Per-device UWT sensors for tracker subentries (or untyped).
+        if subentry_type in (None, "tracker"):
+            tracker_key = TRACKER_SUBENTRY_KEY
+            subentries = getattr(entry, "subentries", None)
+            if isinstance(subentries, Mapping):
+                for sub in subentries.values():
+                    if _subentry_type(sub) == "tracker":
+                        data = getattr(sub, "data", None)
+                        if isinstance(data, Mapping):
+                            tracker_key = data.get(
+                                "group_key", TRACKER_SUBENTRY_KEY
+                            )
+                        break
+            _add_tracker_scope(tracker_key, subentry_identifier)
 
     runtime_data = getattr(entry, "runtime_data", None)
 
@@ -798,3 +944,121 @@ class GoogleFindMyConnectivitySensor(GoogleFindMyEntity, BinarySensorEntity):
         """Attach the sensor to the per-entry service device."""
 
         return self.service_device_info(include_subentry_identifier=True)
+
+
+# --------------------------------------------------------------------------------------
+# Per-device UWT-Mode sensor
+# --------------------------------------------------------------------------------------
+class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
+    """Per-device binary sensor indicating FMDN Unwanted Tracking (UWT) mode.
+
+    Semantics:
+        - ``on``  → The tracker has entered UWT / separated state (away from
+          owner for 8-24 hours).  DULT anti-stalking sound becomes available.
+        - ``off`` → Normal operation, tracker is near owner.
+
+    Data source: bit 7 of the FMDN hashed-flags byte, decoded by the EID
+    resolver as :pyattr:`BLEBatteryState.uwt_mode`.
+
+    Created dynamically alongside the BLE battery sensor when the resolver
+    first decodes hashed-flags data for a device.
+    """
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    entity_description = UWT_MODE_DESC
+
+    _unrecorded_attributes = frozenset({
+        "last_ble_observation",
+        "google_device_id",
+    })
+
+    def __init__(
+        self,
+        coordinator: GoogleFindMyCoordinator,
+        device: dict[str, Any],
+        *,
+        subentry_key: str,
+        subentry_identifier: str,
+    ) -> None:
+        """Initialize the UWT-Mode binary sensor."""
+        super().__init__(
+            coordinator,
+            device,
+            subentry_key=subentry_key,
+            subentry_identifier=subentry_identifier,
+            fallback_label=device.get("name"),
+        )
+        self._device_id: str | None = device.get("id")
+        safe_id = self._device_id if self._device_id is not None else "unknown"
+        entry_id = self.entry_id or "default"
+        self._attr_unique_id = self.build_unique_id(
+            DOMAIN,
+            entry_id,
+            subentry_identifier,
+            f"{safe_id}_uwt_mode",
+            separator="_",
+        )
+
+    def _get_resolver(self) -> Any:
+        """Return the EID resolver from hass.data, or None."""
+        domain_data = self.hass.data.get(DOMAIN)
+        if not isinstance(domain_data, dict):
+            return None
+        return domain_data.get(DATA_EID_RESOLVER)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when UWT / separated state is active."""
+        resolver = self._get_resolver()
+        if resolver is None:
+            return None
+        state = resolver.get_ble_battery_state(self._device_id)
+        if state is None:
+            return None
+        return state.uwt_mode
+
+    @property
+    def icon(self) -> str:
+        """Return a dynamic icon reflecting UWT state."""
+        return "mdi:shield-alert" if self.is_on else "mdi:shield-check"
+
+    @property
+    def available(self) -> bool:
+        """Return True when the coordinator considers the device present."""
+        if not super().available:
+            return False
+        if not self.coordinator_has_device():
+            return False
+        try:
+            if hasattr(self.coordinator, "is_device_present"):
+                return bool(self.coordinator.is_device_present(self._device_id))
+        except Exception:
+            pass
+        return True
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return diagnostic attributes (excluded from recorder)."""
+        resolver = self._get_resolver()
+        if resolver is None:
+            return None
+        state = resolver.get_ble_battery_state(self._device_id)
+        if state is None:
+            return None
+        return {
+            "last_ble_observation": datetime.fromtimestamp(
+                state.observed_at_wall, tz=UTC
+            ).isoformat(),
+            "google_device_id": self._device_id,
+        }
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Refresh Home Assistant state when coordinator data changes."""
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach the sensor to the per-device tracker device."""
+        return super().device_info

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -166,6 +166,26 @@ class BLEBatteryState:
     observed_at_wall: float
 
 
+@dataclass(slots=True)
+class BLEScanInfo:
+    """Last observed BLE scan metadata for a device.
+
+    Stored during EID resolution when a ``ble_address`` is provided by the
+    caller (typically Bermuda or another BLE scanner).  Used by the future
+    BLE ring fallback (Phase 2) to locate the device for a direct GATT
+    connection.
+
+    Attributes:
+        ble_address: Current BLE MAC address (rotates every ~15 min on FMDN).
+        observed_at: Monotonic timestamp (:func:`time.monotonic`) of the scan.
+        observed_at_wall: Wall-clock timestamp (:func:`time.time`) of the scan.
+    """
+
+    ble_address: str
+    observed_at: float
+    observed_at_wall: float
+
+
 # Mapping from FMDN 2-bit battery level to percentage.
 # Aligned with HA Core convention (cf. homeassistant/components/fitbit/const.py)
 # and HA icon thresholds in homeassistant/helpers/icon.py:
@@ -211,11 +231,15 @@ class GoogleFindMyEIDResolverProtocol(Protocol):  # pylint: disable=unnecessary-
         """
         ...
 
-    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:
+    def resolve_eid(
+        self, eid_bytes: bytes, *, ble_address: str | None = None
+    ) -> EIDMatch | None:
         """Resolve EID bytes to a matching device identity.
 
         Args:
             eid_bytes: Raw EID bytes from a BLE advertisement.
+            ble_address: Optional BLE MAC address of the advertising device.
+                When provided, stored for future direct GATT connections.
 
         Returns:
             EIDMatch with device identity info, or None if no match found.
@@ -225,7 +249,9 @@ class GoogleFindMyEIDResolverProtocol(Protocol):  # pylint: disable=unnecessary-
         """
         ...
 
-    def resolve_eid_all(self, eid_bytes: bytes) -> list[EIDMatch]:
+    def resolve_eid_all(
+        self, eid_bytes: bytes, *, ble_address: str | None = None
+    ) -> list[EIDMatch]:
         """Resolve EID bytes to all matching device identities.
 
         This method supports shared devices: when the same physical tracker
@@ -233,10 +259,20 @@ class GoogleFindMyEIDResolverProtocol(Protocol):  # pylint: disable=unnecessary-
 
         Args:
             eid_bytes: Raw EID bytes from a BLE advertisement.
+            ble_address: Optional BLE MAC address of the advertising device.
+                When provided, stored for future direct GATT connections.
 
         Returns:
             List of EIDMatch entries for all accounts that share this device.
             Empty list if no match found.
+        """
+        ...
+
+    def get_ble_scan_info(self, device_id: str) -> BLEScanInfo | None:
+        """Return last observed BLE scan metadata for a device, or None.
+
+        Args:
+            device_id: The canonical_id (Google API device identifier).
         """
         ...
 
@@ -683,6 +719,9 @@ class GoogleFindMyEIDResolver:
     _ble_battery_state: dict[str, BLEBatteryState] = field(
         init=False, default_factory=dict
     )
+    _ble_scan_info: dict[str, BLEScanInfo] = field(
+        init=False, default_factory=dict
+    )
     _cached_identities: list[DeviceIdentity] = field(init=False, default_factory=list)
 
     def __post_init__(self) -> None:
@@ -732,6 +771,8 @@ class GoogleFindMyEIDResolver:
             self._flags_logged_devices = set()
         if not hasattr(self, "_ble_battery_state"):
             self._ble_battery_state = {}
+        if not hasattr(self, "_ble_scan_info"):
+            self._ble_scan_info = {}
         if not hasattr(self, "_cached_identities"):
             self._cached_identities = []
 
@@ -2442,20 +2483,76 @@ class GoogleFindMyEIDResolver:
         """
         return self._ble_battery_state.get(device_id)
 
-    def resolve_eid(self, eid_bytes: bytes) -> EIDMatch | None:  # noqa: PLR0911, PLR0912, PLR0915
+    # ------------------------------------------------------------------
+    # Public BLE scan info API (Phase 2.2 preparation)
+    # ------------------------------------------------------------------
+    def get_ble_scan_info(self, device_id: str) -> BLEScanInfo | None:
+        """Return last observed BLE scan metadata for a device, or None.
+
+        The *device_id* parameter is the **canonical_id** (Google API device
+        identifier, i.e. ``device["id"]`` from the coordinator snapshot),
+        not the HA device-registry ID.
+
+        The returned :class:`BLEScanInfo` contains the current (rotated) BLE
+        MAC address and the timestamp of the last observation.  FMDN trackers
+        rotate their MAC every ~15 minutes, so callers should check
+        ``observed_at`` freshness before attempting GATT connections.
+        """
+        return self._ble_scan_info.get(device_id)
+
+    def _record_ble_scan_info(
+        self, matches: list[EIDMatch], ble_address: str
+    ) -> None:
+        """Store the BLE address for all matched devices.
+
+        Called from :meth:`resolve_eid` when the caller provides a
+        ``ble_address``.  Uses the same canonical_id keying pattern
+        as :attr:`_ble_battery_state`.
+        """
+        now_mono = time.monotonic()
+        now_wall = time.time()
+        for match in matches:
+            storage_key = match.canonical_id or match.device_id
+            self._ble_scan_info[storage_key] = BLEScanInfo(
+                ble_address=ble_address,
+                observed_at=now_mono,
+                observed_at_wall=now_wall,
+            )
+
+    def resolve_eid(  # noqa: PLR0911, PLR0912, PLR0915
+        self,
+        eid_bytes: bytes,
+        *,
+        ble_address: str | None = None,
+    ) -> EIDMatch | None:
         """Resolve a scanned payload to a Home Assistant device registry ID.
 
         For shared devices (same tracker across multiple accounts), this returns
         the match with the smallest time_offset (best match).
         Use resolve_eid_all() to get all matches.
+
+        Args:
+            eid_bytes: Raw EID bytes from a BLE advertisement.
+            ble_address: Optional BLE MAC address of the advertising device.
+                When provided, the address is stored for future direct GATT
+                connections (e.g. BLE ring fallback).  This parameter is
+                backward-compatible: existing callers that omit it are
+                unaffected.
         """
         matches, _, _ = self._resolve_eid_internal(eid_bytes)
         if not matches:
             return None
+        if ble_address is not None:
+            self._record_ble_scan_info(matches, ble_address)
         # Return the match with the smallest absolute time_offset (best match)
         return min(matches, key=lambda m: abs(m.time_offset))
 
-    def resolve_eid_all(self, eid_bytes: bytes) -> list[EIDMatch]:
+    def resolve_eid_all(
+        self,
+        eid_bytes: bytes,
+        *,
+        ble_address: str | None = None,
+    ) -> list[EIDMatch]:
         """Resolve a scanned payload to all matching Home Assistant device registry IDs.
 
         This method supports shared devices: when the same physical tracker
@@ -2465,12 +2562,13 @@ class GoogleFindMyEIDResolver:
 
         Args:
             eid_bytes: Raw EID bytes from a BLE advertisement.
-
-        Returns:
-            List of EIDMatch entries for all accounts that share this device.
-            Empty list if no match found.
+            ble_address: Optional BLE MAC address of the advertising device.
+                When provided, the address is stored for future direct GATT
+                connections (e.g. BLE ring fallback).
         """
         matches, _, _ = self._resolve_eid_internal(eid_bytes)
+        if matches and ble_address is not None:
+            self._record_ble_scan_info(matches, ble_address)
         return matches
 
     def _extract_candidates(  # noqa: PLR0912

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -152,15 +152,15 @@ class BLEBatteryState:
     """Decoded battery state from FMDN hashed-flags BLE advertisement.
 
     Attributes:
-        battery_level: Raw FMDN value (0=GOOD, 1=LOW, 2=CRITICAL).
-        battery_pct: Mapped percentage (100, 25, 5).
+        battery_level: Raw FMDN value (0=GOOD, 1=LOW, 2=CRITICAL, 3=RESERVED).
+        battery_pct: Mapped percentage (100, 25, 5) or None for RESERVED (3).
         uwt_mode: True if Unwanted Tracking mode is active (bit 7).
         decoded_flags: Fully decoded flags byte (after XOR).
         observed_at_wall: Wall-clock timestamp of the BLE observation (time.time()).
     """
 
     battery_level: int
-    battery_pct: int
+    battery_pct: int | None
     uwt_mode: bool
     decoded_flags: int
     observed_at_wall: float
@@ -2386,7 +2386,7 @@ class GoogleFindMyEIDResolver:
             decoded = flags_byte ^ xor_mask
             battery_raw = (decoded >> 5) & 0x03  # bits 5-6
             uwt_mode = bool((decoded >> 7) & 0x01)  # bit 7
-            battery_pct = FMDN_BATTERY_PCT.get(battery_raw, 0)
+            battery_pct = FMDN_BATTERY_PCT.get(battery_raw)
             now_wall = time.time()
 
             state = BLEBatteryState(
@@ -2417,7 +2417,7 @@ class GoogleFindMyEIDResolver:
                     _LOGGER.info(
                         "FMDN_FLAGS_PROBE device=%s canonical=%s "
                         "flags_byte=0x%02x xor_mask=0x%02x decoded=0x%02x "
-                        "battery=%s(%d) battery_pct=%d uwt_mode=%s "
+                        "battery=%s(%d) battery_pct=%s uwt_mode=%s "
                         "observed_frame=%s payload_len=%d",
                         match.device_id,
                         match.canonical_id,

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -131,6 +131,19 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
         Filters for Bermuda tracker entities and triggers FMDN uploads
         only after area has been stable for AREA_STABILIZATION_SECONDS.
         """
+        try:
+            _bermuda_state_changed_inner(event)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Bermuda state event handler failed for %s",
+                event.data.get("entity_id", "<unknown>"),
+                exc_info=True,
+            )
+
+    def _bermuda_state_changed_inner(
+        event: Event[EventStateChangedData],
+    ) -> None:
+        """Inner handler — separated so the outer guard stays minimal."""
         entity_id: str | None = event.data.get("entity_id")
         new_state: State | None = event.data.get("new_state")
         old_state: State | None = event.data.get("old_state")

--- a/custom_components/googlefindmy/fmdn_finder/ble_scanner.py
+++ b/custom_components/googlefindmy/fmdn_finder/ble_scanner.py
@@ -1,0 +1,186 @@
+"""Optional HA-Bluetooth FMDN advertisement listener.
+
+Registers a callback on Home Assistant's built-in Bluetooth scanner to capture
+FMDN advertisements directly, without requiring Bermuda.  This provides:
+
+- **BLE MAC address collection** for future GATT ring connections (Phase 2)
+- **RSSI capture** for proximity estimation
+- **Frame-type detection** (0x40 normal / 0x41 UTP separated state)
+
+The callback piggybacks on HA's existing scanner — no additional BLE scanning
+overhead is introduced.  If the ``bluetooth`` integration is not loaded, setup
+is silently skipped (``after_dependencies`` ensures correct load order).
+
+All data is fed into the existing EID Resolver via ``resolve_eid()`` with the
+``ble_address`` kwarg, populating ``BLEScanInfo`` for each resolved device.
+
+This module is independent of the FMDN Finder (location upload) feature and
+can be enabled even when ``FEATURE_FMDN_FINDER_ENABLED`` is False.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from ..const import DATA_EID_RESOLVER, DOMAIN
+from ..eid_resolver import FMDN_FRAME_TYPE, MODERN_FRAME_TYPE
+
+if TYPE_CHECKING:
+    from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+# Eddystone service UUID used by FMDN advertisements.
+# Standard 16-bit UUID 0xFEAA expanded to 128-bit form as used by HA Bluetooth.
+FEAA_SERVICE_UUID = "0000feaa-0000-1000-8000-00805f9b34fb"
+
+# Google Fast Pair service UUID (some FMDN trackers advertise under this).
+FE2C_SERVICE_UUID = "0000fe2c-0000-1000-8000-00805f9b34fb"
+
+# Minimum payload length: 1 byte frame type + 20 bytes legacy EID.
+MIN_FMDN_PAYLOAD_LENGTH = 21
+
+# Rate-limit DEBUG logs for unresolved EIDs (seconds).
+_UNRESOLVED_LOG_INTERVAL = 300.0
+
+# Storage key in hass.data[DOMAIN] for the unsubscribe callback.
+DATA_BLE_SCANNER_UNSUB = "ble_scanner_unsub"
+
+
+def _is_fmdn_service_data(
+    service_data: dict[str, bytes],
+) -> tuple[bytes | None, str | None]:
+    """Extract FMDN payload from BLE service data, if present.
+
+    Returns (payload, service_uuid) or (None, None).
+    """
+    for uuid in (FEAA_SERVICE_UUID, FE2C_SERVICE_UUID):
+        data = service_data.get(uuid)
+        if data is not None and len(data) >= MIN_FMDN_PAYLOAD_LENGTH:
+            return bytes(data), uuid
+    return None, None
+
+
+async def async_setup_ble_scanner(hass: HomeAssistant) -> bool:
+    """Register HA-Bluetooth callback for FMDN advertisements.
+
+    Returns True if the scanner was successfully registered, False if the
+    bluetooth integration is not available (non-fatal).
+    """
+    try:
+        from homeassistant.components.bluetooth import (  # noqa: PLC0415
+            BluetoothChange,
+            BluetoothScanningMode,
+            BluetoothServiceInfoBleak,
+            async_register_callback,
+        )
+    except ImportError:
+        _LOGGER.debug(
+            "HA Bluetooth integration not available — "
+            "FMDN BLE scanner disabled (install bluetooth integration for "
+            "BLE MAC collection and future BLE ringing support)"
+        )
+        return False
+
+    domain_bucket: dict[str, Any] | None = hass.data.get(DOMAIN)
+    if not isinstance(domain_bucket, dict):
+        _LOGGER.debug("Domain bucket not ready — skipping BLE scanner setup")
+        return False
+
+    # Track last log time for unresolved EIDs (keyed by 4-byte prefix).
+    unresolved_log_at: dict[str, float] = {}
+
+    def _fmdn_advertisement_callback(
+        service_info: BluetoothServiceInfoBleak,
+        change: BluetoothChange,
+    ) -> None:
+        """Process a single FMDN BLE advertisement from HA's scanner."""
+        payload, service_uuid = _is_fmdn_service_data(service_info.service_data)
+        if payload is None:
+            return
+
+        # Determine frame type from the payload.
+        frame_type: int | None = None
+        if len(payload) >= 1 and payload[0] in (FMDN_FRAME_TYPE, MODERN_FRAME_TYPE):
+            frame_type = payload[0]
+
+        # Resolve via the shared EID Resolver.
+        resolver = domain_bucket.get(DATA_EID_RESOLVER)
+        if resolver is None:
+            return
+
+        ble_address = service_info.address
+        rssi = service_info.rssi
+
+        match = resolver.resolve_eid(payload, ble_address=ble_address)
+
+        if match is not None:
+            _LOGGER.debug(
+                "BLE scan: resolved %s → device=%s (canonical=%s) "
+                "mac=%s rssi=%d frame=0x%02x svc=%s",
+                payload[:4].hex(),
+                match.device_id[:8],
+                (match.canonical_id or "?")[:8],
+                ble_address,
+                rssi,
+                frame_type if frame_type is not None else 0,
+                "FEAA" if service_uuid == FEAA_SERVICE_UUID else "FE2C",
+            )
+        else:
+            # Rate-limited debug log for unresolved advertisements.
+            prefix = payload[:4].hex()
+            now = time.monotonic()
+            last = unresolved_log_at.get(prefix, 0.0)
+            if now - last >= _UNRESOLVED_LOG_INTERVAL:
+                unresolved_log_at[prefix] = now
+                _LOGGER.debug(
+                    "BLE scan: unresolved FMDN adv prefix=%s "
+                    "mac=%s rssi=%d frame=0x%02x len=%d",
+                    prefix,
+                    ble_address,
+                    rssi,
+                    frame_type if frame_type is not None else 0,
+                    len(payload),
+                )
+
+    # Register the callback.  HA Bluetooth will call us for EVERY BLE
+    # advertisement — we filter inside _fmdn_advertisement_callback by
+    # checking service_data for FEAA/FE2C.  Using BluetoothScanningMode.PASSIVE
+    # avoids requesting active scans (no extra power draw).
+    #
+    # Note: HA's async_register_callback does not support service_data UUID
+    # filtering natively, so we pass no matcher and filter ourselves.
+    # The overhead is minimal — the callback returns immediately for
+    # non-FMDN advertisements after a single dict lookup.
+    unsub: CALLBACK_TYPE = async_register_callback(
+        hass,
+        _fmdn_advertisement_callback,
+        None,  # No matcher — we filter inside the callback
+        BluetoothScanningMode.PASSIVE,
+    )
+
+    domain_bucket[DATA_BLE_SCANNER_UNSUB] = unsub
+    _LOGGER.info(
+        "FMDN BLE scanner registered — collecting MAC addresses "
+        "and frame types from FMDN advertisements"
+    )
+    return True
+
+
+async def async_unload_ble_scanner(hass: HomeAssistant) -> bool:
+    """Unregister the HA-Bluetooth FMDN callback.
+
+    Returns True if cleanup succeeded or was unnecessary (scanner not loaded).
+    """
+    domain_bucket: dict[str, Any] | None = hass.data.get(DOMAIN)
+    if not isinstance(domain_bucket, dict):
+        return True
+
+    unsub = domain_bucket.pop(DATA_BLE_SCANNER_UNSUB, None)
+    if callable(unsub):
+        unsub()
+        _LOGGER.info("FMDN BLE scanner unregistered")
+
+    return True

--- a/custom_components/googlefindmy/icons.json
+++ b/custom_components/googlefindmy/icons.json
@@ -15,6 +15,13 @@
           "off": "mdi:wifi-off"
         }
       },
+      "uwt_mode": {
+        "default": "mdi:shield-check",
+        "state": {
+          "on": "mdi:shield-alert",
+          "off": "mdi:shield-check"
+        }
+      },
       "nova_auth_status": {
         "default": "mdi:account-alert",
         "state": {

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -2,6 +2,7 @@
   "domain": "googlefindmy",
   "name": "Google Find My Device",
   "after_dependencies": [
+    "bluetooth",
     "recorder"
   ],
   "codeowners": [

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -466,6 +466,17 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Unwanted Tracking Mode",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Last BLE observation"
+          },
+          "google_device_id": {
+            "name": "Google device ID"
+          }
+        }
+      },
       "nova_auth_status": {
         "name": "Nova API authentication status",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -466,6 +466,17 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Modus für unerwünschtes Tracking",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Letzte BLE-Beobachtung"
+          },
+          "google_device_id": {
+            "name": "Google-Geräte-ID"
+          }
+        }
+      },
       "nova_auth_status": {
         "name": "Status der Nova-API-Authentifizierung",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -466,6 +466,17 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Unwanted Tracking Mode",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Last BLE observation"
+          },
+          "google_device_id": {
+            "name": "Google device ID"
+          }
+        }
+      },
       "nova_auth_status": {
         "name": "Nova API authentication status",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -466,6 +466,17 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Modo de rastreo no deseado",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Última observación BLE"
+          },
+          "google_device_id": {
+            "name": "ID de dispositivo Google"
+          }
+        }
+      },
       "nova_auth_status": {
         "name": "Estado de autenticación de la API Nova",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -466,8 +466,19 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Mode de suivi indésirable",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Dernière observation BLE"
+          },
+          "google_device_id": {
+            "name": "ID d'appareil Google"
+          }
+        }
+      },
       "nova_auth_status": {
-        "name": "Statut d’authentification de l’API Nova",
+        "name": "Statut d'authentification de l'API Nova",
         "state_attributes": {
           "nova_api_status": {
             "name": "Statut de l’API Nova"

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -466,8 +466,19 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Modalità tracciamento indesiderato",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Ultima osservazione BLE"
+          },
+          "google_device_id": {
+            "name": "ID dispositivo Google"
+          }
+        }
+      },
       "nova_auth_status": {
-        "name": "Stato dell’autenticazione API Nova",
+        "name": "Stato dell'autenticazione API Nova",
         "state_attributes": {
           "nova_api_status": {
             "name": "Stato dell’API Nova"

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -466,6 +466,17 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Ongewenste trackingmodus",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Laatste BLE-observatie"
+          },
+          "google_device_id": {
+            "name": "Google-apparaat-ID"
+          }
+        }
+      },
       "nova_auth_status": {
         "name": "Nova API-authenticatiestatus",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -466,6 +466,17 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Tryb niechcianego śledzenia",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Ostatnia obserwacja BLE"
+          },
+          "google_device_id": {
+            "name": "ID urządzenia Google"
+          }
+        }
+      },
       "nova_auth_status": {
         "name": "Status uwierzytelniania interfejsu API Nova",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -466,6 +466,17 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Modo de rastreamento indesejado",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Última observação BLE"
+          },
+          "google_device_id": {
+            "name": "ID do dispositivo Google"
+          }
+        }
+      },
       "nova_auth_status": {
         "name": "Status de autenticação da API Nova",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -466,6 +466,17 @@
           }
         }
       },
+      "uwt_mode": {
+        "name": "Modo de rastreamento indesejado",
+        "state_attributes": {
+          "last_ble_observation": {
+            "name": "Última observação BLE"
+          },
+          "google_device_id": {
+            "name": "ID do dispositivo Google"
+          }
+        }
+      },
       "nova_auth_status": {
         "name": "Status de autenticação da API Nova",
         "state_attributes": {

--- a/docs/PLAY_SOUND_ARCHITECTURE.md
+++ b/docs/PLAY_SOUND_ARCHITECTURE.md
@@ -4,8 +4,12 @@
 
 The Play Sound feature allows users to ring a tracked device (FMDN tag, headphones,
 Android phone) from Home Assistant. This document describes the current cloud-only
-implementation, explains why direct BLE ringing does not exist yet, and outlines the
-future architecture that combines both paths.
+implementation, the upstream state (which is identical), and the future architecture
+for direct BLE ringing.
+
+**Key fact:** Neither upstream (leonboe1/GoogleFindMyTools) nor this fork parse the
+Nova API response. Both implementations are fire-and-forget. The response format is
+undocumented by Google and has never been decoded by any known open-source project.
 
 ---
 
@@ -35,60 +39,114 @@ nbe_execute_action.py  create_action_request() + serialize_action_request()
        v
 nova_request.py  async_nova_request(NOVA_ACTION_API_SCOPE, hex_payload)
        |  authenticates (AAS -> ADM token chain)
-       |  POST to Google's Nova endpoint
+       |  POST to https://android.googleapis.com/nova/{NOVA_ACTION_API_SCOPE}
        v
 Google Cloud Server
-       |  routes command via FCM push notification
+       |  routes command via FCM push notification to device
        v
 Target Device rings
+       |  (device sends FCM push back to confirm — see "Two Confirmation Paths")
+       v
+fcm_receiver_ha.py  _handle_notification_async()
+       |  receives DeviceUpdate protobuf via FCM
+       |  BUT: no callback registered for sound events → falls through
+       v
+(Sound confirmation silently lost)
 ```
 
 ### Key Files
 
 | File | Responsibility |
 |------|---------------|
-| `button.py:1043-1130` | `GoogleFindMyPlaySoundButton` — HA button entity, calls service |
-| `button.py:1133-1226` | `GoogleFindMyStopSoundButton` — HA button entity for stop |
-| `api.py:1499-1585` | `async_play_sound()` — entry point, FCM token resolution |
-| `api.py:1587-1684` | `async_stop_sound()` — stop counterpart |
-| `api.py:1438-1456` | `can_play_sound()` — capability check |
-| `api.py:1376-1431` | `is_push_ready()` — FCM transport readiness |
-| `sound_request.py:44-98` | `create_sound_request()` — pure protobuf builder |
-| `nbe_execute_action.py:36-64` | `create_action_request()` — protobuf envelope |
-| `nbe_execute_action.py:66-69` | `serialize_action_request()` — hex serialization |
-| `start_sound_request.py:62-169` | `async_submit_start_sound_request()` — Nova submission |
-| `stop_sound_request.py:63-142` | `async_submit_stop_sound_request()` — Nova submission |
-| `nova_request.py:1202-1632` | `async_nova_request()` — HTTP transport, auth, retry |
+| `button.py` | `GoogleFindMyPlaySoundButton` / `StopSoundButton` — HA button entities |
+| `api.py` | `async_play_sound()` / `async_stop_sound()` — entry point, FCM token resolution |
+| `sound_request.py` | `create_sound_request()` — pure protobuf builder (no I/O) |
+| `nbe_execute_action.py` | `create_action_request()` + `serialize_action_request()` — protobuf envelope |
+| `start_sound_request.py` | `async_submit_start_sound_request()` — Nova submission |
+| `stop_sound_request.py` | `async_submit_stop_sound_request()` — Nova submission |
+| `nova_request.py` | `async_nova_request()` — HTTP transport, auth, retry |
+| `fcm_receiver_ha.py` | FCM push receiver — handles ALL incoming notifications |
 | `_cli_helpers.py` | CLI FCM token resolution for standalone testing |
 
-### Protobuf Structure
+### Protobuf Structure (Request Only — No Response Defined)
 
 ```protobuf
+// DeviceUpdate.proto — only request messages exist
 message ExecuteActionRequest {
-    DeviceScope scope = 1;        // SPOT_DEVICE + canonicId
-    RequestMetadata metadata = 2; // requestUuid, fmdClientUuid, gcmRegistrationId
-    DeviceAction action = 3;      // startSound or stopSound
+    ExecuteActionScope scope = 1;              // SPOT_DEVICE + canonicId
+    ExecuteActionType action = 2;              // startSound or stopSound
+    ExecuteActionRequestMetadata requestMetadata = 3;  // requestUuid, gcmRegistrationId
 }
 
-message DeviceAction {
-    StartSound startSound = 1;    // component = DEVICE_COMPONENT_UNSPECIFIED
-    StopSound stopSound = 2;
+message ExecuteActionType {
+    ExecuteActionLocateTrackerType locateTracker = 30;
+    ExecuteActionSoundType startSound = 31;    // component = DEVICE_COMPONENT_UNSPECIFIED
+    ExecuteActionSoundType stopSound = 32;
 }
+
+// NO ExecuteActionResponse message exists — not in upstream, not here, not in
+// Google's public proto repositories (googleapis/googleapis).
 ```
 
-### What Happens After Submission
+### Two Potential Confirmation Paths (Neither Currently Used)
 
-1. `async_nova_request()` returns `response_hex` (hex-encoded protobuf)
-2. `async_submit_start_sound_request()` returns `(response_hex, request_uuid)`
-3. `api.py` logs success and returns `(True, request_uuid)` to the caller
+There are two distinct mechanisms that could confirm a ring command succeeded:
 
-**Critical gap: The response is never parsed.** The hex payload likely contains a
-Google `rpc.Status` or `ExecuteActionResponse` protobuf, but the code treats any
-non-None response as success. There is no confirmation that:
+#### Path A: Nova HTTP Response (unknown format)
 
-- Google accepted the command
-- The FCM push was delivered
-- The device actually rang
+```
+nova_request.py:1407-1408
+    if status == HTTP_OK:
+        return cast(bytes, content).hex()   # ← raw hex, NEVER PARSED
+```
+
+Google returns a protobuf body on HTTP 200. Its format is unknown:
+- No `ExecuteActionResponse` proto defined anywhere (upstream, Google, or us)
+- `google.internal.spot.v1.SpotService` is deliberately excluded from public APIs
+- `_decode_error_response()` only runs for non-200 statuses
+- `NovaLogicError` is defined but never raised (dead code)
+- Upstream (leonboe1) also ignores this response — return value is discarded
+
+#### Path B: FCM Push Callback (infrastructure exists, not wired for sound)
+
+The LocateTracker flow uses FCM callbacks:
+1. Register callback via `fcm_receiver.async_register_for_location_updates(canonic_id, cb)`
+2. Submit Nova request
+3. Wait for FCM push containing `DeviceUpdate` protobuf with matching `requestUuid`
+
+For sound events, **no callback is registered.** The FCM push arrives via
+`_handle_notification_async()`, but with no registered callback, it falls through
+to `_process_background_update()` which tries to decode it as a location response.
+
+The `DeviceUpdate` protobuf includes `ExecuteActionRequestMetadata.requestUuid` which
+could be matched against the UUID from `start_sound_request()` for correlation.
+
+### What This Means
+
+| What we know | What we don't know |
+|---|---|
+| HTTP 200 = Google accepted the HTTP request | Whether the command reached the device |
+| Response body is non-empty protobuf | The response protobuf schema |
+| FCM push arrives after successful commands | Whether sound-specific FCM pushes differ from location pushes |
+| `requestUuid` is sent and echoed in FCM | Whether the HTTP response also echoes it |
+
+### Upstream Parity
+
+**Our code and upstream are functionally identical for PlaySound:**
+
+| Aspect | Upstream (leonboe1) | This Fork |
+|--------|---------------------|-----------|
+| Nova HTTP response | `return response.content.hex()` — caller discards return value | `return cast(bytes, content).hex()` — caller stores but ignores `_response_hex` |
+| Response parsing | None | None |
+| FCM callback for sound | `lambda x: print(x)` (prints raw hex to stdout) | Not registered |
+| BLE GATT ring code | **None** — only ring key derivation + registration | None |
+| `ExecuteActionResponse` proto | Not defined | Not defined |
+
+**Upstream has no BLE ring implementation.** The ring key derivation in
+`key_derivation.py` and the `ringKey` field in `RegisterBleDeviceRequest` are used
+during device registration to tell Google the ring key. No code exists to use that
+key for direct BLE GATT writes. The BLE ring protocol was independently attempted by
+community members in GitHub Issue #66.
 
 ### Authentication Chain
 
@@ -101,36 +159,40 @@ ADM Token (Android Device Management)
     v  Authorization: Bearer {ADM_TOKEN}
 Nova API Endpoint (NOVA_ACTION_API_SCOPE)
     |
-    v  FCM Push
+    v  FCM Push (device confirms back via FCM)
 Device
 ```
 
 Token management is handled by `AsyncTTLPolicy` in `nova_request.py` with:
 - Proactive refresh before expiry
 - Entry-scoped caching (multi-account safe)
-- Automatic 401 recovery with one retry
+- Automatic 401 recovery with multi-step retry (ADM refresh → AAS+ADM refresh → cooldown)
 
 ---
 
-## What Upstream Has That We Don't: Direct BLE Ringing
+## BLE Ring Protocol (FMDN Specification)
 
 ### FMDN Beacon Actions Characteristic
 
-The FMDN specification defines a GATT characteristic for direct device control:
+The FMDN specification at `developers.google.com/nearby/fast-pair/specifications/extensions/fmdn`
+defines a GATT characteristic for direct device control:
 
 - **UUID:** `FE2C1238-8366-4814-8EB0-01DE32100BEA` (Beacon Actions)
-- **Protocol:** Read nonce -> compute auth -> write command -> read notification
+- **Protocol:** Read nonce → compute auth → write command → read notification
 
 | Data ID | Operation | Description |
 |---------|-----------|-------------|
 | `0x05` | Ring | Start ringing the tracker |
 | `0x06` | Read ringing state | Check if currently ringing |
 
-### BLE Ring Protocol (FMDN Spec)
+**Important:** The FMDN spec documents only the BLE-level protocol. It says nothing
+about server-side APIs, Nova endpoints, or cloud ring commands.
+
+### BLE Ring Protocol Steps
 
 ```
 Step 1: Read Beacon Actions characteristic
-        -> Receive 8-byte random nonce from tracker
+        → Receive 8-byte random nonce from tracker
 
 Step 2: Compute auth key
         ring_key = SHA256(EIK || 0x02)[:8]     # 8-byte truncated
@@ -140,32 +202,37 @@ Step 3: Write to Beacon Actions characteristic
         Payload: [data_id=0x05] [data_len] [8-byte auth_key] [ring_bitmask] [timeout] [volume]
         Where: data_len = len(auth_key) + len(addl_data)  # = 8 + 3 = 11
 
-Step 4: Read notification
-        -> Receive authentication result + status
-        -> GATT response confirms whether command was accepted
+Step 4: Read notification (Table 6 in FMDN spec)
+        → Ring state byte:
+            0x00 = Started successfully
+            0x01 = Failed (auth or hardware)
+            0x02 = Stopped (timeout)
+            0x03 = Stopped (button press)
+            0x04 = Stopped (GATT command)
+        → Components bitmask + remaining time
 ```
 
-### Known Bug in Upstream BLE Implementation (Issue #66)
+### Known Bug in Community BLE Ring Attempt (Issue #66)
 
-The upstream GoogleFindMyTools library has a bug in step 3:
+A community member (mik-laj) attempted direct BLE ringing using a Python script with
+`bleak`. User DefenestratingWizard identified a bug in step 3:
 
 ```
-BUG:     data_len = len(addl_data)              # = 3 (missing auth key length!)
-CORRECT: data_len = len(addl_data) + len(auth_key)  # = 3 + 8 = 11
+BUG:     data_len = len(addl_data)                     # = 3 (missing auth key length!)
+CORRECT: data_len = len(auth_key) + len(addl_data)     # = 8 + 3 = 11
 ```
 
-This causes ATT Error `0x81` (application-level rejection). Our integration is not
-affected because we do not implement BLE GATT ringing. However, if BLE ringing is
-added in the future, this calculation must be correct.
+This causes ATT Error `0x81` (application-level rejection). **Neither upstream
+(leonboe1) nor this fork are affected** — no BLE GATT ring code exists in either
+codebase. The bug exists only in the community member's independent script.
 
-### Why Our Integration Is Cloud-Only
+### Why Neither Codebase Has BLE Ringing
 
-1. **Design context:** HA servers are typically not BLE-adjacent to tracked devices.
-   The Nova cloud API works globally regardless of physical proximity.
-2. **No `bleak` dependency:** The `manifest.json` declares no `bluetooth` dependency
-   and does not include `bleak` or `bleak-retry-connector` in requirements.
-3. **Upstream focus:** The upstream library's BLE code targets CLI/desktop use where
-   a Bluetooth adapter is directly available.
+1. **Upstream is CLI-focused** — designed for OAuth + Nova API interactions, not BLE
+2. **This fork is HA-focused** — HA servers are typically not BLE-adjacent to trackers
+3. **Ring key is registered, not used** — `key_derivation.py` derives the ring key
+   and `create_ble_device.py` sends it to Google during registration, but no code
+   uses it for local BLE commands
 
 ---
 

--- a/docs/PLAY_SOUND_ARCHITECTURE.md
+++ b/docs/PLAY_SOUND_ARCHITECTURE.md
@@ -212,19 +212,94 @@ Step 4: Read notification (Table 6 in FMDN spec)
         → Components bitmask + remaining time
 ```
 
-### Known Bug in Community BLE Ring Attempt (Issue #66)
+### Community BLE Ring Attempt — Detailed Analysis (Issue #66)
 
-A community member (mik-laj) attempted direct BLE ringing using a Python script with
-`bleak`. User DefenestratingWizard identified a bug in step 3:
+Source: https://gist.github.com/mik-laj/4c1c363391115ccb14ee856a9c1c12a1
+
+mik-laj published a standalone `bleak`-based ring script (`ring_nearby.py`). The
+script scans for FMDN advertisements, connects via GATT, and writes ring commands.
+DefenestratingWizard identified **two bugs** (both in `data_len` handling):
+
+#### Bug 1: Payload `data_len` field
+
+```python
+# BUG (mik-laj):
+payload = bytes([DATA_ID_RING, len(addl)]) + auth8 + addl
+#                               ^^^^^^^^  = 4 (only addl, missing auth key!)
+
+# CORRECT:
+payload = bytes([DATA_ID_RING, len(auth8) + len(addl)]) + auth8 + addl
+#                               ^^^^^^^^^^^^^^^^^^^^^^^^  = 8 + 4 = 12
+```
+
+#### Bug 2: HMAC input `data_len` (causes wrong auth key!)
+
+```python
+# BUG (mik-laj):
+data_len = len(addl)       # = 4, but HMAC sees wrong length → wrong auth
+
+# CORRECT:
+data_len = len(addl) + 8   # auth key (8B) IS counted in data_len for HMAC too
+```
+
+Both bugs together cause ATT Error `0x81`. Fixing only one is insufficient because
+`data_len` appears in both the wire format AND the HMAC input — a wrong value
+produces both a malformed payload and an incorrect authentication.
+
+#### Verified Wire Format (from Wireshark capture of real Find Hub app)
 
 ```
-BUG:     data_len = len(addl_data)                     # = 3 (missing auth key length!)
-CORRECT: data_len = len(auth_key) + len(addl_data)     # = 8 + 3 = 11
+Ring command (successful, captured from official Google Find Hub app):
+
+  05 0c a7 25 03 f0 6a 9d d4 2a ff 02 58 00
+  ── ── ──────────────────────── ── ───── ──
+  │  │           │                │    │    │
+  │  │           │                │    │    └── volume (0x00 = default)
+  │  │           │                │    └── timeout (0x0258 = 600 deciseconds = 60s)
+  │  │           │                └── op_mask (0xFF = ring all components)
+  │  │           └── 8-byte HMAC-SHA256 one-time auth key
+  │  └── data_len = 0x0c = 12 = 8 (auth) + 4 (addl)
+  └── data_id = 0x05 (Ring)
+
+Nonce/challenge read (from Beacon Actions characteristic):
+
+  01 f3 be eb 39 9d 61 cf a0
+  ── ────────────────────────
+  │           │
+  │           └── 8-byte random nonce
+  └── proto_major = 0x01
 ```
 
-This causes ATT Error `0x81` (application-level rejection). **Neither upstream
-(leonboe1) nor this fork are affected** — no BLE GATT ring code exists in either
-codebase. The bug exists only in the community member's independent script.
+#### Corrected HMAC Computation
+
+```python
+def make_auth(ring_key, proto_major, nonce8, data_id, addl):
+    data_len = len(addl) + 8     # MUST include auth key length
+    msg = bytes([proto_major]) + nonce8 + bytes([data_id, data_len]) + addl
+    return hmac.new(ring_key, msg, hashlib.sha256).digest()[:8]
+```
+
+#### Corrected Payload Construction
+
+```python
+def build_ring_message(ring_key, nonce8, proto_major,
+                       op_mask=0xFF, timeout_s=60.0, volume=0x00):
+    t_ds = min(int(timeout_s * 10), 6000)
+    addl = bytes([op_mask]) + struct.pack(">H", t_ds) + bytes([volume])
+    auth8 = make_auth(ring_key, proto_major, nonce8, 0x05, addl)
+    return bytes([0x05, len(auth8) + len(addl)]) + auth8 + addl
+```
+
+#### Open Question: Ring Key Derivation
+
+mik-laj reported that keys from `FMDNOwnerOperations.generate_keys()` did not match
+the keys observed in the Wireshark capture. He was uncertain whether the EIK (after
+AES decryption with the owner key) or the raw encrypted identity key should be used.
+
+Our code derives: `ring_key = SHA256(decrypted_EIK || 0x02)[:8]`, which matches the
+FMDN spec. mik-laj may have used the encrypted key by mistake (he logged both).
+DefenestratingWizard's fix resolved the `data_len` bug but did not confirm whether
+the ring key derivation was also corrected — the issue remains open.
 
 ### Why Neither Codebase Has BLE Ringing
 
@@ -233,6 +308,7 @@ codebase. The bug exists only in the community member's independent script.
 3. **Ring key is registered, not used** — `key_derivation.py` derives the ring key
    and `create_ble_device.py` sends it to Google during registration, but no code
    uses it for local BLE commands
+4. **Community attempt unfinished** — mik-laj's script has bugs, no confirmed success
 
 ---
 

--- a/docs/PLAY_SOUND_ARCHITECTURE.md
+++ b/docs/PLAY_SOUND_ARCHITECTURE.md
@@ -1,0 +1,316 @@
+# Play Sound Architecture
+
+## Overview
+
+The Play Sound feature allows users to ring a tracked device (FMDN tag, headphones,
+Android phone) from Home Assistant. This document describes the current cloud-only
+implementation, explains why direct BLE ringing does not exist yet, and outlines the
+future architecture that combines both paths.
+
+---
+
+## Current Architecture: Cloud-Only (Nova API)
+
+### Request Flow
+
+```
+User presses "Play Sound" button in HA
+       |
+       v
+button.py  GoogleFindMyPlaySoundButton.async_press()
+       |  calls hass.services.async_call(DOMAIN, SERVICE_PLAY_SOUND, ...)
+       v
+api.py  async_play_sound()
+       |  validates push readiness, resolves FCM token
+       v
+start_sound_request.py  async_submit_start_sound_request()
+       |  builds protobuf payload, submits to Nova
+       v
+sound_request.py  create_sound_request(should_start=True, ...)
+       |  creates ExecuteActionRequest protobuf
+       v
+nbe_execute_action.py  create_action_request() + serialize_action_request()
+       |  sets scope=SPOT_DEVICE, action=startSound, component=UNSPECIFIED
+       |  serializes to hex
+       v
+nova_request.py  async_nova_request(NOVA_ACTION_API_SCOPE, hex_payload)
+       |  authenticates (AAS -> ADM token chain)
+       |  POST to Google's Nova endpoint
+       v
+Google Cloud Server
+       |  routes command via FCM push notification
+       v
+Target Device rings
+```
+
+### Key Files
+
+| File | Responsibility |
+|------|---------------|
+| `button.py:1043-1130` | `GoogleFindMyPlaySoundButton` — HA button entity, calls service |
+| `button.py:1133-1226` | `GoogleFindMyStopSoundButton` — HA button entity for stop |
+| `api.py:1499-1585` | `async_play_sound()` — entry point, FCM token resolution |
+| `api.py:1587-1684` | `async_stop_sound()` — stop counterpart |
+| `api.py:1438-1456` | `can_play_sound()` — capability check |
+| `api.py:1376-1431` | `is_push_ready()` — FCM transport readiness |
+| `sound_request.py:44-98` | `create_sound_request()` — pure protobuf builder |
+| `nbe_execute_action.py:36-64` | `create_action_request()` — protobuf envelope |
+| `nbe_execute_action.py:66-69` | `serialize_action_request()` — hex serialization |
+| `start_sound_request.py:62-169` | `async_submit_start_sound_request()` — Nova submission |
+| `stop_sound_request.py:63-142` | `async_submit_stop_sound_request()` — Nova submission |
+| `nova_request.py:1202-1632` | `async_nova_request()` — HTTP transport, auth, retry |
+| `_cli_helpers.py` | CLI FCM token resolution for standalone testing |
+
+### Protobuf Structure
+
+```protobuf
+message ExecuteActionRequest {
+    DeviceScope scope = 1;        // SPOT_DEVICE + canonicId
+    RequestMetadata metadata = 2; // requestUuid, fmdClientUuid, gcmRegistrationId
+    DeviceAction action = 3;      // startSound or stopSound
+}
+
+message DeviceAction {
+    StartSound startSound = 1;    // component = DEVICE_COMPONENT_UNSPECIFIED
+    StopSound stopSound = 2;
+}
+```
+
+### What Happens After Submission
+
+1. `async_nova_request()` returns `response_hex` (hex-encoded protobuf)
+2. `async_submit_start_sound_request()` returns `(response_hex, request_uuid)`
+3. `api.py` logs success and returns `(True, request_uuid)` to the caller
+
+**Critical gap: The response is never parsed.** The hex payload likely contains a
+Google `rpc.Status` or `ExecuteActionResponse` protobuf, but the code treats any
+non-None response as success. There is no confirmation that:
+
+- Google accepted the command
+- The FCM push was delivered
+- The device actually rang
+
+### Authentication Chain
+
+```
+AAS Token (Google Account Sign-In)
+    |
+    v  async_nova_request() exchanges AAS -> ADM
+ADM Token (Android Device Management)
+    |
+    v  Authorization: Bearer {ADM_TOKEN}
+Nova API Endpoint (NOVA_ACTION_API_SCOPE)
+    |
+    v  FCM Push
+Device
+```
+
+Token management is handled by `AsyncTTLPolicy` in `nova_request.py` with:
+- Proactive refresh before expiry
+- Entry-scoped caching (multi-account safe)
+- Automatic 401 recovery with one retry
+
+---
+
+## What Upstream Has That We Don't: Direct BLE Ringing
+
+### FMDN Beacon Actions Characteristic
+
+The FMDN specification defines a GATT characteristic for direct device control:
+
+- **UUID:** `FE2C1238-8366-4814-8EB0-01DE32100BEA` (Beacon Actions)
+- **Protocol:** Read nonce -> compute auth -> write command -> read notification
+
+| Data ID | Operation | Description |
+|---------|-----------|-------------|
+| `0x05` | Ring | Start ringing the tracker |
+| `0x06` | Read ringing state | Check if currently ringing |
+
+### BLE Ring Protocol (FMDN Spec)
+
+```
+Step 1: Read Beacon Actions characteristic
+        -> Receive 8-byte random nonce from tracker
+
+Step 2: Compute auth key
+        ring_key = SHA256(EIK || 0x02)[:8]     # 8-byte truncated
+        auth_data = HMAC-SHA256(ring_key, nonce || data_id=0x05 || addl_data)[:8]
+
+Step 3: Write to Beacon Actions characteristic
+        Payload: [data_id=0x05] [data_len] [8-byte auth_key] [ring_bitmask] [timeout] [volume]
+        Where: data_len = len(auth_key) + len(addl_data)  # = 8 + 3 = 11
+
+Step 4: Read notification
+        -> Receive authentication result + status
+        -> GATT response confirms whether command was accepted
+```
+
+### Known Bug in Upstream BLE Implementation (Issue #66)
+
+The upstream GoogleFindMyTools library has a bug in step 3:
+
+```
+BUG:     data_len = len(addl_data)              # = 3 (missing auth key length!)
+CORRECT: data_len = len(addl_data) + len(auth_key)  # = 3 + 8 = 11
+```
+
+This causes ATT Error `0x81` (application-level rejection). Our integration is not
+affected because we do not implement BLE GATT ringing. However, if BLE ringing is
+added in the future, this calculation must be correct.
+
+### Why Our Integration Is Cloud-Only
+
+1. **Design context:** HA servers are typically not BLE-adjacent to tracked devices.
+   The Nova cloud API works globally regardless of physical proximity.
+2. **No `bleak` dependency:** The `manifest.json` declares no `bluetooth` dependency
+   and does not include `bleak` or `bleak-retry-connector` in requirements.
+3. **Upstream focus:** The upstream library's BLE code targets CLI/desktop use where
+   a Bluetooth adapter is directly available.
+
+---
+
+## Comparison: Cloud vs. BLE Ringing
+
+| Aspect | Cloud (Nova API) | Direct BLE (GATT) |
+|--------|------------------|--------------------|
+| **Latency** | 2-15 seconds (FCM push) | < 1 second |
+| **Range** | Global (any crowdsource reporter) | ~30m BLE range |
+| **Prerequisites** | Google auth + FCM token | BLE adapter in proximity |
+| **Confirmation** | None (fire-and-forget) | GATT response = hardware ack |
+| **Reliability** | Depends on FCM delivery | Direct, deterministic |
+| **HA compatibility** | Works everywhere | Requires `bluetooth` integration |
+| **ESPHome proxy** | N/A | Supported (active mode) |
+| **MAC rotation** | N/A (server-side routing) | Must resolve current MAC from EID |
+
+---
+
+## HA Bluetooth Stack for Future BLE Ringing
+
+### Architecture Layers
+
+```
++-------------------------------------------------+
+|  GoogleFindMy-HA (this integration)             |
+|  Uses: establish_connection + write_gatt_char   |
++-------------------------------------------------+
+|  bleak-retry-connector                          |
+|  Handles: retries, backoff, service caching     |
++-------------------------------------------------+
+|  Bleak (BleakClient)                            |
+|  Handles: GATT protocol, platform abstraction   |
++-------------------------------------------------+
+|  homeassistant.components.bluetooth             |
+|  Handles: adapter discovery, scanner sharing,   |
+|  ESPHome proxy routing, adapter failover        |
++-------------------------------------------------+
+|  BlueZ (local USB) OR ESPHome BLE Proxy         |
++-------------------------------------------------+
+```
+
+### Standard Pattern for GATT Writes in HA
+
+```python
+from homeassistant.components.bluetooth import async_ble_device_from_address
+from bleak_retry_connector import establish_connection, BleakClientWithServiceCache
+
+# 1. Obtain BLEDevice from HA's bluetooth component
+ble_device = async_ble_device_from_address(hass, current_mac)
+
+# 2. Connect with retry logic
+client = await establish_connection(
+    BleakClientWithServiceCache,
+    ble_device,
+    name="fmdn_tracker",
+    max_attempts=3,
+)
+
+# 3. Read nonce, compute auth, write ring command
+nonce = await client.read_gatt_char(BEACON_ACTIONS_UUID)
+payload = build_ring_payload(ring_key, nonce)
+await client.write_gatt_char(BEACON_ACTIONS_UUID, payload)
+
+# 4. Read response notification for confirmation
+# ...
+
+await client.disconnect()
+```
+
+### Bermuda vs. HA Bluetooth for BLE Ringing
+
+| Aspect | Bermuda | HA Bluetooth (`homeassistant.components.bluetooth`) |
+|--------|---------|------------------------------------------------------|
+| **Purpose** | Passive room presence / trilateration | Full BLE stack (scan + GATT) |
+| **GATT writes** | No | Yes |
+| **Active connections** | No | Yes (via bleak-retry-connector) |
+| **ESPHome proxy** | Reads RSSI only | Full GATT proxy (active mode) |
+| **Role in this project** | Location signal source, EID advertisement relay | Required for future BLE ringing |
+
+**Bermuda is not needed for BLE ringing.** The HA bluetooth integration provides
+everything required. Bermuda's role remains passive location tracking.
+
+### MAC Address Rotation Challenge
+
+FMDN trackers rotate their BLE MAC address for privacy. To connect via GATT, the
+current MAC must be known. Two resolution paths exist:
+
+1. **From HA scanner data:** `async_ble_device_from_address(hass, current_mac)` — but
+   this requires knowing the rotated MAC, which changes every ~15 minutes.
+2. **From EID resolution:** The `eid_resolver.py` already maps EIDs to device
+   identities. The BLE advertisement that contained the matched EID also carries the
+   current MAC address (in `BluetoothServiceInfoBleak.address`). This address can be
+   captured during EID resolution and stored for the connection window.
+
+### Required Manifest Changes for BLE Support
+
+```json
+{
+    "dependencies": ["http", "bluetooth"],
+    "requirements": [
+        "bleak>=0.21.0",
+        "bleak-retry-connector>=3.4.0",
+        ...existing requirements...
+    ]
+}
+```
+
+---
+
+## Key Derivation for Ringing
+
+The ring authentication key is derived from the Ephemeral Identity Key (EIK):
+
+```
+EIK (32 bytes, from device registration)
+    |
+    v  SHA256(EIK || 0x02)[:8]
+Ring Key (8 bytes)
+    |
+    v  HMAC-SHA256(ring_key, nonce || 0x05 || addl_data)[:8]
+One-Time Auth Key (8 bytes, sent in GATT write)
+```
+
+This derivation is already implemented in `key_derivation.py:58`:
+```python
+self.ringing_key = calculate_truncated_sha256(identity_key_bytes, 0x02)
+```
+
+The ring key is currently only used during device registration
+(`create_ble_device.py:110`), but will be reused for direct BLE ring commands.
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Nova API** | Google's server-side API for Find My Device actions |
+| **FCM** | Firebase Cloud Messaging — push notification transport |
+| **FMDN** | Find My Device Network — Google's crowdsource tracker protocol |
+| **EIK** | Ephemeral Identity Key — 32-byte root key for tracker crypto |
+| **EID** | Ephemeral Identifier — rotating BLE address derived from EIK |
+| **Beacon Actions** | GATT characteristic for direct tracker commands (ring, UTP) |
+| **GATT** | Generic Attribute Profile — BLE protocol for read/write operations |
+| **ADM** | Android Device Management — Google auth token type |
+| **AAS** | Android Account Sign-In — Google auth token type |
+| **Bermuda** | Third-party HA integration for BLE room presence |
+| **bleak** | Python BLE library used by HA's bluetooth integration |

--- a/docs/PLAY_SOUND_ARCHITECTURE.md
+++ b/docs/PLAY_SOUND_ARCHITECTURE.md
@@ -199,8 +199,9 @@ Step 2: Compute auth key
         auth_data = HMAC-SHA256(ring_key, nonce || data_id=0x05 || addl_data)[:8]
 
 Step 3: Write to Beacon Actions characteristic
-        Payload: [data_id=0x05] [data_len] [8-byte auth_key] [ring_bitmask] [timeout] [volume]
-        Where: data_len = len(auth_key) + len(addl_data)  # = 8 + 3 = 11
+        Payload: [data_id=0x05] [data_len] [8-byte auth_key] [op_mask(1B)] [timeout(2B BE)] [volume(1B)]
+        Where: addl_data = op_mask + timeout + volume = 4 bytes
+               data_len = len(auth_key) + len(addl_data) = 8 + 4 = 12
 
 Step 4: Read notification (Table 6 in FMDN spec)
         → Ring state byte:

--- a/docs/PLAY_SOUND_ARCHITECTURE.md
+++ b/docs/PLAY_SOUND_ARCHITECTURE.md
@@ -313,18 +313,130 @@ the ring key derivation was also corrected — the issue remains open.
 
 ---
 
-## Comparison: Cloud vs. BLE Ringing
+## DULT Non-Owner Sound Protocol (AirGuard)
 
-| Aspect | Cloud (Nova API) | Direct BLE (GATT) |
-|--------|------------------|--------------------|
-| **Latency** | 2-15 seconds (FCM push) | < 1 second |
-| **Range** | Global (any crowdsource reporter) | ~30m BLE range |
-| **Prerequisites** | Google auth + FCM token | BLE adapter in proximity |
-| **Confirmation** | None (fire-and-forget) | GATT response = hardware ack |
-| **Reliability** | Depends on FCM delivery | Direct, deterministic |
-| **HA compatibility** | Works everywhere | Requires `bluetooth` integration |
-| **ESPHome proxy** | N/A | Supported (active mode) |
-| **MAC rotation** | N/A (server-side routing) | Must resolve current MAC from EID |
+### Discovery: AirGuard Uses a Completely Different Protocol
+
+leonboe1's anti-stalking app **AirGuard** (`seemoo-lab/AirGuard`) implements BLE
+ringing for Google FMDN trackers, but it does NOT use the FMDN Beacon Actions
+characteristic. Instead, it uses the **DULT (Detecting Unwanted Location Trackers)**
+protocol, defined in [IETF draft-ietf-dult-accessory-protocol-00](https://datatracker.ietf.org/doc/html/draft-ietf-dult-accessory-protocol-00).
+
+This is a separate GATT service with no authentication — designed for the anti-stalking
+use case where the caller does NOT own the tracker.
+
+### DULT ANOS (Accessory Non-Owner Service) Details
+
+| Attribute | Value |
+|-----------|-------|
+| Service UUID | `15190001-12F4-C226-88ED-2AC5579F2A85` |
+| Characteristic UUID | `8E0C0001-1D68-FB92-BF61-48377421680E` |
+| CCCD Descriptor | `00002902-0000-1000-8000-00805F9B34FB` |
+| Byte Order | **Little endian** (opposite of FMDN Beacon Actions!) |
+| Authentication | **None** |
+| Availability | **Separated state only** (tracker away from owner 8-24 hours) |
+
+### DULT Opcodes (Little-Endian Wire Format)
+
+| Opcode Name | Logical Value | Wire Bytes (LE) | Direction | Required |
+|-------------|--------------|-----------------|-----------|----------|
+| Sound_Start | `0x0300` | `[0x00, 0x03]` | → Accessory (Write) | Yes |
+| Sound_Stop | `0x0301` | `[0x01, 0x03]` | → Accessory (Write) | Yes |
+| Command_Response | `0x0302` | `[0x02, 0x03]` | ← Accessory (Indication) | Yes |
+| Sound_Completed | `0x0303` | `[0x03, 0x03]` | ← Accessory (Indication) | Yes |
+| Get_Identifier | `0x0404` | `[0x04, 0x04]` | → Accessory (Write) | Optional |
+| Get_Model_Name | `0x0005` | `[0x05, 0x00]` | → Accessory (Write) | Optional |
+
+### DULT Command_Response Format
+
+```
+Byte 0-1: Response Opcode 0x0302 → wire [0x02, 0x03]
+Byte 2-3: Echoed CommandOpcode (LE) — which command this responds to
+Byte 4-5: ResponseStatus (LE):
+          0x0000 = Success
+          0x0001 = Invalid_state (already ringing / wrong state)
+          0x0002 = Invalid_configuration
+          0x0003 = Invalid_length
+          0x0004 = Invalid_param
+          0xFFFF = Invalid_command (not in separated state, or unsupported)
+```
+
+### DULT Sound Requirements
+
+- Minimum duration: 5 seconds
+- Maximum duration: 30 seconds (auto-stop by accessory)
+- Recommended: 12 seconds
+- Minimum loudness: 60 Phon peak at 25cm (ISO 532-1:2017)
+
+### AirGuard's GATT Flow (Kotlin)
+
+Source: `seemoo-lab/AirGuard` — `GoogleFindMyNetwork.kt`
+
+```
+1. connectGatt(context, false, callback)
+2. onConnectionStateChange(GATT_SUCCESS, STATE_CONNECTED)
+   → gatt.discoverServices()
+3. onServicesDiscovered()
+   → Find service containing "12F4" (substring match)
+   → Get characteristic 8E0C0001-...
+   → setCharacteristicNotification(true)     // no CCCD descriptor write!
+   → writeCharacteristic([0x00, 0x03])       // DULT Sound_Start
+   → broadcast ACTION_EVENT_RUNNING
+4. onCharacteristicWrite(GATT_SUCCESS)
+   → Handler.postDelayed(5000ms):            // hardcoded 5-second timer
+     → writeCharacteristic([0x01, 0x03])     // DULT Sound_Stop
+5. onCharacteristicWrite(GATT_SUCCESS) for stop
+   → disconnect() + broadcast ACTION_EVENT_COMPLETED
+```
+
+**Weaknesses observed in AirGuard:**
+- No timeout on connection or service discovery
+- CCCD descriptor not written (no actual BLE indications received)
+- Sound_Completed notification from tracker is never read
+- Hardcoded 5-second duration (DULT recommends 12s)
+- No handling if connection drops during the 5s timer
+
+### Why DULT Is NOT Suitable For Us
+
+**We are the owner.** Our trackers will typically be near HA (i.e., near the owner's
+account). In near-owner state, the tracker responds to DULT Sound_Start with
+`Invalid_command (0xFFFF)`.
+
+DULT only works when the tracker enters "separated state" — 8-24 hours away from any
+device logged into the owner's Google account. This is the opposite of our use case.
+
+**We must use FMDN Beacon Actions (authenticated ring)** because:
+1. We have the EIK → can derive the ring key
+2. It works regardless of separated state
+3. It provides proper ring state notifications (started/failed/stopped + reason)
+
+### Three Ring Sources (Confirmed by Nordic SDK)
+
+The Nordic nRF Connect SDK (`nrfconnect/sdk-nrf`) confirms FMDN trackers have
+three independent ring trigger sources:
+
+| Source | SDK Constant | Protocol | Auth |
+|--------|-------------|----------|------|
+| Owner BLE ring | `FMDN_BT_GATT` | FMDN Beacon Actions (`FE2C1238`) | HMAC-SHA256 |
+| Non-owner BLE sound | `DULT_BT_GATT` | DULT ANOS (`15190001-12F4`) | None |
+| Motion auto-ring | `DULT_MOTION_DETECTOR` | Internal (separated state) | N/A |
+
+---
+
+## Comparison: All Three Ring Paths
+
+| Aspect | Cloud (Nova API) | BLE Owner Ring (FMDN) | BLE Non-Owner Sound (DULT) |
+|--------|------------------|-----------------------|---------------------------|
+| **Latency** | 2-15 seconds (FCM) | < 1 second | < 1 second |
+| **Range** | Global | ~30m BLE | ~30m BLE |
+| **Auth** | Google OAuth + FCM | HMAC-SHA256 (ring key) | None |
+| **Availability** | Always | Always (owner has key) | Separated state only |
+| **Confirmation** | None (fire-and-forget) | Ring state notification | Command_Response indication |
+| **Reliability** | FCM delivery dependent | Direct, deterministic | Direct, deterministic |
+| **HA compat** | Works everywhere | Requires `bluetooth` | Requires `bluetooth` |
+| **ESPHome proxy** | N/A | Supported (active mode) | Supported (active mode) |
+| **MAC rotation** | N/A (server routing) | Must know current MAC | Must know current MAC |
+| **Our use case** | **Primary path** | **BLE fallback** | Not applicable (owner ≠ separated) |
 
 ---
 
@@ -452,9 +564,15 @@ The ring key is currently only used during device registration
 | **FMDN** | Find My Device Network — Google's crowdsource tracker protocol |
 | **EIK** | Ephemeral Identity Key — 32-byte root key for tracker crypto |
 | **EID** | Ephemeral Identifier — rotating BLE address derived from EIK |
-| **Beacon Actions** | GATT characteristic for direct tracker commands (ring, UTP) |
+| **Beacon Actions** | FMDN GATT characteristic (`FE2C1238`) for owner-authenticated commands (ring, UTP) |
+| **DULT** | Detecting Unwanted Location Trackers — IETF specification for anti-stalking |
+| **ANOS** | Accessory Non-Owner Service — DULT GATT service (`15190001-12F4`) for unauthenticated commands |
+| **Separated State** | Tracker state when away from owner device for 8-24 hours; enables DULT/UTP features |
 | **GATT** | Generic Attribute Profile — BLE protocol for read/write operations |
+| **CCCD** | Client Characteristic Configuration Descriptor — enables BLE notifications/indications |
 | **ADM** | Android Device Management — Google auth token type |
 | **AAS** | Android Account Sign-In — Google auth token type |
 | **Bermuda** | Third-party HA integration for BLE room presence |
 | **bleak** | Python BLE library used by HA's bluetooth integration |
+| **AirGuard** | Anti-stalking app by seemoo-lab/leonboe1 — uses DULT protocol (not FMDN Beacon Actions) |
+| **Nordic SDK** | nRF Connect SDK — reference implementation for FMDN+DULT tracker firmware |

--- a/docs/PLAY_SOUND_IMPLEMENTATION_PLAN.md
+++ b/docs/PLAY_SOUND_IMPLEMENTATION_PLAN.md
@@ -5,39 +5,42 @@
 Transform Play Sound from fire-and-forget cloud-only into a robust two-path system
 with response validation (cloud) and direct BLE ringing (local fallback).
 
+## Context: What Upstream and Google Give Us
+
+Before planning, these facts constrain the design:
+
+1. **No `ExecuteActionResponse` proto exists** — not in upstream, not in Google's
+   public proto repos (`googleapis/googleapis`). The `google.internal.spot.v1.SpotService`
+   namespace is deliberately excluded from public APIs.
+2. **Upstream discards the Nova HTTP response** — `nova_request()` returns hex, but
+   the caller in `start_sound_request.py` never assigns the return value.
+3. **Our code stores but ignores the response** — `_response_hex` is unpacked at
+   `api.py:1538` but never read or validated.
+4. **FCM callback infrastructure exists** — `fcm_receiver_ha.py` can register
+   per-device callbacks (used by LocateTracker), but no callback is registered for
+   sound events. Sound FCM pushes arrive and fall through silently.
+5. **Google's FMDN spec documents only BLE-level ringing** — the Beacon Actions
+   characteristic protocol is well-specified, but the cloud-side API is not.
+6. **Neither upstream nor any known project has BLE GATT ring code** — only community
+   members attempted it independently (Issue #66), finding a `data_len` bug.
+
 ---
 
-## Phase 1: Parse Nova Response (prerequisite for everything else)
+## Phase 1: Response Capture and Parsing
 
-### Problem
+### Step 1.1: Log raw Nova HTTP response and FCM sound pushes
 
-The Nova API returns a protobuf response on HTTP 200, but our code discards it:
+**Files:** `api.py`, `fcm_receiver_ha.py`
 
-```python
-# nova_request.py:1407-1408
-if status == HTTP_OK:
-    return cast(bytes, content).hex()   # raw hex, never parsed
+Two independent data sources must be captured:
 
-# api.py:1538-1540
-_response_hex, request_uuid = result    # _response_hex is ignored
-return (True, request_uuid)             # "True" = HTTP 200, nothing more
-```
-
-There is no `ExecuteActionResponse` message defined in `DeviceUpdate.proto`. The
-response format is unknown and must be reverse-engineered from live traffic.
-
-### Step 1.1: Capture and log the response payload
-
-**Files:** `api.py`
-
-Add structured debug logging of the raw response hex in `async_play_sound()` and
-`async_stop_sound()` so users/developers can inspect what Google returns:
+#### 1.1a: Nova HTTP response hex (in `api.py`)
 
 ```python
-# api.py — async_play_sound()
+# api.py — async_play_sound(), replace lines 1538-1540
 response_hex, request_uuid = result
 _LOGGER.debug(
-    "Play Sound response for %s (uuid=%s): %d bytes: %s",
+    "Play Sound Nova response for %s (uuid=%s): %d bytes: %s",
     device_id,
     request_uuid[:8] if request_uuid else "none",
     len(response_hex) // 2,
@@ -45,71 +48,138 @@ _LOGGER.debug(
 )
 ```
 
-**Acceptance:** Response hex visible in HA debug logs when Play Sound is triggered.
+#### 1.1b: FCM push for sound events (in `fcm_receiver_ha.py`)
 
-### Step 1.2: Attempt generic protobuf decode of the response
-
-**Files:** `api.py` or new `NovaApi/ExecuteAction/PlaySound/response_parser.py`
-
-Since there is no `ExecuteActionResponse` proto definition, try:
-
-1. **google.rpc.Status** — already vendored in `RpcStatus_pb2.py`. If the success
-   response is also an rpc.Status with code=0, we get confirmation for free.
-2. **Raw protobuf field scan** — use `google.protobuf.descriptor_pool` or raw varint
-   parsing to identify field numbers and types without a schema.
-3. **Upstream traffic analysis** — check if GoogleFindMyTools upstream has decoded
-   the response in any branch or issue.
+Currently, FCM notifications with no registered callback fall through to
+`_process_background_update()` which tries to parse them as location responses.
+Add diagnostic logging before the fallthrough:
 
 ```python
+# fcm_receiver_ha.py — _handle_notification_async(), after callback check
+if not cb:
+    _LOGGER.debug(
+        "FCM notification for %s has no registered callback "
+        "(may be sound confirmation): payload_len=%d, hex_prefix=%s",
+        canonic_id[:8],
+        len(hex_string),
+        hex_string[:100],
+    )
+```
+
+**Acceptance:** Both data streams visible in HA debug logs during Play Sound.
+Users with real devices can provide sample payloads for schema analysis.
+
+### Step 1.2: Attempt generic protobuf decode
+
+**Files:** New `NovaApi/ExecuteAction/PlaySound/response_parser.py`
+
+Since the response schema is unknown, the parser must be speculative:
+
+```python
+from enum import Enum
+from dataclasses import dataclass
+
+class ActionStatus(Enum):
+    ACCEPTED = "accepted"        # Server confirmed command routing
+    SUBMITTED = "submitted"      # HTTP 200 but response unparseable
+    REJECTED = "rejected"        # Server returned error in response body
+    UNKNOWN = "unknown"          # Could not determine
+
+@dataclass(frozen=True)
+class ActionResult:
+    status: ActionStatus
+    request_uuid: str | None = None
+    raw_hex: str = ""
+    detail: str = ""
+
 def parse_action_response(response_hex: str) -> ActionResult:
     """Best-effort parse of Nova ExecuteAction response.
 
-    Returns:
-        ActionResult with status (ACCEPTED / REJECTED / UNKNOWN) and
-        optional detail fields.
+    Strategy (ordered by likelihood):
+    1. Try google.rpc.Status — already vendored in RpcStatus_pb2.py.
+       If code=0, that means OK. If code>0, extract error message.
+    2. Try DeviceUpdate — the FCM response format. If the HTTP response
+       echoes the same structure, we get requestUuid for correlation.
+    3. Raw varint field scan — identify field numbers and wire types
+       without a schema. Log discovered structure for future proto def.
+    4. Fall through to SUBMITTED with raw hex for manual inspection.
     """
 ```
 
-**Acceptance:** For a successful Play Sound, the parser returns a structured result.
-For an unknown format, it returns `UNKNOWN` with the raw hex for logging.
+**Why google.rpc.Status first:** It's the standard Google API response wrapper.
+It's already imported in `nova_request.py:259`. If the success response is
+`Status{code: 0}`, we have confirmation with zero reverse engineering.
 
-### Step 1.3: Surface response status to the HA entity
+**Why DeviceUpdate second:** The FCM callback response is a `DeviceUpdate` protobuf.
+If the HTTP response uses the same message type, `parse_device_update_protobuf()`
+already works and we get `requestUuid` matching.
 
-**Files:** `api.py`, `button.py`
+**Acceptance:** Parser returns structured `ActionResult` for any input.
 
-Change `async_play_sound()` return type to carry the parsed result:
+### Step 1.3: Wire FCM callback for sound event correlation
+
+**Files:** `api.py`, `fcm_receiver_ha.py`
+
+This is the higher-value confirmation path. The infrastructure already exists:
 
 ```python
-# Before:
-async def async_play_sound(self, device_id: str) -> tuple[bool, str | None]:
+# Pattern from location_request.py (already working):
+callback = _make_location_callback(...)
+await fcm_receiver.async_register_for_location_updates(canonic_id, callback)
+# ... submit Nova request ...
+await asyncio.wait_for(ctx.event.wait(), timeout=30)
+# ... unregister callback ...
+```
 
-# After:
+For sound events, register a lightweight callback that:
+1. Receives the FCM push containing `DeviceUpdate` with `requestUuid`
+2. Validates `requestUuid` matches the submitted request
+3. Signals an `asyncio.Event` to confirm delivery
+
+```python
+# api.py — async_play_sound() conceptual flow:
 async def async_play_sound(self, device_id: str) -> PlaySoundResult:
-    """Returns PlaySoundResult with .success, .request_uuid, .server_status"""
+    request_uuid = generate_random_uuid()
+
+    # Register short-lived FCM callback for this device
+    confirmation = asyncio.Event()
+    await fcm_receiver.async_register_for_sound_updates(
+        device_id, lambda cid, hex_resp: confirmation.set()
+    )
+
+    try:
+        # Submit cloud command
+        response_hex = await self._submit_sound_request(device_id, request_uuid)
+        nova_result = parse_action_response(response_hex)
+
+        # Wait briefly for FCM confirmation (non-blocking, best-effort)
+        try:
+            await asyncio.wait_for(confirmation.wait(), timeout=10.0)
+            return PlaySoundResult(status=CONFIRMED, ...)
+        except asyncio.TimeoutError:
+            return PlaySoundResult(status=SUBMITTED, ...)  # no FCM ack
+    finally:
+        await fcm_receiver.async_unregister_for_sound_updates(device_id)
 ```
 
-The button entity can then set `extra_state_attributes` with:
-- `last_ring_status`: "accepted" / "submitted" / "rejected" / "error"
-- `last_ring_uuid`: request UUID for correlation
-- `last_ring_timestamp`: ISO timestamp
+**Key difference from LocateTracker:** The sound callback is fire-and-forget with a
+short timeout. LocateTracker blocks for up to 30s waiting for location data. Sound
+confirmation is optional — the command already went out.
 
-**Acceptance:** HA entity attributes reflect whether the command was server-acknowledged.
+**Acceptance:** Play Sound returns `CONFIRMED` when FCM push arrives within timeout,
+`SUBMITTED` when only HTTP 200 was received.
 
-### Step 1.4: Define `ExecuteActionResponse` proto (if structure identified)
+### Step 1.4: Define proto and surface to entity (once schema is known)
 
-**Files:** `ProtoDecoders/DeviceUpdate.proto`, regenerate `DeviceUpdate_pb2.py`
+**Blocked until** sample payloads from step 1.1 are collected and analyzed.
 
-Once the response structure is known from step 1.2, add the message definition:
-
-```protobuf
-message ExecuteActionResponse {
-    int32 status = 1;           // hypothetical
-    string requestUuid = 2;     // echo back
-    // ... discovered fields
-}
-```
-
-**Acceptance:** Response can be parsed into a typed protobuf message.
+**Files (when ready):**
+- `ProtoDecoders/DeviceUpdate.proto` — add `ExecuteActionResponse`
+- `api.py` — change return type to `PlaySoundResult`
+- `button.py` — expose `extra_state_attributes`:
+  - `last_ring_status`: "confirmed" / "submitted" / "rejected" / "error"
+  - `last_ring_uuid`: request UUID
+  - `last_ring_timestamp`: ISO timestamp
 
 ---
 
@@ -117,7 +187,7 @@ message ExecuteActionResponse {
 
 ### Prerequisites
 
-- Phase 1 complete (response parsing established)
+- Phase 1 steps 1.1-1.3 complete (confirmation infrastructure established)
 - Understanding of current BLE MAC from EID resolution
 - `bluetooth` dependency added to `manifest.json`
 
@@ -129,22 +199,20 @@ message ExecuteActionResponse {
 | Active connections | No | Yes (via `bleak-retry-connector`) |
 | ESPHome proxy | RSSI only | Full GATT proxy (active mode) |
 | Purpose | Room presence | Full BLE stack |
+| Used by | This integration (passive EID relay) | SwitchBot, Yale Lock, HomeKit BLE |
 
 **Bermuda is not involved in BLE ringing.** It remains a passive location signal
-source. Direct BLE ringing uses HA's built-in bluetooth integration, which:
+source. Direct BLE ringing uses HA's built-in bluetooth integration, which wraps
+`bleak` with adapter management, ESPHome proxy routing, and connection retry logic.
 
-- Wraps `bleak` (Python BLE library) with HA adapter management
-- Supports transparent routing through ESPHome BLE proxies (active mode)
-- Provides `async_ble_device_from_address()` to resolve BLE devices
-- Is used by SwitchBot, Yale Lock, and other HA integrations for GATT writes
-
-### Step 2.1: Add `bluetooth` dependency
+### Step 2.1: Add optional `bluetooth` dependency
 
 **Files:** `manifest.json`
 
 ```json
 {
-    "dependencies": ["http", "bluetooth"],
+    "dependencies": ["http"],
+    "after_dependencies": ["bluetooth"],
     "requirements": [
         "bleak>=0.21.0",
         "bleak-retry-connector>=3.4.0",
@@ -153,11 +221,10 @@ source. Direct BLE ringing uses HA's built-in bluetooth integration, which:
 }
 ```
 
-**Risk:** This makes the integration depend on a Bluetooth adapter being configured
-in HA. Users without BLE should still work (cloud-only fallback). The `bluetooth`
-dependency must be made optional or the BLE ring path must gracefully degrade.
+Using `after_dependencies` instead of `dependencies` ensures HA loads the bluetooth
+integration first if available, but does not fail if it's not configured.
 
-**Mitigation:** Check `bluetooth` availability at runtime:
+Runtime check:
 
 ```python
 try:
@@ -171,162 +238,122 @@ except ImportError:
 
 **Files:** `eid_resolver.py`
 
-The EID resolver already processes BLE advertisements from Bermuda. Each
-advertisement contains the current (rotated) MAC address. Store it:
+The EID resolver processes BLE advertisements from Bermuda/HA scanner. Each
+advertisement contains the current (rotated) MAC address. Store it alongside the
+EID match:
 
 ```python
-# During EID match:
-match = EIDMatch(
-    device_id=registry_id,
-    canonical_id=canonical_id,
-    ble_address=service_info.address,      # NEW: current MAC
-    ble_address_timestamp=time.time(),     # NEW: when seen
-)
+@dataclass
+class EIDMatch:
+    device_id: str          # registry_id
+    canonical_id: str       # canonical_id
+    ble_address: str | None = None        # NEW: current rotated MAC
+    ble_address_seen: float | None = None # NEW: monotonic timestamp
 ```
 
-**Challenge:** FMDN trackers rotate MAC every ~15 minutes. The stored MAC is valid
-only within the rotation window. A ring attempt with a stale MAC will fail at the
-BLE connection stage (device not found / wrong device).
-
-**Mitigation:** Only attempt BLE ring if `ble_address_timestamp` is < 10 minutes old.
+**Freshness constraint:** FMDN trackers rotate MAC every ~15 minutes. Only attempt
+BLE ring if `monotonic() - ble_address_seen < 600` (10 minutes).
 
 ### Step 2.3: Implement FMDN Beacon Actions GATT client
 
 **Files:** New `FMDNCrypto/beacon_actions.py`
 
-Implement the FMDN ring protocol per the spec:
-
 ```python
 BEACON_ACTIONS_UUID = "FE2C1238-8366-4814-8EB0-01DE32100BEA"
+
+DATA_ID_RING = 0x05
+DATA_ID_READ_RING_STATE = 0x06
+
+class RingState(Enum):
+    STARTED = 0x00
+    FAILED = 0x01
+    STOPPED_TIMEOUT = 0x02
+    STOPPED_BUTTON = 0x03
+    STOPPED_GATT = 0x04
+
+@dataclass(frozen=True)
+class BleRingResult:
+    success: bool
+    state: RingState | None = None
+    detail: str = ""
 
 async def async_ring_via_ble(
     hass: HomeAssistant,
     ble_address: str,
-    ring_key: bytes,        # 8 bytes from key_derivation.py
+    ring_key: bytes,        # 8 bytes from SHA256(EIK || 0x02)[:8]
     *,
-    volume: int = 3,        # 0-3
+    volume: int = 3,        # 0=silent, 3=max
     timeout_ds: int = 100,  # deciseconds (10s default)
     component: int = 0xFF,  # all components
 ) -> BleRingResult:
-    """Ring an FMDN tracker via direct BLE GATT write.
-
-    Protocol:
-        1. Connect to tracker
-        2. Read Beacon Actions characteristic → 8-byte nonce
-        3. Compute one-time auth: HMAC-SHA256(ring_key, nonce || 0x05 || addl)[:8]
-        4. Write ring command: [0x05] [data_len=11] [8B auth] [component] [timeout] [volume]
-        5. Read notification → status byte
-        6. Disconnect
+    """Ring tracker via direct BLE GATT write.
 
     IMPORTANT: data_len = len(auth_key) + len(addl_data) = 8 + 3 = 11
-               (Upstream bug #66 used len(addl_data) only = 3, causing ATT Error 0x81)
+               (Issue #66 bug used len(addl_data)=3, causing ATT Error 0x81)
     """
 ```
 
-**Ring key is already derived** in `key_derivation.py:58`:
-```python
-self.ringing_key = calculate_truncated_sha256(identity_key_bytes, 0x02)  # 8 bytes
-```
+**Ring key derivation** is already in `key_derivation.py:58` — derive on-the-fly
+from EIK at ring time: `SHA256(EIK || 0x02)[:8]`.
 
-Currently only used during device registration. Must be stored/accessible for
-runtime ring operations.
-
-### Step 2.4: Orchestrate cloud + BLE ring with fallback
+### Step 2.4: Orchestrate cloud + BLE ring
 
 **Files:** `api.py`
 
 ```python
 async def async_play_sound(self, device_id: str) -> PlaySoundResult:
-    # 1. Always try cloud first (global reach)
+    # 1. Always try cloud first (global reach, no proximity needed)
     cloud_result = await self._async_play_sound_cloud(device_id)
 
     if cloud_result.confirmed:
         return cloud_result
 
     # 2. If cloud unconfirmed and BLE available, try direct
-    if HAS_BLUETOOTH and self._has_recent_ble_address(device_id):
+    if HAS_BLUETOOTH and self._has_fresh_ble_address(device_id):
         ble_result = await self._async_play_sound_ble(device_id)
-        if ble_result.confirmed:
-            return ble_result
+        if ble_result.success:
+            return PlaySoundResult(
+                status=ActionStatus.CONFIRMED,
+                source="ble",
+                ble_state=ble_result.state,
+            )
 
     # 3. Return best available result
     return cloud_result  # "submitted" but unconfirmed
 ```
-
-**Why cloud first:** Cloud works globally. BLE only works if tracker is in range.
-Most users won't have BLE proximity. Cloud-first means the common case is fast.
-
-**Why BLE fallback matters:** When the tracker is at home (most common "where are my
-keys?" scenario), BLE is faster and provides hardware confirmation.
-
-### Step 2.5: Ring key availability at runtime
-
-**Files:** `coordinator/identity.py`, `api.py`
-
-The ring key must be accessible when `async_play_sound_ble()` is called.
-Options:
-
-1. **Derive on-the-fly** from stored EIK: `SHA256(EIK || 0x02)[:8]`
-   - EIK is already available via `async_retrieve_identity_key()`
-   - Adds ~1ms computation, negligible
-   - Preferred: no additional storage needed
-
-2. **Store during registration:** Already done in `create_ble_device.py:110`
-   but only sent to Google, not stored locally.
-
-**Recommendation:** Option 1 — derive from EIK at ring time.
 
 ---
 
 ## Phase 3: Entity UX improvements (future)
 
 ### Step 3.1: Ring status sensor
-
-Add a `sensor` entity that reflects the ring state:
-
-- `idle` — no active ring
-- `ringing_cloud` — cloud command submitted, awaiting timeout
-- `ringing_ble` — BLE ring confirmed active
-- `failed` — ring attempt failed
+- `idle` / `ringing_cloud` / `ringing_ble` / `confirmed` / `failed`
 
 ### Step 3.2: Component selection for multi-component devices
+- LEFT, RIGHT, CASE via `DeviceComponent` enum (already in proto)
 
-Headphones have LEFT, RIGHT, and CASE components. The proto already supports:
-
-```protobuf
-enum DeviceComponent {
-    DEVICE_COMPONENT_UNSPECIFIED = 0;  // ring all
-    DEVICE_COMPONENT_RIGHT = 1;
-    DEVICE_COMPONENT_LEFT = 2;
-    DEVICE_COMPONENT_CASE = 3;
-}
-```
-
-Add a service parameter or separate buttons for component-specific ringing.
-
-### Step 3.3: Auto-stop and timeout
-
-- BLE ring has explicit timeout (`timeout_ds` parameter)
-- Cloud ring has no known timeout — may ring indefinitely
-- Add HA automation-friendly auto-stop after configurable duration
+### Step 3.3: Auto-stop and configurable timeout
+- BLE: explicit `timeout_ds` parameter
+- Cloud: schedule `async_stop_sound()` after configurable duration
 
 ---
 
 ## Dependency Graph
 
 ```
-Phase 1.1  Capture response hex (logging)
+Phase 1.1a  Log Nova HTTP response hex
+Phase 1.1b  Log FCM sound pushes
+    |           |
+    v           v
+Phase 1.2   Generic protobuf decode attempt
     |
-    v
-Phase 1.2  Decode response format
+    +-------+
+    |       |
+    v       v
+Phase 1.3  FCM sound callback    Phase 1.4  Define response proto
+    |       (async confirmation)     (blocked until samples collected)
     |
-    v
-Phase 1.3  Surface status to entity
-    |
-    v
-Phase 1.4  Define response proto (if applicable)
-    |
-    +-----> Phase 2.1  Add bluetooth dependency
+    +-----> Phase 2.1  Add optional bluetooth dependency
     |           |
     |           v
     |       Phase 2.2  Capture MAC from EID resolution
@@ -338,9 +365,6 @@ Phase 1.4  Define response proto (if applicable)
     +-----> Phase 2.4  Cloud + BLE orchestration
                 |
                 v
-            Phase 2.5  Ring key availability
-                |
-                v
             Phase 3    UX improvements
 ```
 
@@ -350,12 +374,13 @@ Phase 1.4  Define response proto (if applicable)
 
 | Risk | Impact | Likelihood | Mitigation |
 |------|--------|------------|------------|
-| Unknown response format | Phase 1.2 blocked | Medium | Generic protobuf scan, raw hex logging |
-| MAC rotation staleness | BLE ring fails | High | 10-min freshness check, cloud fallback |
-| ESPHome proxy connection slots | BLE ring contention | Medium | Short-lived connections only |
-| `bluetooth` as hard dependency | Breaks non-BLE installs | High | Runtime import check, graceful degrade |
-| Ring key not available | BLE ring impossible | Low | Derive from EIK on-the-fly |
-| Upstream bug #66 data_len | ATT Error 0x81 | Eliminated | Correct formula: data_len = 8 + 3 = 11 |
+| Nova response is empty/opaque protobuf | Phase 1.2 inconclusive | Medium | FCM callback (Phase 1.3) provides independent confirmation path |
+| FCM sound push has different format | Phase 1.3 needs adjustment | Low | `DeviceUpdate` is the only FCM message type; sound pushes likely use same structure |
+| MAC rotation staleness | BLE ring fails | High | 10-min freshness check, cloud fallback always runs first |
+| ESPHome proxy connection slots | BLE ring contention | Medium | Short-lived connections (~2s), immediate disconnect |
+| `bluetooth` as hard dependency | Breaks non-BLE installs | High | `after_dependencies` + runtime import check |
+| Ring key not available at runtime | BLE ring impossible | Low | Derive from EIK on-the-fly (~1ms) |
+| Upstream bug #66 data_len | ATT Error 0x81 | Eliminated | Correct formula documented: data_len = 8 + 3 = 11 |
 
 ---
 
@@ -363,12 +388,12 @@ Phase 1.4  Define response proto (if applicable)
 
 | Phase | File | Change |
 |-------|------|--------|
-| 1.1 | `api.py` | Debug-log response hex |
-| 1.2 | New: `PlaySound/response_parser.py` | Generic response decoder |
-| 1.3 | `api.py`, `button.py` | Return/expose parsed status |
-| 1.4 | `DeviceUpdate.proto` | Add `ExecuteActionResponse` |
-| 2.1 | `manifest.json` | Add `bluetooth` dependency |
-| 2.2 | `eid_resolver.py` | Store BLE address on EID match |
+| 1.1a | `api.py` | Debug-log Nova response hex |
+| 1.1b | `fcm_receiver_ha.py` | Debug-log unhandled FCM pushes (sound candidates) |
+| 1.2 | New: `PlaySound/response_parser.py` | Generic response decoder (rpc.Status → DeviceUpdate → raw scan) |
+| 1.3 | `api.py`, `fcm_receiver_ha.py` | FCM sound callback registration + correlation |
+| 1.4 | `DeviceUpdate.proto`, `DeviceUpdate_pb2.py` | Add `ExecuteActionResponse` (when schema known) |
+| 2.1 | `manifest.json` | Add `bluetooth` to `after_dependencies` |
+| 2.2 | `eid_resolver.py` | Store BLE address + timestamp on EID match |
 | 2.3 | New: `FMDNCrypto/beacon_actions.py` | GATT ring client |
 | 2.4 | `api.py` | Cloud + BLE orchestration |
-| 2.5 | `coordinator/identity.py` | Ring key derivation at runtime |

--- a/docs/PLAY_SOUND_IMPLEMENTATION_PLAN.md
+++ b/docs/PLAY_SOUND_IMPLEMENTATION_PLAN.md
@@ -14,11 +14,12 @@ Before planning, these facts constrain the design:
    namespace is deliberately excluded from public APIs.
 2. **Upstream discards the Nova HTTP response** — `nova_request()` returns hex, but
    the caller in `start_sound_request.py` never assigns the return value.
-3. **Our code stores but ignores the response** — `_response_hex` is unpacked at
-   `api.py:1538` but never read or validated.
+3. **Our code now logs the response** — `response_hex` is unpacked at
+   `api.py:1538` and logged at DEBUG level (implemented in Phase 1.1a).
 4. **FCM callback infrastructure exists** — `fcm_receiver_ha.py` can register
    per-device callbacks (used by LocateTracker), but no callback is registered for
-   sound events. Sound FCM pushes arrive and fall through silently.
+   sound events. Unhandled FCM pushes are now logged at DEBUG level (Phase 1.1b),
+   but no structured callback exists yet for sound events.
 5. **Google's FMDN spec documents only BLE-level ringing** — the Beacon Actions
    characteristic protocol is well-specified, but the cloud-side API is not.
 6. **Neither upstream nor any known project has BLE GATT ring code** — only community
@@ -28,42 +29,51 @@ Before planning, these facts constrain the design:
 
 ## Phase 1: Response Capture and Parsing
 
-### Step 1.1: Log raw Nova HTTP response and FCM sound pushes
+### Step 1.1: Log raw Nova HTTP response and FCM sound pushes ✅ DONE
 
 **Files:** `api.py`, `fcm_receiver_ha.py`
 
-Two independent data sources must be captured:
+Two independent data sources are now captured:
 
-#### 1.1a: Nova HTTP response hex (in `api.py`)
+#### 1.1a: Nova HTTP response hex (in `api.py`) ✅
+
+Implemented for both Play Sound and Stop Sound:
 
 ```python
-# api.py — async_play_sound(), replace lines 1538-1540
+# api.py — async_play_sound() (lines 1538-1547)
 response_hex, request_uuid = result
+_LOGGER.info("Play Sound (async) submitted successfully for %s", device_id)
 _LOGGER.debug(
     "Play Sound Nova response for %s (uuid=%s): %d bytes: %s",
     device_id,
     request_uuid[:8] if request_uuid else "none",
-    len(response_hex) // 2,
-    response_hex[:200],  # first 100 bytes hex
+    len(response_hex) // 2 if response_hex else 0,
+    response_hex[:200] if response_hex else "(empty)",
+)
+
+# api.py — async_stop_sound() (lines 1640-1645)
+_LOGGER.debug(
+    "Stop Sound Nova response for %s: %d bytes: %s",
+    device_id,
+    len(result_hex) // 2 if result_hex else 0,
+    result_hex[:200] if result_hex else "(empty)",
 )
 ```
 
-#### 1.1b: FCM push for sound events (in `fcm_receiver_ha.py`)
+#### 1.1b: FCM push logging for all unhandled events (in `fcm_receiver_ha.py`) ✅
 
-Currently, FCM notifications with no registered callback fall through to
-`_process_background_update()` which tries to parse them as location responses.
-Add diagnostic logging before the fallthrough:
+Universal logging for ALL FCM pushes without a registered callback (not just sound):
 
 ```python
-# fcm_receiver_ha.py — _handle_notification_async(), after callback check
-if not cb:
-    _LOGGER.debug(
-        "FCM notification for %s has no registered callback "
-        "(may be sound confirmation): payload_len=%d, hex_prefix=%s",
-        canonic_id[:8],
-        len(hex_string),
-        hex_string[:100],
-    )
+# fcm_receiver_ha.py — _handle_notification_async() (lines 1150-1160)
+# Fires only in response to user-initiated actions, no log spam.
+_LOGGER.debug(
+    "FCM push for %s has no registered callback "
+    "(may be action confirmation): payload_len=%d, hex_prefix=%s",
+    canonic_id[:8],
+    len(hex_string),
+    hex_string[:120] if hex_string else "(empty)",
+)
 ```
 
 **Acceptance:** Both data streams visible in HA debug logs during Play Sound.
@@ -234,25 +244,36 @@ except ImportError:
     HAS_BLUETOOTH = False
 ```
 
-### Step 2.2: Capture current MAC during EID resolution
+### Step 2.2: Capture current MAC during EID resolution ✅ DONE
 
 **Files:** `eid_resolver.py`
 
 The EID resolver processes BLE advertisements from Bermuda/HA scanner. Each
-advertisement contains the current (rotated) MAC address. Store it alongside the
-EID match:
+advertisement contains the current (rotated) MAC address. The infrastructure to
+capture and store this address is now implemented:
 
 ```python
-@dataclass
-class EIDMatch:
-    device_id: str          # registry_id
-    canonical_id: str       # canonical_id
-    ble_address: str | None = None        # NEW: current rotated MAC
-    ble_address_seen: float | None = None # NEW: monotonic timestamp
+@dataclass(slots=True)
+class BLEScanInfo:
+    ble_address: str             # current rotated MAC
+    observed_at: float           # time.monotonic()
+    observed_at_wall: float      # time.time()
+
+# Storage: _ble_scan_info dict keyed by canonical_id (same pattern as _ble_battery_state)
+# Public API: get_ble_scan_info(canonical_id) -> BLEScanInfo | None
+# Private: _record_ble_scan_info(matches, ble_address) — called from resolve_eid()
+
+# resolve_eid() and resolve_eid_all() accept optional ble_address kwarg:
+def resolve_eid(self, eid_bytes: bytes, *, ble_address: str | None = None) -> EIDMatch | None
+def resolve_eid_all(self, eid_bytes: bytes, *, ble_address: str | None = None) -> list[EIDMatch]
 ```
 
 **Freshness constraint:** FMDN trackers rotate MAC every ~15 minutes. Only attempt
-BLE ring if `monotonic() - ble_address_seen < 600` (10 minutes).
+BLE ring if `monotonic() - observed_at < 600` (10 minutes).
+
+**Remaining work:** Callers (Bermuda listener, HA scanner) need to pass `ble_address`
+from `BluetoothServiceInfoBleak.address` when calling `resolve_eid()`. The parameter
+is backward-compatible (keyword-only, default `None`).
 
 ### Step 2.3: Implement FMDN Beacon Actions GATT client
 
@@ -288,8 +309,9 @@ async def async_ring_via_ble(
 ) -> BleRingResult:
     """Ring tracker via direct BLE GATT write.
 
-    IMPORTANT: data_len = len(auth_key) + len(addl_data) = 8 + 3 = 11
-               (Issue #66 bug used len(addl_data)=3, causing ATT Error 0x81)
+    IMPORTANT: data_len = len(auth_key) + len(addl_data) = 8 + 4 = 12
+               addl_data = [op_mask(1B)] [timeout(2B)] [volume(1B)] = 4 bytes
+               (Issue #66 bug used len(addl_data)=4, causing ATT Error 0x81)
     """
 ```
 
@@ -341,8 +363,8 @@ async def async_play_sound(self, device_id: str) -> PlaySoundResult:
 ## Dependency Graph
 
 ```
-Phase 1.1a  Log Nova HTTP response hex
-Phase 1.1b  Log FCM sound pushes
+Phase 1.1a  Log Nova HTTP response hex                  ✅ DONE
+Phase 1.1b  Log FCM sound pushes                        ✅ DONE
     |           |
     v           v
 Phase 1.2   Generic protobuf decode attempt
@@ -356,7 +378,7 @@ Phase 1.3  FCM sound callback    Phase 1.4  Define response proto
     +-----> Phase 2.1  Add optional bluetooth dependency
     |           |
     |           v
-    |       Phase 2.2  Capture MAC from EID resolution
+    |       Phase 2.2  Capture MAC from EID resolution  ✅ DONE (infra ready)
     |           |
     |           v
     |       Phase 2.3  Implement GATT ring client
@@ -380,20 +402,20 @@ Phase 1.3  FCM sound callback    Phase 1.4  Define response proto
 | ESPHome proxy connection slots | BLE ring contention | Medium | Short-lived connections (~2s), immediate disconnect |
 | `bluetooth` as hard dependency | Breaks non-BLE installs | High | `after_dependencies` + runtime import check |
 | Ring key not available at runtime | BLE ring impossible | Low | Derive from EIK on-the-fly (~1ms) |
-| Upstream bug #66 data_len | ATT Error 0x81 | Eliminated | Correct formula documented: data_len = 8 + 3 = 11 |
+| Upstream bug #66 data_len | ATT Error 0x81 | Eliminated | Correct formula documented: data_len = 8 + 4 = 12 |
 
 ---
 
 ## Files Affected Summary
 
-| Phase | File | Change |
-|-------|------|--------|
-| 1.1a | `api.py` | Debug-log Nova response hex |
-| 1.1b | `fcm_receiver_ha.py` | Debug-log unhandled FCM pushes (sound candidates) |
-| 1.2 | New: `PlaySound/response_parser.py` | Generic response decoder (rpc.Status → DeviceUpdate → raw scan) |
-| 1.3 | `api.py`, `fcm_receiver_ha.py` | FCM sound callback registration + correlation |
-| 1.4 | `DeviceUpdate.proto`, `DeviceUpdate_pb2.py` | Add `ExecuteActionResponse` (when schema known) |
-| 2.1 | `manifest.json` | Add `bluetooth` to `after_dependencies` |
-| 2.2 | `eid_resolver.py` | Store BLE address + timestamp on EID match |
-| 2.3 | New: `FMDNCrypto/beacon_actions.py` | GATT ring client |
-| 2.4 | `api.py` | Cloud + BLE orchestration |
+| Phase | File | Change | Status |
+|-------|------|--------|--------|
+| 1.1a | `api.py` | Debug-log Nova response hex (Play Sound + Stop Sound) | ✅ Done |
+| 1.1b | `fcm_receiver_ha.py` | Debug-log ALL unhandled FCM pushes | ✅ Done |
+| 1.2 | New: `PlaySound/response_parser.py` | Generic response decoder (rpc.Status → DeviceUpdate → raw scan) | Pending |
+| 1.3 | `api.py`, `fcm_receiver_ha.py` | FCM sound callback registration + correlation | Pending |
+| 1.4 | `DeviceUpdate.proto`, `DeviceUpdate_pb2.py` | Add `ExecuteActionResponse` (when schema known) | Blocked |
+| 2.1 | `manifest.json` | Add `bluetooth` to `after_dependencies` | Pending |
+| 2.2 | `eid_resolver.py` | BLEScanInfo dataclass, storage, getter, resolve_eid kwarg | ✅ Done |
+| 2.3 | New: `FMDNCrypto/beacon_actions.py` | GATT ring client | Pending |
+| 2.4 | `api.py` | Cloud + BLE orchestration | Pending |

--- a/docs/PLAY_SOUND_IMPLEMENTATION_PLAN.md
+++ b/docs/PLAY_SOUND_IMPLEMENTATION_PLAN.md
@@ -215,34 +215,58 @@ confirmation is optional — the command already went out.
 source. Direct BLE ringing uses HA's built-in bluetooth integration, which wraps
 `bleak` with adapter management, ESPHome proxy routing, and connection retry logic.
 
-### Step 2.1: Add optional `bluetooth` dependency
+### Step 2.1: Add optional bluetooth dependency and FMDN BLE scanner ✅ DONE
 
-**Files:** `manifest.json`
+**Files:** `manifest.json`, `fmdn_finder/ble_scanner.py`, `__init__.py`
+
+#### 2.1a: manifest.json
 
 ```json
 {
-    "dependencies": ["http"],
-    "after_dependencies": ["bluetooth"],
-    "requirements": [
-        "bleak>=0.21.0",
-        "bleak-retry-connector>=3.4.0",
-        ...existing...
-    ]
+    "after_dependencies": ["bluetooth", "recorder"]
 }
 ```
 
 Using `after_dependencies` instead of `dependencies` ensures HA loads the bluetooth
 integration first if available, but does not fail if it's not configured.
 
-Runtime check:
+#### 2.1b: HA-Bluetooth FMDN advertisement listener
+
+A new module `fmdn_finder/ble_scanner.py` registers a callback on HA's built-in
+Bluetooth scanner to capture FMDN advertisements directly (independent of Bermuda):
 
 ```python
-try:
-    from homeassistant.components.bluetooth import async_ble_device_from_address
-    HAS_BLUETOOTH = True
-except ImportError:
-    HAS_BLUETOOTH = False
+# fmdn_finder/ble_scanner.py
+from homeassistant.components.bluetooth import (
+    BluetoothChange, BluetoothScanningMode,
+    BluetoothServiceInfoBleak, async_register_callback,
+)
+
+FEAA_SERVICE_UUID = "0000feaa-0000-1000-8000-00805f9b34fb"  # Eddystone/FMDN
+FE2C_SERVICE_UUID = "0000fe2c-0000-1000-8000-00805f9b34fb"  # Fast Pair
+
+def _fmdn_advertisement_callback(service_info, change):
+    payload = service_info.service_data.get(FEAA_SERVICE_UUID)
+    # or FE2C_SERVICE_UUID — checked for both
+    frame_type = payload[0]  # 0x40 = normal, 0x41 = UTP/separated
+    match = resolver.resolve_eid(payload, ble_address=service_info.address)
+    # → BLEScanInfo stored, MAC+RSSI+frame captured
 ```
+
+**Key properties:**
+- **Always-on** — independent of `FEATURE_FMDN_FINDER_ENABLED` (works without Bermuda)
+- **Zero overhead** — piggybacks on HA's existing scanner (PASSIVE mode)
+- **Graceful degradation** — silently skipped if bluetooth integration not available
+- **Proper lifecycle** — `async_setup_ble_scanner()` / `async_unload_ble_scanner()`
+- **Rate-limited logging** — unresolved EID prefixes logged at most once per 5 minutes
+
+**Data captured per advertisement:**
+| Field | Source | Storage |
+|-------|--------|---------|
+| BLE MAC | `service_info.address` | `BLEScanInfo.ble_address` via `resolve_eid()` |
+| RSSI | `service_info.rssi` | Logged (not stored yet) |
+| Frame type | `payload[0]` (0x40/0x41) | Logged; UWT stored via existing battery decode |
+| Service UUID | FEAA or FE2C | Logged for diagnostics |
 
 ### Step 2.2: Capture current MAC during EID resolution ✅ DONE
 
@@ -271,9 +295,10 @@ def resolve_eid_all(self, eid_bytes: bytes, *, ble_address: str | None = None) -
 **Freshness constraint:** FMDN trackers rotate MAC every ~15 minutes. Only attempt
 BLE ring if `monotonic() - observed_at < 600` (10 minutes).
 
-**Remaining work:** Callers (Bermuda listener, HA scanner) need to pass `ble_address`
-from `BluetoothServiceInfoBleak.address` when calling `resolve_eid()`. The parameter
-is backward-compatible (keyword-only, default `None`).
+**Caller status:**
+- **ble_scanner.py** (HA Bluetooth): Passes `ble_address=service_info.address` ✅
+- **Bermuda listener**: Does NOT call `resolve_eid()` directly (uses state events).
+  Bermuda's own fork would need updating to pass `ble_address` to the resolver API.
 
 ### Step 2.3: Implement FMDN Beacon Actions GATT client
 
@@ -375,10 +400,10 @@ Phase 1.2   Generic protobuf decode attempt
 Phase 1.3  FCM sound callback    Phase 1.4  Define response proto
     |       (async confirmation)     (blocked until samples collected)
     |
-    +-----> Phase 2.1  Add optional bluetooth dependency
+    +-----> Phase 2.1  Bluetooth dep + FMDN BLE scanner ✅ DONE
     |           |
     |           v
-    |       Phase 2.2  Capture MAC from EID resolution  ✅ DONE (infra ready)
+    |       Phase 2.2  BLE scan info storage             ✅ DONE
     |           |
     |           v
     |       Phase 2.3  Implement GATT ring client
@@ -415,7 +440,9 @@ Phase 1.3  FCM sound callback    Phase 1.4  Define response proto
 | 1.2 | New: `PlaySound/response_parser.py` | Generic response decoder (rpc.Status → DeviceUpdate → raw scan) | Pending |
 | 1.3 | `api.py`, `fcm_receiver_ha.py` | FCM sound callback registration + correlation | Pending |
 | 1.4 | `DeviceUpdate.proto`, `DeviceUpdate_pb2.py` | Add `ExecuteActionResponse` (when schema known) | Blocked |
-| 2.1 | `manifest.json` | Add `bluetooth` to `after_dependencies` | Pending |
+| 2.1a | `manifest.json` | Add `bluetooth` to `after_dependencies` | ✅ Done |
+| 2.1b | New: `fmdn_finder/ble_scanner.py` | HA-Bluetooth FMDN advertisement callback | ✅ Done |
+| 2.1b | `__init__.py` | Wire BLE scanner setup/unload | ✅ Done |
 | 2.2 | `eid_resolver.py` | BLEScanInfo dataclass, storage, getter, resolve_eid kwarg | ✅ Done |
 | 2.3 | New: `FMDNCrypto/beacon_actions.py` | GATT ring client | Pending |
 | 2.4 | `api.py` | Cloud + BLE orchestration | Pending |

--- a/docs/PLAY_SOUND_IMPLEMENTATION_PLAN.md
+++ b/docs/PLAY_SOUND_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,374 @@
+# Play Sound Implementation Plan
+
+## Goal
+
+Transform Play Sound from fire-and-forget cloud-only into a robust two-path system
+with response validation (cloud) and direct BLE ringing (local fallback).
+
+---
+
+## Phase 1: Parse Nova Response (prerequisite for everything else)
+
+### Problem
+
+The Nova API returns a protobuf response on HTTP 200, but our code discards it:
+
+```python
+# nova_request.py:1407-1408
+if status == HTTP_OK:
+    return cast(bytes, content).hex()   # raw hex, never parsed
+
+# api.py:1538-1540
+_response_hex, request_uuid = result    # _response_hex is ignored
+return (True, request_uuid)             # "True" = HTTP 200, nothing more
+```
+
+There is no `ExecuteActionResponse` message defined in `DeviceUpdate.proto`. The
+response format is unknown and must be reverse-engineered from live traffic.
+
+### Step 1.1: Capture and log the response payload
+
+**Files:** `api.py`
+
+Add structured debug logging of the raw response hex in `async_play_sound()` and
+`async_stop_sound()` so users/developers can inspect what Google returns:
+
+```python
+# api.py — async_play_sound()
+response_hex, request_uuid = result
+_LOGGER.debug(
+    "Play Sound response for %s (uuid=%s): %d bytes: %s",
+    device_id,
+    request_uuid[:8] if request_uuid else "none",
+    len(response_hex) // 2,
+    response_hex[:200],  # first 100 bytes hex
+)
+```
+
+**Acceptance:** Response hex visible in HA debug logs when Play Sound is triggered.
+
+### Step 1.2: Attempt generic protobuf decode of the response
+
+**Files:** `api.py` or new `NovaApi/ExecuteAction/PlaySound/response_parser.py`
+
+Since there is no `ExecuteActionResponse` proto definition, try:
+
+1. **google.rpc.Status** — already vendored in `RpcStatus_pb2.py`. If the success
+   response is also an rpc.Status with code=0, we get confirmation for free.
+2. **Raw protobuf field scan** — use `google.protobuf.descriptor_pool` or raw varint
+   parsing to identify field numbers and types without a schema.
+3. **Upstream traffic analysis** — check if GoogleFindMyTools upstream has decoded
+   the response in any branch or issue.
+
+```python
+def parse_action_response(response_hex: str) -> ActionResult:
+    """Best-effort parse of Nova ExecuteAction response.
+
+    Returns:
+        ActionResult with status (ACCEPTED / REJECTED / UNKNOWN) and
+        optional detail fields.
+    """
+```
+
+**Acceptance:** For a successful Play Sound, the parser returns a structured result.
+For an unknown format, it returns `UNKNOWN` with the raw hex for logging.
+
+### Step 1.3: Surface response status to the HA entity
+
+**Files:** `api.py`, `button.py`
+
+Change `async_play_sound()` return type to carry the parsed result:
+
+```python
+# Before:
+async def async_play_sound(self, device_id: str) -> tuple[bool, str | None]:
+
+# After:
+async def async_play_sound(self, device_id: str) -> PlaySoundResult:
+    """Returns PlaySoundResult with .success, .request_uuid, .server_status"""
+```
+
+The button entity can then set `extra_state_attributes` with:
+- `last_ring_status`: "accepted" / "submitted" / "rejected" / "error"
+- `last_ring_uuid`: request UUID for correlation
+- `last_ring_timestamp`: ISO timestamp
+
+**Acceptance:** HA entity attributes reflect whether the command was server-acknowledged.
+
+### Step 1.4: Define `ExecuteActionResponse` proto (if structure identified)
+
+**Files:** `ProtoDecoders/DeviceUpdate.proto`, regenerate `DeviceUpdate_pb2.py`
+
+Once the response structure is known from step 1.2, add the message definition:
+
+```protobuf
+message ExecuteActionResponse {
+    int32 status = 1;           // hypothetical
+    string requestUuid = 2;     // echo back
+    // ... discovered fields
+}
+```
+
+**Acceptance:** Response can be parsed into a typed protobuf message.
+
+---
+
+## Phase 2: Direct BLE Ringing via HA Bluetooth Stack
+
+### Prerequisites
+
+- Phase 1 complete (response parsing established)
+- Understanding of current BLE MAC from EID resolution
+- `bluetooth` dependency added to `manifest.json`
+
+### Architecture Decision: HA Bluetooth, NOT Bermuda
+
+| | Bermuda | HA Bluetooth (`homeassistant.components.bluetooth`) |
+|--|---------|------------------------------------------------------|
+| GATT writes | No | Yes |
+| Active connections | No | Yes (via `bleak-retry-connector`) |
+| ESPHome proxy | RSSI only | Full GATT proxy (active mode) |
+| Purpose | Room presence | Full BLE stack |
+
+**Bermuda is not involved in BLE ringing.** It remains a passive location signal
+source. Direct BLE ringing uses HA's built-in bluetooth integration, which:
+
+- Wraps `bleak` (Python BLE library) with HA adapter management
+- Supports transparent routing through ESPHome BLE proxies (active mode)
+- Provides `async_ble_device_from_address()` to resolve BLE devices
+- Is used by SwitchBot, Yale Lock, and other HA integrations for GATT writes
+
+### Step 2.1: Add `bluetooth` dependency
+
+**Files:** `manifest.json`
+
+```json
+{
+    "dependencies": ["http", "bluetooth"],
+    "requirements": [
+        "bleak>=0.21.0",
+        "bleak-retry-connector>=3.4.0",
+        ...existing...
+    ]
+}
+```
+
+**Risk:** This makes the integration depend on a Bluetooth adapter being configured
+in HA. Users without BLE should still work (cloud-only fallback). The `bluetooth`
+dependency must be made optional or the BLE ring path must gracefully degrade.
+
+**Mitigation:** Check `bluetooth` availability at runtime:
+
+```python
+try:
+    from homeassistant.components.bluetooth import async_ble_device_from_address
+    HAS_BLUETOOTH = True
+except ImportError:
+    HAS_BLUETOOTH = False
+```
+
+### Step 2.2: Capture current MAC during EID resolution
+
+**Files:** `eid_resolver.py`
+
+The EID resolver already processes BLE advertisements from Bermuda. Each
+advertisement contains the current (rotated) MAC address. Store it:
+
+```python
+# During EID match:
+match = EIDMatch(
+    device_id=registry_id,
+    canonical_id=canonical_id,
+    ble_address=service_info.address,      # NEW: current MAC
+    ble_address_timestamp=time.time(),     # NEW: when seen
+)
+```
+
+**Challenge:** FMDN trackers rotate MAC every ~15 minutes. The stored MAC is valid
+only within the rotation window. A ring attempt with a stale MAC will fail at the
+BLE connection stage (device not found / wrong device).
+
+**Mitigation:** Only attempt BLE ring if `ble_address_timestamp` is < 10 minutes old.
+
+### Step 2.3: Implement FMDN Beacon Actions GATT client
+
+**Files:** New `FMDNCrypto/beacon_actions.py`
+
+Implement the FMDN ring protocol per the spec:
+
+```python
+BEACON_ACTIONS_UUID = "FE2C1238-8366-4814-8EB0-01DE32100BEA"
+
+async def async_ring_via_ble(
+    hass: HomeAssistant,
+    ble_address: str,
+    ring_key: bytes,        # 8 bytes from key_derivation.py
+    *,
+    volume: int = 3,        # 0-3
+    timeout_ds: int = 100,  # deciseconds (10s default)
+    component: int = 0xFF,  # all components
+) -> BleRingResult:
+    """Ring an FMDN tracker via direct BLE GATT write.
+
+    Protocol:
+        1. Connect to tracker
+        2. Read Beacon Actions characteristic → 8-byte nonce
+        3. Compute one-time auth: HMAC-SHA256(ring_key, nonce || 0x05 || addl)[:8]
+        4. Write ring command: [0x05] [data_len=11] [8B auth] [component] [timeout] [volume]
+        5. Read notification → status byte
+        6. Disconnect
+
+    IMPORTANT: data_len = len(auth_key) + len(addl_data) = 8 + 3 = 11
+               (Upstream bug #66 used len(addl_data) only = 3, causing ATT Error 0x81)
+    """
+```
+
+**Ring key is already derived** in `key_derivation.py:58`:
+```python
+self.ringing_key = calculate_truncated_sha256(identity_key_bytes, 0x02)  # 8 bytes
+```
+
+Currently only used during device registration. Must be stored/accessible for
+runtime ring operations.
+
+### Step 2.4: Orchestrate cloud + BLE ring with fallback
+
+**Files:** `api.py`
+
+```python
+async def async_play_sound(self, device_id: str) -> PlaySoundResult:
+    # 1. Always try cloud first (global reach)
+    cloud_result = await self._async_play_sound_cloud(device_id)
+
+    if cloud_result.confirmed:
+        return cloud_result
+
+    # 2. If cloud unconfirmed and BLE available, try direct
+    if HAS_BLUETOOTH and self._has_recent_ble_address(device_id):
+        ble_result = await self._async_play_sound_ble(device_id)
+        if ble_result.confirmed:
+            return ble_result
+
+    # 3. Return best available result
+    return cloud_result  # "submitted" but unconfirmed
+```
+
+**Why cloud first:** Cloud works globally. BLE only works if tracker is in range.
+Most users won't have BLE proximity. Cloud-first means the common case is fast.
+
+**Why BLE fallback matters:** When the tracker is at home (most common "where are my
+keys?" scenario), BLE is faster and provides hardware confirmation.
+
+### Step 2.5: Ring key availability at runtime
+
+**Files:** `coordinator/identity.py`, `api.py`
+
+The ring key must be accessible when `async_play_sound_ble()` is called.
+Options:
+
+1. **Derive on-the-fly** from stored EIK: `SHA256(EIK || 0x02)[:8]`
+   - EIK is already available via `async_retrieve_identity_key()`
+   - Adds ~1ms computation, negligible
+   - Preferred: no additional storage needed
+
+2. **Store during registration:** Already done in `create_ble_device.py:110`
+   but only sent to Google, not stored locally.
+
+**Recommendation:** Option 1 — derive from EIK at ring time.
+
+---
+
+## Phase 3: Entity UX improvements (future)
+
+### Step 3.1: Ring status sensor
+
+Add a `sensor` entity that reflects the ring state:
+
+- `idle` — no active ring
+- `ringing_cloud` — cloud command submitted, awaiting timeout
+- `ringing_ble` — BLE ring confirmed active
+- `failed` — ring attempt failed
+
+### Step 3.2: Component selection for multi-component devices
+
+Headphones have LEFT, RIGHT, and CASE components. The proto already supports:
+
+```protobuf
+enum DeviceComponent {
+    DEVICE_COMPONENT_UNSPECIFIED = 0;  // ring all
+    DEVICE_COMPONENT_RIGHT = 1;
+    DEVICE_COMPONENT_LEFT = 2;
+    DEVICE_COMPONENT_CASE = 3;
+}
+```
+
+Add a service parameter or separate buttons for component-specific ringing.
+
+### Step 3.3: Auto-stop and timeout
+
+- BLE ring has explicit timeout (`timeout_ds` parameter)
+- Cloud ring has no known timeout — may ring indefinitely
+- Add HA automation-friendly auto-stop after configurable duration
+
+---
+
+## Dependency Graph
+
+```
+Phase 1.1  Capture response hex (logging)
+    |
+    v
+Phase 1.2  Decode response format
+    |
+    v
+Phase 1.3  Surface status to entity
+    |
+    v
+Phase 1.4  Define response proto (if applicable)
+    |
+    +-----> Phase 2.1  Add bluetooth dependency
+    |           |
+    |           v
+    |       Phase 2.2  Capture MAC from EID resolution
+    |           |
+    |           v
+    |       Phase 2.3  Implement GATT ring client
+    |           |
+    |           v
+    +-----> Phase 2.4  Cloud + BLE orchestration
+                |
+                v
+            Phase 2.5  Ring key availability
+                |
+                v
+            Phase 3    UX improvements
+```
+
+---
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Unknown response format | Phase 1.2 blocked | Medium | Generic protobuf scan, raw hex logging |
+| MAC rotation staleness | BLE ring fails | High | 10-min freshness check, cloud fallback |
+| ESPHome proxy connection slots | BLE ring contention | Medium | Short-lived connections only |
+| `bluetooth` as hard dependency | Breaks non-BLE installs | High | Runtime import check, graceful degrade |
+| Ring key not available | BLE ring impossible | Low | Derive from EIK on-the-fly |
+| Upstream bug #66 data_len | ATT Error 0x81 | Eliminated | Correct formula: data_len = 8 + 3 = 11 |
+
+---
+
+## Files Affected Summary
+
+| Phase | File | Change |
+|-------|------|--------|
+| 1.1 | `api.py` | Debug-log response hex |
+| 1.2 | New: `PlaySound/response_parser.py` | Generic response decoder |
+| 1.3 | `api.py`, `button.py` | Return/expose parsed status |
+| 1.4 | `DeviceUpdate.proto` | Add `ExecuteActionResponse` |
+| 2.1 | `manifest.json` | Add `bluetooth` dependency |
+| 2.2 | `eid_resolver.py` | Store BLE address on EID match |
+| 2.3 | New: `FMDNCrypto/beacon_actions.py` | GATT ring client |
+| 2.4 | `api.py` | Cloud + BLE orchestration |
+| 2.5 | `coordinator/identity.py` | Ring key derivation at runtime |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,6 +275,10 @@ filterwarnings = [
     # which aiohttp has deprecated. This cannot be fixed in this project.
     # Remove when HA Core addresses this deprecation.
     "ignore:Inheritance class HomeAssistantApplication from web.Application is discouraged:DeprecationWarning:homeassistant.components.http",
+    # Upstream issue in trio: register_random receives a weakref-eligible object
+    # that may be GC'd immediately. Cannot be fixed in this project.
+    # Remove when trio addresses this (see trio issue tracker).
+    "ignore:It looks like `register_random` was passed an object:hypothesis.errors.HypothesisWarning:trio",
 ]
 markers = [
     "hypothesis: Property-based tests using Hypothesis (can be run in isolation with -m hypothesis)",

--- a/tests/test_ble_battery_sensor.py
+++ b/tests/test_ble_battery_sensor.py
@@ -198,9 +198,14 @@ class TestBLEBatteryStateDataclass:
         """FMDN_BATTERY_PCT should map 0->100, 1->25, 2->5."""
         assert FMDN_BATTERY_PCT == {0: 100, 1: 25, 2: 5}
 
-    def test_battery_pct_unknown_raw_returns_zero(self) -> None:
-        """An unrecognized raw value (3=RESERVED) should map to 0."""
-        assert FMDN_BATTERY_PCT.get(3, 0) == 0
+    def test_battery_pct_reserved_raw_returns_none(self) -> None:
+        """An unrecognized raw value (3=RESERVED) should map to None, not 0.
+
+        A tracker sending battery_raw=3 can still transmit (battery is not
+        physically dead).  Mapping to 0% would be a false positive — the
+        correct representation is None (HA shows 'unknown').
+        """
+        assert FMDN_BATTERY_PCT.get(3) is None
 
     def test_slots_optimization(self) -> None:
         """BLEBatteryState uses __slots__ for memory efficiency."""
@@ -456,8 +461,13 @@ class TestUpdateBLEBattery:
         assert resolver._ble_battery_state["dev-change"].battery_pct == 25
         assert resolver._ble_battery_state["dev-change"].battery_level == 1
 
-    def test_reserved_battery_raw_3_maps_to_0_pct(self) -> None:
-        """Raw battery value 3 (RESERVED) maps to 0% via FMDN_BATTERY_PCT.get fallback."""
+    def test_reserved_battery_raw_3_maps_to_none_pct(self) -> None:
+        """Raw battery value 3 (RESERVED) maps to None via FMDN_BATTERY_PCT.get.
+
+        A device transmitting battery_raw=3 is still operational (it can send
+        RF packets), so 0% would be a false-positive empty-battery alarm.
+        None causes HA to display the sensor as 'unknown'.
+        """
         resolver = _make_resolver()
         eid = b"\xaa" * LEGACY_EID_LENGTH
         xor_mask = 0x00
@@ -470,7 +480,7 @@ class TestUpdateBLEBattery:
         state = resolver._ble_battery_state.get("dev-reserved")
         assert state is not None
         assert state.battery_level == 3
-        assert state.battery_pct == 0
+        assert state.battery_pct is None
 
     def test_combined_battery_and_uwt(self) -> None:
         """Battery CRITICAL + UWT -> battery_pct=5, uwt_mode=True."""

--- a/tests/test_uwt_mode_binary_sensor.py
+++ b/tests/test_uwt_mode_binary_sensor.py
@@ -1,0 +1,332 @@
+# tests/test_uwt_mode_binary_sensor.py
+"""Tests for the UWT-Mode binary sensor entity."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.googlefindmy.binary_sensor import (
+    UWT_MODE_DESC,
+    GoogleFindMyUWTModeSensor,
+)
+from custom_components.googlefindmy.const import DATA_EID_RESOLVER, DOMAIN
+from custom_components.googlefindmy.eid_resolver import BLEBatteryState
+
+# ---------------------------------------------------------------------------
+# Helpers (same pattern as test_ble_battery_sensor.py)
+# ---------------------------------------------------------------------------
+
+
+def _fake_hass(domain_data: dict[str, Any] | None = None) -> SimpleNamespace:
+    """Return a lightweight hass stand-in."""
+    data: dict[str, Any] = {}
+    if domain_data is not None:
+        data[DOMAIN] = domain_data
+    return SimpleNamespace(data=data)
+
+
+def _make_resolver_stub() -> SimpleNamespace:
+    """Return a minimal resolver stub with a battery state dict."""
+    return SimpleNamespace(
+        _ble_battery_state={},
+        get_ble_battery_state=lambda did: None,
+    )
+
+
+def _make_resolver_with_state(
+    device_id: str,
+    uwt_mode: bool = False,
+    battery_level: int = 0,
+    battery_pct: int | None = 100,
+) -> SimpleNamespace:
+    """Return a resolver stub with pre-loaded battery state."""
+    state = BLEBatteryState(
+        battery_level=battery_level,
+        battery_pct=battery_pct,
+        uwt_mode=uwt_mode,
+        decoded_flags=0x00,
+        observed_at_wall=1700000000.0,
+    )
+    states = {device_id: state}
+    return SimpleNamespace(
+        _ble_battery_state=states,
+        get_ble_battery_state=lambda did: states.get(did),
+    )
+
+
+def _fake_coordinator(
+    device_id: str = "dev-1",
+    present: bool = True,
+    visible: bool = True,
+    entry_id: str = "entry-1",
+    snapshot: list[dict[str, Any]] | None = None,
+) -> SimpleNamespace:
+    """Create a minimal coordinator stub for sensor tests."""
+    return SimpleNamespace(
+        config_entry=SimpleNamespace(entry_id=entry_id),
+        is_device_present=lambda did: present,
+        is_device_visible_in_subentry=lambda key, did: visible,
+        async_update_listeners=lambda: None,
+        get_subentry_snapshot=lambda key: snapshot or [],
+        last_update_success=True,
+    )
+
+
+def _build_uwt_sensor(
+    device_id: str = "dev-1",
+    device_name: str = "Test Tracker",
+    coordinator: Any = None,
+    hass: Any = None,
+    resolver: Any = None,
+) -> GoogleFindMyUWTModeSensor:
+    """Create a UWT-Mode binary sensor with minimal stubs."""
+    if coordinator is None:
+        coordinator = _fake_coordinator(device_id=device_id)
+    if hass is None:
+        domain_data: dict[str, Any] = {}
+        if resolver is not None:
+            domain_data[DATA_EID_RESOLVER] = resolver
+        hass = _fake_hass(domain_data)
+
+    sensor = GoogleFindMyUWTModeSensor.__new__(GoogleFindMyUWTModeSensor)
+    sensor._subentry_identifier = "tracker"
+    sensor._subentry_key = "core_tracking"
+    sensor.coordinator = coordinator
+    sensor.hass = hass
+    sensor._device_id = device_id
+    sensor._device = {"id": device_id, "name": device_name}
+    sensor.entity_description = UWT_MODE_DESC
+    sensor._attr_has_entity_name = True
+    sensor._attr_entity_category = None
+    sensor._unrecorded_attributes = frozenset({
+        "last_ble_observation",
+        "google_device_id",
+    })
+    sensor._fallback_label = device_name
+    sensor._attr_unique_id = (
+        f"googlefindmy_{coordinator.config_entry.entry_id}"
+        f"_tracker_{device_id}_uwt_mode"
+    )
+    sensor.entity_id = f"binary_sensor.test_{device_id}_uwt_mode"
+
+    return sensor
+
+
+# ===========================================================================
+# 1. UWT_MODE_DESC entity description
+# ===========================================================================
+
+
+class TestUWTModeDescription:
+    """Tests for the UWT-Mode entity description constants."""
+
+    def test_key(self) -> None:
+        assert UWT_MODE_DESC.key == "uwt_mode"
+
+    def test_translation_key(self) -> None:
+        assert UWT_MODE_DESC.translation_key == "uwt_mode"
+
+    def test_entity_category(self) -> None:
+        from homeassistant.helpers.entity import EntityCategory
+
+        assert UWT_MODE_DESC.entity_category == EntityCategory.DIAGNOSTIC
+
+
+# ===========================================================================
+# 2. GoogleFindMyUWTModeSensor — is_on property
+# ===========================================================================
+
+
+class TestUWTModeSensorIsOn:
+    """Tests for the is_on property."""
+
+    def test_is_on_true_when_uwt_active(self) -> None:
+        """is_on returns True when UWT mode is active."""
+        resolver = _make_resolver_with_state("dev-1", uwt_mode=True)
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=resolver)
+        assert sensor.is_on is True
+
+    def test_is_on_false_when_uwt_inactive(self) -> None:
+        """is_on returns False when UWT mode is not active."""
+        resolver = _make_resolver_with_state("dev-1", uwt_mode=False)
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=resolver)
+        assert sensor.is_on is False
+
+    def test_is_on_none_without_resolver(self) -> None:
+        """is_on returns None when resolver is not available."""
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=None)
+        assert sensor.is_on is None
+
+    def test_is_on_none_without_battery_data(self) -> None:
+        """is_on returns None when resolver has no data for the device."""
+        resolver = _make_resolver_stub()
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=resolver)
+        assert sensor.is_on is None
+
+    def test_is_on_none_when_domain_not_dict(self) -> None:
+        """is_on returns None when hass.data[DOMAIN] is not a dict."""
+        hass = SimpleNamespace(data={DOMAIN: "not-a-dict"})
+        sensor = _build_uwt_sensor(device_id="dev-1", hass=hass)
+        assert sensor.is_on is None
+
+    def test_is_on_reflects_state_changes(self) -> None:
+        """is_on reflects changes when resolver state is updated."""
+        state_false = BLEBatteryState(
+            battery_level=0,
+            battery_pct=100,
+            uwt_mode=False,
+            decoded_flags=0x00,
+            observed_at_wall=1000.0,
+        )
+        state_true = BLEBatteryState(
+            battery_level=0,
+            battery_pct=100,
+            uwt_mode=True,
+            decoded_flags=0x80,
+            observed_at_wall=2000.0,
+        )
+        states: dict[str, BLEBatteryState] = {"dev-1": state_false}
+        resolver = SimpleNamespace(
+            get_ble_battery_state=lambda did: states.get(did),
+        )
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=resolver)
+
+        assert sensor.is_on is False
+        states["dev-1"] = state_true
+        assert sensor.is_on is True
+
+
+# ===========================================================================
+# 3. GoogleFindMyUWTModeSensor — icon property
+# ===========================================================================
+
+
+class TestUWTModeSensorIcon:
+    """Tests for the dynamic icon."""
+
+    def test_icon_alert_when_on(self) -> None:
+        resolver = _make_resolver_with_state("dev-1", uwt_mode=True)
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=resolver)
+        assert sensor.icon == "mdi:shield-alert"
+
+    def test_icon_check_when_off(self) -> None:
+        resolver = _make_resolver_with_state("dev-1", uwt_mode=False)
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=resolver)
+        assert sensor.icon == "mdi:shield-check"
+
+    def test_icon_check_when_none(self) -> None:
+        """When is_on is None (falsy), icon should be shield-check."""
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=None)
+        assert sensor.icon == "mdi:shield-check"
+
+
+# ===========================================================================
+# 4. GoogleFindMyUWTModeSensor — available property
+# ===========================================================================
+
+
+class TestUWTModeSensorAvailability:
+    """Tests for the available property."""
+
+    def test_available_when_present(self) -> None:
+        resolver = _make_resolver_with_state("dev-1")
+        coordinator = _fake_coordinator(device_id="dev-1", present=True)
+        sensor = _build_uwt_sensor(
+            device_id="dev-1", coordinator=coordinator, resolver=resolver
+        )
+        assert sensor.available is True
+
+    def test_unavailable_when_not_present(self) -> None:
+        resolver = _make_resolver_with_state("dev-1")
+        coordinator = _fake_coordinator(device_id="dev-1", present=False)
+        sensor = _build_uwt_sensor(
+            device_id="dev-1", coordinator=coordinator, resolver=resolver
+        )
+        assert sensor.available is False
+
+    def test_unavailable_when_hidden(self) -> None:
+        resolver = _make_resolver_with_state("dev-1")
+        coordinator = _fake_coordinator(
+            device_id="dev-1", present=True, visible=False
+        )
+        sensor = _build_uwt_sensor(
+            device_id="dev-1", coordinator=coordinator, resolver=resolver
+        )
+        assert sensor.available is False
+
+    def test_available_fallback_on_exception(self) -> None:
+        """When is_device_present raises, falls back to True."""
+        resolver = _make_resolver_with_state("dev-1")
+
+        def _raise(did: str) -> bool:
+            raise RuntimeError("boom")
+
+        coordinator = _fake_coordinator(device_id="dev-1", present=True)
+        coordinator.is_device_present = _raise
+        sensor = _build_uwt_sensor(
+            device_id="dev-1", coordinator=coordinator, resolver=resolver
+        )
+        # Exception path => falls to bottom return True
+        assert sensor.available is True
+
+    def test_available_without_is_device_present(self) -> None:
+        """When coordinator lacks is_device_present, available returns True."""
+        resolver = _make_resolver_with_state("dev-1")
+        coordinator = _fake_coordinator(device_id="dev-1", present=True)
+        del coordinator.is_device_present
+        sensor = _build_uwt_sensor(
+            device_id="dev-1", coordinator=coordinator, resolver=resolver
+        )
+        assert sensor.available is True
+
+
+# ===========================================================================
+# 5. GoogleFindMyUWTModeSensor — extra_state_attributes
+# ===========================================================================
+
+
+class TestUWTModeSensorExtraAttributes:
+    """Tests for extra_state_attributes."""
+
+    def test_attributes_with_data(self) -> None:
+        resolver = _make_resolver_with_state("dev-1", uwt_mode=True)
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=resolver)
+        attrs = sensor.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["google_device_id"] == "dev-1"
+        assert "last_ble_observation" in attrs
+        assert "T" in attrs["last_ble_observation"]
+        # uwt_mode and battery_raw_level should NOT be in attrs
+        # (they are separate entities / on the battery sensor)
+        assert "uwt_mode" not in attrs
+        assert "battery_raw_level" not in attrs
+
+    def test_attributes_none_without_resolver(self) -> None:
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=None)
+        assert sensor.extra_state_attributes is None
+
+    def test_attributes_none_without_data(self) -> None:
+        resolver = _make_resolver_stub()
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=resolver)
+        assert sensor.extra_state_attributes is None
+
+
+# ===========================================================================
+# 6. GoogleFindMyUWTModeSensor — _handle_coordinator_update
+# ===========================================================================
+
+
+class TestUWTModeSensorCoordinatorUpdate:
+    """Tests for _handle_coordinator_update."""
+
+    def test_update_writes_state(self) -> None:
+        resolver = _make_resolver_with_state("dev-1", uwt_mode=False)
+        sensor = _build_uwt_sensor(device_id="dev-1", resolver=resolver)
+        sensor.async_write_ha_state = MagicMock()
+
+        sensor._handle_coordinator_update()
+
+        sensor.async_write_ha_state.assert_called_once()


### PR DESCRIPTION
[fix: battery_raw=3 maps to None (not 0%) and Bermuda event guard](https://github.com/jleinenbach/GoogleFindMy-HA/commit/a8d923a747f7bbff83a0595218989faa001ec7b5) 

Bug https://github.com/jleinenbach/GoogleFindMy-HA/pull/1 (Critical): FMDN_BATTERY_PCT.get(battery_raw, 0) returned 0%
for the RESERVED value 3. A tracker sending battery_raw=3 is still
transmitting RF packets — its battery is not dead. Mapping to 0%
triggered false empty-battery alarms. Now returns None so HA shows
the sensor as 'unknown' instead.

Changes in eid_resolver.py:
- BLEBatteryState.battery_pct type: int → int | None
- FMDN_BATTERY_PCT.get(battery_raw, 0) → .get(battery_raw)
- Log format battery_pct=%d → %s to handle None

Bug https://github.com/jleinenbach/GoogleFindMy-HA/pull/4 (Minor): The Bermuda state-change event handler had no
top-level exception guard. An unexpected error would propagate into
HA's event loop, potentially blocking other event handlers.

Changes in bermuda_listener.py:
- Split _bermuda_state_changed into outer guard + inner handler
- Outer guard catches all exceptions with debug logging

Test updates:
- test_battery_pct_unknown_raw_returns_zero → reserved_raw_returns_none
- test_reserved_battery_raw_3_maps_to_0_pct → maps_to_none_pct
- Assertions updated: == 0 → is None