### PR TITLE
fix: add proactive owner key version mismatch check before decryption

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -288,6 +288,26 @@ async def async_retrieve_identity_key(
 
     owner_key_version = getattr(encrypted_user_secrets, "ownerKeyVersion", 0)
     owner_key_info: OwnerKeyInfo = await async_get_owner_key(cache=cache)
+
+    # --- Proactive Owner Key Version Mismatch Check ---
+    # If the tracker requires a newer owner key version than what we have cached,
+    # force-refresh the owner key BEFORE attempting decryption to avoid an
+    # unnecessary AES-GCM InvalidTag failure followed by a reactive retry.
+    if (
+        owner_key_version
+        and owner_key_info.version is not None
+        and owner_key_version > owner_key_info.version
+    ):
+        _LOGGER.info(
+            "Owner Key Version mismatch detected: Tracker requires V%s, "
+            "Cache has V%s. Refreshing...",
+            owner_key_version,
+            owner_key_info.version,
+        )
+        owner_key_info = await async_get_owner_key(
+            cache=cache, force_refresh=True
+        )
+
     candidates: list[bytes] = []
     decrypt_errors: list[Exception] = []
 

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -1876,6 +1876,12 @@ class GoogleFindMyEIDResolver:
             and owner_key_info.version is not None
             and owner_key_info.version < identity.owner_key_version
         ):
+            _LOGGER.info(
+                "Owner Key Version mismatch detected: Tracker requires V%s, "
+                "Cache has V%s. Refreshing...",
+                identity.owner_key_version,
+                owner_key_info.version,
+            )
             refreshed = await _fetch(force_refresh=True)
             if refreshed is not None:
                 return refreshed


### PR DESCRIPTION
When Google rotates the owner key (increments ownerKeyVersion), the cached key becomes stale. Previously, the code would attempt decryption with the old key, fail with an AES-GCM InvalidTag error, and only then reactively detect the version mismatch and retry.

This change adds a proactive version comparison in both decryption paths:

- decrypt_locations.py (async_retrieve_identity_key): Compare the tracker's ownerKeyVersion from encryptedUserSecrets against the cached OwnerKeyInfo.version BEFORE attempting EIK decryption. If the tracker requires a newer version, force-refresh the owner key immediately.

- eid_resolver.py (_resolve_owner_key): Add INFO-level logging when a version mismatch triggers a force refresh, making key rotation events visible in the logs for diagnostics.

https://claude.ai/code/session_01HRCnYiuiDTc5WLj8bj61tK
