### PR TITLE
fix: replace hardcoded 50m significance threshold with accuracy-adapt…

### DIFF
--- a/custom_components/googlefindmy/coordinator/helpers/cache.py
+++ b/custom_components/googlefindmy/coordinator/helpers/cache.py
@@ -33,7 +33,7 @@ from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
 
-from .geo import haversine_distance
+from .geo import haversine_distance, safe_accuracy
 from .subentry import format_epoch_utc, normalize_epoch_seconds
 
 __all__ = [
@@ -112,9 +112,6 @@ SOURCE_PRIORITY: dict[str, int] = {
     "cache": 2,
     "unknown": 0,
 }
-
-# Default significant change threshold in meters
-_DEFAULT_SIGNIFICANT_CHANGE_M = 50.0
 
 # Epsilon for timestamp comparison (floating point tolerance)
 _TIMESTAMP_EPSILON = 0.001
@@ -553,7 +550,6 @@ def fill_missing_coordinates(
 def merge_cache_row(
     existing: dict[str, Any] | None,
     incoming: dict[str, Any],
-    significant_change_meters: float = _DEFAULT_SIGNIFICANT_CHANGE_M,
 ) -> dict[str, Any]:
     """Merge incoming location data with existing cache row.
 
@@ -563,10 +559,21 @@ def merge_cache_row(
     3. Preserve monotonic timestamps
     4. Fill missing coordinates from existing
 
+    When timestamp-based ordering is inconclusive (``should_allow_location_update``
+    returns ``None``), an **accuracy-adaptive significance threshold** decides
+    whether the positional change is real or measurement noise.  The threshold
+    is ``0.5 * sqrt(acc_existing² + acc_incoming²)`` -- the combined standard
+    deviation of two independent Gaussian position errors, scaled by 0.5 so
+    that genuine movement is accepted quickly while jitter is suppressed.
+
+    Practical examples:
+    - GPS 10 m + GPS 10 m  →  threshold ≈  7 m  (fine-grained updates)
+    - BLE 200 m + BLE 200 m →  threshold ≈ 141 m  (only real jumps)
+    - GNSS 2 m + GNSS 2 m  →  threshold ≈  1.4 m (near-realtime)
+
     Args:
         existing: Existing cache entry (or None).
         incoming: Incoming location data.
-        significant_change_meters: Distance threshold for significant change.
 
     Returns:
         Merged cache row dictionary.
@@ -603,7 +610,22 @@ def merge_cache_row(
                 dist = haversine_distance(
                     existing_lat, existing_lon, incoming_lat, incoming_lon
                 )
-                allow_update = dist > significant_change_meters
+                # Accuracy-adaptive significance: movement must exceed
+                # the combined measurement uncertainty to be real.
+                # sqrt(a1² + a2²) is the joint std-dev of two independent
+                # Gaussian-distributed position errors.  Factor 0.5 keeps
+                # us permissive enough for genuine movement while still
+                # suppressing jitter.
+                existing_acc = safe_accuracy(
+                    _coerce_float(existing.get("accuracy"))
+                )
+                incoming_acc = safe_accuracy(
+                    _coerce_float(incoming.get("accuracy"))
+                )
+                adaptive_threshold = (
+                    math.sqrt(existing_acc**2 + incoming_acc**2) * 0.5
+                )
+                allow_update = dist > adaptive_threshold
             except Exception:
                 allow_update = False
         else:

--- a/tests/test_coordinator_cache_merge.py
+++ b/tests/test_coordinator_cache_merge.py
@@ -585,19 +585,17 @@ class TestMergeCacheRow:
         existing: dict[str, Any] = {
             "latitude": 52.0,
             "longitude": 13.0,
+            "accuracy": 20.0,
             "last_seen": 1000.0,
         }
         incoming: dict[str, Any] = {
             "latitude": 53.0,  # ~111km north
             "longitude": 13.0,
+            "accuracy": 20.0,
             "last_seen": None,
         }
-        result = merge_cache_row(
-            existing=existing,
-            incoming=incoming,
-            significant_change_meters=50.0,  # Default threshold
-        )
-        # Should allow update due to significant distance
+        result = merge_cache_row(existing=existing, incoming=incoming)
+        # 111km >> adaptive threshold (~14m for 20m+20m accuracy)
         assert result["latitude"] == 53.0
 
     def test_insignificant_distance_blocks_update_without_timestamp(self) -> None:
@@ -605,21 +603,73 @@ class TestMergeCacheRow:
         existing: dict[str, Any] = {
             "latitude": 52.0,
             "longitude": 13.0,
+            "accuracy": 20.0,
             "last_seen": 1000.0,
         }
         incoming: dict[str, Any] = {
-            "latitude": 52.0001,  # Very close
+            "latitude": 52.0001,  # ~11m - below adaptive threshold
             "longitude": 13.0001,
+            "accuracy": 20.0,
             "last_seen": None,
         }
-        result = merge_cache_row(
-            existing=existing,
-            incoming=incoming,
-            significant_change_meters=50.0,
-        )
-        # Should block update due to insignificant distance
+        result = merge_cache_row(existing=existing, incoming=incoming)
+        # 11m < adaptive threshold (~14m for 20m+20m accuracy)
         assert result["latitude"] == 52.0
         assert result["longitude"] == 13.0
+
+    def test_adaptive_threshold_gps_allows_small_movement(self) -> None:
+        """Good GPS accuracy (10m) allows small but real movements (>7m)."""
+        existing: dict[str, Any] = {
+            "latitude": 52.0,
+            "longitude": 13.0,
+            "accuracy": 10.0,
+            "last_seen": 1000.0,
+        }
+        incoming: dict[str, Any] = {
+            # ~15m north-east - above adaptive threshold (~7m for 10m+10m)
+            "latitude": 52.0001,
+            "longitude": 13.00015,
+            "accuracy": 10.0,
+            "last_seen": None,
+        }
+        result = merge_cache_row(existing=existing, incoming=incoming)
+        assert result["latitude"] == 52.0001
+
+    def test_adaptive_threshold_ble_blocks_noise(self) -> None:
+        """Poor BLE accuracy (200m) blocks small positional noise."""
+        existing: dict[str, Any] = {
+            "latitude": 52.0,
+            "longitude": 13.0,
+            "accuracy": 200.0,
+            "last_seen": 1000.0,
+        }
+        incoming: dict[str, Any] = {
+            # ~50m north - below adaptive threshold (~141m for 200m+200m)
+            "latitude": 52.00045,
+            "longitude": 13.0,
+            "accuracy": 200.0,
+            "last_seen": None,
+        }
+        result = merge_cache_row(existing=existing, incoming=incoming)
+        # 50m < 141m threshold → blocked
+        assert result["latitude"] == 52.0
+
+    def test_adaptive_threshold_no_accuracy_uses_fallback(self) -> None:
+        """Missing accuracy falls back to 200m, creating a high threshold."""
+        existing: dict[str, Any] = {
+            "latitude": 52.0,
+            "longitude": 13.0,
+            "last_seen": 1000.0,
+        }
+        incoming: dict[str, Any] = {
+            # ~50m north - below fallback threshold (~141m for 200m+200m)
+            "latitude": 52.00045,
+            "longitude": 13.0,
+            "last_seen": None,
+        }
+        result = merge_cache_row(existing=existing, incoming=incoming)
+        # No accuracy → 200m fallback → threshold ~141m → blocked
+        assert result["latitude"] == 52.0
 
     def test_does_not_mutate_inputs(self) -> None:
         """Input dictionaries are not mutated."""


### PR DESCRIPTION
…ive gate

The old 50m flat threshold silently dropped location updates for stationary trackers with fluctuating accuracy (upstream #127).  The new adaptive threshold uses the combined measurement uncertainty of both readings: 0.5 * sqrt(acc_old² + acc_new²).

Practical effect:
- GPS 10m + 10m  → threshold ≈  7m  (fine-grained updates pass)
- BLE 200m + 200m → threshold ≈ 141m (noise suppressed)
- GNSS 2m + 2m   → threshold ≈  1.4m (near-realtime)
- No accuracy     → 200m fallback     (conservative)

No config option needed — the physics of the measurement determines the threshold automatically.

https://claude.ai/code/session_01P8iLL632vfvSzqv5ndbJRH
