### PR TITLE
fix: don't switch GCM sender on PHONE_REGISTRATION_ERROR

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -559,39 +559,27 @@ class FcmRegister:
 
             if error_code:
                 last_error = f"Error={error_code}"
-                if error_code == "PHONE_REGISTRATION_ERROR" and sender_index + 1 < len(
-                    sender_candidates
-                ):
-                    _logger.debug(
-                        "GCM register encountered PHONE_REGISTRATION_ERROR with sender=%s (%s)",
+                if error_code == "PHONE_REGISTRATION_ERROR":
+                    # Transient error — just retry with the same sender.
+                    # Upstream GoogleFindMyTools treats this as transient and
+                    # retries without switching sender, which eventually succeeds.
+                    _logger.info(
+                        "GCM register %s (transient, attempt %d/%d); "
+                        "retrying with same sender=%s (%s)",
+                        error_code,
+                        attempt,
+                        retries,
                         body["sender"],
                         sender_mode(body["sender"]),
                     )
-                    sender_index += 1
-                    body["sender"] = sender_candidates[sender_index]
-                    label = (
-                        "legacy server key"
-                        if sender_candidates[sender_index] == GCM_SERVER_KEY_B64
-                        else "configured numeric sender"
-                    )
+                else:
                     _logger.warning(
-                        "GCM register error %s encountered; switching sender fallback to %s (sender=%s)",
-                        error_code,
-                        label,
-                        body["sender"],
+                        "GCM register error via %s (attempt %d/%d): %s",
+                        indicator,
+                        attempt,
+                        retries,
+                        last_error,
                     )
-                    if attempt < retries:
-                        await asyncio.sleep(1)
-                    attempt += 1
-                    continue
-
-                _logger.warning(
-                    "GCM register error via %s (attempt %d/%d): %s",
-                    indicator,
-                    attempt,
-                    retries,
-                    last_error,
-                )
             else:
                 snippet = response_text[:200]
                 if html_like:

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -418,32 +418,6 @@ async def _setup_fcm_receiver(cache: object) -> Any:
     return fcm
 
 
-def _try_seed_fcm_credentials(cache: object) -> None:
-    """Import FCM credentials from a user-provided file if the cache is empty.
-
-    If ``Auth/fcm_credentials.json`` exists and the cache does not yet contain
-    ``fcm_credentials``, the file is read and injected into the cache.  This
-    provides a workaround for environments where fresh GCM registration is
-    unreliable: the user can export credentials from a working HA installation
-    and place them in the ``Auth/`` directory.
-    """
-    import json  # noqa: PLC0415
-
-    if hasattr(cache, "sync_get") and cache.sync_get("fcm_credentials"):  # type: ignore[union-attr]
-        return  # already seeded
-    creds_file = _this_dir / "Auth" / "fcm_credentials.json"
-    if not creds_file.is_file():
-        return
-    try:
-        with open(creds_file, encoding="utf-8") as fh:
-            fcm_creds = json.load(fh)
-        if isinstance(fcm_creds, dict) and hasattr(cache, "sync_set"):
-            cache.sync_set("fcm_credentials", fcm_creds)  # type: ignore[union-attr]
-            print("FCM credentials imported from fcm_credentials.json")
-    except Exception:  # noqa: BLE001
-        pass
-
-
 if __name__ == "__main__":
     import asyncio  # noqa: PLC0415
 
@@ -454,7 +428,6 @@ if __name__ == "__main__":
     if _standalone:
         _ensure_authenticated()
         _file_cache = _register_file_cache()
-        _try_seed_fcm_credentials(_file_cache)
 
         async def _cli_main() -> None:
             fcm = await _setup_fcm_receiver(_file_cache)

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -418,6 +418,32 @@ async def _setup_fcm_receiver(cache: object) -> Any:
     return fcm
 
 
+def _try_seed_fcm_credentials(cache: object) -> None:
+    """Import FCM credentials from a user-provided file if the cache is empty.
+
+    If ``Auth/fcm_credentials.json`` exists and the cache does not yet contain
+    ``fcm_credentials``, the file is read and injected into the cache.  This
+    provides a workaround for environments where fresh GCM registration is
+    unreliable: the user can export credentials from a working HA installation
+    and place them in the ``Auth/`` directory.
+    """
+    import json  # noqa: PLC0415
+
+    if hasattr(cache, "sync_get") and cache.sync_get("fcm_credentials"):  # type: ignore[union-attr]
+        return  # already seeded
+    creds_file = _this_dir / "Auth" / "fcm_credentials.json"
+    if not creds_file.is_file():
+        return
+    try:
+        with open(creds_file, encoding="utf-8") as fh:
+            fcm_creds = json.load(fh)
+        if isinstance(fcm_creds, dict) and hasattr(cache, "sync_set"):
+            cache.sync_set("fcm_credentials", fcm_creds)  # type: ignore[union-attr]
+            print("FCM credentials imported from fcm_credentials.json")
+    except Exception:  # noqa: BLE001
+        pass
+
+
 if __name__ == "__main__":
     import asyncio  # noqa: PLC0415
 
@@ -428,6 +454,7 @@ if __name__ == "__main__":
     if _standalone:
         _ensure_authenticated()
         _file_cache = _register_file_cache()
+        _try_seed_fcm_credentials(_file_cache)
 
         async def _cli_main() -> None:
             fcm = await _setup_fcm_receiver(_file_cache)

--- a/tests/test_fcm_register.py
+++ b/tests/test_fcm_register.py
@@ -274,10 +274,10 @@ def test_gcm_register_non_retryable_error(monkeypatch: pytest.MonkeyPatch) -> No
     assert len(session.calls) == 2
 
 
-def test_gcm_register_falls_back_to_numeric_sender(
+def test_gcm_register_phone_registration_error_retries_same_sender(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PHONE_REGISTRATION_ERROR triggers a second attempt using the numeric sender."""
+    """PHONE_REGISTRATION_ERROR is transient — retries with the same sender (no switch)."""
 
     responses = [
         _FakeResponse(
@@ -306,14 +306,15 @@ def test_gcm_register_falls_back_to_numeric_sender(
 
     assert result["token"] == "xyz"
     assert len(session.calls) == 2
+    # Both attempts use the same legacy sender — no switch to numeric
     assert session.calls[0]["data"]["sender"] == GCM_SERVER_KEY_B64
-    assert session.calls[1]["data"]["sender"] == "1234567890123"
+    assert session.calls[1]["data"]["sender"] == GCM_SERVER_KEY_B64
 
 
-def test_gcm_register_phone_registration_error_logs_sender(
+def test_gcm_register_phone_registration_error_logs_transient(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """PHONE_REGISTRATION_ERROR debug log reports which sender was active."""
+    """PHONE_REGISTRATION_ERROR log reports the error as transient."""
 
     responses = [
         _FakeResponse(
@@ -336,7 +337,7 @@ def test_gcm_register_phone_registration_error_logs_sender(
 
     monkeypatch.setattr(asyncio, "sleep", fast_sleep)
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.INFO):
         result = asyncio.run(
             register.gcm_register({"androidId": 7, "securityToken": 9}, retries=3)
         )
@@ -344,12 +345,7 @@ def test_gcm_register_phone_registration_error_logs_sender(
     assert result["token"] == "xyz"
     assert any(
         "PHONE_REGISTRATION_ERROR" in record.getMessage()
-        and f"sender={GCM_SERVER_KEY_B64} (legacy server key)" in record.getMessage()
-        for record in caplog.records
-    )
-    assert any(
-        "switching sender fallback" in record.getMessage()
-        and "sender=1234567890123" in record.getMessage()
+        and "transient" in record.getMessage()
         for record in caplog.records
     )
 


### PR DESCRIPTION
[fix: don't switch GCM sender on PHONE_REGISTRATION_ERROR (upstream al…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/1034eff0ac1e39a4438e44a9474b130e644618ba) 

…ignment)

The GCM registration in gcm_register() immediately switched from the legacy
server key to the numeric sender on the first PHONE_REGISTRATION_ERROR.
The numeric sender then caused 404 on every subsequent attempt, burning
through all retries on a sender that never works.

Upstream GoogleFindMyTools (Issue https://github.com/jleinenbach/GoogleFindMy-HA/pull/90) treats PHONE_REGISTRATION_ERROR as
transient and retries with the same legacy key (GCM_SERVER_KEY_B64), which
eventually succeeds. This commit aligns our behavior:

- PHONE_REGISTRATION_ERROR: retry with same sender (no switch)
- 404/HTML responses: still trigger sender fallback (kept as-is)

Also adds fcm_credentials.json import for standalone CLI mode as a safety
net when GCM registration remains difficult.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)

[fix: remove _try_seed_fcm_credentials — FCM creds belong in secrets.json](https://github.com/jleinenbach/GoogleFindMy-HA/commit/d928e80e8ddaa8c12691a554197ef94d23b3e75e) 

FCM credentials should be stored in Auth/secrets.json under the
"fcm_credentials" key, not in a separate file. The existing _FileCache
already reads secrets.json, so _ensure_client_for_entry picks them up
automatically via cache.get("fcm_credentials").

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK