### PR TITLE
refactor: deduplicate diagnostics components

### DIFF
--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -61,8 +61,13 @@ from .entity import (
     GoogleFindMyEntity,
     ensure_config_subentry_id,
     ensure_dispatcher_dependencies,
+    known_ids_for_subentry_type,
     resolve_coordinator,
+    sanitize_state_text,
     schedule_add_entities,
+)
+from .entity import (
+    subentry_type as _subentry_type,
 )
 from .ha_typing import BinarySensorEntity, callback
 
@@ -77,24 +82,6 @@ class _ServiceScope(NamedTuple):
     subentry_key: str
     config_subentry_id: str | None
     identifier: str
-
-
-def _subentry_type(subentry: Any | None) -> str | None:
-    """Return the declared subentry type for dispatcher filtering."""
-
-    if subentry is None or isinstance(subentry, str):
-        return None
-
-    declared_type = getattr(subentry, "subentry_type", None)
-    if isinstance(declared_type, str):
-        return declared_type
-
-    data = getattr(subentry, "data", None)
-    if isinstance(data, Mapping):
-        fallback_type = data.get("subentry_type") or data.get("type")
-        if isinstance(fallback_type, str):
-            return fallback_type
-    return None
 
 
 # --------------------------------------------------------------------------------------
@@ -147,33 +134,6 @@ async def async_setup_entry(  # noqa: PLR0915
     ensure_dispatcher_dependencies(hass)
     if getattr(coordinator, "config_entry", None) is None:
         coordinator.config_entry = entry
-
-    def _known_ids_for_type(expected_type: str) -> set[str]:
-        ids: set[str] = set()
-
-        subentries = getattr(entry, "subentries", None)
-        if isinstance(subentries, Mapping):
-            for subentry in subentries.values():
-                if _subentry_type(subentry) == expected_type:
-                    candidate = getattr(subentry, "subentry_id", None) or getattr(
-                        subentry, "entry_id", None
-                    )
-                    if isinstance(candidate, str) and candidate:
-                        ids.add(candidate)
-
-        runtime_data = getattr(entry, "runtime_data", None)
-        subentry_manager = getattr(runtime_data, "subentry_manager", None)
-        managed_subentries = getattr(subentry_manager, "managed_subentries", None)
-        if isinstance(managed_subentries, Mapping):
-            for subentry in managed_subentries.values():
-                if _subentry_type(subentry) == expected_type:
-                    candidate = getattr(subentry, "subentry_id", None) or getattr(
-                        subentry, "entry_id", None
-                    )
-                    if isinstance(candidate, str) and candidate:
-                        ids.add(candidate)
-
-        return ids
 
     def _collect_service_scopes(
         hint_subentry_id: str | None = None,
@@ -263,7 +223,7 @@ async def async_setup_entry(  # noqa: PLR0915
 
     def _add_scope(scope: _ServiceScope, forwarded_config_id: str | None) -> None:
         nonlocal primary_scope, primary_scheduler
-        service_ids = _known_ids_for_type(SUBENTRY_TYPE_SERVICE)
+        service_ids = known_ids_for_subentry_type(entry, SUBENTRY_TYPE_SERVICE)
         sanitized_config_id = ensure_config_subentry_id(
             entry,
             "binary_sensor",
@@ -364,7 +324,7 @@ async def async_setup_entry(  # noqa: PLR0915
         forwarded_config_id: str | None,
     ) -> None:
         """Create per-device UWT binary sensors for a tracker subentry."""
-        tracker_ids = _known_ids_for_type(SUBENTRY_TYPE_TRACKER)
+        tracker_ids = known_ids_for_subentry_type(entry, SUBENTRY_TYPE_TRACKER)
         sanitized_config_id = ensure_config_subentry_id(
             entry,
             "binary_sensor_tracker",
@@ -817,7 +777,7 @@ class GoogleFindMyAuthStatusSensor(GoogleFindMyEntity, BinarySensorEntity):
             attributes["nova_api_status"] = state
         reason = getattr(status, "reason", None)
         if isinstance(reason, str) and reason:
-            attributes["nova_api_status_reason"] = reason
+            attributes["nova_api_status_reason"] = sanitize_state_text(reason)
         changed_at = getattr(status, "changed_at", None)
         changed_at_iso = format_epoch_utc(changed_at)
         if changed_at_iso is not None:
@@ -829,7 +789,7 @@ class GoogleFindMyAuthStatusSensor(GoogleFindMyEntity, BinarySensorEntity):
             attributes["nova_fcm_status"] = fcm_state
         fcm_reason = getattr(fcm_status, "reason", None)
         if isinstance(fcm_reason, str) and fcm_reason:
-            attributes["nova_fcm_status_reason"] = fcm_reason
+            attributes["nova_fcm_status_reason"] = sanitize_state_text(fcm_reason)
         fcm_changed_at = getattr(fcm_status, "changed_at", None)
         fcm_changed_at_iso = format_epoch_utc(fcm_changed_at)
         if fcm_changed_at_iso is not None:
@@ -935,7 +895,7 @@ class GoogleFindMyConnectivitySensor(GoogleFindMyEntity, BinarySensorEntity):
             fatal_error = fatal_by_entry.get(entry_id)
         fatal_error = fatal_error or getattr(fcm, "_fatal_error", None)
         if isinstance(fatal_error, str) and fatal_error:
-            attributes["fcm_fatal_error"] = fatal_error
+            attributes["fcm_fatal_error"] = sanitize_state_text(fatal_error)
 
         return attributes or None
 

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -25,7 +25,7 @@ import time
 from collections.abc import Iterable, Mapping
 from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -57,15 +57,10 @@ from .const import (
     OPT_MIN_POLL_INTERVAL,
 )
 from .ha_typing import callback
+from .shared_helpers import normalize_fcm_entry_snapshot, safe_fcm_health_snapshots
 
-# ---------------------------------------------------------------------------
-# Compatibility placeholders
-# ---------------------------------------------------------------------------
-
-
-class GoogleFindMyCoordinator:  # pragma: no cover - patched in tests
-    """Placeholder coordinator type for tests to monkeypatch."""
-
+if TYPE_CHECKING:
+    from .coordinator import GoogleFindMyCoordinator  # noqa: F401
 
 # ---------------------------------------------------------------------------
 # Redaction policy
@@ -334,11 +329,7 @@ def _fcm_receiver_state(hass: HomeAssistant) -> dict[str, Any] | None:
     if not rcvr:
         return None
 
-    snapshots: dict[str, dict[str, Any]] = {}
-    try:
-        snapshots = rcvr.get_health_snapshots()
-    except Exception:  # pragma: no cover - defensive guard
-        snapshots = {}
+    snapshots = safe_fcm_health_snapshots(rcvr)
 
     entries = []
     connected_entries: list[str] = []
@@ -346,19 +337,17 @@ def _fcm_receiver_state(hass: HomeAssistant) -> dict[str, Any] | None:
         if snap.get("healthy"):
             connected_entries.append(entry_id)
 
-        entries.append(
+        # Start with the shared base fields and extend with diagnostics-specific ones
+        entry_data = normalize_fcm_entry_snapshot(entry_id, snap)
+        entry_data.update(
             {
-                "entry_id": entry_id,
-                "healthy": bool(snap.get("healthy")),
                 "supervisor_running": bool(snap.get("supervisor_running")),
                 "client_ready": bool(snap.get("client_ready")),
-                "run_state": snap.get("run_state"),
                 "do_listen": bool(snap.get("do_listen")),
                 "last_activity_monotonic": snap.get("last_activity_monotonic"),
-                "seconds_since_last_activity": snap.get("seconds_since_last_activity"),
-                "activity_stale": bool(snap.get("activity_stale")),
             }
         )
+        entries.append(entry_data)
 
     def _get(attr: str, default: Any = None) -> Any:
         try:

--- a/custom_components/googlefindmy/entity.py
+++ b/custom_components/googlefindmy/entity.py
@@ -76,6 +76,13 @@ from .const import (
 )
 from .coordinator import GoogleFindMyCoordinator
 from .ha_typing import CoordinatorEntity, callback
+from .shared_helpers import (  # noqa: F401 - re-exported for platform modules
+    known_ids_for_subentry_type,
+    normalize_fcm_entry_snapshot,
+    safe_fcm_health_snapshots,
+    sanitize_state_text,
+    subentry_type,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -53,8 +53,12 @@ from .entity import (
     GoogleFindMyEntity,
     ensure_config_subentry_id,
     ensure_dispatcher_dependencies,
+    known_ids_for_subentry_type,
     resolve_coordinator,
     schedule_add_entities,
+)
+from .entity import (
+    subentry_type as _subentry_type,
 )
 from .ha_typing import RestoreSensor, SensorEntity, callback
 
@@ -67,24 +71,6 @@ class _Scope(NamedTuple):
     subentry_key: str
     config_subentry_id: str | None
     identifier: str
-
-
-def _subentry_type(subentry: Any | None) -> str | None:
-    """Return the declared subentry type for dispatcher filtering."""
-
-    if subentry is None or isinstance(subentry, str):
-        return None
-
-    declared_type = getattr(subentry, "subentry_type", None)
-    if isinstance(declared_type, str):
-        return declared_type
-
-    data = getattr(subentry, "data", None)
-    if isinstance(data, Mapping):
-        fallback_type = data.get("subentry_type") or data.get("type")
-        if isinstance(fallback_type, str):
-            return fallback_type
-    return None
 
 
 # ----------------------------- Entity Descriptions -----------------------------
@@ -186,33 +172,6 @@ async def async_setup_entry(
     ensure_dispatcher_dependencies(hass)
     if getattr(coordinator, "config_entry", None) is None:
         coordinator.config_entry = entry
-
-    def _known_ids_for_type(expected_type: str) -> set[str]:
-        ids: set[str] = set()
-
-        subentries = getattr(entry, "subentries", None)
-        if isinstance(subentries, Mapping):
-            for subentry in subentries.values():
-                if _subentry_type(subentry) == expected_type:
-                    candidate = getattr(subentry, "subentry_id", None) or getattr(
-                        subentry, "entry_id", None
-                    )
-                    if isinstance(candidate, str) and candidate:
-                        ids.add(candidate)
-
-        runtime_data = getattr(entry, "runtime_data", None)
-        subentry_manager = getattr(runtime_data, "subentry_manager", None)
-        managed_subentries = getattr(subentry_manager, "managed_subentries", None)
-        if isinstance(managed_subentries, Mapping):
-            for subentry in managed_subentries.values():
-                if _subentry_type(subentry) == expected_type:
-                    candidate = getattr(subentry, "subentry_id", None) or getattr(
-                        subentry, "entry_id", None
-                    )
-                    if isinstance(candidate, str) and candidate:
-                        ids.add(candidate)
-
-        return ids
 
     def _collect_scopes(
         *,
@@ -324,7 +283,7 @@ async def async_setup_entry(
         )
 
     def _add_service_scope(scope: _Scope, forwarded_config_id: str | None) -> None:
-        service_ids = _known_ids_for_type(SUBENTRY_TYPE_SERVICE)
+        service_ids = known_ids_for_subentry_type(entry, SUBENTRY_TYPE_SERVICE)
         sanitized_config_id = ensure_config_subentry_id(
             entry,
             "sensor_service",
@@ -430,7 +389,7 @@ async def async_setup_entry(
             candidate_subentry_id = forwarded_config_id
         candidate_subentry_id = candidate_subentry_id or scope.identifier
 
-        tracker_ids = _known_ids_for_type(SUBENTRY_TYPE_TRACKER)
+        tracker_ids = known_ids_for_subentry_type(entry, SUBENTRY_TYPE_TRACKER)
         sanitized_config_id = ensure_config_subentry_id(
             entry,
             "sensor_tracker",

--- a/custom_components/googlefindmy/shared_helpers.py
+++ b/custom_components/googlefindmy/shared_helpers.py
@@ -1,0 +1,127 @@
+# custom_components/googlefindmy/shared_helpers.py
+"""Shared utility functions for the Google Find My Device integration.
+
+This module centralizes pure helper functions used by multiple platform modules
+(``sensor.py``, ``binary_sensor.py``, ``diagnostics.py``, ``system_health.py``)
+without importing the coordinator or other heavy modules.
+
+The module is intentionally lightweight—it may only depend on the standard
+library, ``homeassistant.config_entries``, and ``.const``—so that it can be
+safely imported from any module in the integration without triggering circular
+import chains.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any, cast
+
+from homeassistant.config_entries import ConfigEntry
+
+
+def subentry_type(subentry: Any | None) -> str | None:
+    """Return the declared subentry type for dispatcher filtering.
+
+    Shared helper for sensor and binary_sensor platforms to avoid duplicating
+    subentry introspection logic.
+    """
+    if subentry is None or isinstance(subentry, str):
+        return None
+
+    declared_type = getattr(subentry, "subentry_type", None)
+    if isinstance(declared_type, str):
+        return declared_type
+
+    data = getattr(subentry, "data", None)
+    if isinstance(data, Mapping):
+        fallback_type = data.get("subentry_type") or data.get("type")
+        if isinstance(fallback_type, str):
+            return fallback_type
+    return None
+
+
+def known_ids_for_subentry_type(entry: ConfigEntry, expected_type: str) -> set[str]:
+    """Return known subentry IDs matching the expected type.
+
+    Consolidates identical logic previously duplicated in sensor.py and
+    binary_sensor.py.
+    """
+    ids: set[str] = set()
+
+    subentries = getattr(entry, "subentries", None)
+    if isinstance(subentries, Mapping):
+        for sub in subentries.values():
+            if subentry_type(sub) == expected_type:
+                candidate = getattr(sub, "subentry_id", None) or getattr(
+                    sub, "entry_id", None
+                )
+                if isinstance(candidate, str) and candidate:
+                    ids.add(candidate)
+
+    runtime_data = getattr(entry, "runtime_data", None)
+    subentry_manager = getattr(runtime_data, "subentry_manager", None)
+    managed_subentries = getattr(subentry_manager, "managed_subentries", None)
+    if isinstance(managed_subentries, Mapping):
+        for sub in managed_subentries.values():
+            if subentry_type(sub) == expected_type:
+                candidate = getattr(sub, "subentry_id", None) or getattr(
+                    sub, "entry_id", None
+                )
+                if isinstance(candidate, str) and candidate:
+                    ids.add(candidate)
+
+    return ids
+
+
+def sanitize_state_text(text: Any, limit: int = 160) -> str:
+    """Sanitize a state text value by stripping potential PII and truncating.
+
+    Removes parenthesized content that might contain device names or email
+    addresses, then truncates to ``limit`` characters.  This mirrors the
+    privacy hardening applied in ``diagnostics.py`` so that binary sensor
+    attributes never leak more data than the diagnostics JSON download.
+    """
+    try:
+        s = str(text)
+    except Exception:
+        return ""
+    # Strip parenthesized content to avoid PII leakage (e.g. device names, emails)
+    s = re.sub(r"\([^)]*\)", "(*)", s)
+    if len(s) <= limit:
+        return s
+    return s[: max(0, limit - 1)] + "…"
+
+
+def safe_fcm_health_snapshots(receiver: Any) -> dict[str, dict[str, Any]]:
+    """Safely extract FCM health snapshots from the receiver.
+
+    Shared by ``diagnostics.py`` and ``system_health.py`` to avoid
+    duplicating the defensive snapshot retrieval logic.
+    """
+    if not receiver:
+        return {}
+    try:
+        result: dict[str, dict[str, Any]] = cast(
+            dict[str, dict[str, Any]], receiver.get_health_snapshots()
+        )
+        return result
+    except Exception:  # pragma: no cover - defensive guard
+        return {}
+
+
+def normalize_fcm_entry_snapshot(
+    entry_id: str, snap: dict[str, Any]
+) -> dict[str, Any]:
+    """Normalize a single FCM health snapshot entry.
+
+    Returns a dict with the common fields used by both ``diagnostics.py``
+    and ``system_health.py``.  Callers can extend with additional fields.
+    """
+    return {
+        "entry_id": entry_id,
+        "healthy": bool(snap.get("healthy")),
+        "run_state": snap.get("run_state"),
+        "seconds_since_last_activity": snap.get("seconds_since_last_activity"),
+        "activity_stale": bool(snap.get("activity_stale")),
+    }

--- a/custom_components/googlefindmy/system_health.py
+++ b/custom_components/googlefindmy/system_health.py
@@ -14,6 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 
 from .const import CONF_GOOGLE_EMAIL, DATA_SECRET_BUNDLE, DOMAIN, INTEGRATION_VERSION
 from .email import normalize_email
+from .shared_helpers import normalize_fcm_entry_snapshot, safe_fcm_health_snapshots
 
 
 class SystemHealthRegistration(Protocol):
@@ -119,11 +120,7 @@ def _get_fcm_info(receiver: Any) -> dict[str, Any]:
         ready_value = bool(ready_attr) if ready_attr is not None else None
     info["is_ready"] = ready_value
 
-    snapshots: dict[str, dict[str, Any]] = {}
-    try:
-        snapshots = receiver.get_health_snapshots()
-    except Exception:  # pragma: no cover - defensive guard
-        snapshots = {}
+    snapshots = safe_fcm_health_snapshots(receiver)
 
     info["healthy_entries"] = sorted(
         entry_id for entry_id, snap in snapshots.items() if snap.get("healthy")
@@ -137,13 +134,7 @@ def _get_fcm_info(receiver: Any) -> dict[str, Any]:
     if snapshots:
         info["entry_count"] = len(snapshots)
         info["entries"] = [
-            {
-                "entry_id": entry_id,
-                "healthy": bool(snap.get("healthy")),
-                "run_state": snap.get("run_state"),
-                "seconds_since_last_activity": snap.get("seconds_since_last_activity"),
-                "activity_stale": bool(snap.get("activity_stale")),
-            }
+            normalize_fcm_entry_snapshot(entry_id, snap)
             for entry_id, snap in snapshots.items()
         ]
 

--- a/tests/test_diagnostics_buffer_summary.py
+++ b/tests/test_diagnostics_buffer_summary.py
@@ -141,7 +141,6 @@ def test_async_get_config_entry_diagnostics_includes_buffer(
         diagnostics.er, "async_get", lambda _hass: SimpleNamespace(entities={})
     )
     monkeypatch.setattr(diagnostics, "async_redact_data", _redact)
-    monkeypatch.setattr(diagnostics, "GoogleFindMyCoordinator", _StubCoordinator)
 
     payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
 


### PR DESCRIPTION
Address peer review findings for diagnostics components:

1. **Privacy fix (critical):** Apply PII sanitization (`sanitize_state_text`) to binary_sensor.py attributes `nova_api_status_reason`, `nova_fcm_status_reason`, and `fcm_fatal_error`. These previously exposed raw error strings that could contain email addresses or device names, while diagnostics.py was defensively stripping such data.

2. **DRY refactoring:** Extract duplicated `_subentry_type` and `_known_ids_for_type` functions from sensor.py and binary_sensor.py into `shared_helpers.py` (re-exported via entity.py). Reduces maintenance risk when subentry resolution logic changes.

3. **FCM extraction unification:** Create `safe_fcm_health_snapshots` and `normalize_fcm_entry_snapshot` shared helpers used by both diagnostics.py and system_health.py, eliminating duplicated snapshot iteration logic.

4. **TYPE_CHECKING fix:** Replace placeholder `GoogleFindMyCoordinator` class in diagnostics.py with proper `TYPE_CHECKING`-guarded import. Remove corresponding dead monkeypatch in test_diagnostics_buffer_summary.py.

All 2310 tests pass with Python 3.13.

https://claude.ai/code/session_012pTUHboYnkPQyM8dVmAX2h
