### PR TITLE
fix: translate contributor_mode options and update stale_threshold de…

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,7 @@ Accessible via the ⚙️ cogwheel button on the main Google Find My Device Inte
 | `semantic_locations` | none | - | User-defined semantic location zones (managed via a dedicated options flow step). |
 | `delete_caches_on_remove` | true | toggle | Removes stored authentication caches when the integration is deleted. |
 | `contributor_mode` | in_all_areas | selection | Chooses whether Google shares aggregated network-only data (`high_traffic`) or participates in full crowdsourced reporting (`in_all_areas`). |
-| `stale_threshold` | 7200 | seconds | After this many seconds without a location update, the tracker state becomes `unknown`. |
-| `stale_threshold_enabled` | false | toggle | Enables the stale-threshold check that marks trackers as `unknown` after prolonged silence. |
+| `stale_threshold` | 1800 | seconds | After this many seconds (default: 30 minutes) without a location update, the tracker state becomes `unknown`. Use the "Last Location" entity to always see the last known position. |
 
 ### Google Home filter behavior
 

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -5414,10 +5414,21 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
             _register(vol.Optional(OPT_GOOGLE_HOME_FILTER_KEYWORDS), str)
         if OPT_ENABLE_STATS_ENTITIES is not None:
             _register(vol.Optional(OPT_ENABLE_STATS_ENTITIES), bool)
-        _register(
-            vol.Optional(OPT_CONTRIBUTOR_MODE),
-            vol.In([CONTRIBUTOR_MODE_HIGH_TRAFFIC, CONTRIBUTOR_MODE_IN_ALL_AREAS]),
-        )
+        if selector is not None:
+            _register(
+                vol.Optional(OPT_CONTRIBUTOR_MODE),
+                selector({
+                    "select": {
+                        "options": [CONTRIBUTOR_MODE_HIGH_TRAFFIC, CONTRIBUTOR_MODE_IN_ALL_AREAS],
+                        "translation_key": "contributor_mode",
+                    }
+                }),
+            )
+        else:
+            _register(
+                vol.Optional(OPT_CONTRIBUTOR_MODE),
+                vol.In([CONTRIBUTOR_MODE_HIGH_TRAFFIC, CONTRIBUTOR_MODE_IN_ALL_AREAS]),
+            )
         _register(
             vol.Optional(OPT_STALE_THRESHOLD),
             vol.All(vol.Coerce(int), vol.Range(min=300, max=86400)),

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -745,5 +745,13 @@
       "fcm": "FCM receiver",
       "fcm_lock_contention_count": "FCM lock contention count"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "High-traffic areas only",
+        "in_all_areas": "All areas (crowdsourcing)"
+      }
+    }
   }
 }

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -745,5 +745,13 @@
       "fcm": "FCM-Empfänger",
       "fcm_lock_contention_count": "FCM-Sperrkonflikte"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "Nur stark frequentierte Bereiche",
+        "in_all_areas": "Alle Bereiche (Crowdsourcing)"
+      }
+    }
   }
 }

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -745,5 +745,13 @@
       "fcm": "FCM receiver",
       "fcm_lock_contention_count": "FCM lock contention count"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "High-traffic areas only",
+        "in_all_areas": "All areas (crowdsourcing)"
+      }
+    }
   }
 }

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -745,5 +745,13 @@
       "fcm": "Receptor FCM",
       "fcm_lock_contention_count": "Conteo de contención de bloqueo FCM"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "Solo áreas de alto tráfico",
+        "in_all_areas": "Todas las áreas (crowdsourcing)"
+      }
+    }
   }
 }

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -745,5 +745,13 @@
       "fcm": "Récepteur FCM",
       "fcm_lock_contention_count": "Nombre de contentions du verrou FCM"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "Zones à fort trafic uniquement",
+        "in_all_areas": "Toutes les zones (crowdsourcing)"
+      }
+    }
   }
 }

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -745,5 +745,13 @@
       "fcm": "Ricevitore FCM",
       "fcm_lock_contention_count": "Conteggio conflitti di lock FCM"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "Solo aree ad alto traffico",
+        "in_all_areas": "Tutte le aree (crowdsourcing)"
+      }
+    }
   }
 }

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -745,5 +745,13 @@
       "fcm": "FCM-ontvanger",
       "fcm_lock_contention_count": "FCM lock-contentieteller"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "Alleen drukke gebieden",
+        "in_all_areas": "Alle gebieden (crowdsourcing)"
+      }
+    }
   }
 }

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -745,5 +745,13 @@
       "fcm": "Odbiornik FCM",
       "fcm_lock_contention_count": "Liczba konfliktów blokady FCM"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "Tylko obszary o dużym ruchu",
+        "in_all_areas": "Wszystkie obszary (crowdsourcing)"
+      }
+    }
   }
 }

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -745,5 +745,13 @@
       "fcm": "Receptor FCM",
       "fcm_lock_contention_count": "Contagem de contenção de bloqueio do FCM"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "Apenas áreas de alto tráfego",
+        "in_all_areas": "Todas as áreas (crowdsourcing)"
+      }
+    }
   }
 }

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -745,5 +745,13 @@
       "fcm": "Receptor FCM",
       "fcm_lock_contention_count": "Contagem de contenção de bloqueio do FCM"
     }
+  },
+  "selector": {
+    "contributor_mode": {
+      "options": {
+        "high_traffic": "Apenas áreas de alto tráfego",
+        "in_all_areas": "Todas as áreas (crowdsourcing)"
+      }
+    }
   }
 }


### PR DESCRIPTION
…fault

- Add translated labels for contributor_mode selector options in all supported languages (high_traffic → localized, in_all_areas → localized)
- Use SelectSelector with translation_key for proper HA Core translation
- Fix README.md: stale_threshold default is 1800s (30min), not 7200s (2h)
- Remove obsolete stale_threshold_enabled option from documentation (stale threshold is now always enabled with the Last Location entity)

https://claude.ai/code/session_016Vcayg9k3z176uoEW2XyFe

