### PR TITLE
feat: make external URL optional, fall back to internal URL for map view

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -7559,21 +7559,27 @@ async def _async_refresh_device_urls(hass: HomeAssistant) -> None:
                 hass,
                 prefer_external=True,
                 allow_cloud=True,
-                allow_internal=False,
+                allow_internal=True,
             ),
         )
     except (HomeAssistantError, NoURLAvailableError) as err:
         _LOGGER.warning(
-            "Skipping configuration URL refresh; external URL unavailable: %s",
+            "Skipping configuration URL refresh; no reachable URL available: %s",
             err,
         )
         return
 
     if not base_url or "://" not in base_url:
         _LOGGER.warning(
-            "Skipping configuration URL refresh; external URL unavailable",
+            "Skipping configuration URL refresh; no reachable URL available",
         )
         return
+
+    if not hass.config.external_url:
+        _LOGGER.info(
+            "Using internal URL for map view links; "
+            "set an external URL in Home Assistant settings for remote access",
+        )
 
     base_url = base_url.rstrip("/")
 

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -7575,7 +7575,13 @@ async def _async_refresh_device_urls(hass: HomeAssistant) -> None:
         )
         return
 
-    if not hass.config.external_url:
+    try:
+        internal_url = get_url(
+            hass, allow_external=False, allow_cloud=False, allow_internal=True,
+        )
+    except (HomeAssistantError, NoURLAvailableError):
+        internal_url = None
+    if base_url.rstrip("/") == (internal_url or "").rstrip("/"):
         _LOGGER.info(
             "Using internal URL for map view links; "
             "set an external URL in Home Assistant settings for remote access",

--- a/custom_components/googlefindmy/entity.py
+++ b/custom_components/googlefindmy/entity.py
@@ -572,12 +572,22 @@ class GoogleFindMyDeviceEntity(GoogleFindMyEntity):
                 self._base_url_warning_emitted = True
             return None
 
-        if not self._base_url_warning_emitted and not self.hass.config.external_url:
-            _LOGGER.info(
-                "Using internal URL for map view links; "
-                "set an external URL in Home Assistant settings for remote access",
-            )
-            self._base_url_warning_emitted = True
+        if not self._base_url_warning_emitted:
+            try:
+                internal_url = get_url(
+                    self.hass,
+                    allow_external=False,
+                    allow_cloud=False,
+                    allow_internal=True,
+                )
+            except (HomeAssistantError, NoURLAvailableError):
+                internal_url = None
+            if base_url.rstrip("/") == (internal_url or "").rstrip("/"):
+                _LOGGER.info(
+                    "Using internal URL for map view links; "
+                    "set an external URL in Home Assistant settings for remote access",
+                )
+                self._base_url_warning_emitted = True
 
         return base_url.rstrip("/")
 

--- a/custom_components/googlefindmy/entity.py
+++ b/custom_components/googlefindmy/entity.py
@@ -542,7 +542,7 @@ class GoogleFindMyDeviceEntity(GoogleFindMyEntity):
         return self._DEFAULT_DEVICE_LABEL
 
     def _resolve_absolute_base_url(self) -> str | None:
-        """Return the Home Assistant external base URL when available."""
+        """Return the Home Assistant base URL (prefers external, falls back to internal)."""
 
         try:
             base_url = cast(
@@ -551,13 +551,13 @@ class GoogleFindMyDeviceEntity(GoogleFindMyEntity):
                     self.hass,
                     prefer_external=True,
                     allow_cloud=True,
-                    allow_internal=False,
+                    allow_internal=True,
                 ),
             )
         except (HomeAssistantError, NoURLAvailableError) as err:
             if not self._base_url_warning_emitted:
                 _LOGGER.warning(
-                    "Unable to resolve external URL; set the External URL in Home Assistant settings: %s",
+                    "Unable to resolve any Home Assistant URL for map view: %s",
                     err,
                 )
                 self._base_url_warning_emitted = True
@@ -566,11 +566,18 @@ class GoogleFindMyDeviceEntity(GoogleFindMyEntity):
         if not base_url or "://" not in base_url:
             if not self._base_url_warning_emitted:
                 _LOGGER.warning(
-                    "Unable to resolve external URL; set the External URL in Home Assistant settings: %s",
+                    "Unable to resolve any Home Assistant URL for map view: %s",
                     base_url,
                 )
                 self._base_url_warning_emitted = True
             return None
+
+        if not self._base_url_warning_emitted and not self.hass.config.external_url:
+            _LOGGER.info(
+                "Using internal URL for map view links; "
+                "set an external URL in Home Assistant settings for remote access",
+            )
+            self._base_url_warning_emitted = True
 
         return base_url.rstrip("/")
 

--- a/custom_components/googlefindmy/services.py
+++ b/custom_components/googlefindmy/services.py
@@ -1003,20 +1003,26 @@ async def async_register_services(hass: HomeAssistant, ctx: dict[str, Any]) -> N
                 hass,
                 prefer_external=True,
                 allow_cloud=True,
-                allow_internal=False,
+                allow_internal=True,
             )
         except (HomeAssistantError, NoURLAvailableError) as err:
             _LOGGER.warning(
-                "Skipping configuration URL refresh; external URL unavailable: %s",
+                "Skipping configuration URL refresh; no reachable URL available: %s",
                 err,
             )
             return
 
         if not base_url:
             _LOGGER.warning(
-                "Skipping configuration URL refresh; external URL unavailable",
+                "Skipping configuration URL refresh; no reachable URL available",
             )
             return
+
+        if not hass.config.external_url:
+            _LOGGER.info(
+                "Using internal URL for map view links; "
+                "set an external URL in Home Assistant settings for remote access",
+            )
 
         entries = hass.config_entries.async_entries(DOMAIN)
         entries_by_id = {entry.entry_id: entry for entry in entries}

--- a/custom_components/googlefindmy/services.py
+++ b/custom_components/googlefindmy/services.py
@@ -1018,7 +1018,13 @@ async def async_register_services(hass: HomeAssistant, ctx: dict[str, Any]) -> N
             )
             return
 
-        if not hass.config.external_url:
+        try:
+            internal_url = get_url(
+                hass, allow_external=False, allow_cloud=False, allow_internal=True,
+            )
+        except (HomeAssistantError, NoURLAvailableError):
+            internal_url = None
+        if base_url.rstrip("/") == (internal_url or "").rstrip("/"):
             _LOGGER.info(
                 "Using internal URL for map view links; "
                 "set an external URL in Home Assistant settings for remote access",

--- a/tests/test_metadata_helpers.py
+++ b/tests/test_metadata_helpers.py
@@ -117,7 +117,7 @@ def test_device_configuration_url_warns_when_external_url_missing(
     warnings = [
         record
         for record in caplog.records
-        if "Unable to resolve external URL" in record.getMessage()
+        if "Unable to resolve any Home Assistant URL for map view" in record.getMessage()
     ]
     assert len(warnings) == 1
     assert entity._base_url_warning_emitted is True


### PR DESCRIPTION
[feat: make external URL optional, fall back to internal URL for map view](https://github.com/jleinenbach/GoogleFindMy-HA/commit/38b6185c219ace387be28233983527491a7c2357) 

Users without an external URL configured in Home Assistant (e.g. VPN-only
setups) previously got repeated warnings and no device map links at all.
The external URL is only used for building absolute configuration URLs for
the device registry's map view and has no impact on core functionality.

Allow fallback to the internal URL so LAN users can still access the map
view. External URLs are still preferred when configured. An info-level log
is emitted when falling back to an internal URL so users are aware that
map links will only work on their local network.

https://claude.ai/code/session_01PQchA5hZTKGf31f6auSFZY
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 33 minutes ago
[fix: detect internal URL by comparison instead of checking external_u…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/be7d9e37f91fbd5abed418cdfcbadc44f6b23811) 

…rl config

Replace `not hass.config.external_url` with an actual comparison of the
resolved base URL against the internal-only URL from get_url().  This
avoids a false-positive "Using internal URL" INFO log when a Nabu Casa
Cloud URL is resolved but no explicit external_url is configured.

https://claude.ai/code/session_01PQchA5hZTKGf31f6auSFZY