### PR TITLE
refactor: modernize __init__.py toward HA 2026.2 standards

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -2,7 +2,8 @@
 
 """Google Find My Device integration for Home Assistant.
 
-Version: 2.6.6 — Multi-account enabled (E3) + owner-index routing attach
+Version: see INTEGRATION_VERSION in const.py / manifest.json (SSOT).
+Multi-account enabled (E3) + owner-index routing attach
 - Multi-account support: multiple config entries are allowed concurrently.
 - Duplicate-account protection: if two entries use the same Google email, we raise a
   Repair issue and abort the later entry to avoid mixing credentials/state.
@@ -130,6 +131,17 @@ else:  # pragma: no cover - test environments without full Home Assistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.storage import Store
 
+try:  # pragma: no cover - HassKey introduced in HA 2024.6
+    from homeassistant.util.hass_dict import HassKey
+except ImportError:  # pragma: no cover - legacy Home Assistant builds
+
+    class HassKey(str):  # type: ignore[no-redef]
+        """Minimal shim for pre-2024.6 Home Assistant builds."""
+
+        def __class_getitem__(cls, item: Any) -> type:
+            return cls
+
+
 # Eagerly import diagnostics to prevent blocking calls on-demand
 from . import diagnostics  # noqa: F401
 
@@ -162,6 +174,7 @@ from .const import (
     DEFAULT_OPTIONS,
     DOMAIN,
     FEATURE_FMDN_FINDER_ENABLED,
+    ISSUE_MULTIPLE_CONFIG_ENTRIES,
     LEGACY_SERVICE_IDENTIFIER,
     OPT_ALLOW_HISTORY_FALLBACK,
     OPT_CONTRIBUTOR_MODE,
@@ -184,6 +197,9 @@ from .const import (
     TRACKER_FEATURE_PLATFORMS,
     TRACKER_SUBENTRY_KEY,
     TRACKER_SUBENTRY_TRANSLATION_KEY,
+    TRANSLATION_KEY_CACHE_PURGED,
+    TRANSLATION_KEY_DUPLICATE_ACCOUNT,
+    TRANSLATION_KEY_UNIQUE_ID_COLLISION,
     coerce_ignored_mapping,
     map_token_hex_digest,
     map_token_secret_seed,
@@ -2379,10 +2395,15 @@ class GoogleFindMyDomainData(TypedDict, total=False):
     recent_reconfigure_markers: dict[str, float]
 
 
+# Typed hass.data key for the global domain bucket (HA 2024.6+ HassKey).
+# Using HassKey enables static type analysis (MyPy) on hass.data[DATA_DOMAIN].
+DATA_DOMAIN: HassKey[GoogleFindMyDomainData] = HassKey(DOMAIN)
+
+
 def _domain_data(hass: HomeAssistant) -> GoogleFindMyDomainData:
     """Return the typed domain data bucket, creating it on first access."""
 
-    return cast(GoogleFindMyDomainData, hass.data.setdefault(DOMAIN, {}))
+    return cast(GoogleFindMyDomainData, hass.data.setdefault(DATA_DOMAIN, {}))
 
 
 _SUBENTRY_SETUP_RETRY_DELAY = 2.0
@@ -4773,7 +4794,7 @@ async def _async_create_uid_collision_issue(
             f"unique_id_collision_{entry.entry_id}",
             is_fixable=False,
             severity=ir.IssueSeverity.WARNING,
-            translation_key="unique_id_collision",
+            translation_key=TRANSLATION_KEY_UNIQUE_ID_COLLISION,
             translation_placeholders={
                 "entry": entry.title or entry.entry_id,
                 "count": str(len(entity_ids)),
@@ -5698,7 +5719,7 @@ def _log_duplicate_and_raise_repair_issue(
             issue_id,
             is_fixable=False,
             severity=severity_value,
-            translation_key="duplicate_account_entries",
+            translation_key=TRANSLATION_KEY_DUPLICATE_ACCOUNT,
             translation_placeholders=placeholders,
         )
     except Exception as err:  # pragma: no cover - defensive log only
@@ -6473,13 +6494,21 @@ async def _async_setup_legacy_child_subentry(
         )
         return False
 
-    bucket = _domain_data(hass)
-    entries_bucket = _ensure_entries_bucket(bucket)
+    # Prefer entry.runtime_data on the parent ConfigEntry (2026 standard) before
+    # falling back to the domain-level entries bucket for legacy compatibility.
+    parent_payload: RuntimeData | GoogleFindMyCoordinator | None = None
+    parent_entry = hass.config_entries.async_get_entry(parent_entry_id)
+    if parent_entry is not None:
+        parent_payload = getattr(parent_entry, "runtime_data", None)
 
-    parent_payload = cast(
-        RuntimeData | GoogleFindMyCoordinator | None,
-        entries_bucket.get(parent_entry_id),
-    )
+    if parent_payload is None:
+        bucket = _domain_data(hass)
+        entries_bucket = _ensure_entries_bucket(bucket)
+        parent_payload = cast(
+            RuntimeData | GoogleFindMyCoordinator | None,
+            entries_bucket.get(parent_entry_id),
+        )
+
     if parent_payload is None:
         _LOGGER.debug(
             "[%s] Parent runtime data bucket missing for %s; deferring setup",  # noqa: G004
@@ -6583,10 +6612,14 @@ async def _async_setup_subentry(
             f"Config subentry {subentry_identifier} is not registered"
         )
 
-    bucket = _domain_data(hass)
-    entries_bucket = _ensure_entries_bucket(bucket)
+    # Prefer entry.runtime_data on the parent ConfigEntry (2026 standard) before
+    # falling back to the domain-level entries bucket for legacy compatibility.
+    parent_runtime_data = getattr(parent_entry, "runtime_data", None)
+    if parent_runtime_data is None:
+        bucket = _domain_data(hass)
+        entries_bucket = _ensure_entries_bucket(bucket)
+        parent_runtime_data = entries_bucket.get(parent_entry_id)
 
-    parent_runtime_data = entries_bucket.get(parent_entry_id)
     if parent_runtime_data is None:
         _LOGGER.warning(
             "[%s] Parent runtime data bucket missing for %s; deferring setup",
@@ -6813,7 +6846,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
     # --- Multi-entry policy: allow MA; block duplicate-account (same email) ----
     # Legacy issue cleanup: we no longer block on multiple config entries
     try:
-        ir.async_delete_issue(hass, DOMAIN, "multiple_config_entries")
+        ir.async_delete_issue(hass, DOMAIN, ISSUE_MULTIPLE_CONFIG_ENTRIES)
     except Exception:
         pass
 
@@ -7684,13 +7717,14 @@ async def async_remove_config_entry_device(
         return False
 
     try:
-        bucket = _domain_data(hass)
-        entries_bucket = _ensure_entries_bucket(bucket)
-        runtime: RuntimeData | GoogleFindMyCoordinator | None = entries_bucket.get(
-            entry.entry_id
+        # Prefer entry.runtime_data (2026 standard), fall back to entries bucket.
+        runtime: RuntimeData | GoogleFindMyCoordinator | None = getattr(
+            entry, "runtime_data", None
         )
         if runtime is None:
-            runtime = getattr(entry, "runtime_data", None)
+            bucket = _domain_data(hass)
+            entries_bucket = _ensure_entries_bucket(bucket)
+            runtime = entries_bucket.get(entry.entry_id)
 
         coordinator: GoogleFindMyCoordinator | None = None
         purge_device: Callable[[str], Any] | None = None
@@ -8213,12 +8247,17 @@ async def async_remove_entry(hass: HomeAssistant, entry: MyConfigEntry) -> None:
 
     _ensure_runtime_imports()
 
+    # Prefer entry.runtime_data (2026 standard), then clean up entries bucket.
     bucket = _domain_data(hass)
     entries_bucket = bucket.get("entries")
 
-    runtime: RuntimeData | GoogleFindMyCoordinator | None = None
-    if isinstance(entries_bucket, dict):
+    runtime: RuntimeData | GoogleFindMyCoordinator | None = getattr(
+        entry, "runtime_data", None
+    )
+    if runtime is None and isinstance(entries_bucket, dict):
         runtime = entries_bucket.pop(entry.entry_id, None)
+    elif isinstance(entries_bucket, dict):
+        entries_bucket.pop(entry.entry_id, None)
 
     fallback_runtime = getattr(entry, "runtime_data", None)
     if runtime is None and isinstance(
@@ -8392,7 +8431,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: MyConfigEntry) -> None:
                     issue_id,
                     is_fixable=False,
                     severity=severity_value,
-                    translation_key="cache_purged",
+                    translation_key=TRANSLATION_KEY_CACHE_PURGED,
                     translation_placeholders={"entry_title": display_name},
                 )
             except Exception as err:
@@ -8421,10 +8460,24 @@ async def async_remove_entry(hass: HomeAssistant, entry: MyConfigEntry) -> None:
 
 
 def _get_local_ip_sync() -> str:
-    """Best-effort local IP discovery via UDP connect (executor-only)."""
+    """Best-effort local IP discovery via UDP connect (executor-only).
+
+    WARNING: This function performs a blocking socket operation and MUST NOT be
+    called directly from the async event loop.  Always use the non-blocking
+    wrapper :func:`async_get_local_ip` instead.
+    """
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
             s.connect(("8.8.8.8", 80))
             return cast(str, s.getsockname()[0])
     except OSError:
         return ""
+
+
+async def async_get_local_ip(hass: HomeAssistant) -> str:
+    """Non-blocking wrapper for local IP discovery.
+
+    Delegates the blocking socket call to the HA executor so the event loop is
+    never stalled by DNS resolution or network timeouts.
+    """
+    return await hass.async_add_executor_job(_get_local_ip_sync)

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -457,6 +457,12 @@ TRANSLATION_KEY_AUTH_STATUS: str = "nova_auth_status"
 # Issue key used for Repairs (translations use the same key).
 ISSUE_AUTH_EXPIRED_KEY: str = "auth_expired"
 
+# Issue/translation keys for common repair issues (keep aligned with translations/*.json).
+ISSUE_MULTIPLE_CONFIG_ENTRIES: str = "multiple_config_entries"
+TRANSLATION_KEY_CACHE_PURGED: str = "cache_purged"
+TRANSLATION_KEY_UNIQUE_ID_COLLISION: str = "unique_id_collision"
+TRANSLATION_KEY_DUPLICATE_ACCOUNT: str = "duplicate_account_entries"
+
 
 def issue_id_for(entry_id: str) -> str:
     """Return a stable Repairs issue_id for a given config entry.
@@ -596,6 +602,10 @@ __all__ = [
     "EVENT_AUTH_OK",
     "TRANSLATION_KEY_AUTH_STATUS",
     "ISSUE_AUTH_EXPIRED_KEY",
+    "ISSUE_MULTIPLE_CONFIG_ENTRIES",
+    "TRANSLATION_KEY_CACHE_PURGED",
+    "TRANSLATION_KEY_UNIQUE_ID_COLLISION",
+    "TRANSLATION_KEY_DUPLICATE_ACCOUNT",
     "issue_id_for",
     "STORAGE_KEY",
     "STORAGE_VERSION",

--- a/custom_components/googlefindmy/coordinator/registry.py
+++ b/custom_components/googlefindmy/coordinator/registry.py
@@ -363,6 +363,7 @@ class RegistryOperations:
             return
 
         try:
+            # hass.data[DOMAIN] is compatible with HassKey-based DATA_DOMAIN in __init__.
             bucket = hass.data.setdefault(DOMAIN, {})
             owner_index: dict[str, str] = bucket.setdefault("device_owner_index", {})
         except Exception as err:  # noqa: BLE001 - defensive guard

--- a/custom_components/googlefindmy/discovery.py
+++ b/custom_components/googlefindmy/discovery.py
@@ -261,6 +261,7 @@ def _cloud_discovery_runtime(
                 _LOGGER.debug("Cloud discovery runtime lookup failed", exc_info=True)
 
     if runtime_owner is None:
+        # hass.data[DOMAIN] is compatible with HassKey-based DATA_DOMAIN in __init__.
         domain_data = hass.data.setdefault(DOMAIN, {})
         runtime_owner = domain_data.get("cloud_discovery_runtime_owner")
         if not isinstance(runtime_owner, SimpleNamespace):

--- a/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
+++ b/custom_components/googlefindmy/fmdn_finder/bermuda_listener.py
@@ -119,7 +119,8 @@ async def async_setup_bermuda_listener(hass: HomeAssistant) -> None:
     """
     _LOGGER.info("Registering Bermuda FMDN beacon listener")
 
-    # Initialize caches
+    # Initialize caches.  hass.data[DOMAIN] is compatible with the
+    # HassKey-based DATA_DOMAIN defined in __init__.py.
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN].setdefault(DATA_LAST_AREA_CACHE, {})
     hass.data[DOMAIN].setdefault(DATA_AREA_DEBOUNCE, {})

--- a/custom_components/googlefindmy/services.py
+++ b/custom_components/googlefindmy/services.py
@@ -698,6 +698,9 @@ async def async_register_services(hass: HomeAssistant, ctx: dict[str, Any]) -> N
             except Exception:  # pragma: no cover - defensive guard
                 pass
 
+        # Fallback: scan domain-level entries bucket for runtimes not yet
+        # discovered via entry.runtime_data.  hass.data[DOMAIN] is compatible
+        # with the HassKey-based DATA_DOMAIN defined in __init__.py.
         entries: dict[str, Any] = hass.data.setdefault(DOMAIN, {}).setdefault(
             "entries", {}
         )
@@ -797,6 +800,7 @@ async def async_register_services(hass: HomeAssistant, ctx: dict[str, Any]) -> N
         if dev:
             for entry_id in dev.config_entries:
                 entry = _entry_for_id(hass, entry_id)
+                # Prefer entry.runtime_data (2026 standard), then entries bucket.
                 runtime = getattr(entry, "runtime_data", None)
                 if runtime:
                     return runtime, canonical_id

--- a/tests/test_flows_and_repairs.py
+++ b/tests/test_flows_and_repairs.py
@@ -54,7 +54,12 @@ def test_repairs_hooks_and_translations(integration_root: Path) -> None:
     init_text = (integration_root / "__init__.py").read_text(encoding="utf-8")
     assert "issue_registry" in init_text
     assert "ir.async_create_issue" in init_text
-    assert "duplicate_account_entries" in init_text
+    # The literal was extracted to const.TRANSLATION_KEY_DUPLICATE_ACCOUNT;
+    # accept either the raw string or the constant name in the source.
+    assert (
+        "duplicate_account_entries" in init_text
+        or "TRANSLATION_KEY_DUPLICATE_ACCOUNT" in init_text
+    )
 
     translations = json.loads(
         (integration_root / "translations" / "en.json").read_text(encoding="utf-8")


### PR DESCRIPTION
Address peer review findings for __init__.py:
- Fix version discrepancy: replace hardcoded "2.6.6" with SSOT reference to INTEGRATION_VERSION in const.py / manifest.json
- Add HassKey (HA 2024.6+) for typed domain-level hass.data access with backward-compatible shim for older HA builds
- Add async_get_local_ip() wrapper to prevent blocking I/O in event loop; _get_local_ip_sync now has explicit docstring warning
- Extract hardcoded translation/issue keys (cache_purged, multiple_config_entries, unique_id_collision, duplicate_account_entries) to const.py as named constants
- Unify entries_bucket lookups: prefer entry.runtime_data (2026 standard) with fallback to domain-level bucket for legacy compatibility
- Annotate external files (services.py, discovery.py, registry.py, bermuda_listener.py) regarding HassKey compatibility

https://claude.ai/code/session_01SFPVr86fyvHpXT7HDqBWG7
