### PR TITLE
fix: add base64 padding to FCM crypto_key and salt decoding

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -434,8 +434,8 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         salt_str: str,
         raw_data: bytes,
     ) -> bytes:
-        crypto_key = urlsafe_b64decode(crypto_key_str.encode("ascii"))
-        salt = urlsafe_b64decode(salt_str.encode("ascii"))
+        crypto_key = urlsafe_b64decode(crypto_key_str.encode("ascii") + b"=" * (-len(crypto_key_str) % 4))
+        salt = urlsafe_b64decode(salt_str.encode("ascii") + b"=" * (-len(salt_str) % 4))
 
         keys_section = credentials.get("keys")
         if not isinstance(keys_section, Mapping):
@@ -446,8 +446,8 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         if not (isinstance(private_value, str) and isinstance(secret_value, str)):
             raise ValueError("Invalid key values in credential payload")
 
-        der_data = urlsafe_b64decode(private_value.encode("ascii") + b"========")
-        secret = urlsafe_b64decode(secret_value.encode("ascii") + b"========")
+        der_data = urlsafe_b64decode(private_value.encode("ascii") + b"=" * (-len(private_value) % 4))
+        secret = urlsafe_b64decode(secret_value.encode("ascii") + b"=" * (-len(secret_value) % 4))
         privkey = load_der_private_key(der_data, password=None)
         decrypted = http_decrypt(
             raw_data,


### PR DESCRIPTION
The FCM server sends crypto-key and salt values as unpadded base64url strings. Python's urlsafe_b64decode requires correct padding, causing binascii.Error: Incorrect padding when decoding these values.

Apply the same dynamic padding pattern (-len(s) % 4) already used in shared_key_retrieval.py and get_owner_key.py. Also normalizes the hard-coded b"========" padding on der_data/secret to use the same consistent approach.

https://claude.ai/code/session_01VWxmuXrfwXXxKi579zNJsa
