### PR TITLE
fix: parse FCM crypto-key and encryption headers by parameter name

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -470,6 +470,20 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             return ""
         raise RuntimeError(f"couldn't find in app_data {key}")
 
+    @staticmethod
+    def _extract_header_param(header: str, param: str) -> str:
+        """Extract a named parameter from a semicolon-separated header value.
+
+        FCM headers like crypto-key and encryption use the format
+        ``key=value;key2=value2``.  Blindly slicing off a fixed prefix
+        breaks when extra parameters (e.g. ``p256ecdsa=...``) are present.
+        """
+        for part in header.split(";"):
+            key, _, value = part.strip().partition("=")
+            if key == param:
+                return value
+        raise ValueError(f"Parameter '{param}' not found in header: {header}")
+
     def _handle_data_message(
         self,
         msg: DataMessageStanza,
@@ -487,8 +501,12 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         ):
             # The deleted_messages message does not contain data.
             return
-        crypto_key = self._app_data_by_key(msg, "crypto-key")[3:]  # strip dh=
-        salt = self._app_data_by_key(msg, "encryption")[5:]  # strip salt=
+        crypto_key = self._extract_header_param(
+            self._app_data_by_key(msg, "crypto-key"), "dh"
+        )
+        salt = self._extract_header_param(
+            self._app_data_by_key(msg, "encryption"), "salt"
+        )
         subtype = self._app_data_by_key(msg, "subtype")
         if TYPE_CHECKING:
             assert self.credentials

--- a/tests/test_fcm_crypto_header_parsing.py
+++ b/tests/test_fcm_crypto_header_parsing.py
@@ -1,0 +1,36 @@
+# tests/test_fcm_crypto_header_parsing.py
+"""Tests for FcmPushClient._extract_header_param."""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClient,
+)
+
+
+class TestExtractHeaderParam:
+    """Verify semicolon-separated header values are parsed correctly."""
+
+    def test_simple_dh(self) -> None:
+        assert FcmPushClient._extract_header_param("dh=BPxxx", "dh") == "BPxxx"
+
+    def test_dh_with_vapid_key(self) -> None:
+        header = "dh=BPxxx;p256ecdsa=BYyyy"
+        assert FcmPushClient._extract_header_param(header, "dh") == "BPxxx"
+
+    def test_simple_salt(self) -> None:
+        assert FcmPushClient._extract_header_param("salt=abc", "salt") == "abc"
+
+    def test_salt_with_extra_params(self) -> None:
+        header = "salt=abc;rs=4096"
+        assert FcmPushClient._extract_header_param(header, "salt") == "abc"
+
+    def test_whitespace_around_parts(self) -> None:
+        header = "dh=BPxxx ; p256ecdsa=BYyyy"
+        assert FcmPushClient._extract_header_param(header, "dh") == "BPxxx"
+        assert FcmPushClient._extract_header_param(header, "p256ecdsa") == "BYyyy"
+
+    def test_missing_param_raises(self) -> None:
+        with pytest.raises(ValueError, match="Parameter 'dh' not found"):
+            FcmPushClient._extract_header_param("salt=abc", "dh")


### PR DESCRIPTION
The crypto-key header can contain semicolon-separated key-value pairs (e.g. `dh=BPxxx;p256ecdsa=BYyyy`).  The previous code blindly sliced the first 3 / 5 characters, which included trailing parameters in the base64 payload and caused `ValueError: Invalid EC key` during decryption.

Parse the header properly by splitting on `;` and matching by key name so only the intended `dh=` or `salt=` value is extracted.

https://claude.ai/code/session_0126BYUTtsXPj8MAvcGSTgn1

Fixes https://github.com/BSkando/GoogleFindMy-HA/issues/147
