### PR TITLE
Claude/fix googlefindmy integration l16 jg

### DIFF
--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -500,17 +500,23 @@ async def async_get_aas_token(
     return token
 
 
-# ----------------------- Legacy sync wrapper (unsupported) -----------------------
+# ----------------------- Legacy sync wrapper (CLI/offline only) -----------------------
 
 
-def get_aas_token() -> (
-    str
-):  # pragma: no cover - legacy path kept for compatibility messaging
-    """Legacy sync API is intentionally unsupported to prevent event loop deadlocks.
+def get_aas_token() -> str:
+    """Synchronous facade for CLI/offline usage; not allowed in the HA event loop.
 
     Raises:
-        NotImplementedError: Always. Use `await async_get_aas_token()` instead.
+        RuntimeError: If called from within a running event loop.
     """
-    raise NotImplementedError(
-        "Use `await async_get_aas_token(cache=...)` instead of the synchronous get_aas_token()."
-    )
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop -> allowed (CLI/offline usage)
+        return asyncio.run(async_get_aas_token())
+    if loop.is_running():
+        raise RuntimeError(
+            "Sync get_aas_token() called from the event loop. "
+            "Use `await async_get_aas_token()` instead."
+        )
+    return asyncio.run(async_get_aas_token())

--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -503,7 +503,7 @@ async def async_get_aas_token(
 # ----------------------- Legacy sync wrapper (CLI/offline only) -----------------------
 
 
-def get_aas_token() -> str:
+def get_aas_token(*, cache: TokenCache) -> str:
     """Synchronous facade for CLI/offline usage; not allowed in the HA event loop.
 
     Raises:
@@ -512,11 +512,10 @@ def get_aas_token() -> str:
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
-        # No running loop -> allowed (CLI/offline usage)
-        return asyncio.run(async_get_aas_token())
+        return asyncio.run(async_get_aas_token(cache=cache))
     if loop.is_running():
         raise RuntimeError(
             "Sync get_aas_token() called from the event loop. "
             "Use `await async_get_aas_token()` instead."
         )
-    return asyncio.run(async_get_aas_token())
+    return asyncio.run(async_get_aas_token(cache=cache))

--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -510,12 +510,10 @@ def get_aas_token(*, cache: TokenCache) -> str:
         RuntimeError: If called from within a running event loop.
     """
     try:
-        loop = asyncio.get_running_loop()
+        asyncio.get_running_loop()
     except RuntimeError:
         return asyncio.run(async_get_aas_token(cache=cache))
-    if loop.is_running():
-        raise RuntimeError(
-            "Sync get_aas_token() called from the event loop. "
-            "Use `await async_get_aas_token()` instead."
-        )
-    return asyncio.run(async_get_aas_token(cache=cache))
+    raise RuntimeError(
+        "Sync get_aas_token() called from the event loop. "
+        "Use `await async_get_aas_token()` instead."
+    )

--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -282,7 +282,7 @@ async def _async_cli_main(entry_id: str | None = None) -> None:
                 "custom_components.googlefindmy.SpotApi.CreateBleDevice.create_ble_device"
             ).register_esp32
 
-            register_esp32()
+            register_esp32(cache=cache)
 
         # Run potential blocking/IO work in a worker thread to avoid blocking the loop.
         await asyncio.to_thread(_register_esp32_cli)

--- a/custom_components/googlefindmy/SpotApi/CreateBleDevice/create_ble_device.py
+++ b/custom_components/googlefindmy/SpotApi/CreateBleDevice/create_ble_device.py
@@ -7,6 +7,7 @@
 import secrets
 import time
 
+from custom_components.googlefindmy.Auth.token_cache import TokenCache
 from custom_components.googlefindmy.const import MICRO
 from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
     ROTATION_PERIOD,
@@ -32,8 +33,8 @@ from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_k
 from custom_components.googlefindmy.SpotApi.spot_request import spot_request
 
 
-def register_esp32() -> None:
-    owner_key: bytes = get_owner_key()
+def register_esp32(*, cache: TokenCache) -> None:
+    owner_key: bytes = get_owner_key(cache=cache).key
 
     eik: bytes = secrets.token_bytes(32)
     eid: bytes = generate_eid_variant(eik, 0, EidVariant.LEGACY_SECP160R1_X20_BE)

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -425,7 +425,7 @@ async def async_get_owner_key(  # noqa: PLR0912,PLR0915
 # ---------------------------------------------------------------------------
 
 
-def get_owner_key() -> bytes:
+def get_owner_key(*, cache: TokenCache) -> OwnerKeyInfo:
     """Synchronous facade for CLI/offline usage; not allowed in the HA event loop.
 
     Raises:
@@ -434,11 +434,10 @@ def get_owner_key() -> bytes:
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
-        # No running loop -> allowed (CLI/offline usage)
-        return asyncio.run(async_get_owner_key())
+        return asyncio.run(async_get_owner_key(cache=cache))
     if loop.is_running():
         raise RuntimeError(
             "Sync get_owner_key() called from the event loop. "
             "Use `await async_get_owner_key()` instead."
         )
-    return asyncio.run(async_get_owner_key())
+    return asyncio.run(async_get_owner_key(cache=cache))

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -432,12 +432,10 @@ def get_owner_key(*, cache: TokenCache) -> OwnerKeyInfo:
         RuntimeError: If called from within a running event loop.
     """
     try:
-        loop = asyncio.get_running_loop()
+        asyncio.get_running_loop()
     except RuntimeError:
         return asyncio.run(async_get_owner_key(cache=cache))
-    if loop.is_running():
-        raise RuntimeError(
-            "Sync get_owner_key() called from the event loop. "
-            "Use `await async_get_owner_key()` instead."
-        )
-    return asyncio.run(async_get_owner_key(cache=cache))
+    raise RuntimeError(
+        "Sync get_owner_key() called from the event loop. "
+        "Use `await async_get_owner_key()` instead."
+    )

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -27,6 +27,7 @@ Injection points (optional):
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 import re
@@ -420,19 +421,24 @@ async def async_get_owner_key(  # noqa: PLR0912,PLR0915
 
 
 # ---------------------------------------------------------------------------
-# Legacy sync facade (disabled by design)
+# Legacy sync facade (CLI/offline only)
 # ---------------------------------------------------------------------------
 
 
-def get_owner_key() -> bytes:  # pragma: no cover - kept for import compatibility
-    """Legacy sync facade - intentionally unsupported inside Home Assistant.
-
-    This function exists only to preserve import compatibility for external/CLI scripts.
-    It **must not** be used from within the HA event loop and intentionally raises to
-    enforce the async-first contract. CLI users should run `async_get_owner_key()` via
-    `asyncio.run(...)`.
+def get_owner_key() -> bytes:
+    """Synchronous facade for CLI/offline usage; not allowed in the HA event loop.
 
     Raises:
-        NotImplementedError: Always. Use `async_get_owner_key()` instead.
+        RuntimeError: If called from within a running event loop.
     """
-    raise NotImplementedError("Use async_get_owner_key() instead.")
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop -> allowed (CLI/offline usage)
+        return asyncio.run(async_get_owner_key())
+    if loop.is_running():
+        raise RuntimeError(
+            "Sync get_owner_key() called from the event loop. "
+            "Use `await async_get_owner_key()` instead."
+        )
+    return asyncio.run(async_get_owner_key())

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -7006,27 +7006,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
     await _async_relink_button_devices(hass, entry)
     await _async_relink_subentry_entities(hass, entry)
 
-    # Acquire shared FCM and create a startup barrier for the first poll cycle.
-    fcm_ready_event = asyncio.Event()
-    fcm = await _async_acquire_shared_fcm(
-        hass,
-        entry=entry,
-        cache=cache,
-        entry_resolver=lambda: getattr(entry, "entry_id", None),
-    )
-    pm_fcm_acquired = time.monotonic()
-    fcm_ready_event.set()
-
-    # Signal-only stop on unload (bounded; actual await in async_unload_entry)
-    def _on_unload_signal_fcm() -> None:
-        try:
-            fcm.request_stop()
-        except Exception as err:
-            _LOGGER.debug("FCM stop signal during unload raised: %s", err)
-
-    entry.async_on_unload(_on_unload_signal_fcm)
-
-    # Credentials seed: legacy bundle OR individual oauth_token+email must be present
+    # Credentials seed: legacy bundle OR individual oauth_token+email must be present.
+    # IMPORTANT: This MUST run BEFORE _async_acquire_shared_fcm() because the FCM
+    # receiver reads fcm_credentials from the cache during async_initialize() →
+    # _prime_cache_state().  Without this, cold starts leave fcm_credentials empty
+    # and device locations stay "Unknown" (Issue #152).
     secrets_data = entry.data.get(DATA_SECRET_BUNDLE)
     oauth_token = entry.data.get(CONF_OAUTH_TOKEN)
     aas_token_entry = entry.data.get(DATA_AAS_TOKEN)
@@ -7063,6 +7047,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
             "No credentials found in config entry (neither secrets_data nor oauth_token+google_email)"
         )
         raise ConfigEntryNotReady("Credentials missing")
+
+    # Acquire shared FCM and create a startup barrier for the first poll cycle.
+    fcm_ready_event = asyncio.Event()
+    fcm = await _async_acquire_shared_fcm(
+        hass,
+        entry=entry,
+        cache=cache,
+        entry_resolver=lambda: getattr(entry, "entry_id", None),
+    )
+    pm_fcm_acquired = time.monotonic()
+    fcm_ready_event.set()
+
+    # Signal-only stop on unload (bounded; actual await in async_unload_entry)
+    def _on_unload_signal_fcm() -> None:
+        try:
+            fcm.request_stop()
+        except Exception as err:
+            _LOGGER.debug("FCM stop signal during unload raised: %s", err)
+
+    entry.async_on_unload(_on_unload_signal_fcm)
 
     # Remove legacy parent links from tracker devices before building runtime state.
     _self_heal_device_registry(hass, entry)

--- a/tests/test_aas_token_retrieval.py
+++ b/tests/test_aas_token_retrieval.py
@@ -751,9 +751,10 @@ async def test_async_get_aas_token_ttl_write_failure(
 
 
 def test_get_aas_token_sync_raises() -> None:
-    """Legacy sync API should raise NotImplementedError."""
-    with pytest.raises(NotImplementedError, match="async_get_aas_token"):
-        aas_token_retrieval.get_aas_token()
+    """Sync API should raise RuntimeError when called from a running event loop."""
+    cache = _DummyCache()
+    with pytest.raises(RuntimeError, match="async_get_aas_token"):
+        aas_token_retrieval.get_aas_token(cache=cache)
 
 
 async def test_get_or_generate_android_id_fcm_without_gcm_block() -> None:

--- a/tests/test_aas_token_retrieval.py
+++ b/tests/test_aas_token_retrieval.py
@@ -750,7 +750,7 @@ async def test_async_get_aas_token_ttl_write_failure(
     assert result == "aas_token"
 
 
-def test_get_aas_token_sync_raises() -> None:
+async def test_get_aas_token_sync_raises() -> None:
     """Sync API should raise RuntimeError when called from a running event loop."""
     cache = _DummyCache()
     with pytest.raises(RuntimeError, match="async_get_aas_token"):

--- a/tests/test_create_ble_device.py
+++ b/tests/test_create_ble_device.py
@@ -122,7 +122,11 @@ def test_register_esp32(monkeypatch) -> None:
 
     monkeypatch.setattr(module.secrets, "token_bytes", fake_token_bytes)
     monkeypatch.setattr(module.time, "time", lambda: float(fake_time_value))
-    monkeypatch.setattr(module, "get_owner_key", lambda: fake_owner_key)
+    monkeypatch.setattr(
+        module,
+        "get_owner_key",
+        lambda **_kw: SimpleNamespace(key=fake_owner_key),
+    )
     generate_calls: list[tuple[bytes, int, object]] = []
 
     def fake_generate_eid_variant(eik: bytes, counter: int, variant: object) -> bytes:
@@ -137,7 +141,7 @@ def test_register_esp32(monkeypatch) -> None:
     monkeypatch.setattr(module, "max_truncated_eid_seconds_server", 30, False)
     monkeypatch.setattr(module, "ROTATION_PERIOD", 10, False)
 
-    create_ble_device.register_esp32()
+    create_ble_device.register_esp32(cache=None)
 
     assert spot_calls == [("CreateBleDevice", b"stub-serialized")]
 

--- a/tests/test_create_ble_device.py
+++ b/tests/test_create_ble_device.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+from custom_components.googlefindmy.Auth.token_cache import TokenCache
 from custom_components.googlefindmy.SpotApi.CreateBleDevice import create_ble_device
 
 
@@ -141,7 +143,7 @@ def test_register_esp32(monkeypatch) -> None:
     monkeypatch.setattr(module, "max_truncated_eid_seconds_server", 30, False)
     monkeypatch.setattr(module, "ROTATION_PERIOD", 10, False)
 
-    create_ble_device.register_esp32(cache=None)
+    create_ble_device.register_esp32(cache=MagicMock(spec=TokenCache))
 
     assert spot_calls == [("CreateBleDevice", b"stub-serialized")]
 


### PR DESCRIPTION
## Fix: Seed FCM credentials before receiver initialization (Issue #152)

### Summary

- **Root cause:** On cold starts, `fcm_credentials` were not present in the `TokenCache` when the FCM receiver called `_prime_cache_state()` during `async_initialize()`. The credentials seeding (`_async_save_secrets_data`) happened *after* `_async_acquire_shared_fcm()`, so the receiver found an empty cache and device locations stayed "Unknown".
- **Fix:** Move the entire credentials seeding block (secrets bundle + manual credentials fallback) **before** the FCM acquisition call, ensuring `fcm_credentials` are available when the receiver initializes.
- **Additional fixes:** `get_aas_token()` and `get_owner_key()` now use `asyncio.run()` as a sync fallback (matching the existing `get_adm_token()` pattern) instead of raising `NotImplementedError`, restoring CLI/`main.py` usability.

### Changes

| File | Change |
|------|--------|
| `__init__.py` | Moved credentials seeding block before `_async_acquire_shared_fcm()` to fix race condition |
| `Auth/aas_token_retrieval.py` | Replaced `NotImplementedError` with `asyncio.run()` sync fallback |
| `SpotApi/.../get_owner_key.py` | Added missing `import asyncio`; replaced `NotImplementedError` with `asyncio.run()` sync fallback |

### Test plan

- [ ] Cold start HA with a configured GoogleFindMy integration → verify device locations resolve (not "Unknown")
- [ ] Restart HA (warm start) → verify locations still resolve correctly
- [ ] Run `main.py` CLI to generate `secrets.json` → verify `get_aas_token()` and `get_owner_key()` work synchronously
- [ ] Verify no regressions in FCM push-based location updates

https://claude.ai/code/session_016MCv3D4NVmypeUdjrmHrvp
