### PR TITLE
fix: enable translation-based naming for Last Location entity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -764,6 +764,10 @@ artifacts remain exempt when explicitly flagged by repo configuration).
   - **Secondary entities** (additional features): use `translation_key` with a `name` in translations; HA auto-composes the friendly name as "Device Name + Translation" (e.g., "Galaxy S25 Ultra Last location").
   - **Translation files**: for the primary entity's `translation_key`, **omit** the `"name"` key entirely (presence of `"name"` would append a suffix); for secondary entities, **include** the `"name"` key with the suffix text.
   - Never set `_attr_name` dynamically at runtime (e.g., in coordinator update callbacks) when using `has_entity_name=True`—the device registry is the single source of truth for the device name.
+  - **CRITICAL: `_attr_name = None` vs. attribute not set** — These behave differently with `has_entity_name=True`:
+    - `_attr_name = None` (explicitly set) → entity inherits **only** the device name, no suffix
+    - `_attr_name` **not set** (attribute doesn't exist) → name comes from `translation_key`
+    - If a parent class sets `_attr_name = None` in `__init__()` and a child class needs the translation-based name, the child must **delete** the attribute after `super().__init__()`: `del self._attr_name`
 
 ### 11.8 Release & operations
 

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -1233,9 +1233,13 @@ class GoogleFindMyLastLocationTracker(GoogleFindMyDeviceTracker):
             f"{dev_id}:last_location",
         )
 
-        # With has_entity_name=True (inherited) and translation_key="last_location",
-        # the entity name is automatically composed as "<device_name> <translated_suffix>"
-        # e.g. "Galaxy S25 Ultra Last location". Do NOT override _attr_name here.
+        # CRITICAL: Remove the _attr_name = None that was set by the parent class.
+        # With has_entity_name=True:
+        #   - _attr_name = None → entity inherits ONLY device name (no suffix)
+        #   - _attr_name not set → name comes from translation_key ("last_location")
+        # We need the latter behavior so HA composes "<device_name> <translation_suffix>"
+        # e.g. "Galaxy S25 Ultra Letzter Standort"
+        del self._attr_name
 
     def _is_location_stale(self) -> bool:
         """Never stale - always show last known location."""


### PR DESCRIPTION
[fix: enable translation-based naming for Last Location entity](https://github.com/jleinenbach/GoogleFindMy-HA/commit/a81f8b62debe157bb070586765049f13ecbbb56d) 

The previous implementation set _attr_name = None for all device_tracker
entities. With has_entity_name=True:
  - _attr_name = None → entity inherits ONLY device name (no suffix)
  - _attr_name not set → name comes from translation_key

For the Last Location entity, we need the translation-based suffix
(e.g., "Letzter Standort" in German). By deleting _attr_name after
the parent's __init__, HA now correctly composes the name as
"<device_name> <translated_suffix>".

Before: "Galaxy S25 Ultra" (both entities had same name)
After:  "Galaxy S25 Ultra" and "Galaxy S25 Ultra Letzter Standort"

https://claude.ai/code/session_012MaKPZBe61ozNnwEwfkRFQ