### PR TITLE
fix: support standalone execution of main.py outside HA structure

### DIFF
--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -4,14 +4,27 @@
 #
 
 import sys
+import types
 from pathlib import Path
 
-# When run as `python main.py` from the googlefindmy/ directory, the repo root
-# must be on sys.path so that internal `custom_components.googlefindmy.*`
-# imports (used throughout the codebase for HA compatibility) can resolve.
-_repo_root = str(Path(__file__).resolve().parents[2])
-if _repo_root not in sys.path:
-    sys.path.insert(0, _repo_root)
+_this_dir = Path(__file__).resolve().parent
+
+if _this_dir.name == "googlefindmy" and _this_dir.parent.name == "custom_components":
+    # Running inside the HA repo structure – add repo root to sys.path
+    _repo_root = str(_this_dir.parents[2])
+    if _repo_root not in sys.path:
+        sys.path.insert(0, _repo_root)
+else:
+    # Running standalone (files copied to a flat directory like GoogleFindMyTools/)
+    # Create virtual package so `custom_components.googlefindmy.*` imports resolve here
+    if "custom_components" not in sys.modules:
+        _cc = types.ModuleType("custom_components")
+        _cc.__path__ = []
+        sys.modules["custom_components"] = _cc
+    if "custom_components.googlefindmy" not in sys.modules:
+        _ccg = types.ModuleType("custom_components.googlefindmy")
+        _ccg.__path__ = [str(_this_dir)]
+        sys.modules["custom_components.googlefindmy"] = _ccg
 
 from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import list_devices  # noqa: E402
 


### PR DESCRIPTION
When users copy custom_components/googlefindmy/ contents to a flat directory (e.g. GoogleFindMyTools/), the custom_components.googlefindmy.* imports fail because the package hierarchy doesn't exist.

Detect at runtime whether main.py is inside the HA repo structure or running standalone, and create virtual sys.modules entries for the custom_components.googlefindmy namespace in the standalone case.
