### PR TITLE
fix: auto-extract email from Chrome session and register standalone F…

### DIFF
--- a/custom_components/googlefindmy/Auth/auth_flow.py
+++ b/custom_components/googlefindmy/Auth/auth_flow.py
@@ -17,7 +17,15 @@ if TYPE_CHECKING:
     from selenium.webdriver.remote.webdriver import WebDriver
 
 
-def request_oauth_account_token_flow(headless: bool = False) -> str:
+def request_oauth_account_token_flow(
+    headless: bool = False,
+) -> tuple[str, str | None]:
+    """Open Chrome for Google login and return ``(oauth_token, email)``.
+
+    The *email* is extracted from the Chrome session after login if possible.
+    It may be ``None`` when the DOM selectors fail (e.g. Google changes their
+    page layout) — callers should fall back to prompting the user.
+    """
     # In Home Assistant context, skip the interactive prompts
     is_home_assistant = "homeassistant" in sys.modules
 
@@ -59,15 +67,55 @@ def request_oauth_account_token_flow(headless: bool = False) -> str:
             msg = "OAuth token cookie value is missing or not a string"
             raise RuntimeError(msg)
 
+        # Try to extract the logged-in email from the page before closing.
+        email: str | None = _extract_email_from_session(driver)
+
         # Print the value of the "oauth_token" cookie
         if not is_home_assistant:
             print("[AuthFlow] Retrieved Account Token successfully.")
+            if email:
+                print(f"[AuthFlow] Detected account: {email}")
 
-        return oauth_token_value
+        return oauth_token_value, email
 
     finally:
         # Close the browser
         driver.quit()
+
+
+def _extract_email_from_session(driver: WebDriver) -> str | None:
+    """Best-effort extraction of the Google account email from the Chrome session.
+
+    Google's EmbeddedSetup page stores the email in various places after login.
+    We try several strategies; if none works we return ``None`` and the caller
+    can fall back to a manual prompt.
+    """
+    # Strategy 1: data-email attribute (common in Google account pages)
+    for selector in (
+        "[data-email]",
+        "#profileIdentifier",
+    ):
+        try:
+            result = driver.execute_script(
+                f"var el = document.querySelector('{selector}');"
+                "if (!el) return null;"
+                "return el.dataset.email || el.textContent || null;"
+            )
+            if isinstance(result, str) and "@" in result:
+                return result.strip()
+        except Exception:  # noqa: BLE001
+            continue
+
+    # Strategy 2: scan all cookies for one that looks like an email
+    try:
+        for c in driver.get_cookies():
+            val = c.get("value", "")
+            if isinstance(val, str) and "@" in val and "." in val.split("@")[-1]:
+                return val.strip()
+    except Exception:  # noqa: BLE001
+        pass
+
+    return None
 
 
 if __name__ == "__main__":

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -6,6 +6,7 @@
 import sys
 import types
 from pathlib import Path
+from typing import Any
 
 _this_dir = Path(__file__).resolve().parent
 _standalone = not (
@@ -188,12 +189,14 @@ else:
 from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import list_devices  # noqa: E402
 
 
-def _register_file_cache() -> None:
+def _register_file_cache() -> object:
     """Create a file-backed TokenCache and register it for standalone CLI use.
 
     Reads/writes ``Auth/secrets.json`` (the upstream GoogleFindMyTools layout)
     so that ``_resolve_cli_cache`` in ``nbe_list_devices`` finds a registered
     cache and the CLI flow works without Home Assistant.
+
+    Returns the cache instance so callers can pass it to the FCM setup.
     """
     import json  # noqa: PLC0415
 
@@ -305,6 +308,7 @@ def _register_file_cache() -> None:
     # mypy: _FileCache is duck-typed, not a real TokenCache subclass.
     _register_instance("standalone", file_cache)  # type: ignore[arg-type]
     _set_default_entry_id("standalone", force=True)
+    return file_cache
 
 
 def _ensure_authenticated() -> None:
@@ -342,15 +346,20 @@ def _ensure_authenticated() -> None:
         request_oauth_account_token_flow,
     )
 
-    oauth_token = request_oauth_account_token_flow()
+    oauth_token, detected_email = request_oauth_account_token_flow()
 
-    # 2) Ask for the Google account e-mail (needed for gpsoauth exchange)
+    # 2) Set the Google account e-mail (needed for gpsoauth exchange).
+    #    Prefer the email extracted from the Chrome session; fall back to
+    #    a CLI prompt only when extraction failed.
     if not has_user:
-        email = input("\nEnter your Google account email: ").strip()
-        if not email:
-            print("Error: email is required.", file=sys.stderr)
-            sys.exit(1)
-        data["username"] = email
+        if detected_email:
+            data["username"] = detected_email
+        else:
+            email = input("\nEnter your Google account email: ").strip()
+            if not email:
+                print("Error: email is required.", file=sys.stderr)
+                sys.exit(1)
+            data["username"] = email
 
     data["oauth_token"] = oauth_token
 
@@ -362,8 +371,75 @@ def _ensure_authenticated() -> None:
     print("\nCredentials saved. Continuing...\n")
 
 
+async def _setup_fcm_receiver(cache: object) -> Any:
+    """Initialize the FCM push-notification receiver for standalone CLI use.
+
+    This is required because Google delivers location data exclusively via
+    FCM push notifications, not HTTP responses.  Without a registered FCM
+    receiver, location queries would fail with
+    ``RuntimeError: FCM receiver provider has not been registered.``
+    """
+    from types import SimpleNamespace  # noqa: PLC0415
+
+    from custom_components.googlefindmy.Auth.fcm_receiver_ha import (  # noqa: PLC0415
+        FcmReceiverHA,
+    )
+    from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request import (  # noqa: PLC0415
+        register_fcm_receiver_provider as loc_register,
+    )
+
+    fcm = FcmReceiverHA()
+    await fcm.async_initialize(entry_id="standalone", cache=cache)  # type: ignore[arg-type]
+
+    # Minimal coordinator stub so _select_manual_locate_entry finds an entry.
+    coordinator_stub = SimpleNamespace(
+        config_entry=SimpleNamespace(entry_id="standalone"),
+        cache=cache,
+        is_device_present=lambda _cid: True,
+        get_device_display_name=lambda _cid: None,
+    )
+    fcm.register_coordinator(coordinator_stub)
+
+    def _get_fcm(entry_id: str | None = None) -> FcmReceiverHA:  # noqa: ARG001
+        return fcm
+
+    loc_register(_get_fcm)
+
+    # Also register in api.py if available (used by some code paths).
+    try:
+        from custom_components.googlefindmy.api import (  # noqa: PLC0415
+            register_fcm_receiver_provider as api_register,
+        )
+
+        api_register(_get_fcm)
+    except Exception:  # noqa: BLE001
+        pass
+
+    return fcm
+
+
 if __name__ == "__main__":
+    import asyncio  # noqa: PLC0415
+
+    from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import (  # noqa: E402, PLC0415
+        _async_cli_main,
+    )
+
     if _standalone:
         _ensure_authenticated()
-        _register_file_cache()
-    list_devices()
+        _file_cache = _register_file_cache()
+
+        async def _cli_main() -> None:
+            fcm = await _setup_fcm_receiver(_file_cache)
+            try:
+                await _async_cli_main()
+            finally:
+                with __import__("contextlib").suppress(Exception):
+                    await fcm.async_stop()
+
+        try:
+            asyncio.run(_cli_main())
+        except KeyboardInterrupt:
+            print("\nExiting.")
+    else:
+        list_devices()

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -61,6 +61,12 @@ class FakeDriver:
     def quit(self) -> None:
         self.quit_calls += 1
 
+    def execute_script(self, script: str) -> Any:  # noqa: ARG002
+        return None
+
+    def get_cookies(self) -> list[dict[str, str]]:
+        return []
+
 
 class ImmediateWaitFactory:
     """Replacement for WebDriverWait that immediately evaluates predicates."""
@@ -101,9 +107,10 @@ def test_request_oauth_account_token_flow_returns_cookie(
     driver = FakeDriver(cookie_after_wait={"value": "token123"})
     wait_factory = _apply_flow_patches(monkeypatch, driver)
 
-    token = request_oauth_account_token_flow(headless=True)
+    token, email = request_oauth_account_token_flow(headless=True)
 
     assert token == "token123"
+    assert email is None  # FakeDriver has no real session
     assert driver.visited_urls == ["https://accounts.google.com/EmbeddedSetup"]
     assert driver.quit_calls == 1
     assert wait_factory.instances and wait_factory.instances[0].until_calls == 1


### PR DESCRIPTION
When running standalone without an existing secrets.json, the code now replicates the original GoogleFindMyTools first-run experience:

1. Opens Chrome for Google OAuth login (via auth_flow.py)
2. Prompts for the Google account email
3. Persists both oauth_token and username to Auth/secrets.json
4. Then proceeds to register the file cache and list devices

Previously, running without secrets.json would crash with "ValueError: Username is not available for async_nova_request" because the empty cache had no credentials.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK

