### PR TITLE
fix: resolve all mypy --strict errors

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -8476,4 +8476,5 @@ async def async_get_local_ip(hass: HomeAssistant) -> str:
     Delegates the blocking socket call to the HA executor so the event loop is
     never stalled by DNS resolution or network timeouts.
     """
-    return await hass.async_add_executor_job(_get_local_ip_sync)
+    result: str = await hass.async_add_executor_job(_get_local_ip_sync)
+    return result

--- a/custom_components/googlefindmy/agents/typing_guidance/AGENTS.md
+++ b/custom_components/googlefindmy/agents/typing_guidance/AGENTS.md
@@ -50,6 +50,114 @@ except ImportError:  # Pre-2025.5 HA builds do not expose the helper.
 
 The dynamically created fallback must inherit from an existing Home Assistant error (usually `HomeAssistantError`) and be assigned immediately after the guarded import so downstream modules can reference the shared symbol without additional `# type: ignore` comments. Prefer short inline comments that state which Home Assistant versions lack the helper so future contributors know when the guard can be removed.
 
+## Coordinator mixin typing — `_MixinBase` pattern
+
+The coordinator uses a **mixin composition pattern**: six Operations classes
+(`RegistryOperations`, `SubentryOperations`, `LocateOperations`,
+`IdentityOperations`, `PollingOperations`, `CacheOperations`) are composed into
+the final `GoogleFindMyCoordinator` via multiple inheritance.
+
+### Problem
+
+Mypy cannot resolve cross-mixin attribute and method references (e.g.
+`self.hass`, `self.config_entry`, or a call from `PollingOperations` into a
+`CacheOperations` method) because each mixin class does not individually
+inherit from the coordinator or `DataUpdateCoordinator`.
+
+The earlier workaround — annotating `self: GoogleFindMyCoordinator` on every
+mixin method — is rejected by mypy `--strict` with `[misc]` errors because
+`GoogleFindMyCoordinator` is a *subtype* (child) of each mixin, not a
+*supertype* (parent), violating mypy's requirement that the self-type
+annotation must be a supertype of the enclosing class.
+
+### Solution
+
+`coordinator/_mixin_typing.py` defines `_MixinBase`, a **type-declaration-only
+base class** that declares the union of all attributes and method signatures
+from `DataUpdateCoordinator`, `GoogleFindMyCoordinator.__init__`, and every
+cross-mixin method. All six mixin classes inherit from `_MixinBase`:
+
+```python
+from ._mixin_typing import _MixinBase
+
+class RegistryOperations(_MixinBase):
+    ...
+```
+
+At runtime `_MixinBase` is essentially empty: attribute annotations create no
+instance state, and method stubs raise `NotImplementedError` (immediately
+shadowed by the real implementations in the composed class hierarchy). Mypy,
+however, gains full visibility into the coordinator interface when type-checking
+any mixin.
+
+### Maintenance rules
+
+* When adding a **new attribute** to `GoogleFindMyCoordinator.__init__`, add a
+  matching annotation to `_MixinBase`.
+* When adding a **new method** that is called across mixin boundaries, add a
+  stub to `_MixinBase` with the same signature and `raise NotImplementedError`.
+* Keep `_MixinBase` free of any runtime logic — it exists purely for static
+  analysis.
+
+## Explicit re-export pattern
+
+Under `mypy --strict` (specifically `no_implicit_reexport`), a bare
+`from .module import x` is **not** considered a public re-export. Modules that
+re-export symbols for use by other packages must use the explicit form:
+
+```python
+from .shared_helpers import (
+    known_ids_for_subentry_type as known_ids_for_subentry_type,
+    normalize_fcm_entry_snapshot as normalize_fcm_entry_snapshot,
+)
+```
+
+The `as x` suffix signals to mypy that the import is intentionally public.
+Without it, downstream imports trigger `[attr-defined]` errors.
+
+## `cast()` for Home Assistant API returns
+
+Because `pyproject.toml` sets `follow_imports = "skip"` for all `homeassistant`
+modules, every HA API call returns `Any` from mypy's perspective. When
+`warn_return_any` is active (included in `--strict`), returning such values
+from typed functions triggers `[no-any-return]`. Use `cast()` to assert the
+expected type:
+
+```python
+from typing import cast
+
+result: str = await hass.async_add_executor_job(_get_local_ip_sync)
+return result
+```
+
+Or for optional lookups:
+
+```python
+return cast("GoogleFindMyEIDResolver | None", domain_data.get(DATA_EID_RESOLVER))
+```
+
+Prefer `cast()` over `# type: ignore[no-any-return]` so the expected type is
+documented and future regressions are caught if the return type changes.
+
+## Exception variable scoping
+
+Python 3 deletes exception variables after the `except` block exits. Do not
+reuse the same variable name for a manually constructed exception within the
+same scope:
+
+```python
+# BAD — auth_exc is deleted after the except block
+except ConfigEntryAuthFailed as auth_exc:
+    ...
+auth_exc = ConfigEntryAuthFailed("manual reason")  # NameError at runtime
+
+# GOOD — use a different name
+except ConfigEntryAuthFailed as auth_exc:
+    ...
+reauth_exc = ConfigEntryAuthFailed("manual reason")
+```
+
 ## Cross-reference checklist
 
+* [`coordinator/_mixin_typing.py`](../../coordinator/_mixin_typing.py) — Canonical `_MixinBase` type-declaration base for coordinator mixins.
 * [`docs/CONFIG_SUBENTRIES_HANDBOOK.md`](../../../docs/CONFIG_SUBENTRIES_HANDBOOK.md) — Documents where these strict-mypy fallbacks are applied in the runtime, including the new subentry cross-link list. Keep the handbook and this guide synchronized whenever typing guards or iterator requirements change.

--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Iterable, Mapping
 from datetime import UTC, datetime
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -70,6 +70,9 @@ from .entity import (
     subentry_type as _subentry_type,
 )
 from .ha_typing import BinarySensorEntity, callback
+
+if TYPE_CHECKING:
+    from .eid_resolver import GoogleFindMyEIDResolver
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -312,12 +315,12 @@ async def async_setup_entry(  # noqa: PLR0915
     processed_tracker_identifiers: set[str] = set()
     known_uwt_ids: set[str] = set()
 
-    def _get_ble_resolver() -> Any:
+    def _get_ble_resolver() -> GoogleFindMyEIDResolver | None:
         """Return the EID resolver from hass.data, or None."""
         domain_data = hass.data.get(DOMAIN)
         if not isinstance(domain_data, dict):
             return None
-        return domain_data.get(DATA_EID_RESOLVER)
+        return cast("GoogleFindMyEIDResolver | None", domain_data.get(DATA_EID_RESOLVER))
 
     def _add_tracker_scope(  # noqa: PLR0915
         tracker_key: str,
@@ -957,18 +960,18 @@ class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
             separator="_",
         )
 
-    def _get_resolver(self) -> Any:
+    def _get_resolver(self) -> GoogleFindMyEIDResolver | None:
         """Return the EID resolver from hass.data, or None."""
         domain_data = self.hass.data.get(DOMAIN)
         if not isinstance(domain_data, dict):
             return None
-        return domain_data.get(DATA_EID_RESOLVER)
+        return cast("GoogleFindMyEIDResolver | None", domain_data.get(DATA_EID_RESOLVER))
 
     @property
     def is_on(self) -> bool | None:
         """Return True when UWT / separated state is active."""
         resolver = self._get_resolver()
-        if resolver is None:
+        if resolver is None or self._device_id is None:
             return None
         state = resolver.get_ble_battery_state(self._device_id)
         if state is None:
@@ -988,7 +991,7 @@ class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
         if not self.coordinator_has_device():
             return False
         try:
-            if hasattr(self.coordinator, "is_device_present"):
+            if self._device_id is not None and hasattr(self.coordinator, "is_device_present"):
                 return bool(self.coordinator.is_device_present(self._device_id))
         except Exception:
             pass
@@ -998,7 +1001,7 @@ class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return diagnostic attributes (excluded from recorder)."""
         resolver = self._get_resolver()
-        if resolver is None:
+        if resolver is None or self._device_id is None:
             return None
         state = resolver.get_ble_battery_state(self._device_id)
         if state is None:

--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -3,6 +3,16 @@
 This package contains the GoogleFindMyCoordinator class and related components.
 All public symbols are re-exported here for backwards compatibility.
 
+Architecture:
+    The coordinator uses a mixin composition pattern.  Six Operations classes
+    (RegistryOperations, SubentryOperations, LocateOperations,
+    IdentityOperations, PollingOperations, CacheOperations) are composed into
+    GoogleFindMyCoordinator via multiple inheritance.
+
+    All mixins inherit from ``_MixinBase`` (defined in ``_mixin_typing.py``),
+    a type-declaration-only base class that gives mypy visibility into the full
+    coordinator interface without introducing runtime overhead.
+
 Usage (unchanged):
     from .coordinator import GoogleFindMyCoordinator
 """
@@ -30,7 +40,7 @@ from .helpers.stats import (
     StatusSnapshot,
 )
 
-# Operations classes - currently empty, will be filled in Phases 2-6
+# Operations mixin classes (all inherit from _MixinBase for strict typing)
 from .identity import IdentityOperations
 from .locate import LocateOperations
 

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -1,0 +1,378 @@
+"""Typing-only base class for coordinator mixin modules.
+
+This module defines ``_MixinBase`` — a class whose **sole purpose** is to provide
+attribute and method type declarations so that mypy has visibility into the full
+``GoogleFindMyCoordinator`` interface when type-checking mixin classes
+(``RegistryOperations``, ``SubentryOperations``, etc.).
+
+At **runtime** the class is essentially empty:
+- Attribute annotations (without assignment) are stored in ``__annotations__``
+  but create no instance state.
+- Method stubs raise ``NotImplementedError``; they are overridden by the real
+  implementations provided by the mixin classes or the main coordinator.
+
+Why this is needed:
+- The mixin pattern relies on each Operations class being composed into the
+  final ``GoogleFindMyCoordinator`` via multiple inheritance.
+- Without explicit ``self: GoogleFindMyCoordinator`` annotations (which mypy
+  rejects because the coordinator is a *sub*type, not a *super*type of each
+  mixin), mypy cannot see attributes and methods defined on sibling mixins
+  or on the ``DataUpdateCoordinator`` base.
+- This class bridges the gap by declaring the union of all relevant attributes
+  so that ``self.hass``, ``self.config_entry``, cross-mixin method calls, etc.
+  resolve correctly during static analysis.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import device_registry as dr
+
+    from ..api import GoogleFindMyAPI
+    from .subentry import SubentryMetadata
+
+
+class _MixinBase:
+    """Type-declaration-only base for coordinator mixin classes.
+
+    All mixins (``RegistryOperations``, ``SubentryOperations``, …) inherit
+    from this class to gain visibility into the full coordinator interface
+    during mypy analysis.  At runtime the stubs below are immediately
+    shadowed by the real implementations in the composed class hierarchy.
+    """
+
+    # ------------------------------------------------------------------
+    # Attributes from DataUpdateCoordinator / HomeAssistant
+    # ------------------------------------------------------------------
+    hass: HomeAssistant
+    config_entry: ConfigEntry | None
+    data: list[dict[str, Any]]
+
+    # ------------------------------------------------------------------
+    # Attributes from GoogleFindMyCoordinator.__init__
+    # ------------------------------------------------------------------
+    api: GoogleFindMyAPI
+    location_poll_interval: int
+    device_poll_delay: int
+    min_poll_interval: int
+    allow_history_fallback: bool
+
+    # Internal caches
+    _device_location_data: dict[str, dict[str, Any]]
+    _device_caps: dict[str, dict[str, Any]]
+    _present_last_seen: dict[str, float]
+    _poll_lock: asyncio.Lock
+    _push_cooldown_until: float
+    _locate_inflight: set[str]
+    _locate_cooldown_until: dict[str, float]
+    _device_action_locks: dict[str, asyncio.Lock]
+    _sound_request_uuids: dict[str, str]
+    _device_poll_cooldown_until: dict[str, float]
+    _enabled_poll_device_ids: set[str]
+    _devices_with_entry: set[str]
+    _identity_key_to_devices: dict[bytes, set[str]]
+    _subentry_metadata: dict[str, SubentryMetadata]
+    _default_subentry_key_value: str
+
+    # Polling state
+    _consecutive_timeouts: int
+    _last_poll_result: str | None
+    _last_device_list: list[dict[str, Any]]
+    _empty_list_streak: int
+    _last_list_poll_mono: float
+    _last_nonempty_wall: float
+    _force_device_list_refresh: bool
+    _initial_discovery_done: bool
+    _fcm_defer_started_mono: float
+    _consecutive_transient_auth_failures: int
+    _last_transient_auth_error: str | None
+
+    # Diagnostics / statistics
+    stats: dict[str, int]
+    performance_metrics: dict[str, float]
+    _propagating_location: bool
+
+    # Service device tracking
+    _service_device_ready: bool
+    _service_device_id: str | None
+
+    # ------------------------------------------------------------------
+    # Methods from DataUpdateCoordinator
+    # ------------------------------------------------------------------
+    def async_set_updated_data(self, data: list[dict[str, Any]]) -> None:
+        raise NotImplementedError
+
+    async def async_request_refresh(self) -> None:
+        raise NotImplementedError
+
+    def async_set_update_error(self, error: Exception) -> None:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Methods from GoogleFindMyCoordinator (main.py)
+    # ------------------------------------------------------------------
+    def increment_stat(self, stat_name: str) -> None:
+        raise NotImplementedError
+
+    def push_updated(
+        self,
+        device_ids: list[str] | None = None,
+        *,
+        reset_baseline: bool = True,
+    ) -> None:
+        raise NotImplementedError
+
+    def get_device_display_name(self, device_id: str) -> str | None:
+        raise NotImplementedError
+
+    def note_error(
+        self, exc: Exception, *, where: str = "", device: str | None = None
+    ) -> None:
+        raise NotImplementedError
+
+    def safe_update_metric(self, key: str, value: float) -> None:
+        raise NotImplementedError
+
+    def get_metric(self, key: str) -> float | None:
+        raise NotImplementedError
+
+    def is_ignored(self, device_id: str) -> bool:
+        raise NotImplementedError
+
+    def _get_ignored_set(self) -> set[str]:
+        raise NotImplementedError
+
+    def _get_google_home_filter(self) -> Any:
+        raise NotImplementedError
+
+    def _set_auth_state(
+        self, *, failed: bool, reason: str | None = None
+    ) -> None:
+        raise NotImplementedError
+
+    def _short_error_message(self, exc: Exception | str) -> str:
+        raise NotImplementedError
+
+    def _get_duration(self, start_key: str, end_key: str) -> float | None:
+        raise NotImplementedError
+
+    def _record_semantic_label(
+        self, payload: Mapping[str, Any], *, device_id: str | None = None
+    ) -> None:
+        raise NotImplementedError
+
+    def _apply_semantic_mapping(self, payload: dict[str, Any]) -> bool:
+        raise NotImplementedError
+
+    def _should_preserve_precise_home_coordinates(
+        self,
+        prev_location: Mapping[str, Any] | None,
+        replacement_attrs: Mapping[str, Any],
+    ) -> bool:
+        raise NotImplementedError
+
+    async def _async_save_sound_uuids(self) -> None:
+        raise NotImplementedError
+
+    async def _async_build_device_snapshot_with_fallbacks(
+        self, devices: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def _build_snapshot_from_cache(
+        self, devices: list[dict[str, Any]], wall_now: float
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def is_device_present(self, device_id: str) -> bool:
+        raise NotImplementedError
+
+    def get_device_last_seen(self, device_id: str) -> datetime | None:
+        raise NotImplementedError
+
+    def _api_push_ready(self) -> bool:
+        raise NotImplementedError
+
+    # Static methods exposed as instance methods in mixins
+    @staticmethod
+    def _normalize_identity_key(raw: object) -> bytes | None:
+        raise NotImplementedError
+
+    @staticmethod
+    def _normalize_identity_key_candidates(raw: object) -> list[bytes]:
+        raise NotImplementedError
+
+    @staticmethod
+    def _normalize_optional_string(raw: object) -> str | None:
+        raise NotImplementedError
+
+    @staticmethod
+    def _normalize_encrypted_blob(raw: object) -> bytes | None:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Cross-mixin methods: RegistryOperations
+    # ------------------------------------------------------------------
+    def _entry_id(self) -> str | None:
+        raise NotImplementedError
+
+    def _config_entry_exists(self, entry_id: str | None = None) -> bool:
+        raise NotImplementedError
+
+    def _reindex_poll_targets_from_device_registry(self) -> None:
+        raise NotImplementedError
+
+    def _extract_our_identifier(
+        self, device: dr.DeviceEntry
+    ) -> str | None:
+        raise NotImplementedError
+
+    def _ensure_service_device_exists(
+        self, entry: ConfigEntry | None = None
+    ) -> None:
+        raise NotImplementedError
+
+    def _ensure_device_name_cache(self) -> dict[str, str]:
+        raise NotImplementedError
+
+    def _ensure_registry_for_devices(
+        self,
+        devices: list[dict[str, Any]],
+        ignored: set[str],
+    ) -> int:
+        raise NotImplementedError
+
+    def _sync_owner_index(
+        self, devices: list[dict[str, Any]] | None
+    ) -> None:
+        raise NotImplementedError
+
+    def _find_tracker_entity_entry(self, device_id: str) -> Any:
+        raise NotImplementedError
+
+    def _redact_text(self, text: str | None) -> str:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Cross-mixin methods: SubentryOperations
+    # ------------------------------------------------------------------
+    def _refresh_subentry_index(
+        self,
+        visible_devices: Sequence[Mapping[str, Any]] | None = None,
+        *,
+        skip_manager_update: bool = False,
+        skip_repair: bool = False,
+    ) -> None:
+        raise NotImplementedError
+
+    def _store_subentry_snapshots(
+        self, snapshot: Sequence[Mapping[str, Any]]
+    ) -> None:
+        raise NotImplementedError
+
+    def get_subentry_snapshot(
+        self,
+        key: str | None = None,
+        *,
+        feature: str | None = None,
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Cross-mixin methods: PollingOperations
+    # ------------------------------------------------------------------
+    def _is_on_hass_loop(self) -> bool:
+        raise NotImplementedError
+
+    def _run_on_hass_loop(
+        self, func: Callable[..., None], *args: Any, **kwargs: Any
+    ) -> None:
+        raise NotImplementedError
+
+    def _apply_report_type_cooldown(
+        self, device_id: str, report_hint: str | None
+    ) -> None:
+        raise NotImplementedError
+
+    def _note_push_transport_problem(self, cooldown_s: int = 90) -> None:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Cross-mixin methods: IdentityOperations
+    # ------------------------------------------------------------------
+    def _schedule_eid_resolver_refresh(self) -> None:
+        raise NotImplementedError
+
+    def _register_identity_key(
+        self, device_id: str, identity_key: bytes
+    ) -> None:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Cross-mixin methods: LocateOperations
+    # ------------------------------------------------------------------
+    def _normalize_coords(
+        self,
+        payload: dict[str, Any],
+        *,
+        device_label: str | None = None,
+        warn_on_invalid: bool = True,
+    ) -> bool:
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Cross-mixin methods: CacheOperations
+    # ------------------------------------------------------------------
+    def get_device_location_data(
+        self, device_id: str
+    ) -> dict[str, Any] | None:
+        raise NotImplementedError
+
+    def update_device_cache(
+        self,
+        device_id: str,
+        payload: dict[str, Any],
+        *,
+        source: str = "poll",
+    ) -> None:
+        raise NotImplementedError
+
+    def _apply_weighted_location_fusion(
+        self,
+        device_id: str,
+        new_data: dict[str, Any],
+    ) -> bool:
+        raise NotImplementedError
+
+    def _merge_with_existing_cache_row(
+        self,
+        device_id: str,
+        new_row: dict[str, Any],
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _persist_anchor_metadata(
+        self,
+        device_id: str,
+        payload: dict[str, Any],
+        *,
+        clear_metadata_only: bool = False,
+    ) -> None:
+        raise NotImplementedError
+
+    def seed_device_last_seen(
+        self, device_id: str, ts: float
+    ) -> None:
+        raise NotImplementedError
+
+    def prime_device_location_cache(
+        self, device_id: str, data: dict[str, Any]
+    ) -> None:
+        raise NotImplementedError

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -21,7 +21,7 @@ import math
 import time
 from collections import deque
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ..const import DATA_EID_RESOLVER, DOMAIN
 from .helpers.cache import (
@@ -118,11 +118,10 @@ def _normalize_metadata_keys(data: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
-if TYPE_CHECKING:
-    from .main import GoogleFindMyCoordinator
+from ._mixin_typing import _MixinBase
 
 
-class CacheOperations:
+class CacheOperations(_MixinBase):
     """Cache operations mixin for GoogleFindMyCoordinator.
 
     This class contains methods that manage the device location cache,
@@ -130,7 +129,7 @@ class CacheOperations:
     """
 
     def get_device_location_data(
-        self: GoogleFindMyCoordinator, device_id: str
+        self, device_id: str
     ) -> dict[str, Any] | None:
         """Return the cached location data for a single device (copy)."""
         raw = self._device_location_data.get(device_id)
@@ -139,7 +138,7 @@ class CacheOperations:
         return dict(raw)
 
     def prime_device_location_cache(
-        self: GoogleFindMyCoordinator, device_id: str, data: dict[str, Any]
+        self, device_id: str, data: dict[str, Any]
     ) -> None:
         """Prime the internal location cache with externally-provided data.
 
@@ -156,13 +155,13 @@ class CacheOperations:
             self._device_location_data[device_id] = dict(data)
 
     def seed_device_last_seen(
-        self: GoogleFindMyCoordinator, device_id: str, timestamp: float
+        self, device_id: str, timestamp: float
     ) -> None:
         """Seed a device's last-seen timestamp for cache initialization."""
         self._present_last_seen[device_id] = timestamp
 
     def _track_device_interval(
-        self: GoogleFindMyCoordinator, device_id: str, last_seen: float | None
+        self, device_id: str, last_seen: float | None
     ) -> None:
         """Track last_seen history to predict future poll targets."""
         if last_seen is None:
@@ -179,7 +178,7 @@ class CacheOperations:
             history.append(last_seen)
 
     def _persist_anchor_metadata(
-        self: GoogleFindMyCoordinator,
+        self,
         device_id: str,
         payload: dict[str, Any],
         *,
@@ -263,7 +262,7 @@ class CacheOperations:
                     hass_obj.async_create_task(refresh_coro())
 
     def update_device_cache(
-        self: GoogleFindMyCoordinator,
+        self,
         device_id: str,
         location_data: dict[str, Any],
         *,
@@ -508,7 +507,7 @@ class CacheOperations:
                 schedule_fn()
 
     def _propagate_location_to_shared_devices(
-        self: GoogleFindMyCoordinator,
+        self,
         source_device_id: str,
         location: dict[str, Any],
     ) -> None:
@@ -587,7 +586,7 @@ class CacheOperations:
             )
 
     def _is_significant_update(
-        self: GoogleFindMyCoordinator,
+        self,
         device_id: str,
         new_data: dict[str, Any],
     ) -> bool:
@@ -703,7 +702,7 @@ class CacheOperations:
         return True
 
     def _merge_with_existing_cache_row(
-        self: GoogleFindMyCoordinator,
+        self,
         device_id: str,
         incoming: dict[str, Any],
     ) -> dict[str, Any]:
@@ -732,7 +731,7 @@ class CacheOperations:
         return merged
 
     def _haversine_distance(
-        self: GoogleFindMyCoordinator,
+        self,
         lat1: float,
         lon1: float,
         lat2: float,
@@ -742,7 +741,7 @@ class CacheOperations:
         return _haversine_distance_impl(lat1, lon1, lat2, lon2)
 
     def _apply_weighted_location_fusion(
-        self: GoogleFindMyCoordinator,
+        self,
         device_id: str,
         new_data: dict[str, Any],
     ) -> bool:

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -24,6 +24,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from ..const import DATA_EID_RESOLVER, DOMAIN
+from ._mixin_typing import _MixinBase
 from .helpers.cache import (
     merge_cache_row as _merge_cache_row_impl,
 )
@@ -116,9 +117,6 @@ def _normalize_metadata_keys(data: dict[str, Any]) -> dict[str, Any]:
         if normalized_key not in result:
             result[normalized_key] = value
     return result
-
-
-from ._mixin_typing import _MixinBase
 
 
 class CacheOperations(_MixinBase):

--- a/custom_components/googlefindmy/coordinator/identity.py
+++ b/custom_components/googlefindmy/coordinator/identity.py
@@ -29,6 +29,7 @@ from ..const import (
     issue_id_for,
 )
 from ..KeyBackup.cloud_key_decryptor import decrypt_eik
+from ._mixin_typing import _MixinBase
 from .helpers.identity import (
     extract_pair_date as _extract_pair_date_impl,
 )
@@ -59,9 +60,6 @@ if TYPE_CHECKING:
     from .main import DeviceIdentity
 
 _LOGGER = logging.getLogger(__name__)
-
-
-from ._mixin_typing import _MixinBase
 
 
 class IdentityOperations(_MixinBase):

--- a/custom_components/googlefindmy/coordinator/identity.py
+++ b/custom_components/googlefindmy/coordinator/identity.py
@@ -56,19 +56,22 @@ from .helpers.identity import (
 from .helpers.subentry import normalize_epoch_seconds
 
 if TYPE_CHECKING:
-    from .main import DeviceIdentity, GoogleFindMyCoordinator
+    from .main import DeviceIdentity
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class IdentityOperations:
+from ._mixin_typing import _MixinBase
+
+
+class IdentityOperations(_MixinBase):
     """Identity operations mixin for GoogleFindMyCoordinator.
 
     This class contains methods that manage device identities,
     including identity key registration and account information.
     """
 
-    def _get_account_email(self: GoogleFindMyCoordinator) -> str:
+    def _get_account_email(self) -> str:
         """Return the configured Google account email for this entry (empty if unknown)."""
         entry = self.config_entry
         if entry is not None:
@@ -77,7 +80,7 @@ class IdentityOperations:
                 return email_value
         return ""
 
-    def _create_auth_issue(self: GoogleFindMyCoordinator) -> None:
+    def _create_auth_issue(self) -> None:
         """Create (idempotent) a Repairs issue for an authentication problem.
 
         Uses:
@@ -104,7 +107,7 @@ class IdentityOperations:
         except Exception as err:
             _LOGGER.debug("Failed to create Repairs issue: %s", err)
 
-    def _dismiss_auth_issue(self: GoogleFindMyCoordinator) -> bool:
+    def _dismiss_auth_issue(self) -> bool:
         """Dismiss (idempotently) the Repairs issue if present.
 
         Returns True when an issue existed and was removed, False otherwise.
@@ -135,7 +138,7 @@ class IdentityOperations:
 
         return issue_present
 
-    def _schedule_eid_resolver_refresh(self: GoogleFindMyCoordinator) -> None:
+    def _schedule_eid_resolver_refresh(self) -> None:
         """Refresh the global EID resolver when active device sets change."""
 
         hass = getattr(self, "hass", None)
@@ -155,7 +158,7 @@ class IdentityOperations:
                 create_task(refresh())
 
     def _register_identity_key(
-        self: GoogleFindMyCoordinator, device_id: str, identity_key: bytes
+        self, device_id: str, identity_key: bytes
     ) -> None:
         """Register a device's identity_key for shared tracker detection.
 
@@ -180,7 +183,7 @@ class IdentityOperations:
                     sorted(device_set),
                 )
 
-    def _reset_resolver_offset(self: GoogleFindMyCoordinator, device_id: str) -> None:
+    def _reset_resolver_offset(self, device_id: str) -> None:
         """Clear resolver offsets using registry IDs when identity keys rotate."""
 
         hass = getattr(self, "hass", None)
@@ -229,7 +232,7 @@ class IdentityOperations:
             reset(registry_id)
 
     def get_active_device_identities(
-        self: GoogleFindMyCoordinator,
+        self,
     ) -> list[DeviceIdentity]:
         """Return identity keys for enabled, non-ignored devices.
 

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -19,7 +19,7 @@ import logging
 import math
 import time
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from aiohttp import ClientConnectionError, ClientError
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
@@ -35,9 +35,6 @@ from ..NovaApi.nova_request import (
 from ..SpotApi.spot_request import SpotAuthPermanentError
 from .helpers.geo import MIN_PHYSICAL_ACCURACY_M
 
-if TYPE_CHECKING:
-    from .main import GoogleFindMyCoordinator
-
 _LOGGER = logging.getLogger(__name__)
 
 # Cooldown guardrails for owner purge window
@@ -50,7 +47,10 @@ def _clamp(value: float, min_val: float, max_val: float) -> float:
     return max(min_val, min(max_val, value))
 
 
-class LocateOperations:
+from ._mixin_typing import _MixinBase
+
+
+class LocateOperations(_MixinBase):
     """Locate operations mixin for GoogleFindMyCoordinator.
 
     This class contains methods that handle device location requests,
@@ -61,7 +61,7 @@ class LocateOperations:
     _is_polling: bool
 
     def _normalize_coords(
-        self: GoogleFindMyCoordinator,
+        self,
         payload: dict[str, Any],
         *,
         device_label: str | None = None,
@@ -140,7 +140,7 @@ class LocateOperations:
 
         return True
 
-    def can_play_sound(self: GoogleFindMyCoordinator, device_id: str) -> bool:
+    def can_play_sound(self, device_id: str) -> bool:
         """Return True if 'Play Sound' should be enabled for the device.
 
         **No network in availability path.**
@@ -197,7 +197,7 @@ class LocateOperations:
         return True
 
     # ---------------------------- Public control / Locate gating ------------
-    def _get_device_lock(self: GoogleFindMyCoordinator, device_id: str) -> asyncio.Lock:
+    def _get_device_lock(self, device_id: str) -> asyncio.Lock:
         """Get or create a lock for a specific device.
 
         This prevents race conditions when multiple concurrent locate requests
@@ -207,7 +207,7 @@ class LocateOperations:
             self._device_action_locks[device_id] = asyncio.Lock()
         return self._device_action_locks[device_id]
 
-    def can_request_location(self: GoogleFindMyCoordinator, device_id: str) -> bool:
+    def can_request_location(self, device_id: str) -> bool:
         """Return True if a manual 'Locate now' request is currently allowed.
 
         Gate conditions:
@@ -237,7 +237,7 @@ class LocateOperations:
 
     # ---------------------------- Passthrough API ---------------------------
     async def async_locate_device(
-        self: GoogleFindMyCoordinator, device_id: str
+        self, device_id: str
     ) -> dict[str, Any]:
         """Locate a device using the native async API (no executor).
 
@@ -572,7 +572,7 @@ class LocateOperations:
                 # Push an update so buttons/entities can refresh availability
                 self.async_set_updated_data(self.data)
 
-    async def async_play_sound(self: GoogleFindMyCoordinator, device_id: str) -> bool:
+    async def async_play_sound(self, device_id: str) -> bool:
         """Play sound on a device using the native async API (no executor).
 
         Guard with can_play_sound(); on failure, start a short cooldown to avoid repeated errors.
@@ -640,7 +640,7 @@ class LocateOperations:
             return False
 
     async def async_stop_sound(
-        self: GoogleFindMyCoordinator,
+        self,
         device_id: str,
         request_uuid: str | None = None,
     ) -> bool:

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -33,6 +33,7 @@ from ..NovaApi.nova_request import (
     NovaRateLimitError,
 )
 from ..SpotApi.spot_request import SpotAuthPermanentError
+from ._mixin_typing import _MixinBase
 from .helpers.geo import MIN_PHYSICAL_ACCURACY_M
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,9 +46,6 @@ _COOLDOWN_OWNER_MAX_S = 600.0
 def _clamp(value: float, min_val: float, max_val: float) -> float:
     """Clamp a value between min and max."""
     return max(min_val, min(max_val, value))
-
-
-from ._mixin_typing import _MixinBase
 
 
 class LocateOperations(_MixinBase):

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -55,6 +55,7 @@ from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
     SpotApiEmptyResponseError,
 )
 from ..SpotApi.spot_request import SpotAuthPermanentError
+from ._mixin_typing import _MixinBase
 from .helpers.cache import sanitize_decoder_row as _sanitize_decoder_row
 from .helpers.stats import ApiStatus, FcmStatus, StatusSnapshot
 from .helpers.subentry import normalize_epoch_seconds as _normalize_epoch_seconds
@@ -97,9 +98,6 @@ _PUSH_NOT_READY_TIMEOUT_S = 15
 
 # Predictive polling buffer to avoid requesting data before it is available server-side
 _PREDICTION_BUFFER_S = 45
-
-
-from ._mixin_typing import _MixinBase
 
 
 class PollingOperations(_MixinBase):

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -38,7 +38,7 @@ import time
 from collections.abc import Callable, Mapping
 from datetime import datetime
 from statistics import mean, stdev
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntryAuthFailed
 from homeassistant.core import Event
@@ -98,11 +98,11 @@ _PUSH_NOT_READY_TIMEOUT_S = 15
 # Predictive polling buffer to avoid requesting data before it is available server-side
 _PREDICTION_BUFFER_S = 45
 
-if TYPE_CHECKING:
-    from .main import GoogleFindMyCoordinator
+
+from ._mixin_typing import _MixinBase
 
 
-class PollingOperations:
+class PollingOperations(_MixinBase):
     """Polling operations mixin for GoogleFindMyCoordinator.
 
     This class contains methods that manage the polling lifecycle,
@@ -126,7 +126,7 @@ class PollingOperations:
     _startup_complete: bool
 
     def _set_api_status(
-        self: GoogleFindMyCoordinator, status: str, *, reason: str | None = None
+        self, status: str, *, reason: str | None = None
     ) -> None:
         """Update the API polling status and notify listeners if it changed."""
         if status == self._api_status_state and reason == self._api_status_reason:
@@ -143,7 +143,7 @@ class PollingOperations:
             pass
 
     def _set_fcm_status(
-        self: GoogleFindMyCoordinator, status: str, *, reason: str | None = None
+        self, status: str, *, reason: str | None = None
     ) -> None:
         """Update the push transport status while avoiding noisy churn."""
         if status == self._fcm_status_state and reason == self._fcm_status_reason:
@@ -159,7 +159,7 @@ class PollingOperations:
             pass
 
     @property
-    def api_status(self: GoogleFindMyCoordinator) -> StatusSnapshot:
+    def api_status(self) -> StatusSnapshot:
         """Return a snapshot describing the current API polling health."""
         return StatusSnapshot(
             state=self._api_status_state,
@@ -168,7 +168,7 @@ class PollingOperations:
         )
 
     @property
-    def fcm_status(self: GoogleFindMyCoordinator) -> StatusSnapshot:
+    def fcm_status(self) -> StatusSnapshot:
         """Return a snapshot describing the current push transport health."""
         return StatusSnapshot(
             state=self._fcm_status_state,
@@ -177,21 +177,21 @@ class PollingOperations:
         )
 
     @property
-    def is_fcm_connected(self: GoogleFindMyCoordinator) -> bool:
+    def is_fcm_connected(self) -> bool:
         """Convenience boolean for entities relying on push transport availability."""
         return self._fcm_status_state == FcmStatus.CONNECTED
 
     @property
-    def consecutive_timeouts(self: GoogleFindMyCoordinator) -> int:
+    def consecutive_timeouts(self) -> int:
         """Return the number of consecutive poll timeouts."""
         return self._consecutive_timeouts
 
     @property
-    def last_poll_result(self: GoogleFindMyCoordinator) -> str | None:
+    def last_poll_result(self) -> str | None:
         """Return the last recorded poll result ("success"/"failed")."""
         return self._last_poll_result
 
-    def _is_on_hass_loop(self: GoogleFindMyCoordinator) -> bool:
+    def _is_on_hass_loop(self) -> bool:
         """Return True if currently executing on the HA event loop thread."""
         loop = self.hass.loop
         try:
@@ -200,7 +200,7 @@ class PollingOperations:
             return False
 
     def _run_on_hass_loop(
-        self: GoogleFindMyCoordinator,
+        self,
         func: Callable[..., None],
         *args: Any,
         **kwargs: Any,
@@ -220,7 +220,7 @@ class PollingOperations:
             self.hass.loop.call_soon_threadsafe(func, *args)
 
     def _dispatch_async_request_refresh(
-        self: GoogleFindMyCoordinator, *, task_name: str, log_context: str
+        self, *, task_name: str, log_context: str
     ) -> None:
         """Invoke ``async_request_refresh`` safely regardless of its implementation."""
         fn = getattr(self, "async_request_refresh", None)
@@ -243,7 +243,7 @@ class PollingOperations:
             self._run_on_hass_loop(_invoke)
 
     def _schedule_short_retry(
-        self: GoogleFindMyCoordinator, delay_s: float = 5.0
+        self, delay_s: float = 5.0
     ) -> None:
         """Schedule a short, coalesced refresh instead of shifting the poll baseline.
 
@@ -287,7 +287,7 @@ class PollingOperations:
         else:
             self._run_on_hass_loop(_do_schedule)
 
-    async def _handle_dr_event(self: GoogleFindMyCoordinator, _event: Event) -> None:
+    async def _handle_dr_event(self, _event: Event) -> None:
         """Handle Device Registry changes by rebuilding poll targets (rare)."""
         self._reindex_poll_targets_from_device_registry()
         # After changes, request a refresh so the next tick uses the new target sets.
@@ -297,7 +297,7 @@ class PollingOperations:
         )
 
     def _compute_type_cooldown_seconds(
-        self: GoogleFindMyCoordinator, report_hint: str | None
+        self, report_hint: str | None
     ) -> int:
         """Return a server-aware cooldown duration in seconds for a crowdsourced report type.
 
@@ -325,7 +325,7 @@ class PollingOperations:
         return max(base_cooldown, effective_poll)
 
     def _apply_report_type_cooldown(
-        self: GoogleFindMyCoordinator, device_id: str, report_hint: str | None
+        self, device_id: str, report_hint: str | None
     ) -> None:
         """Apply a per-device **poll** cooldown based on the crowdsourced report type.
 
@@ -355,7 +355,7 @@ class PollingOperations:
 
     # -------------------- Public read-only state for diagnostics/UI --------------------
     @property
-    def is_polling(self: GoogleFindMyCoordinator) -> bool:
+    def is_polling(self) -> bool:
         """Expose current polling state (public read-only API).
 
         Returns:
@@ -364,7 +364,7 @@ class PollingOperations:
         return self._is_polling
 
     def get_fcm_acquire_duration_seconds(
-        self: GoogleFindMyCoordinator,
+        self,
     ) -> float | None:
         """Duration between 'setup_start_monotonic' and 'fcm_acquired_monotonic'."""
         from .helpers.stats import get_duration as _get_duration_impl
@@ -375,13 +375,13 @@ class PollingOperations:
         )
 
     def get_last_poll_duration_seconds(
-        self: GoogleFindMyCoordinator,
+        self,
     ) -> float | None:
         """Duration of the most recent sequential polling cycle (if recorded)."""
         return self._get_duration("last_poll_start_mono", "last_poll_end_mono")
 
     # -------------------- FCM readiness checks --------------------
-    def _is_fcm_ready_soft(self: GoogleFindMyCoordinator) -> bool:
+    def _is_fcm_ready_soft(self) -> bool:
         """Return True if push transport appears ready (no awaits, no I/O).
 
         Priority order:
@@ -426,7 +426,7 @@ class PollingOperations:
         except Exception:
             return False
 
-    def _note_fcm_deferral(self: GoogleFindMyCoordinator, now_mono: float) -> None:
+    def _note_fcm_deferral(self, now_mono: float) -> None:
         """Advance a quiet escalation timeline while FCM is not ready.
 
         FIX: Use less aggressive log levels to reduce log spam (#124).
@@ -467,7 +467,7 @@ class PollingOperations:
                 reason="Push transport not connected after prolonged wait",
             )
 
-    def _clear_fcm_deferral(self: GoogleFindMyCoordinator) -> None:
+    def _clear_fcm_deferral(self) -> None:
         """Clear the escalation timeline once FCM becomes ready (log once)."""
         if self._fcm_defer_started_mono:
             _LOGGER.info("FCM/push is ready; resuming scheduled polling.")
@@ -476,7 +476,7 @@ class PollingOperations:
         self._set_fcm_status(FcmStatus.CONNECTED)
 
     # -------------------- Poll timing prediction --------------------
-    def _get_predicted_poll_time(self: GoogleFindMyCoordinator) -> float | None:
+    def _get_predicted_poll_time(self) -> float | None:
         """Predict the earliest next update time based on device histories."""
 
         history_store = getattr(self, "_device_update_history", None)
@@ -506,7 +506,7 @@ class PollingOperations:
 
     # -------------------- Push transport error handling --------------------
     def _note_push_transport_problem(
-        self: GoogleFindMyCoordinator, cooldown_s: int = 90
+        self, cooldown_s: int = 90
     ) -> None:
         """Enter a temporary cooldown after a push transport failure to avoid spamming.
 
@@ -523,14 +523,14 @@ class PollingOperations:
             reason=f"Push transport recovering from error (cooldown {cooldown_s}s)",
         )
 
-    def force_poll_due(self: GoogleFindMyCoordinator) -> None:
+    def force_poll_due(self) -> None:
         """Force the next poll to be due immediately (no private access required externally)."""
         effective_interval = max(self.location_poll_interval, self.min_poll_interval)
         # Move the baseline back so that (now - _last_poll_mono) >= effective_interval
         self._last_poll_mono = time.monotonic() - float(effective_interval)
 
     # ---------------------------- HA Coordinator ----------------------------
-    async def _async_update_data(self: GoogleFindMyCoordinator) -> list[dict[str, Any]]:
+    async def _async_update_data(self) -> list[dict[str, Any]]:
         """Provide cached device data; trigger background poll if due.
 
         Discovery semantics:
@@ -989,7 +989,7 @@ class PollingOperations:
 
     # ---------------------------- Polling Cycle -----------------------------
     async def _async_start_poll_cycle(
-        self: GoogleFindMyCoordinator,
+        self,
         devices: list[dict[str, Any]],
         *,
         force: bool = False,
@@ -1309,11 +1309,11 @@ class PollingOperations:
                         cycle_failed = True
                         self._last_poll_result = "failed"
                         self._consecutive_timeouts = 0
-                        auth_exc = ConfigEntryAuthFailed(
+                        reauth_exc = ConfigEntryAuthFailed(
                             "Google session invalid; re-authentication required"
                         )
-                        last_exception = auth_exc
-                        raise auth_exc from auth_err
+                        last_exception = reauth_exc
+                        raise reauth_exc from auth_err
                     except SpotApiEmptyResponseError:
                         _LOGGER.warning(
                             "Authentication failed for %s; triggering reauth flow.",
@@ -1326,11 +1326,11 @@ class PollingOperations:
                         cycle_failed = True
                         self._last_poll_result = "failed"
                         self._consecutive_timeouts = 0
-                        auth_exc = ConfigEntryAuthFailed(
+                        reauth_exc = ConfigEntryAuthFailed(
                             "Google session invalid; re-authentication required"
                         )
-                        last_exception = auth_exc
-                        raise auth_exc
+                        last_exception = reauth_exc
+                        raise reauth_exc
                     except NovaAuthPermanentError as perm_err:
                         # Permanent auth failure (AAS token invalid) - immediate reauth
                         _LOGGER.error(
@@ -1346,11 +1346,11 @@ class PollingOperations:
                         self._last_poll_result = "failed"
                         self._consecutive_timeouts = 0
                         self._consecutive_transient_auth_failures = 0
-                        auth_exc = ConfigEntryAuthFailed(
+                        reauth_exc = ConfigEntryAuthFailed(
                             "Google credentials invalid; re-authentication required"
                         )
-                        last_exception = auth_exc
-                        raise auth_exc from perm_err
+                        last_exception = reauth_exc
+                        raise reauth_exc from perm_err
                     except NovaAuthError as transient_err:
                         # Transient auth failure - may self-heal in subsequent poll cycles.
                         # Only trigger reauth after multiple consecutive failures.
@@ -1375,11 +1375,11 @@ class PollingOperations:
                             cycle_failed = True
                             self._last_poll_result = "failed"
                             self._consecutive_timeouts = 0
-                            auth_exc = ConfigEntryAuthFailed(
+                            reauth_exc = ConfigEntryAuthFailed(
                                 f"Authentication failed after {self._consecutive_transient_auth_failures} attempts; re-authentication required"
                             )
-                            last_exception = auth_exc
-                            raise auth_exc from transient_err
+                            last_exception = reauth_exc
+                            raise reauth_exc from transient_err
 
                         # Not yet at threshold - log warning and continue to next device
                         _LOGGER.warning(

--- a/custom_components/googlefindmy/coordinator/registry.py
+++ b/custom_components/googlefindmy/coordinator/registry.py
@@ -54,6 +54,7 @@ from ..const import (
     TRACKER_SUBENTRY_KEY,
     service_device_identifier,
 )
+from ._mixin_typing import _MixinBase
 from .helpers.registry import (
     build_canonical_unique_id as _build_canonical_unique_id_impl,
 )
@@ -107,9 +108,6 @@ from .helpers.subentry import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-from ._mixin_typing import _MixinBase
 
 
 class RegistryOperations(_MixinBase):

--- a/custom_components/googlefindmy/coordinator/registry.py
+++ b/custom_components/googlefindmy/coordinator/registry.py
@@ -25,7 +25,7 @@ import inspect
 import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.config_entries import (
@@ -106,13 +106,13 @@ from .helpers.subentry import (
     sanitize_subentry_identifier as _sanitize_subentry_id_impl,
 )
 
-if TYPE_CHECKING:
-    from .main import GoogleFindMyCoordinator
-
 _LOGGER = logging.getLogger(__name__)
 
 
-class RegistryOperations:
+from ._mixin_typing import _MixinBase
+
+
+class RegistryOperations(_MixinBase):
     """Device registry operations mixin for GoogleFindMyCoordinator.
 
     This class contains methods that manage device registry entries,
@@ -121,7 +121,7 @@ class RegistryOperations:
     """
 
     def _call_device_registry_api(
-        self: GoogleFindMyCoordinator,
+        self,
         call: Callable[..., Any],
         *,
         base_kwargs: Mapping[str, Any] | None = None,
@@ -166,7 +166,7 @@ class RegistryOperations:
             return call(**fallback_kwargs)
 
     def _device_registry_kwargs_need_legacy_retry(
-        self: GoogleFindMyCoordinator,
+        self,
         call: Callable[..., Any],
         err: TypeError,
         kwargs: Mapping[str, Any],
@@ -183,7 +183,7 @@ class RegistryOperations:
         return _build_legacy_kwargs_impl(kwargs)
 
     def _device_registry_config_subentry_kwarg_name(
-        self: GoogleFindMyCoordinator, call: Callable[..., Any]
+        self, call: Callable[..., Any]
     ) -> str | None:
         """Return the config-subentry kwarg name accepted by ``call``.
 
@@ -228,7 +228,7 @@ class RegistryOperations:
         return kwarg_name
 
     def _device_registry_allows_translation_update(
-        self: GoogleFindMyCoordinator, dev_reg: Any
+        self, dev_reg: Any
     ) -> bool:
         """Return True if the registry accepts translation metadata during updates."""
 
@@ -256,7 +256,7 @@ class RegistryOperations:
 
     @callback  # type: ignore[misc, untyped-decorator, unused-ignore]
     def _reindex_poll_targets_from_device_registry(
-        self: GoogleFindMyCoordinator,
+        self,
     ) -> None:
         """Rebuild internal poll target sets from registries (fast, robust, diagnostics-aware).
 
@@ -323,7 +323,7 @@ class RegistryOperations:
         self._schedule_eid_resolver_refresh()
 
     def _extract_our_identifier(
-        self: GoogleFindMyCoordinator, device: dr.DeviceEntry
+        self, device: dr.DeviceEntry
     ) -> str | None:
         """Return the first valid (DOMAIN, identifier) from a device, else None.
 
@@ -354,7 +354,7 @@ class RegistryOperations:
         return None
 
     def _sync_owner_index(
-        self: GoogleFindMyCoordinator, devices: list[dict[str, Any]] | None
+        self, devices: list[dict[str, Any]] | None
     ) -> None:
         """Sync hass.data owner index for this entry (FCM fallback support)."""
         hass = getattr(self, "hass", None)
@@ -414,7 +414,7 @@ class RegistryOperations:
                 )
 
     def _ensure_device_name_cache(
-        self: GoogleFindMyCoordinator,
+        self,
     ) -> dict[str, str]:
         """Return the lazily initialized device-name cache."""
         cache = getattr(self, "_device_names", None)
@@ -423,7 +423,7 @@ class RegistryOperations:
             setattr(self, "_device_names", cache)
         return cache
 
-    def _apply_pending_via_updates(self: GoogleFindMyCoordinator) -> None:
+    def _apply_pending_via_updates(self) -> None:
         """Deprecated no-op retained for backward compatibility."""
         # Tracker devices no longer link to the service device via ``via_device``.
         # Keep the method defined to avoid AttributeError in case third-party
@@ -431,18 +431,18 @@ class RegistryOperations:
         return
 
     def _device_display_name(
-        self: GoogleFindMyCoordinator, dev: dr.DeviceEntry, fallback: str
+        self, dev: dr.DeviceEntry, fallback: str
     ) -> str:
         """Return the best human-friendly device name without sensitive data."""
         return _extract_display_name_impl(dev.name_by_user, dev.name, fallback)
 
-    def _entry_id(self: GoogleFindMyCoordinator) -> str | None:
+    def _entry_id(self) -> str | None:
         """Small helper to read the bound ConfigEntry ID (None at very early startup)."""
         entry = getattr(self, "config_entry", None)
         return getattr(entry, "entry_id", None)
 
     def _config_entry_exists(
-        self: GoogleFindMyCoordinator, entry_id: str | None = None
+        self, entry_id: str | None = None
     ) -> bool:
         """Return True when the coordinator's entry is still registered."""
         hass = getattr(self, "hass", None)
@@ -463,7 +463,7 @@ class RegistryOperations:
         return True
 
     def _redact_text(
-        self: GoogleFindMyCoordinator, value: str | None, max_len: int = 120
+        self, value: str | None, max_len: int = 120
     ) -> str:
         """Return a short, redacted string variant suitable for logs/diagnostics."""
         if not value:
@@ -472,7 +472,7 @@ class RegistryOperations:
         return s if len(s) <= max_len else (s[:max_len] + "…")
 
     def _ensure_service_device_exists(
-        self: GoogleFindMyCoordinator, entry: ConfigEntry | None = None
+        self, entry: ConfigEntry | None = None
     ) -> None:
         """Idempotently create/update the per-entry 'service device' in the device registry.
 
@@ -1015,7 +1015,7 @@ class RegistryOperations:
     ensure_service_device_exists = _ensure_service_device_exists
 
     def _find_tracker_entity_entry(
-        self: GoogleFindMyCoordinator, device_id: str
+        self, device_id: str
     ) -> EntityRegistryEntry | None:
         """Return the registry entry for a tracker and migrate legacy unique IDs.
 
@@ -1289,13 +1289,13 @@ class RegistryOperations:
         return None
 
     def find_tracker_entity_entry(
-        self: GoogleFindMyCoordinator, device_id: str
+        self, device_id: str
     ) -> EntityRegistryEntry | None:
         """Public wrapper to expose tracker entity lookup to platforms."""
         return self._find_tracker_entity_entry(device_id)
 
     def _ensure_registry_for_devices(
-        self: GoogleFindMyCoordinator,
+        self,
         devices: list[dict[str, Any]],
         ignored: set[str],
     ) -> int:

--- a/custom_components/googlefindmy/coordinator/subentry.py
+++ b/custom_components/googlefindmy/coordinator/subentry.py
@@ -28,6 +28,7 @@ from ..const import (
     TRACKER_SUBENTRY_KEY,
     TRACKER_SUBENTRY_TRANSLATION_KEY,
 )
+from ._mixin_typing import _MixinBase
 from .helpers.subentry import (
     detect_missing_core_subentry_keys as _detect_missing_core_keys_impl,
 )
@@ -102,7 +103,6 @@ def _sanitize_subentry_identifier(candidate: Any) -> str | None:
 
 
 # --- SubentryOperations mixin ------------------------------------------------
-from ._mixin_typing import _MixinBase
 
 
 class SubentryOperations(_MixinBase):

--- a/custom_components/googlefindmy/coordinator/subentry.py
+++ b/custom_components/googlefindmy/coordinator/subentry.py
@@ -48,7 +48,6 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     from .. import ConfigEntrySubentryDefinition, ConfigEntrySubEntryManager
-    from .main import GoogleFindMyCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,7 +102,10 @@ def _sanitize_subentry_identifier(candidate: Any) -> str | None:
 
 
 # --- SubentryOperations mixin ------------------------------------------------
-class SubentryOperations:
+from ._mixin_typing import _MixinBase
+
+
+class SubentryOperations(_MixinBase):
     """Subentry operations mixin for GoogleFindMyCoordinator.
 
     This class contains methods that manage config entry subentries,
@@ -118,7 +120,7 @@ class SubentryOperations:
     _present_device_ids: set[str]
 
     def attach_subentry_manager(
-        self: GoogleFindMyCoordinator,
+        self,
         manager: ConfigEntrySubEntryManager,
         *,
         is_reload: bool = False,
@@ -152,13 +154,13 @@ class SubentryOperations:
                     err,
                 )
 
-    def _default_subentry_key(self: GoogleFindMyCoordinator) -> str:
+    def _default_subentry_key(self) -> str:
         """Return the default subentry key used when no explicit mapping exists."""
 
         return self._default_subentry_key_value or "core_tracking"
 
     async def async_wait_subentry_visibility_updates(
-        self: GoogleFindMyCoordinator,
+        self,
     ) -> None:
         """Await pending visibility updates scheduled by the subentry manager."""
 
@@ -179,7 +181,7 @@ class SubentryOperations:
             )
 
     def _build_core_subentry_definitions(
-        self: GoogleFindMyCoordinator,
+        self,
     ) -> list[ConfigEntrySubentryDefinition]:
         """Return definitions for the core tracker/service subentries."""
 
@@ -242,7 +244,7 @@ class SubentryOperations:
         return [tracker_definition, service_definition]
 
     def _schedule_core_subentry_repair(
-        self: GoogleFindMyCoordinator, missing_keys: set[str]
+        self, missing_keys: set[str]
     ) -> None:
         """Schedule a repair task to recreate missing core subentries."""
 
@@ -317,7 +319,7 @@ class SubentryOperations:
             task = asyncio.create_task(_repair(), name=task_name)
         self._pending_subentry_repair = task
 
-    def _cancel_pending_subentry_repair(self: GoogleFindMyCoordinator) -> None:
+    def _cancel_pending_subentry_repair(self) -> None:
         """Cancel any pending core subentry repair task."""
 
         pending = self._pending_subentry_repair
@@ -330,7 +332,7 @@ class SubentryOperations:
         self._pending_subentry_repair = None
 
     def _refresh_subentry_index(
-        self: GoogleFindMyCoordinator,
+        self,
         visible_devices: Sequence[Mapping[str, Any]] | None = None,
         *,
         skip_manager_update: bool = False,
@@ -784,7 +786,7 @@ class SubentryOperations:
             self._subentry_snapshots.setdefault(key, ())
 
     def _group_snapshot_by_subentry(
-        self: GoogleFindMyCoordinator, snapshot: Sequence[Mapping[str, Any]]
+        self, snapshot: Sequence[Mapping[str, Any]]
     ) -> dict[str, list[dict[str, Any]]]:
         """Return snapshot entries grouped by subentry key."""
         # Build device-to-subentry mapping from metadata
@@ -801,7 +803,7 @@ class SubentryOperations:
         )
 
     def _store_subentry_snapshots(
-        self: GoogleFindMyCoordinator, snapshot: Sequence[Mapping[str, Any]]
+        self, snapshot: Sequence[Mapping[str, Any]]
     ) -> None:
         """Persist grouped snapshots for subentry-aware consumers."""
 
@@ -811,14 +813,14 @@ class SubentryOperations:
         }
 
     def _resolve_subentry_key_for_feature(
-        self: GoogleFindMyCoordinator, feature: str
+        self, feature: str
     ) -> str:
         """Return the subentry key for a platform feature without warnings."""
 
         return self._feature_to_subentry.get(feature, self._default_subentry_key())
 
     def get_subentry_key_for_feature(
-        self: GoogleFindMyCoordinator, feature: str
+        self, feature: str
     ) -> str:
         """Return the subentry key responsible for a platform feature."""
 
@@ -831,7 +833,7 @@ class SubentryOperations:
         return self._resolve_subentry_key_for_feature(feature)
 
     def get_subentry_metadata(
-        self: GoogleFindMyCoordinator,
+        self,
         *,
         key: str | None = None,
         feature: str | None = None,
@@ -846,7 +848,7 @@ class SubentryOperations:
         return self._subentry_metadata.get(lookup_key)
 
     def stable_subentry_identifier(
-        self: GoogleFindMyCoordinator,
+        self,
         *,
         key: str | None = None,
         feature: str | None = None,
@@ -863,7 +865,7 @@ class SubentryOperations:
         return self._default_subentry_key()
 
     def get_subentry_snapshot(
-        self: GoogleFindMyCoordinator,
+        self,
         key: str | None = None,
         *,
         feature: str | None = None,
@@ -881,7 +883,7 @@ class SubentryOperations:
         return [dict(row) for row in entries]
 
     def is_device_visible_in_subentry(
-        self: GoogleFindMyCoordinator, subentry_key: str, device_id: str
+        self, subentry_key: str, device_id: str
     ) -> bool:
         """Return True if a device is visible within the subentry scope.
 
@@ -907,7 +909,7 @@ class SubentryOperations:
         return False
 
     def get_device_location_data_for_subentry(
-        self: GoogleFindMyCoordinator, subentry_key: str, device_id: str
+        self, subentry_key: str, device_id: str
     ) -> dict[str, Any] | None:
         """Return location data for a device if it belongs to the subentry."""
 
@@ -916,7 +918,7 @@ class SubentryOperations:
         return self.get_device_location_data(device_id)
 
     def get_device_last_seen_for_subentry(
-        self: GoogleFindMyCoordinator, subentry_key: str, device_id: str
+        self, subentry_key: str, device_id: str
     ) -> datetime | None:
         """Return last_seen for a device within the given subentry."""
 

--- a/custom_components/googlefindmy/entity.py
+++ b/custom_components/googlefindmy/entity.py
@@ -77,11 +77,11 @@ from .const import (
 from .coordinator import GoogleFindMyCoordinator
 from .ha_typing import CoordinatorEntity, callback
 from .shared_helpers import (  # noqa: F401 - re-exported for platform modules
-    known_ids_for_subentry_type,
-    normalize_fcm_entry_snapshot,
-    safe_fcm_health_snapshots,
-    sanitize_state_text,
-    subentry_type,
+    known_ids_for_subentry_type as known_ids_for_subentry_type,
+    normalize_fcm_entry_snapshot as normalize_fcm_entry_snapshot,
+    safe_fcm_health_snapshots as safe_fcm_health_snapshots,
+    sanitize_state_text as sanitize_state_text,
+    subentry_type as subentry_type,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/googlefindmy/entity.py
+++ b/custom_components/googlefindmy/entity.py
@@ -78,9 +78,17 @@ from .coordinator import GoogleFindMyCoordinator
 from .ha_typing import CoordinatorEntity, callback
 from .shared_helpers import (  # noqa: F401 - re-exported for platform modules
     known_ids_for_subentry_type as known_ids_for_subentry_type,
+)
+from .shared_helpers import (
     normalize_fcm_entry_snapshot as normalize_fcm_entry_snapshot,
+)
+from .shared_helpers import (
     safe_fcm_health_snapshots as safe_fcm_health_snapshots,
+)
+from .shared_helpers import (
     sanitize_state_text as sanitize_state_text,
+)
+from .shared_helpers import (
     subentry_type as subentry_type,
 )
 

--- a/custom_components/googlefindmy/google_home_filter.py
+++ b/custom_components/googlefindmy/google_home_filter.py
@@ -84,7 +84,7 @@ def callback(
 ) -> TypingCallable[[GoogleHomeFilter, Event | None], None]:
     """Typed wrapper around Home Assistant's callback decorator."""
 
-    return cast(TypingCallable[[GoogleHomeFilter, Event | None], None], ha_callback(func))
+    return cast("TypingCallable[[GoogleHomeFilter, Event | None], None]", ha_callback(func))
 
 
 # Keep local names for zone attributes to avoid fragile imports.

--- a/custom_components/googlefindmy/google_home_filter.py
+++ b/custom_components/googlefindmy/google_home_filter.py
@@ -40,7 +40,7 @@ import logging
 import time
 from collections.abc import Callable, Mapping
 from collections.abc import Callable as TypingCallable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -84,7 +84,7 @@ def callback(
 ) -> TypingCallable[[GoogleHomeFilter, Event | None], None]:
     """Typed wrapper around Home Assistant's callback decorator."""
 
-    return ha_callback(func)  # type: ignore[return-value]
+    return cast(TypingCallable[[GoogleHomeFilter, Event | None], None], ha_callback(func))
 
 
 # Keep local names for zone attributes to avoid fragile imports.

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Iterable, Mapping
 from datetime import UTC, datetime
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -61,6 +61,9 @@ from .entity import (
     subentry_type as _subentry_type,
 )
 from .ha_typing import RestoreSensor, SensorEntity, callback
+
+if TYPE_CHECKING:
+    from .eid_resolver import GoogleFindMyEIDResolver
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -449,12 +452,12 @@ async def async_setup_entry(
         if tracker_scheduler is None:
             tracker_scheduler = _schedule_tracker_entities
 
-        def _get_ble_resolver() -> Any:
+        def _get_ble_resolver() -> GoogleFindMyEIDResolver | None:
             """Return the EID resolver from hass.data, or None."""
             domain_data = hass.data.get(DOMAIN)
             if not isinstance(domain_data, dict):
                 return None
-            return domain_data.get(DATA_EID_RESOLVER)
+            return cast("GoogleFindMyEIDResolver | None", domain_data.get(DATA_EID_RESOLVER))
 
         def _build_entities() -> list[SensorEntity]:
             """Build sensor entities for visible devices in the current subentry."""
@@ -1271,18 +1274,18 @@ class GoogleFindMyBLEBatterySensor(GoogleFindMyDeviceEntity, RestoreSensor):
         )
         self._attr_native_value: int | None = None
 
-    def _get_resolver(self) -> Any:
+    def _get_resolver(self) -> GoogleFindMyEIDResolver | None:
         """Return the EID resolver from hass.data, or None."""
         domain_data = self.hass.data.get(DOMAIN)
         if not isinstance(domain_data, dict):
             return None
-        return domain_data.get(DATA_EID_RESOLVER)
+        return cast("GoogleFindMyEIDResolver | None", domain_data.get(DATA_EID_RESOLVER))
 
     @property
     def native_value(self) -> int | None:
         """Return battery percentage from resolver, or restored value."""
         resolver = self._get_resolver()
-        if resolver is None:
+        if resolver is None or self._device_id is None:
             return self._attr_native_value
         state = resolver.get_ble_battery_state(self._device_id)
         if state is None:
@@ -1303,7 +1306,7 @@ class GoogleFindMyBLEBatterySensor(GoogleFindMyDeviceEntity, RestoreSensor):
             return False
 
         try:
-            if hasattr(self.coordinator, "is_device_present"):
+            if self._device_id is not None and hasattr(self.coordinator, "is_device_present"):
                 raw = self.coordinator.is_device_present(self._device_id)
                 present = bool(raw) if not isinstance(raw, bool) else raw
                 if present:
@@ -1320,7 +1323,7 @@ class GoogleFindMyBLEBatterySensor(GoogleFindMyDeviceEntity, RestoreSensor):
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return diagnostic attributes (excluded from recorder)."""
         resolver = self._get_resolver()
-        if resolver is None:
+        if resolver is None or self._device_id is None:
             return None
         state = resolver.get_ble_battery_state(self._device_id)
         if state is None:
@@ -1344,7 +1347,7 @@ class GoogleFindMyBLEBatterySensor(GoogleFindMyDeviceEntity, RestoreSensor):
 
         # Update cached native_value from resolver for restore persistence
         resolver = self._get_resolver()
-        if resolver is not None:
+        if resolver is not None and self._device_id is not None:
             state = resolver.get_ble_battery_state(self._device_id)
             if state is not None:
                 self._attr_native_value = state.battery_pct
@@ -1366,7 +1369,7 @@ class GoogleFindMyBLEBatterySensor(GoogleFindMyDeviceEntity, RestoreSensor):
             )
             value = None
 
-        if value in (None, "unknown", "unavailable"):
+        if value is None or value in ("unknown", "unavailable"):
             return
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,7 @@ markers = [
 ]
 
 [tool.mypy]
-python_version = "3.14"
+python_version = "3.13"
 warn_unused_ignores = true
 show_error_codes = true
 mypy_path = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,7 +286,7 @@ markers = [
 ]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.14"
 warn_unused_ignores = true
 show_error_codes = true
 mypy_path = ["."]
@@ -321,67 +321,9 @@ module = [
 ]
 ignore_missing_imports = true
 
-# Coordinator mixin modules use self: "GoogleFindMyCoordinator" pattern
-# which mypy doesn't handle well with the [misc] error code
-[[tool.mypy.overrides]]
-module = [
-    "custom_components.googlefindmy.coordinator.registry",
-    "custom_components.googlefindmy.coordinator.subentry",
-    "custom_components.googlefindmy.coordinator.locate",
-    "custom_components.googlefindmy.coordinator.identity",
-    "custom_components.googlefindmy.coordinator.polling",
-    "custom_components.googlefindmy.coordinator.cache",
-]
-disable_error_code = [
-    "misc",
-    "assignment",      # SimpleNamespace fallback assignment
-    "arg-type",        # Awaitable vs Coroutine variance
-]
-
 [[tool.mypy.overrides]]
 module = ["tests.test_fcm_receiver_guard"]
 ignore_errors = false
-
-# HomeAssistant API compatibility: FlowResult generics, Entity covariance,
-# and TypedDict issues that require HA upstream type improvements to fix.
-# These are checked manually and don't affect runtime behavior.
-[[tool.mypy.overrides]]
-module = [
-    "custom_components.googlefindmy",
-    "custom_components.googlefindmy.config_flow",
-    "custom_components.googlefindmy.map_view",
-    "custom_components.googlefindmy.entity",
-    "custom_components.googlefindmy.sensor",
-    "custom_components.googlefindmy.services",
-    "custom_components.googlefindmy.button",
-    "custom_components.googlefindmy.location_recorder",
-    "custom_components.googlefindmy.google_home_filter",
-    "custom_components.googlefindmy.device_tracker",
-    "custom_components.googlefindmy.binary_sensor",
-    "custom_components.googlefindmy.discovery",
-    "custom_components.googlefindmy.eid_resolver",
-    "custom_components.googlefindmy.ha_typing",
-    "custom_components.googlefindmy.system_health",
-]
-disable_error_code = [
-    "arg-type",        # Entity subtype covariance issues
-    "assignment",      # FlowResult generic assignment
-    "empty-body",      # Protocol stubs without implementation
-    "func-returns-value",  # Void function return expectations
-    "misc",            # Complex HA type inference issues
-    "no-any-return",   # Dynamic return types in HA APIs
-    "override",        # ConfigFlow return type covariance
-    "redundant-cast",  # Casts needed for older HA versions
-    "return-value",    # FlowResult return type variance
-    "type-var",        # Store type variance
-    "typeddict-item",  # FlowResult TypedDict fields
-    "typeddict-unknown-key",  # HA TypedDict extensions
-    "union-attr",      # State | dict union access
-    "attr-defined",    # Optional HA const imports
-    "var-annotated",   # Store type inference
-    "unused-ignore",   # Cross-version compatibility ignores
-    "truthy-function", # Recorder get_instance pattern
-]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,7 @@ ignore = ["E501"]
     "PLC0415",
     "PLR2004",
 ]
-"custom_components/googlefindmy/entity.py" = ["PLR0913"]
+"custom_components/googlefindmy/entity.py" = ["PLR0913", "PLC0414"]
 "custom_components/googlefindmy/get_oauth_token.py" = ["PLC0415"]
 "custom_components/googlefindmy/google_home_filter.py" = ["PLC0415", "PLR0911"]
 "custom_components/googlefindmy/ha_typing.py" = ["UP047", "UP046"]


### PR DESCRIPTION
[fix: resolve all mypy --strict errors for Python 3.14 + mypy 1.19.1](https://github.com/jleinenbach/GoogleFindMy-HA/commit/90bf1466d9c30281ea8abab57ae507ecb7d875c9) 

Root-cause fixes for all 96 mypy --strict errors:

**Coordinator mixin typing (83 [misc] errors):**
- Remove invalid `self: GoogleFindMyCoordinator` annotations from all 6 mixin
  classes (registry, subentry, locate, identity, polling, cache). mypy rejects
  these because the coordinator is a subtype, not a supertype, of the mixins.
- Add `_MixinBase` typing base class that declares the full coordinator
  interface (attributes + cross-mixin methods) so mypy can resolve `self.hass`,
  `self.config_entry`, and all cross-mixin method calls correctly.

**Entity re-exports (5 [attr-defined] errors):**
- Use explicit `as` re-export pattern in entity.py for `known_ids_for_subentry_type`,
  `sanitize_state_text`, `subentry_type` (mypy strict no_implicit_reexport).

**Type safety (4 [no-any-return], 3 [arg-type], 1 [unused-ignore]):**
- Type `_get_resolver` return as `GoogleFindMyEIDResolver | None` with cast
  instead of `Any` in sensor.py and binary_sensor.py.
- Add None guards for `_device_id: str | None` before `is_device_present()`
  and `get_ble_battery_state()` calls.
- Use explicit `is None` check for restored sensor value before `float()`.
- Replace `type: ignore[return-value]` with proper `cast()` in
  google_home_filter.py callback wrapper.
- Type `async_get_local_ip` return via explicit annotation.

**Polling variable scoping (3 [misc] errors):**
- Rename manually-created `auth_exc` to `reauth_exc` to avoid name collision
  with exception-caught `auth_exc` variable in the same scope.

**Config updates:**
- Update mypy python_version to 3.14
- Remove all `disable_error_code` overrides from pyproject.toml

https://claude.ai/code/session_012ADLmtgF8USbFxGP5ntkvJ
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 11 minutes ago
[docs: document _MixinBase typing pattern and restore python_version 3.13](https://github.com/jleinenbach/GoogleFindMy-HA/commit/71ff7e9ed2e9defd1383472a1680393ba7b675f0) 

Revert mypy python_version from 3.14 to 3.13 to maintain backward
compatibility with Python 3.13 and HA 2025.9. Document the coordinator
mixin typing architecture (_MixinBase pattern), explicit re-export
requirements, cast() usage for HA API returns, and exception variable
scoping rules in the typing guidance.

https://claude.ai/code/session_012ADLmtgF8USbFxGP5ntkvJ