### PR TITLE
fix: add X-Android-Package/Cert headers to Firebase API calls

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -662,6 +662,7 @@ class FcmReceiverHA:
                 api_key=self.api_key,
                 messaging_sender_id=self.message_sender_id,
                 bundle_id="com.google.android.apps.adm",
+                android_cert_sha1="38918a453d07199354f8b19af05ec6562ced5788",
             )
 
             # Per-entry credentials update callback

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -76,10 +76,13 @@ from .proto.checkin_pb2 import (
 _logger = logging.getLogger(__name__)
 
 
+_SHA1_HEX_LENGTH = 40
+
+
 def _normalize_sha1_fingerprint(v: str) -> str:
     """Strip colons/spaces and validate a SHA-1 hex fingerprint."""
     v = v.replace(":", "").replace(" ", "").strip().lower()
-    if len(v) != 40 or not all(c in "0123456789abcdef" for c in v):
+    if len(v) != _SHA1_HEX_LENGTH or not all(c in "0123456789abcdef" for c in v):
         raise ValueError(f"Invalid SHA-1 fingerprint: {v!r}")
     return v
 

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -76,6 +76,14 @@ from .proto.checkin_pb2 import (
 _logger = logging.getLogger(__name__)
 
 
+def _normalize_sha1_fingerprint(v: str) -> str:
+    """Strip colons/spaces and validate a SHA-1 hex fingerprint."""
+    v = v.replace(":", "").replace(" ", "").strip().lower()
+    if len(v) != 40 or not all(c in "0123456789abcdef" for c in v):
+        raise ValueError(f"Invalid SHA-1 fingerprint: {v!r}")
+    return v
+
+
 @dataclass
 class FcmRegisterConfig:
     """Configuration for FCM/GCM registration.
@@ -99,6 +107,10 @@ class FcmRegisterConfig:
           to avoid server errors.
         - If Google rejects the numeric sender with `PHONE_REGISTRATION_ERROR`, we
           automatically fall back to the legacy server key used by upstream tools.
+        - `android_cert_sha1` is the SHA-1 fingerprint of the Android signing
+          certificate. When set together with `bundle_id`, both values are sent as
+          ``X-Android-Package`` / ``X-Android-Cert`` headers on Firebase API calls
+          so that API-key restrictions are satisfied.
     """
 
     project_id: str
@@ -111,11 +123,16 @@ class FcmRegisterConfig:
     vapid_key: str | None = GCM_SERVER_KEY_B64
     persistent_ids: list[str] | None = None
     heartbeat_interval_ms: int = 5 * 60 * 1000  # 5 mins
+    android_cert_sha1: str | None = None
 
     def __post_init__(self) -> None:
         """Post-initialization hook to set default for persistent_ids."""
         if self.persistent_ids is None:
             self.persistent_ids = []
+        if self.android_cert_sha1 is not None:
+            self.android_cert_sha1 = _normalize_sha1_fingerprint(
+                self.android_cert_sha1
+            )
 
 
 class FcmRegister:
@@ -158,6 +175,13 @@ class FcmRegister:
     # ---------------------------------------------------------------------
     # Helpers (logging / URL handling / redaction)
     # ---------------------------------------------------------------------
+    def _add_android_restriction_headers(self, headers: dict[str, str]) -> None:
+        """Add X-Android-Package/Cert headers when configured."""
+        if self.config.bundle_id:
+            headers["X-Android-Package"] = self.config.bundle_id
+        if self.config.android_cert_sha1:
+            headers["X-Android-Cert"] = self.config.android_cert_sha1
+
     @staticmethod
     def _redact(value: Any, keep_tail: int = 6) -> str:
         """Return a redacted version of tokens/ids for safe logging."""
@@ -640,6 +664,7 @@ class FcmRegister:
             "x-firebase-client": hb_header,
             "x-goog-api-key": self.config.api_key,
         }
+        self._add_android_restriction_headers(headers)
         payload = {
             "appId": self.config.app_id,
             "authVersion": AUTH_VERSION,
@@ -704,6 +729,7 @@ class FcmRegister:
             "x-firebase-client": hb_header,
             "x-goog-api-key": self.config.api_key,
         }
+        self._add_android_restriction_headers(headers)
         payload = {
             "installation": {"sdkVersion": SDK_VERSION, "appId": self.config.app_id}
         }
@@ -781,6 +807,7 @@ class FcmRegister:
             "x-goog-api-key": self.config.api_key,
             "x-goog-firebase-installations-auth": installation["token"],
         }
+        self._add_android_restriction_headers(headers)
         # If vapid_key is the default do not send it here or it will error
         vapid_key = (
             self.config.vapid_key


### PR DESCRIPTION
Google now enforces API key restrictions on Firebase Installations, requiring X-Android-Package and X-Android-Cert headers. Without them the androidPackage appears as <empty> and requests are blocked with API_KEY_ANDROID_APP_BLOCKED (403).

Add android_cert_sha1 field to FcmRegisterConfig and inject both headers into fcm_install(), fcm_refresh_install_token(), and fcm_register() when configured. Uses the SHA1 fingerprint from the Google Find My Device APK (com.google.android.apps.adm).

Fixes upstream issue leonboe1/GoogleFindMyTools#90.

https://claude.ai/code/session_01M7PXiBP5Tf4KhQjZfXcd2N
