### PR TITLE
perf: add cooperative yielding to EID cache refresh loop

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -304,9 +304,7 @@ async def async_retrieve_identity_key(
             owner_key_version,
             owner_key_info.version,
         )
-        owner_key_info = await async_get_owner_key(
-            cache=cache, force_refresh=True
-        )
+        owner_key_info = await async_get_owner_key(cache=cache, force_refresh=True)
 
     candidates: list[bytes] = []
     decrypt_errors: list[Exception] = []

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -1582,7 +1582,9 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                             delay = _compute_delay(
                                 attempt, response.headers.get("Retry-After")
                             )
-                            log_fn = _LOGGER.info if retries_used == 0 else _LOGGER.warning
+                            log_fn = (
+                                _LOGGER.info if retries_used == 0 else _LOGGER.warning
+                            )
                             log_fn(
                                 "Nova API request failed (Attempt %d/%d): HTTP %d for %s. "
                                 "Server response: %s. Retrying in %.2f seconds...",

--- a/custom_components/googlefindmy/SpotApi/UploadPrecomputedPublicKeyIds/upload_precomputed_public_key_ids.py
+++ b/custom_components/googlefindmy/SpotApi/UploadPrecomputedPublicKeyIds/upload_precomputed_public_key_ids.py
@@ -33,9 +33,7 @@ _MAX_DEVICES_PER_BATCH = 40
 
 
 def refresh_custom_trackers(device_list: DevicesList) -> None:
-    all_device_eids: list[
-        UploadPrecomputedPublicKeyIdsRequest.DevicePublicKeyIds
-    ] = []
+    all_device_eids: list[UploadPrecomputedPublicKeyIdsRequest.DevicePublicKeyIds] = []
 
     for device in device_list.deviceMetadata:
         # This is a microcontroller

--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -370,9 +370,7 @@ async def async_setup_entry(  # noqa: PLR0915
                     continue
 
                 visible = True
-                is_visible = getattr(
-                    coordinator, "is_device_visible_in_subentry", None
-                )
+                is_visible = getattr(coordinator, "is_device_visible_in_subentry", None)
                 if callable(is_visible):
                     try:
                         visible = bool(is_visible(tracker_key, dev_id))
@@ -401,8 +399,7 @@ async def async_setup_entry(  # noqa: PLR0915
                     known_uwt_ids.add(dev_id)
                     entities.append(uwt_entity)
                     _LOGGER.info(
-                        "UWT-Mode binary sensor created for device=%s "
-                        "(uwt_mode=%s)",
+                        "UWT-Mode binary sensor created for device=%s (uwt_mode=%s)",
                         dev_id,
                         battery_state.uwt_mode,
                     )
@@ -467,9 +464,7 @@ async def async_setup_entry(  # noqa: PLR0915
                     if _subentry_type(sub) == "tracker":
                         data = getattr(sub, "data", None)
                         if isinstance(data, Mapping):
-                            tracker_key = data.get(
-                                "group_key", TRACKER_SUBENTRY_KEY
-                            )
+                            tracker_key = data.get("group_key", TRACKER_SUBENTRY_KEY)
                         break
             _add_tracker_scope(tracker_key, subentry_identifier)
 
@@ -928,10 +923,12 @@ class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     entity_description = UWT_MODE_DESC
 
-    _unrecorded_attributes = frozenset({
-        "last_ble_observation",
-        "google_device_id",
-    })
+    _unrecorded_attributes = frozenset(
+        {
+            "last_ble_observation",
+            "google_device_id",
+        }
+    )
 
     def __init__(
         self,

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -213,7 +213,9 @@ class PollingOperations:
           **return None** and are safe to run on the HA loop.
         """
         if kwargs:
-            self.hass.loop.call_soon_threadsafe(functools.partial(func, *args, **kwargs))
+            self.hass.loop.call_soon_threadsafe(
+                functools.partial(func, *args, **kwargs)
+            )
         else:
             self.hass.loop.call_soon_threadsafe(func, *args)
 

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -1069,7 +1069,9 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
                 self._attr_longitude = data.get("longitude")
                 acc = data.get("accuracy")
                 try:
-                    self._attr_location_accuracy = float(acc) if acc is not None else 0.0
+                    self._attr_location_accuracy = (
+                        float(acc) if acc is not None else 0.0
+                    )
                 except (TypeError, ValueError):
                     self._attr_location_accuracy = 0.0
 

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -724,9 +724,7 @@ class GoogleFindMyEIDResolver:
     _ble_battery_state: dict[str, BLEBatteryState] = field(
         init=False, default_factory=dict
     )
-    _ble_scan_info: dict[str, BLEScanInfo] = field(
-        init=False, default_factory=dict
-    )
+    _ble_scan_info: dict[str, BLEScanInfo] = field(init=False, default_factory=dict)
     _cached_identities: list[DeviceIdentity] = field(init=False, default_factory=list)
 
     def __post_init__(self) -> None:
@@ -2416,9 +2414,7 @@ class GoogleFindMyEIDResolver:
             )
 
             battery_labels = {0: "GOOD", 1: "LOW", 2: "CRITICAL", 3: "RESERVED"}
-            battery_label = battery_labels.get(
-                battery_raw, f"UNKNOWN({battery_raw})"
-            )
+            battery_label = battery_labels.get(battery_raw, f"UNKNOWN({battery_raw})")
 
             # Store for ALL matches (shared-device propagation).
             # Key by canonical_id (Google API device ID) — this is the same
@@ -2518,9 +2514,7 @@ class GoogleFindMyEIDResolver:
         """
         return self._ble_scan_info.get(device_id)
 
-    def _record_ble_scan_info(
-        self, matches: list[EIDMatch], ble_address: str
-    ) -> None:
+    def _record_ble_scan_info(self, matches: list[EIDMatch], ble_address: str) -> None:
         """Store the BLE address for all matched devices.
 
         Called from :meth:`resolve_eid` when the caller provides a
@@ -2638,8 +2632,7 @@ class GoogleFindMyEIDResolver:
                 ):
                     candidates.append(
                         payload[
-                            RAW_HEADER_LENGTH : RAW_HEADER_LENGTH
-                            + LEGACY_EID_LENGTH
+                            RAW_HEADER_LENGTH : RAW_HEADER_LENGTH + LEGACY_EID_LENGTH
                         ]
                     )
                 elif frame_type == MODERN_FRAME_TYPE:

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -94,6 +94,11 @@ KNOWN_OFFSET_KEY_LENGTH = 2
 # of clock drift at 1024s rotation.
 LOCK_TRACKING_WINDOW_STEPS = 2
 
+# Maximum wall-clock time (seconds) the EID refresh loop may run before
+# yielding control back to the event loop via ``await asyncio.sleep(0)``.
+# Keeps the main thread responsive under HA's 10 ms watchdog budget.
+_YIELD_BUDGET_SECONDS: float = 0.008
+
 # =============================================================================
 # Heuristic Phone Discovery Configuration
 # =============================================================================
@@ -1512,6 +1517,7 @@ class GoogleFindMyEIDResolver:
         work_items = self._collect_work_items(identities, now_unix=now_unix)
         _LOGGER.debug("Refresh stage: collected %d work items", len(work_items))
         builder = CacheBuilder()
+        _yield_deadline = time.monotonic() + _YIELD_BUDGET_SECONDS
 
         for work_item in work_items:
             windows, invalid_hint = self._compute_time_windows(
@@ -1551,6 +1557,12 @@ class GoogleFindMyEIDResolver:
                             advertisement_reversed=generated.is_reversed,
                             flags_xor_mask=xor_mask,
                         )
+
+            # Cooperative yield: give the event loop a chance to process
+            # pending callbacks when the CPU budget for this tick is spent.
+            if time.monotonic() >= _yield_deadline:
+                await asyncio.sleep(0)
+                _yield_deadline = time.monotonic() + _YIELD_BUDGET_SECONDS
 
         self._lookup, self._lookup_metadata = builder.finalize()
         _LOGGER.debug(

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -1235,11 +1235,13 @@ class GoogleFindMyBLEBatterySensor(GoogleFindMyDeviceEntity, RestoreSensor):
     _attr_entity_registry_enabled_default = True
     entity_description = BLE_BATTERY_DESCRIPTION
 
-    _unrecorded_attributes = frozenset({
-        "last_ble_observation",
-        "google_device_id",
-        "battery_raw_level",
-    })
+    _unrecorded_attributes = frozenset(
+        {
+            "last_ble_observation",
+            "google_device_id",
+            "battery_raw_level",
+        }
+    )
 
     def __init__(
         self,

--- a/custom_components/googlefindmy/shared_helpers.py
+++ b/custom_components/googlefindmy/shared_helpers.py
@@ -110,9 +110,7 @@ def safe_fcm_health_snapshots(receiver: Any) -> dict[str, dict[str, Any]]:
         return {}
 
 
-def normalize_fcm_entry_snapshot(
-    entry_id: str, snap: dict[str, Any]
-) -> dict[str, Any]:
+def normalize_fcm_entry_snapshot(entry_id: str, snap: dict[str, Any]) -> dict[str, Any]:
     """Normalize a single FCM health snapshot entry.
 
     Returns a dict with the common fields used by both ``diagnostics.py``

--- a/tests/test_ble_battery_sensor.py
+++ b/tests/test_ble_battery_sensor.py
@@ -155,11 +155,13 @@ def _build_battery_sensor(
     sensor.entity_description = BLE_BATTERY_DESCRIPTION
     sensor._attr_has_entity_name = True
     sensor._attr_entity_registry_enabled_default = True
-    sensor._unrecorded_attributes = frozenset({
-        "last_ble_observation",
-        "google_device_id",
-        "battery_raw_level",
-    })
+    sensor._unrecorded_attributes = frozenset(
+        {
+            "last_ble_observation",
+            "google_device_id",
+            "battery_raw_level",
+        }
+    )
     sensor._fallback_label = device_name
 
     safe_id = device_id if device_id is not None else "unknown"
@@ -509,9 +511,7 @@ class TestUpdateBLEBattery:
         raw = _service_data_payload(eid, flags_byte)
         match = _match("dev-frame")
         # Pass a non-None observed_frame to cover the 0x{:02x} formatting branch
-        resolver._update_ble_battery(
-            raw, 0x40, {"flags_xor_mask": xor_mask}, [match]
-        )
+        resolver._update_ble_battery(raw, 0x40, {"flags_xor_mask": xor_mask}, [match])
         state = resolver._ble_battery_state.get("dev-frame")
         assert state is not None
         assert state.battery_pct == 100
@@ -529,7 +529,7 @@ class TestUpdateBLEBattery:
         """CANNOT_DECODE with long payload should truncate raw_hex to 40 bytes."""
         resolver = _make_resolver()
         # Build a long payload that won't match FMDN frame type at position 0 or 7
-        raw = b"\xFF" * 100
+        raw = b"\xff" * 100
         match = _match("dev-long")
         resolver._update_ble_battery(raw, None, {}, [match])
         assert "dev-long" in resolver._flags_logged_devices
@@ -537,7 +537,7 @@ class TestUpdateBLEBattery:
     def test_cannot_decode_short_payload_full_hex(self) -> None:
         """CANNOT_DECODE with short payload should emit full raw hex."""
         resolver = _make_resolver()
-        raw = b"\xAB" * 20
+        raw = b"\xab" * 20
         match = _match("dev-short-hex")
         resolver._update_ble_battery(raw, None, {}, [match])
         assert "dev-short-hex" in resolver._flags_logged_devices
@@ -545,7 +545,7 @@ class TestUpdateBLEBattery:
     def test_second_cannot_decode_same_device_no_double_log(self) -> None:
         """CANNOT_DECODE for an already-logged device should not re-log."""
         resolver = _make_resolver()
-        raw = b"\xAB" * 20
+        raw = b"\xab" * 20
         match = _match("dev-double")
         resolver._update_ble_battery(raw, None, {}, [match])
         assert "dev-double" in resolver._flags_logged_devices
@@ -804,9 +804,7 @@ class TestBLEBatterySensorAvailability:
     def test_unavailable_when_coordinator_hidden(self) -> None:
         """Unavailable when coordinator marks device as not visible."""
         resolver = _make_resolver()
-        coordinator = _fake_coordinator(
-            device_id="dev-1", present=True, visible=False
-        )
+        coordinator = _fake_coordinator(device_id="dev-1", present=True, visible=False)
         sensor = _build_battery_sensor(
             device_id="dev-1",
             coordinator=coordinator,
@@ -954,9 +952,7 @@ class TestBLEBatterySensorCoordinatorUpdate:
     def test_update_without_device_writes_state(self) -> None:
         """When coordinator_has_device is False, still writes state."""
         resolver = _make_resolver()
-        coordinator = _fake_coordinator(
-            device_id="dev-1", present=False, visible=False
-        )
+        coordinator = _fake_coordinator(device_id="dev-1", present=False, visible=False)
         sensor = _build_battery_sensor(
             device_id="dev-1",
             coordinator=coordinator,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,7 +47,10 @@ class TestListDevices:
     """list_devices() dispatches to _async_cli_main and handles errors."""
 
     @mock.patch("custom_components.googlefindmy.main.asyncio")
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
+    @mock.patch(
+        "custom_components.googlefindmy.main._async_cli_main",
+        new_callable=mock.MagicMock,
+    )
     def test_happy_path_with_entry_id(
         self, mock_cli: mock.MagicMock, mock_asyncio: mock.MagicMock
     ) -> None:
@@ -58,7 +61,10 @@ class TestListDevices:
         mock_asyncio.run.assert_called_once()
 
     @mock.patch("custom_components.googlefindmy.main.asyncio")
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
+    @mock.patch(
+        "custom_components.googlefindmy.main._async_cli_main",
+        new_callable=mock.MagicMock,
+    )
     def test_entry_id_from_env(
         self,
         mock_cli: mock.MagicMock,
@@ -73,7 +79,10 @@ class TestListDevices:
         mock_asyncio.run.assert_called_once()
 
     @mock.patch("custom_components.googlefindmy.main.asyncio")
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
+    @mock.patch(
+        "custom_components.googlefindmy.main._async_cli_main",
+        new_callable=mock.MagicMock,
+    )
     def test_no_entry_id(
         self,
         mock_cli: mock.MagicMock,
@@ -87,7 +96,10 @@ class TestListDevices:
         mock_cli.assert_called_once_with(None)
         mock_asyncio.run.assert_called_once()
 
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
+    @mock.patch(
+        "custom_components.googlefindmy.main._async_cli_main",
+        new_callable=mock.MagicMock,
+    )
     def test_keyboard_interrupt(
         self, mock_cli: mock.MagicMock, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -99,7 +111,10 @@ class TestListDevices:
 
         assert "Exiting." in capsys.readouterr().out
 
-    @mock.patch("custom_components.googlefindmy.main._async_cli_main", new_callable=mock.MagicMock)
+    @mock.patch(
+        "custom_components.googlefindmy.main._async_cli_main",
+        new_callable=mock.MagicMock,
+    )
     def test_generic_exception(
         self, mock_cli: mock.MagicMock, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/test_uwt_mode_binary_sensor.py
+++ b/tests/test_uwt_mode_binary_sensor.py
@@ -100,14 +100,15 @@ def _build_uwt_sensor(
     sensor.entity_description = UWT_MODE_DESC
     sensor._attr_has_entity_name = True
     sensor._attr_entity_category = None
-    sensor._unrecorded_attributes = frozenset({
-        "last_ble_observation",
-        "google_device_id",
-    })
+    sensor._unrecorded_attributes = frozenset(
+        {
+            "last_ble_observation",
+            "google_device_id",
+        }
+    )
     sensor._fallback_label = device_name
     sensor._attr_unique_id = (
-        f"googlefindmy_{coordinator.config_entry.entry_id}"
-        f"_tracker_{device_id}_uwt_mode"
+        f"googlefindmy_{coordinator.config_entry.entry_id}_tracker_{device_id}_uwt_mode"
     )
     sensor.entity_id = f"binary_sensor.test_{device_id}_uwt_mode"
 
@@ -248,9 +249,7 @@ class TestUWTModeSensorAvailability:
 
     def test_unavailable_when_hidden(self) -> None:
         resolver = _make_resolver_with_state("dev-1")
-        coordinator = _fake_coordinator(
-            device_id="dev-1", present=True, visible=False
-        )
+        coordinator = _fake_coordinator(device_id="dev-1", present=True, visible=False)
         sensor = _build_uwt_sensor(
             device_id="dev-1", coordinator=coordinator, resolver=resolver
         )


### PR DESCRIPTION
[perf: add cooperative yielding to EID cache refresh loop](https://github.com/jleinenbach/GoogleFindMy-HA/commit/163a5eb06b1574c9e2423e4f485affd2b689f042) 

The _refresh_cache method runs CPU-intensive cryptographic operations
(AES-256-ECB + EC point multiplication) synchronously for all devices
and time windows without yielding to the event loop. On setups with
many trackers this can block the main thread long enough to trigger
HA watchdog warnings.

Insert a time-budgeted yield point (8 ms budget) after each work item
so the event loop can process pending callbacks between devices.

https://claude.ai/code/session_01KmuKWzf7K2dSL5gJ72sfLZ