### PR TITLE
fix: adopt HA entity naming best practice for device_tracker entities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -758,6 +758,12 @@ artifacts remain exempt when explicitly flagged by repo configuration).
 * Repairs/Diagnostics: provide both; redact aggressively.
 * Storage: use `helpers.storage.Store` for tokens/state; throttle writes (batch/merge).
 * System health: prefer the `SystemHealthRegistration` helper (`homeassistant.components.system_health.SystemHealthRegistration`) when available and keep the legacy component import only as a guarded fallback.
+* **Entity naming** (HA Best Practice, ref: [Adopting a new way to name entities](https://developers.home-assistant.io/blog/2022/07/10/entity_naming/)):
+  - Always set `_attr_has_entity_name = True` on entity classes.
+  - **Primary entity** (represents the device itself): set `_attr_name = None` so it inherits only the device name (e.g., "Galaxy S25 Ultra").
+  - **Secondary entities** (additional features): use `translation_key` with a `name` in translations; HA auto-composes the friendly name as "Device Name + Translation" (e.g., "Galaxy S25 Ultra Last location").
+  - **Translation files**: for the primary entity's `translation_key`, **omit** the `"name"` key entirely (presence of `"name"` would append a suffix); for secondary entities, **include** the `"name"` key with the suffix text.
+  - Never set `_attr_name` dynamically at runtime (e.g., in coordinator update callbacks) when using `has_entity_name=True`—the device registry is the single source of truth for the device name.
 
 ### 11.8 Release & operations
 

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -821,8 +821,8 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
     """Representation of a Google Find My Device tracker."""
 
     # Convention: trackers represent the device itself; the entity name
-    # should not have a suffix and will track the device name.
-    _attr_has_entity_name = False
+    # inherits from the device name via has_entity_name=True.
+    _attr_has_entity_name = True
     _attr_source_type = SourceType.GPS
     _attr_entity_category: EntityCategory | None = (
         None  # ensure tracker is not diagnostic
@@ -872,9 +872,10 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             dev_id,
         )
 
-        # With has_entity_name=False we must set the entity's name ourselves.
-        # If name is missing during cold boot, HA will show the entity_id; that's fine.
-        self._attr_name = self._display_name(device.get("name"))
+        # With has_entity_name=True, setting name to None means the entity
+        # inherits only the device name (no suffix). The translation_key "device"
+        # is used for state attributes but not for the entity name itself.
+        self._attr_name = None
 
         # Attribution for data source identification (helps distinguish from Bermuda etc.)
         email = _extract_email_from_entry(coordinator.config_entry)
@@ -1173,15 +1174,8 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             return
 
         self.refresh_device_label_from_coordinator(log_prefix="DeviceTracker")
-        desired_display = self._display_name(self._device.get("name"))
-        if self._attr_name != desired_display:
-            _LOGGER.debug(
-                "Updating entity name for %s: '%s' -> '%s'",
-                self.entity_id,
-                self._attr_name,
-                desired_display,
-            )
-            self._attr_name = desired_display
+        # With has_entity_name=True, the entity name is derived from the device
+        # registry name. No need to manually update _attr_name here.
 
         device_data = self._current_row()
         if not device_data:
@@ -1239,9 +1233,9 @@ class GoogleFindMyLastLocationTracker(GoogleFindMyDeviceTracker):
             f"{dev_id}:last_location",
         )
 
-        # Override name with "Last Location" suffix
-        base_name = self._display_name(device.get("name"))
-        self._attr_name = f"{base_name} Last Location"
+        # With has_entity_name=True (inherited) and translation_key="last_location",
+        # the entity name is automatically composed as "<device_name> <translated_suffix>"
+        # e.g. "Galaxy S25 Ultra Last location". Do NOT override _attr_name here.
 
     def _is_location_stale(self) -> bool:
         """Never stale - always show last known location."""

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Device",
         "state_attributes": {
           "device_name": {
             "name": "Device name"

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Gerät",
         "state_attributes": {
           "device_name": {
             "name": "Gerätename"

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -272,7 +272,7 @@
           "stale_threshold": "Nach dieser Zeit (in Sekunden) ohne Standortaktualisierung wird der Tracker-Status unbekannt. Verwende die Entität 'Letzter Standort', um immer die letzte bekannte Position zu sehen. Standard: 1800 (30 Minuten).",
           "delete_caches_on_remove": "Löscht zwischengespeicherte Tokens und Gerätemetadaten, wenn dieser Eintrag entfernt wird.",
           "map_view_token_expiration": "Wenn aktiviert, laufen die Token für die Kartenansicht nach 1 Woche ab. Wenn deaktiviert (Standard), laufen die Token nicht ab.",
-          "contributor_mode": "Lege fest, wie dein Gerät zum Google-Netzwerk beiträgt (standardmäßig stark frequentierte Bereiche oder Alle Bereiche für Crowdsourcing).",
+          "contributor_mode": "Lege fest, wie dein Gerät zum Google-Netzwerk beiträgt (standardmäßig Alle Bereiche für Crowdsourcing oder nur stark frequentierte Bereiche).",
           "subentry": "Speichern Sie diese Optionen in der ausgewählten Funktionsgruppe. Beispiele finden Sie unter [Subeinträge und Funktionsgruppen]({subentries_docs_url})."
         }
       },

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Device",
         "state_attributes": {
           "device_name": {
             "name": "Device name"

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -272,7 +272,7 @@
           "stale_threshold": "After this many seconds without a location update, the tracker state becomes unknown. Use the 'Last Location' entity to always see the last known position. Default: 1800 (30 minutes).",
           "delete_caches_on_remove": "Remove cached tokens and device metadata when this entry is deleted.",
           "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire.",
-          "contributor_mode": "Choose how your device contributes to Google's network (High-traffic areas by default, or All areas for crowdsourced reporting).",
+          "contributor_mode": "Choose how your device contributes to Google's network (All areas by default for crowdsourced reporting, or High-traffic areas only).",
           "subentry": "Store these options on the selected feature group. See [Subentries and feature groups]({subentries_docs_url}) for examples."
         }
       },

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Dispositivo",
         "state_attributes": {
           "device_name": {
             "name": "Nombre del dispositivo"

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -272,7 +272,7 @@
           "stale_threshold": "Tras este número de segundos sin una actualización de ubicación, el estado del rastreador pasa a desconocido. Usa la entidad 'Última ubicación' para ver siempre la última posición conocida. Por defecto: 1800 (30 minutos).",
           "delete_caches_on_remove": "Borra los tokens almacenados en caché y los metadatos de los dispositivos cuando se elimina esta entrada.",
           "map_view_token_expiration": "Si está activado, los tokens de la vista de mapa caducan tras 1 semana. Si está desactivado (por defecto), no caducan.",
-          "contributor_mode": "Elige cómo contribuye tu dispositivo a la red de Google (Zonas de alto tránsito por defecto o Todas las zonas para aportes colaborativos).",
+          "contributor_mode": "Elige cómo contribuye tu dispositivo a la red de Google (Todas las zonas por defecto para aportes colaborativos o solo Zonas de alto tránsito).",
           "subentry": "Guarda estas opciones en el grupo de funciones seleccionado. Consulta [Subentradas y grupos de funciones]({subentries_docs_url}) para ver ejemplos."
         }
       },

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Appareil",
         "state_attributes": {
           "device_name": {
             "name": "Nom de l’appareil"

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -272,7 +272,7 @@
           "stale_threshold": "Après ce délai en secondes sans mise à jour de position, l'état du traceur passe à inconnu. Utilisez l'entité 'Dernière position' pour toujours voir la dernière position connue. Par défaut : 1800 (30 minutes).",
           "delete_caches_on_remove": "Supprime les jetons mis en cache et les métadonnées des appareils lors de la suppression de cette entrée.",
           "map_view_token_expiration": "Lorsqu'elle est activée, les jetons de la vue carte expirent après 1 semaine. Lorsqu'elle est désactivée (par défaut), ils n'expirent pas.",
-          "contributor_mode": "Choisissez comment votre appareil contribue au réseau Google (par défaut les zones à forte affluence ou Toutes les zones pour une contribution participative).",
+          "contributor_mode": "Choisissez comment votre appareil contribue au réseau Google (par défaut Toutes les zones pour une contribution participative ou uniquement les zones à forte affluence).",
           "subentry": "Enregistrez ces options pour le groupe de fonctionnalités sélectionné. Consultez [Sous-entrées et groupes de fonctionnalités]({subentries_docs_url}) pour des exemples."
         }
       },

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -272,7 +272,7 @@
           "stale_threshold": "Dopo questo numero di secondi senza aggiornamento di posizione, lo stato del tracker diventa sconosciuto. Usa l'entità 'Ultima posizione' per vedere sempre l'ultima posizione nota. Predefinito: 1800 (30 minuti).",
           "delete_caches_on_remove": "Elimina i token memorizzati in cache e i metadati dei dispositivi quando questa voce viene rimossa.",
           "map_view_token_expiration": "Se abilitato, i token della vista mappa scadono dopo 1 settimana. Se disabilitato (predefinito), non scadono.",
-          "contributor_mode": "Scegli come il dispositivo contribuisce alla rete di Google (per impostazione predefinita Aree ad alto traffico oppure Tutte le aree per un contributo collaborativo).",
+          "contributor_mode": "Scegli come il dispositivo contribuisce alla rete di Google (per impostazione predefinita Tutte le aree per un contributo collaborativo oppure solo Aree ad alto traffico).",
           "subentry": "Salva queste opzioni nel gruppo di funzionalità selezionato. Consulta [Sotto-voci e gruppi di funzionalità]({subentries_docs_url}) per esempi pratici."
         }
       },

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Dispositivo",
         "state_attributes": {
           "device_name": {
             "name": "Nome del dispositivo"

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -272,7 +272,7 @@
           "stale_threshold": "Wanneer een locatie ouder is dan deze drempel (in seconden), wordt de trackerstatus 'onbekend'. Gebruik de entiteit 'Laatste locatie' om altijd de laatst bekende positie te zien. Standaard: 1800 (30 minuten).",
           "delete_caches_on_remove": "Verwijder gecachete tokens en apparaatmetadata wanneer dit item wordt verwijderd.",
           "map_view_token_expiration": "Indien ingeschakeld, verlopen kaartweergavetokens na 1 week. Indien uitgeschakeld (standaard), verlopen tokens niet.",
-          "contributor_mode": "Kies hoe je apparaat bijdraagt aan het Google-netwerk (standaard drukbezochte gebieden, of Alle gebieden voor crowdsourced rapportage).",
+          "contributor_mode": "Kies hoe je apparaat bijdraagt aan het Google-netwerk (standaard Alle gebieden voor crowdsourced rapportage, of alleen drukbezochte gebieden).",
           "subentry": "Sla deze opties op in de geselecteerde functiegroep. Zie [Subentries en functiegroepen]({subentries_docs_url}) voor voorbeelden."
         }
       },

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Apparaat",
         "state_attributes": {
           "device_name": {
             "name": "Apparaatnaam"

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Urządzenie",
         "state_attributes": {
           "device_name": {
             "name": "Nazwa urządzenia"

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -272,7 +272,7 @@
           "stale_threshold": "Po upływie tej liczby sekund bez aktualizacji lokalizacji, status trackera zmienia się na nieznany. Użyj encji 'Ostatnia lokalizacja', aby zawsze widzieć ostatnią znaną pozycję. Domyślnie: 1800 (30 minut).",
           "delete_caches_on_remove": "Usuwa buforowane tokeny i metadane urządzeń podczas usuwania tego wpisu.",
           "map_view_token_expiration": "Po włączeniu tokeny widoku mapy wygasają po 1 tygodniu. Po wyłączeniu (domyślnie) nie wygasają.",
-          "contributor_mode": "Wybierz, jak urządzenie współpracuje z siecią Google (domyślnie obszary o dużym ruchu lub Wszystkie obszary w trybie crowdsourcingu).",
+          "contributor_mode": "Wybierz, jak urządzenie współpracuje z siecią Google (domyślnie Wszystkie obszary w trybie crowdsourcingu lub tylko obszary o dużym ruchu).",
           "subentry": "Zapisz te opcje w wybranej grupie funkcji. Zobacz [Podpozycje i grupy funkcji]({subentries_docs_url}), aby poznać przykłady."
         }
       },

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -272,7 +272,7 @@
           "stale_threshold": "Após este número de segundos sem atualização de localização, o status do rastreador muda para desconhecido. Use a entidade 'Última localização' para ver sempre a última posição conhecida. Padrão: 1800 (30 minutos).",
           "delete_caches_on_remove": "Remova os tokens armazenados em cache e os metadados do dispositivo quando esta entrada for excluída.",
           "map_view_token_expiration": "Quando ativado, os tokens de visualização do mapa expiram após 1 semana. ",
-          "contributor_mode": "Escolha como seu dispositivo contribui para a rede do Google (áreas de alto tráfego por padrão ou todas as áreas para relatórios de crowdsourcing).",
+          "contributor_mode": "Escolha como seu dispositivo contribui para a rede do Google (todas as áreas por padrão para relatórios de crowdsourcing ou apenas áreas de alto tráfego).",
           "subentry": "Armazene essas opções no grupo de recursos selecionado. Consulte [Subentradas e grupos de recursos]({subentries_docs_url}) para exemplos."
         }
       },

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Dispositivo",
         "state_attributes": {
           "device_name": {
             "name": "Nome do dispositivo"

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -272,7 +272,7 @@
           "stale_threshold": "Após este número de segundos sem atualização de localização, o estado do rastreador muda para desconhecido. Use a entidade 'Última localização' para ver sempre a última posição conhecida. Predefinição: 1800 (30 minutos).",
           "delete_caches_on_remove": "Remova os tokens armazenados em cache e os metadados do dispositivo quando esta entrada for excluída.",
           "map_view_token_expiration": "Quando ativado, os tokens de visualização do mapa expiram após 1 semana. ",
-          "contributor_mode": "Escolha como seu dispositivo contribui para a rede do Google (áreas de alto tráfego por padrão ou todas as áreas para relatórios de crowdsourcing).",
+          "contributor_mode": "Escolha como seu dispositivo contribui para a rede do Google (todas as áreas por padrão para relatórios de crowdsourcing ou apenas áreas de alto tráfego).",
           "subentry": "Armazene essas opções no grupo de recursos selecionado. Consulte [Subentradas e grupos de recursos]({subentries_docs_url}) para exemplos."
         }
       },

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -500,7 +500,6 @@
     },
     "device_tracker": {
       "device": {
-        "name": "Dispositivo",
         "state_attributes": {
           "device_name": {
             "name": "Nome do dispositivo"

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -394,7 +394,10 @@ def test_push_updated_keeps_known_name_for_blank_snapshots(
     entity.entity_id = "device_tracker.googlefindmy_dev_1"
     entity._handle_coordinator_update()
 
-    assert entity._attr_name == "Pixel 9"
+    # With has_entity_name=True, _attr_name is None; the entity name is derived
+    # from the device registry. The coordinator cache preserves the display name.
+    assert entity._attr_name is None
+    assert entity._attr_has_entity_name is True
     assert entity.subentry_key == TRACKER_SUBENTRY_KEY
     assert subentry_identifier in entity.unique_id
 


### PR DESCRIPTION
[fix: correct contributor_mode default in all translation files](https://github.com/jleinenbach/GoogleFindMy-HA/commit/3edebc323b322da4ac41cf02605a2d8c22aca1ed) 

The description for contributor_mode incorrectly stated that "High-traffic
areas" is the default. The actual default from const.py is "in_all_areas"
(All areas). Updated all 9 translation files (de, en, es, fr, it, nl, pl,
pt-BR, pt) to reflect the correct default value.

https://claude.ai/code/session_012MaKPZBe61ozNnwEwfkRFQ
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 7 hours ago
[fix: adopt HA entity naming best practice for device_tracker entities](https://github.com/jleinenbach/GoogleFindMy-HA/commit/8c378d43138a56191d71e46be4c7ad91e0060c2b) 

Following Home Assistant's entity naming convention (has_entity_name=True):
- Primary tracker entity now inherits only the device name (e.g. "Galaxy S25 Ultra")
- Last Location entity appends translated suffix (e.g. "Galaxy S25 Ultra Last location")

Changes:
- Set _attr_has_entity_name=True for device tracker entities
- Set _attr_name=None for primary tracker (inherits device name only)
- Remove hardcoded name assignment in _handle_coordinator_update()
- Remove "name" key from device_tracker.device translation (all 10 files)
- Keep "name" key in device_tracker.last_location for suffix translation

This fixes the issue where both entities displayed the same name.

https://claude.ai/code/session_012MaKPZBe61ozNnwEwfkRFQ
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 12 minutes ago
[docs: add entity naming best practice to AGENTS.md](https://github.com/jleinenbach/GoogleFindMy-HA/commit/43d27362e43abb70c59c2c65b7e31635b8cac527) 

Documents the Home Assistant entity naming convention following the
official developer guide. Key points:
- has_entity_name=True required
- Primary entity: _attr_name=None (inherits device name only)
- Secondary entities: translation_key with name in translations
- Translation files: omit "name" for primary, include for secondary
- Never update _attr_name dynamically with has_entity_name=True

Reference: https://developers.home-assistant.io/blog/2022/07/10/entity_naming/

https://claude.ai/code/session_012MaKPZBe61ozNnwEwfkRFQ