### PR TITLE
fix: stub homeassistant modules for standalone execution

### DIFF
--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -28,7 +28,13 @@ else:
 
     # Provide lightweight stubs for homeassistant so HA-specific imports
     # in token_cache.py and exceptions.py don't fail at import time.
-    if "homeassistant" not in sys.modules:
+    # Only inject stubs when HA is genuinely unavailable (not just not-yet-imported).
+    _ha_available = "homeassistant" in sys.modules
+    if not _ha_available:
+        from importlib.util import find_spec
+
+        _ha_available = find_spec("homeassistant") is not None
+    if not _ha_available:
         _ha = types.ModuleType("homeassistant")
         _ha.__path__ = []
         sys.modules["homeassistant"] = _ha

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -26,6 +26,29 @@ else:
         _ccg.__path__ = [str(_this_dir)]
         sys.modules["custom_components.googlefindmy"] = _ccg
 
+    # Provide lightweight stubs for homeassistant so HA-specific imports
+    # in token_cache.py and exceptions.py don't fail at import time.
+    if "homeassistant" not in sys.modules:
+        _ha = types.ModuleType("homeassistant")
+        _ha.__path__ = []
+        sys.modules["homeassistant"] = _ha
+
+        _ha_core = types.ModuleType("homeassistant.core")
+        _ha_core.HomeAssistant = type("HomeAssistant", (), {})  # type: ignore[attr-defined]
+        sys.modules["homeassistant.core"] = _ha_core
+
+        _ha_helpers = types.ModuleType("homeassistant.helpers")
+        _ha_helpers.__path__ = []
+        sys.modules["homeassistant.helpers"] = _ha_helpers
+
+        _ha_storage = types.ModuleType("homeassistant.helpers.storage")
+        _ha_storage.Store = type("Store", (), {})  # type: ignore[attr-defined]
+        sys.modules["homeassistant.helpers.storage"] = _ha_storage
+
+        _ha_exceptions = types.ModuleType("homeassistant.exceptions")
+        _ha_exceptions.HomeAssistantError = type("HomeAssistantError", (Exception,), {})  # type: ignore[attr-defined]
+        sys.modules["homeassistant.exceptions"] = _ha_exceptions
+
 from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import list_devices  # noqa: E402
 
 if __name__ == "__main__":


### PR DESCRIPTION
When users copy custom_components/googlefindmy/ contents to a flat directory (e.g. GoogleFindMyTools/), the custom_components.googlefindmy.* imports fail because the package hierarchy doesn't exist.

Detect at runtime whether main.py is inside the HA repo structure or running standalone, and create virtual sys.modules entries for the custom_components.googlefindmy namespace in the standalone case.
