### PR TITLE
fix: hide subentry UI buttons by returning empty dict

### DIFF
--- a/custom_components/googlefindmy/agents/config_flow/AGENTS.md
+++ b/custom_components/googlefindmy/agents/config_flow/AGENTS.md
@@ -67,14 +67,14 @@ Add similar guards whenever a new optional attribute becomes relevant so future 
 
 ## Subentry handler registration (HA 2026.x compatibility)
 
-### `async_get_supported_subentry_types` must return class types
+### `async_get_supported_subentry_types` MUST return empty dict
 
-**Critical:** Home Assistant expects `async_get_supported_subentry_types` to return `dict[str, type[ConfigSubentryFlow]]` — actual class types, NOT factory functions (lambdas).
+**Critical:** This method MUST return `{}` to hide unwanted UI buttons in the config entry panel.
 
-**Why this matters:**
-1. HA calls `hasattr(handler_class, "async_step_reconfigure")` to check feature support
-2. Lambdas don't have class methods, so feature detection fails silently
-3. The "Invalid handler specified" error can occur when handler registration is broken
+**Why empty dict is required:**
+- Returning handler classes causes HA to display "+ Add hub feature group" and "+ Add service feature group" buttons
+- These manual subentry buttons should NOT be visible to users
+- Subentries are provisioned **programmatically** by the integration coordinator, not manually
 
 **Correct implementation:**
 ```python
@@ -82,37 +82,47 @@ Add similar guards whenever a new optional attribute becomes relevant so future 
 @callback
 def async_get_supported_subentry_types(
     cls,
-    config_entry: ConfigEntry,
+    _config_entry: ConfigEntry,
 ) -> dict[str, type[ConfigSubentryFlow]]:
-    """Return handler classes (not factories)."""
-    return {
-        SUBENTRY_TYPE_HUB: HubSubentryFlowHandler,      # Class, not lambda
-        SUBENTRY_TYPE_SERVICE: ServiceSubentryFlowHandler,
-        SUBENTRY_TYPE_TRACKER: TrackerSubentryFlowHandler,
-    }
+    """Return empty dict to hide subentry UI buttons."""
+    return {}  # MUST be empty to hide manual add buttons
 ```
 
-**Wrong implementation (causes silent failures):**
+**Wrong implementation (exposes unwanted UI):**
 ```python
-# DON'T DO THIS - lambdas break hasattr() checks
+# DON'T DO THIS - exposes "Add hub/service feature group" buttons!
 return {
-    SUBENTRY_TYPE_HUB: lambda: HubSubentryFlowHandler(config_entry),
+    SUBENTRY_TYPE_HUB: HubSubentryFlowHandler,
+    SUBENTRY_TYPE_SERVICE: ServiceSubentryFlowHandler,
 }
 ```
 
-### Lazy `config_entry` resolution for HA flow manager compatibility
+### `async_step_hub` must instantiate handlers directly
 
-HA 2026.x may instantiate subentry handlers WITHOUT passing `config_entry` in the constructor. The flow manager sets up context (including `_get_entry()` method) AFTER instantiation.
+Since `async_get_supported_subentry_types` returns empty, the "Add Hub" flow entry point (`async_step_hub`) must instantiate the handler class directly:
 
-**Solution:** Use a property with lazy resolution:
+```python
+async def async_step_hub(self, user_input=None):
+    # Don't use async_get_supported_subentry_types - it returns {}
+    # Instantiate the handler directly instead
+    handler = HubSubentryFlowHandler(config_entry)
+    setattr(handler, "hass", hass)
+    setattr(handler, "context", {"entry_id": config_entry.entry_id})
+    result = handler.async_step_user(user_input)
+    return await self._async_resolve_flow_result(result)
+```
+
+### Lazy `config_entry` resolution for handler compatibility
+
+Subentry handlers use a `config_entry` property with lazy resolution to support both direct instantiation and potential future HA flow manager usage:
+
 ```python
 @property
 def config_entry(self) -> ConfigEntry:
-    # 1. Check our cache first
     if self._config_entry_cache is not None:
         return self._config_entry_cache
 
-    # 2. Try HA's _get_entry() method (HA 2026.x)
+    # Fallback: try HA's _get_entry() method
     get_entry_method = getattr(self, "_get_entry", None)
     if callable(get_entry_method):
         entry = get_entry_method()
@@ -123,15 +133,9 @@ def config_entry(self) -> ConfigEntry:
     raise RuntimeError("Cannot resolve config_entry")
 ```
 
-### Test expectations must match implementation
+### Test expectations
 
-When updating `async_get_supported_subentry_types` to return handlers instead of an empty dict, update ALL related tests:
-- `tests/test_config_flow_basic.py`
-- `tests/test_config_flow_hub_entry.py`
-- `tests/test_config_flow_subentry_sync.py`
-
-Tests should verify:
-1. All subentry types are registered
-2. Values are class types (not factories)
-3. Hub flow creates entries (not aborts)
+Tests must verify:
+1. `async_get_supported_subentry_types` returns empty dict `{}`
+2. `async_step_hub` creates entries successfully (via direct handler instantiation)
 

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -2330,22 +2330,20 @@ class ConfigFlow(
     @_typed_callback
     def async_get_supported_subentry_types(
         cls,
-        config_entry: ConfigEntry,
+        _config_entry: ConfigEntry,
     ) -> dict[str, type[ConfigSubentryFlow]]:
-        """Return supported subentry types with their handler classes.
+        """Return an empty mapping to hide subentry UI elements.
 
-        Home Assistant uses these class types to:
-        1. Check for supported features (e.g., hasattr for async_step_reconfigure)
-        2. Instantiate handlers when users initiate subentry flows
+        Subentries (hub, service, tracker feature groups) are provisioned
+        programmatically by the integration coordinator, NOT manually by users.
+        Returning an empty dict prevents Home Assistant from displaying
+        "Add subentry" buttons (+ Add hub feature group, + Add service feature
+        group) in the config entry UI.
 
-        The handler classes inherit from ConfigSubentryFlow and will receive
-        the config_entry context from Home Assistant's flow manager.
+        The async_step_hub entry point (for "Hub hinzufügen" / "Add Hub")
+        instantiates handlers directly without relying on this mapping.
         """
-        return {
-            SUBENTRY_TYPE_HUB: HubSubentryFlowHandler,
-            SUBENTRY_TYPE_SERVICE: ServiceSubentryFlowHandler,
-            SUBENTRY_TYPE_TRACKER: TrackerSubentryFlowHandler,
-        }
+        return {}
 
     async def async_step_discovery(
         self, discovery_info: Mapping[str, Any] | None
@@ -2704,19 +2702,12 @@ class ConfigFlow(
 
         config_entry = cast(ConfigEntry, config_entry_obj)
 
-        supported_types = type(self).async_get_supported_subentry_types(config_entry)
-        handler_class = supported_types.get(SUBENTRY_TYPE_HUB)
-        if handler_class is None:
-            _LOGGER.error(
-                "Add Hub flow unavailable: hub subentry type not supported (entry_id=%s)",
-                config_entry.entry_id,
-            )
-            return self.async_abort(reason="not_supported")
-
-        # Instantiate handler with config_entry for direct invocation
-        # (HA's flow manager would do this differently, but async_step_hub
-        # is a manual entry point that bypasses the normal flow manager)
-        handler = handler_class(config_entry)
+        # Instantiate HubSubentryFlowHandler directly - we don't use
+        # async_get_supported_subentry_types here because that method
+        # intentionally returns {} to hide subentry UI buttons.
+        # The "Add Hub" flow is a special entry point that bypasses the
+        # normal HA subentry flow manager.
+        handler = HubSubentryFlowHandler(config_entry)
         _LOGGER.info(
             "Add Hub flow requested; provisioning hub subentry (entry_id=%s)",
             config_entry.entry_id,

--- a/tests/test_config_flow_basic.py
+++ b/tests/test_config_flow_basic.py
@@ -35,15 +35,10 @@ def test_flow_module_import_and_handler_registry() -> None:
     assert getattr(handler, "domain", None) == DOMAIN
 
 
-def test_supported_subentry_types_returns_handler_classes() -> None:
-    """Config flow should expose subentry handler classes for HA 2026.x compatibility."""
+def test_supported_subentry_types_returns_empty_to_hide_ui() -> None:
+    """Config flow should return empty dict to hide subentry UI buttons."""
 
     from custom_components.googlefindmy import config_flow  # noqa: PLC0415
-    from custom_components.googlefindmy.const import (
-        SUBENTRY_TYPE_HUB,
-        SUBENTRY_TYPE_SERVICE,
-        SUBENTRY_TYPE_TRACKER,
-    )
 
     entry = SimpleNamespace(
         entry_id="entry-test",
@@ -54,19 +49,10 @@ def test_supported_subentry_types_returns_handler_classes() -> None:
 
     mapping = config_flow.ConfigFlow.async_get_supported_subentry_types(entry)  # type: ignore[arg-type]
 
-    # Verify all three subentry types are registered
-    assert SUBENTRY_TYPE_HUB in mapping, "Hub subentry type should be registered"
-    assert SUBENTRY_TYPE_SERVICE in mapping, (
-        "Service subentry type should be registered"
-    )
-    assert SUBENTRY_TYPE_TRACKER in mapping, (
-        "Tracker subentry type should be registered"
-    )
-
-    # Verify they are class types (not factory functions)
-    assert mapping[SUBENTRY_TYPE_HUB] is config_flow.HubSubentryFlowHandler
-    assert mapping[SUBENTRY_TYPE_SERVICE] is config_flow.ServiceSubentryFlowHandler
-    assert mapping[SUBENTRY_TYPE_TRACKER] is config_flow.TrackerSubentryFlowHandler
+    # Must return empty dict to hide "Add hub feature group" and
+    # "Add service feature group" buttons in the HA config entry UI.
+    # Subentries are provisioned programmatically, not manually by users.
+    assert mapping == {}, "UI should not expose manual subentry buttons"
 
 
 def test_subentry_update_constructor_allows_config_entry_and_subentry() -> None:

--- a/tests/test_config_flow_hub_entry.py
+++ b/tests/test_config_flow_hub_entry.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 
 import inspect
 import logging
-from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Protocol
 
 import pytest
-from homeassistant.config_entries import ConfigEntry
 
 from custom_components.googlefindmy import config_flow
 from custom_components.googlefindmy.const import (
@@ -39,11 +37,11 @@ class _SubentrySupportToggle(Protocol):
     "simulate_legacy_core",
     [False, True],
 )
-def test_supported_subentry_types_returns_handlers(
+def test_supported_subentry_types_returns_empty_to_hide_ui(
     subentry_support: _SubentrySupportToggle,
     simulate_legacy_core: bool,
 ) -> None:
-    """Subentry handlers should be registered for HA 2026.x compatibility."""
+    """Subentry mapping must be empty to hide manual add buttons in HA UI."""
 
     if simulate_legacy_core:
         subentry_support.as_legacy()
@@ -54,15 +52,13 @@ def test_supported_subentry_types_returns_handlers(
         SimpleNamespace()
     )
 
-    # All three subentry types should be registered
-    assert SUBENTRY_TYPE_HUB in mapping
-    assert SUBENTRY_TYPE_SERVICE in mapping
-    assert SUBENTRY_TYPE_TRACKER in mapping
-
-    # Verify they are the correct handler classes
-    assert mapping[SUBENTRY_TYPE_HUB] is config_flow.HubSubentryFlowHandler
-    assert mapping[SUBENTRY_TYPE_SERVICE] is config_flow.ServiceSubentryFlowHandler
-    assert mapping[SUBENTRY_TYPE_TRACKER] is config_flow.TrackerSubentryFlowHandler
+    # Must return empty dict to hide "Add hub feature group" and
+    # "Add service feature group" buttons. Subentries are provisioned
+    # programmatically by the coordinator, not manually by users.
+    assert mapping == {}
+    assert SUBENTRY_TYPE_HUB not in mapping
+    assert SUBENTRY_TYPE_SERVICE not in mapping
+    assert SUBENTRY_TYPE_TRACKER not in mapping
 
 
 @pytest.mark.asyncio
@@ -133,65 +129,6 @@ async def test_hub_flow_aborts_without_entry_context(
 
     assert result["type"] == "abort"
     assert result["reason"] == "unknown"
-
-
-@pytest.mark.asyncio
-async def test_hub_flow_aborts_when_hub_unsupported(
-    caplog: pytest.LogCaptureFixture,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Cores without hub subentry support should abort with not_supported."""
-
-    caplog.set_level(logging.ERROR)
-
-    entry = SimpleNamespace(entry_id="entry-legacy", data={}, options={}, subentries={})
-
-    class _ConfigEntriesManager(ConfigEntriesDomainUniqueIdLookupMixin):
-        def __init__(self) -> None:
-            self.entry = entry
-            attach_config_entries_flow_manager(self)
-
-        def async_get_entry(self, entry_id: str) -> SimpleNamespace | None:
-            if entry_id == entry.entry_id:
-                return self.entry
-            return None
-
-    hass = SimpleNamespace(config_entries=_ConfigEntriesManager())
-
-    def _no_hub(
-        _: ConfigEntry,
-    ) -> dict[str, Callable[[], config_flow.ConfigSubentryFlow]]:
-        return {
-            config_flow.SUBENTRY_TYPE_SERVICE: lambda: config_flow.ServiceSubentryFlowHandler(
-                entry
-            ),
-            config_flow.SUBENTRY_TYPE_TRACKER: lambda: config_flow.TrackerSubentryFlowHandler(
-                entry
-            ),
-        }
-
-    monkeypatch.setattr(
-        config_flow.ConfigFlow,
-        "async_get_supported_subentry_types",
-        staticmethod(_no_hub),
-        raising=False,
-    )
-
-    flow = config_flow.ConfigFlow()
-    flow.hass = hass  # type: ignore[assignment]
-    flow.context = {"source": "hub", "entry_id": entry.entry_id}
-    flow.config_entry = entry  # type: ignore[assignment]
-
-    result = await flow.async_step_hub()
-    if inspect.isawaitable(result):
-        result = await result
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "not_supported"
-    assert any(
-        "hub subentry type not supported" in record.getMessage()
-        for record in caplog.records
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow_subentry_sync.py
+++ b/tests/test_config_flow_subentry_sync.py
@@ -815,27 +815,16 @@ async def test_subentry_manager_preserves_adopted_owner_during_cleanup() -> None
     assert hass.config_entries.removed == []
 
 
-def test_supported_subentry_types_returns_handler_classes() -> None:
-    """Config flow should expose subentry handler classes for HA 2026.x compatibility."""
-
-    from custom_components.googlefindmy.const import (
-        SUBENTRY_TYPE_HUB,
-        SUBENTRY_TYPE_SERVICE,
-        SUBENTRY_TYPE_TRACKER,
-    )
+def test_supported_subentry_types_returns_empty_to_hide_ui() -> None:
+    """Config flow should return empty dict to hide manual subentry UI buttons."""
 
     entry = _EntryStub()
     mapping = config_flow.ConfigFlow.async_get_supported_subentry_types(entry)
 
-    # All three subentry types should be registered
-    assert SUBENTRY_TYPE_HUB in mapping
-    assert SUBENTRY_TYPE_SERVICE in mapping
-    assert SUBENTRY_TYPE_TRACKER in mapping
-
-    # Verify they are the correct handler classes
-    assert mapping[SUBENTRY_TYPE_HUB] is config_flow.HubSubentryFlowHandler
-    assert mapping[SUBENTRY_TYPE_SERVICE] is config_flow.ServiceSubentryFlowHandler
-    assert mapping[SUBENTRY_TYPE_TRACKER] is config_flow.TrackerSubentryFlowHandler
+    # Must return empty dict to hide "Add hub feature group" and
+    # "Add service feature group" buttons in the HA config entry UI.
+    # Subentries are provisioned programmatically by the coordinator.
+    assert mapping == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
[fix: hide subentry UI buttons by returning empty dict from async_get_…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/1fb0ecd37896259a493c81b0e8e4f26112e10914) 

…supported_subentry_types

The previous fix incorrectly exposed handler classes in async_get_supported_subentry_types,
which caused Home Assistant to display unwanted "+ Add hub feature group" and
"+ Add service feature group" buttons in the config entry UI.

Changes:
- Revert async_get_supported_subentry_types to return {} (empty dict)
- Update async_step_hub to instantiate HubSubentryFlowHandler directly,
  bypassing the subentry type mapping entirely
- Remove obsolete test_hub_flow_aborts_when_hub_unsupported test
- Update AGENTS.md documentation to reflect correct behavior:
  - async_get_supported_subentry_types MUST return empty dict to hide UI
  - async_step_hub instantiates handlers directly

Subentries are provisioned programmatically by the integration coordinator,
not manually by users. The "Add Hub" button works via async_step_hub which
directly creates the handler, while the unwanted "+ Add X feature group"
buttons are hidden by returning an empty mapping.

https://claude.ai/code/session_01TA2zE9mTtHfQEwCYApQR7y