### PR TITLE
fix: auto-generate HA exception stubs for standalone mode

### DIFF
--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -100,8 +100,21 @@ else:
         _ha_storage.Store = type("Store", (), {})  # type: ignore[attr-defined]
         sys.modules["homeassistant.helpers.storage"] = _ha_storage
 
-        _ha_exceptions = types.ModuleType("homeassistant.exceptions")
-        _ha_exceptions.HomeAssistantError = type("HomeAssistantError", (Exception,), {})  # type: ignore[attr-defined]
+        class _StubHAExceptions(types.ModuleType):
+            """Auto-generate HA exception stubs on demand."""
+
+            _HomeAssistantError: type = type("HomeAssistantError", (Exception,), {})
+
+            def __getattr__(self, name: str) -> object:
+                if name.startswith("_"):
+                    raise AttributeError(name)
+                # All HA exceptions inherit from HomeAssistantError
+                cls = type(name, (self._HomeAssistantError,), {})
+                setattr(self, name, cls)
+                return cls
+
+        _ha_exceptions = _StubHAExceptions("homeassistant.exceptions")
+        _ha_exceptions.HomeAssistantError = _ha_exceptions._HomeAssistantError  # type: ignore[attr-defined]
         sys.modules["homeassistant.exceptions"] = _ha_exceptions
 
 from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import list_devices  # noqa: E402

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -84,19 +84,43 @@ else:
 
         _ha_available = find_spec("homeassistant") is not None
     if not _ha_available:
-        _ha = types.ModuleType("homeassistant")
+
+        class _StubHAPackage(types.ModuleType):
+            """Auto-generate HA submodule stubs on demand.
+
+            Any ``from homeassistant.X.Y import Z`` that reaches an
+            unregistered submodule will get an empty stub module created
+            automatically, so transitive imports never fail.
+            """
+
+            def __getattr__(self, name: str) -> object:
+                if name.startswith("_"):
+                    raise AttributeError(name)
+                fullname = f"{self.__name__}.{name}"
+                if fullname in sys.modules:
+                    return sys.modules[fullname]
+                sub = _StubHAPackage(fullname)
+                sub.__path__ = []
+                sys.modules[fullname] = sub
+                setattr(self, name, sub)
+                return sub
+
+        _ha = _StubHAPackage("homeassistant")
         _ha.__path__ = []
         sys.modules["homeassistant"] = _ha
 
-        _ha_core = types.ModuleType("homeassistant.core")
+        # Override specific submodules with concrete stubs where needed.
+        _ha_core = _StubHAPackage("homeassistant.core")
+        _ha_core.__path__ = []
         _ha_core.HomeAssistant = type("HomeAssistant", (), {})  # type: ignore[attr-defined]
         sys.modules["homeassistant.core"] = _ha_core
 
-        _ha_helpers = types.ModuleType("homeassistant.helpers")
+        _ha_helpers = _StubHAPackage("homeassistant.helpers")
         _ha_helpers.__path__ = []
         sys.modules["homeassistant.helpers"] = _ha_helpers
 
-        _ha_storage = types.ModuleType("homeassistant.helpers.storage")
+        _ha_storage = _StubHAPackage("homeassistant.helpers.storage")
+        _ha_storage.__path__ = []
         _ha_storage.Store = type("Store", (), {})  # type: ignore[attr-defined]
         sys.modules["homeassistant.helpers.storage"] = _ha_storage
 
@@ -208,6 +232,12 @@ def _register_file_cache() -> None:
 
         def sync_get(self, name: str) -> object:
             return self._data.get(name)
+
+        def sync_pop(self, name: str, default: object = None) -> object:
+            val = self._data.pop(name, default)
+            if val is not default:
+                self._save()
+            return val
 
         async def all(self) -> dict[str, object]:
             return dict(self._data)

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -90,29 +90,37 @@ else:
         class _DummyMeta(type):
             """Metaclass so dummy classes double as pass-through decorators."""
 
-            def __call__(cls, *args, **kwargs):  # type: ignore[override]
+            def __call__(cls, *args: object, **kwargs: object) -> object:
                 # @some_ha_decorator usage: return the function unchanged
                 if len(args) == 1 and callable(args[0]) and not kwargs:
                     return args[0]
-                obj = cls.__new__(cls)
-                obj.__init__(*args, **kwargs)
-                return obj
+                return super().__call__(*args, **kwargs)
 
         class _Dummy(metaclass=_DummyMeta):
             """Versatile stand-in for any HA symbol (class, decorator, constant)."""
 
-            def __init__(self, *args, **kwargs):  # noqa: ARG002
+            def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: ARG002
                 pass
 
-            def __init_subclass__(cls, **kwargs):
+            def __init_subclass__(cls, **kwargs: object) -> None:
                 super().__init_subclass__(**kwargs)
 
         class _StubHAModule(types.ModuleType):
-            """Stub module – missing attributes become ``_Dummy`` subclasses."""
+            """Stub module – missing attributes become ``_Dummy`` subclasses.
+
+            Attribute lookup first checks ``sys.modules`` for a registered
+            submodule so that ``from homeassistant import core`` (attribute-
+            style access after the finder has already loaded the submodule)
+            returns the real stub module rather than fabricating a dummy.
+            """
 
             def __getattr__(self, name: str) -> object:
                 if name.startswith("_"):
                     raise AttributeError(name)
+                # If a submodule with this name exists, return it.
+                fullname = f"{self.__name__}.{name}"
+                if fullname in sys.modules:
+                    return sys.modules[fullname]
                 cls = type(name, (_Dummy,), {})
                 setattr(self, name, cls)
                 return cls
@@ -132,7 +140,7 @@ else:
         class _HAStubFinder(importlib.abc.MetaPathFinder):
             """Import hook: auto-create stub modules for any ``homeassistant.*``."""
 
-            def find_spec(  # type: ignore[override]
+            def find_spec(
                 self,
                 fullname: str,
                 path: object,
@@ -143,14 +151,16 @@ else:
                     or fullname.startswith("homeassistant.")
                 ) and fullname not in sys.modules:
                     return importlib.machinery.ModuleSpec(
-                        fullname, self, is_package=True,  # type: ignore[arg-type]
+                        fullname,
+                        self,  # type: ignore[arg-type]
+                        is_package=True,
                     )
                 return None
 
             # Loader protocol -------------------------------------------------
             def create_module(self, spec: importlib.machinery.ModuleSpec) -> types.ModuleType:
                 mod = _StubHAModule(spec.name)
-                mod.__path__ = []  # type: ignore[attr-defined]
+                mod.__path__ = []
                 return mod
 
             def exec_module(self, module: types.ModuleType) -> None:  # noqa: ARG002
@@ -162,17 +172,17 @@ else:
         # critical import chain (token_cache, exceptions, get_owner_key)
         # gets the exact types it needs.
         _ha_core = _StubHAModule("homeassistant.core")
-        _ha_core.__path__ = []  # type: ignore[attr-defined]
-        _ha_core.HomeAssistant = type("HomeAssistant", (), {})  # type: ignore[attr-defined]
+        _ha_core.__path__ = []
+        setattr(_ha_core, "HomeAssistant", type("HomeAssistant", (), {}))
         sys.modules["homeassistant.core"] = _ha_core
 
         _ha_storage = _StubHAModule("homeassistant.helpers.storage")
-        _ha_storage.__path__ = []  # type: ignore[attr-defined]
-        _ha_storage.Store = type("Store", (), {})  # type: ignore[attr-defined]
+        _ha_storage.__path__ = []
+        setattr(_ha_storage, "Store", type("Store", (), {}))
         sys.modules["homeassistant.helpers.storage"] = _ha_storage
 
         _ha_exceptions = _StubHAExceptions("homeassistant.exceptions")
-        _ha_exceptions.HomeAssistantError = _ha_exceptions._HomeAssistantError  # type: ignore[attr-defined]
+        setattr(_ha_exceptions, "HomeAssistantError", _ha_exceptions._HomeAssistantError)
         sys.modules["homeassistant.exceptions"] = _ha_exceptions
 
 from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import list_devices  # noqa: E402

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -84,58 +84,92 @@ else:
 
         _ha_available = find_spec("homeassistant") is not None
     if not _ha_available:
+        import importlib.abc  # noqa: PLC0415
+        import importlib.machinery  # noqa: PLC0415
 
-        class _StubHAPackage(types.ModuleType):
-            """Auto-generate HA submodule stubs on demand.
+        class _DummyMeta(type):
+            """Metaclass so dummy classes double as pass-through decorators."""
 
-            Any ``from homeassistant.X.Y import Z`` that reaches an
-            unregistered submodule will get an empty stub module created
-            automatically, so transitive imports never fail.
-            """
+            def __call__(cls, *args, **kwargs):  # type: ignore[override]
+                # @some_ha_decorator usage: return the function unchanged
+                if len(args) == 1 and callable(args[0]) and not kwargs:
+                    return args[0]
+                obj = cls.__new__(cls)
+                obj.__init__(*args, **kwargs)
+                return obj
+
+        class _Dummy(metaclass=_DummyMeta):
+            """Versatile stand-in for any HA symbol (class, decorator, constant)."""
+
+            def __init__(self, *args, **kwargs):  # noqa: ARG002
+                pass
+
+            def __init_subclass__(cls, **kwargs):
+                super().__init_subclass__(**kwargs)
+
+        class _StubHAModule(types.ModuleType):
+            """Stub module – missing attributes become ``_Dummy`` subclasses."""
 
             def __getattr__(self, name: str) -> object:
                 if name.startswith("_"):
                     raise AttributeError(name)
-                fullname = f"{self.__name__}.{name}"
-                if fullname in sys.modules:
-                    return sys.modules[fullname]
-                sub = _StubHAPackage(fullname)
-                sub.__path__ = []
-                sys.modules[fullname] = sub
-                setattr(self, name, sub)
-                return sub
-
-        _ha = _StubHAPackage("homeassistant")
-        _ha.__path__ = []
-        sys.modules["homeassistant"] = _ha
-
-        # Override specific submodules with concrete stubs where needed.
-        _ha_core = _StubHAPackage("homeassistant.core")
-        _ha_core.__path__ = []
-        _ha_core.HomeAssistant = type("HomeAssistant", (), {})  # type: ignore[attr-defined]
-        sys.modules["homeassistant.core"] = _ha_core
-
-        _ha_helpers = _StubHAPackage("homeassistant.helpers")
-        _ha_helpers.__path__ = []
-        sys.modules["homeassistant.helpers"] = _ha_helpers
-
-        _ha_storage = _StubHAPackage("homeassistant.helpers.storage")
-        _ha_storage.__path__ = []
-        _ha_storage.Store = type("Store", (), {})  # type: ignore[attr-defined]
-        sys.modules["homeassistant.helpers.storage"] = _ha_storage
+                cls = type(name, (_Dummy,), {})
+                setattr(self, name, cls)
+                return cls
 
         class _StubHAExceptions(types.ModuleType):
-            """Auto-generate HA exception stubs on demand."""
+            """Stub for ``homeassistant.exceptions`` – generates Exception subclasses."""
 
             _HomeAssistantError: type = type("HomeAssistantError", (Exception,), {})
 
             def __getattr__(self, name: str) -> object:
                 if name.startswith("_"):
                     raise AttributeError(name)
-                # All HA exceptions inherit from HomeAssistantError
                 cls = type(name, (self._HomeAssistantError,), {})
                 setattr(self, name, cls)
                 return cls
+
+        class _HAStubFinder(importlib.abc.MetaPathFinder):
+            """Import hook: auto-create stub modules for any ``homeassistant.*``."""
+
+            def find_spec(  # type: ignore[override]
+                self,
+                fullname: str,
+                path: object,
+                target: object = None,
+            ) -> "importlib.machinery.ModuleSpec | None":
+                if (
+                    fullname == "homeassistant"
+                    or fullname.startswith("homeassistant.")
+                ) and fullname not in sys.modules:
+                    return importlib.machinery.ModuleSpec(
+                        fullname, self, is_package=True,  # type: ignore[arg-type]
+                    )
+                return None
+
+            # Loader protocol -------------------------------------------------
+            def create_module(self, spec: importlib.machinery.ModuleSpec) -> types.ModuleType:
+                mod = _StubHAModule(spec.name)
+                mod.__path__ = []  # type: ignore[attr-defined]
+                return mod
+
+            def exec_module(self, module: types.ModuleType) -> None:  # noqa: ARG002
+                pass
+
+        sys.meta_path.insert(0, _HAStubFinder())
+
+        # Pre-populate specific submodules with concrete stubs so the
+        # critical import chain (token_cache, exceptions, get_owner_key)
+        # gets the exact types it needs.
+        _ha_core = _StubHAModule("homeassistant.core")
+        _ha_core.__path__ = []  # type: ignore[attr-defined]
+        _ha_core.HomeAssistant = type("HomeAssistant", (), {})  # type: ignore[attr-defined]
+        sys.modules["homeassistant.core"] = _ha_core
+
+        _ha_storage = _StubHAModule("homeassistant.helpers.storage")
+        _ha_storage.__path__ = []  # type: ignore[attr-defined]
+        _ha_storage.Store = type("Store", (), {})  # type: ignore[attr-defined]
+        sys.modules["homeassistant.helpers.storage"] = _ha_storage
 
         _ha_exceptions = _StubHAExceptions("homeassistant.exceptions")
         _ha_exceptions.HomeAssistantError = _ha_exceptions._HomeAssistantError  # type: ignore[attr-defined]


### PR DESCRIPTION
[fix: auto-generate HA exception stubs for standalone mode](https://github.com/jleinenbach/GoogleFindMy-HA/commit/be84f85d7c88ca91b55aa766b8ad715cd5f1089c) 

Replace the single HomeAssistantError stub with a dynamic module
that generates exception classes on demand via __getattr__. This
handles ConfigEntryAuthFailed and any other HA exception that
transitive imports may reference, without maintaining a manual list.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)

[fix: make HA stubs auto-generate submodules and add sync_pop](https://github.com/jleinenbach/GoogleFindMy-HA/commit/279e3f4a60504fc59bdc94d6ed1d919a8c70ebe2) 

Bug 1: Replace static HA stub modules with _StubHAPackage that
auto-generates submodules via __getattr__. Any
`from homeassistant.X.Y import Z` now gets an auto-created stub
module instead of failing with ImportError. Specific overrides
(core.HomeAssistant, helpers.storage.Store, exceptions.*) are
preserved.

Bug 2: Add missing sync_pop() to _FileCache for parity with
TokenCache, preventing AttributeError in auth flows that remove
temporary tokens.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK