### PR TITLE
fix: remove ALL sender switching in gcm_register (complete upstream a…

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -378,16 +378,11 @@ class FcmRegister:
 
         sender_candidates: list[str] = []
 
-        # Prefer the legacy server key because it consistently succeeds without
-        # additional retries for existing deployments.
+        # Always use the legacy server key — upstream GoogleFindMyTools only
+        # ever uses GCM_SERVER_KEY_B64 and never falls back to the numeric
+        # sender.  The numeric sender causes persistent 404 responses, wasting
+        # retries.  See upstream Issue #90.
         sender_candidates.append(GCM_SERVER_KEY_B64)
-
-        if (
-            isinstance(self.config.messaging_sender_id, str)
-            and self.config.messaging_sender_id
-            and self.config.messaging_sender_id != GCM_SERVER_KEY_B64
-        ):
-            sender_candidates.append(self.config.messaging_sender_id)
 
         body = {
             "app": self.config.chrome_id,
@@ -397,7 +392,6 @@ class FcmRegister:
         }
 
         last_error: str | Exception | None = None
-        sender_index = 0
         attempt = 1
         endpoints = (GCM_REGISTER3_URL, GCM_REGISTER_URL)
         endpoint_index = 0
@@ -491,36 +485,13 @@ class FcmRegister:
             if status == HTTPStatus.NOT_FOUND or html_like:
                 snippet = response_text[:200]
                 last_error = f"Unexpected register response (status={status}, ctype={content_type}): {snippet}"
-                fallback_triggered = False
-                if sender_index + 1 < len(sender_candidates):
-                    # Treat persistent HTML/404 responses as a signal to advance to the
-                    # next sender candidate so we do not waste the entire retry budget
-                    # on an endpoint that is not provisioned for the numeric sender.
-                    previous_sender = body["sender"]
-                    sender_index += 1
-                    body["sender"] = sender_candidates[sender_index]
-                    endpoint_index = 0
-                    fallback_triggered = True
-                    _logger.warning(
-                        "GCM register received HTML/404 via %s; switching sender from %s (%s) to %s (%s)",
-                        indicator,
-                        previous_sender,
-                        sender_mode(previous_sender),
-                        body["sender"],
-                        sender_mode(body["sender"]),
-                    )
                 if attempt < retries:
-                    if not fallback_triggered:
-                        next_index = (endpoint_index + 1) % len(endpoints)
-                        log_endpoint_switch(
-                            f"HTTP {status}", endpoint_index, next_index
-                        )
-                        endpoint_index = next_index
-                    elif self._log_debug_verbose:
-                        _logger.debug(
-                            "GCM register resetting endpoint rotation after HTML/404 sender fallback"
-                        )
-                    await asyncio.sleep(1 if fallback_triggered else 0.5)
+                    next_index = (endpoint_index + 1) % len(endpoints)
+                    log_endpoint_switch(
+                        f"HTTP {status}", endpoint_index, next_index
+                    )
+                    endpoint_index = next_index
+                    await asyncio.sleep(1)
                 else:
                     _logger.warning(
                         "GCM register 404/HTML via %s (status=%s); no retries left.",

--- a/tests/test_fcm_register.py
+++ b/tests/test_fcm_register.py
@@ -84,16 +84,13 @@ def test_gcm_register_prefers_legacy_sender_first(
     assert session.calls[0]["data"]["sender"] == GCM_SERVER_KEY_B64
 
 
-def test_gcm_register_html_response_triggers_sender_fallback(
+def test_gcm_register_html_response_rotates_endpoint_not_sender(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """HTML/404 responses trigger a sender fallback before the next attempt."""
+    """HTML/404 responses rotate the endpoint but never switch sender (upstream alignment)."""
 
     responses = [
         _FakeResponse(404, "<!doctype html>not found", {"Content-Type": "text/html"}),
-        _FakeResponse(
-            404, "<!doctype html>legacy not found", {"Content-Type": "text/html"}
-        ),
         _FakeResponse(200, "token=abc123", {"Content-Type": "text/plain"}),
     ]
     session = _FakeSession(responses)
@@ -118,23 +115,15 @@ def test_gcm_register_html_response_triggers_sender_fallback(
 
     assert result["token"] == "abc123"
     assert result["android_id"] == 42
+    # Endpoint rotates, but sender stays as legacy key
     assert [call["url"] for call in session.calls] == [
-        GCM_REGISTER3_URL,
         GCM_REGISTER3_URL,
         GCM_REGISTER_URL,
     ]
     assert [call["data"]["sender"] for call in session.calls] == [
         GCM_SERVER_KEY_B64,
-        "1234567890123",
-        "1234567890123",
+        GCM_SERVER_KEY_B64,
     ]
-    assert any(
-        "switching sender from" in record.getMessage()
-        and "HTML/404" in record.getMessage()
-        and "1234567890123" in record.getMessage()
-        and GCM_SERVER_KEY_B64 in record.getMessage()
-        for record in caplog.records
-    )
 
 
 def test_gcm_register_rotation_logs_reason_and_sender(
@@ -175,10 +164,10 @@ def test_gcm_register_rotation_logs_reason_and_sender(
     )
 
 
-def test_gcm_register_fallback_succeeds_on_second_attempt(
+def test_gcm_register_404_retries_with_same_sender(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A failing attempt triggers a sender fallback and succeeds immediately."""
+    """A 404 rotates endpoint but keeps the same legacy sender."""
 
     responses = [
         _FakeResponse(404, "<!doctype html>not found", {"Content-Type": "text/html"}),
@@ -202,13 +191,15 @@ def test_gcm_register_fallback_succeeds_on_second_attempt(
     result = asyncio.run(register.gcm_register({"androidId": 11, "securityToken": 22}))
 
     assert result["token"] == "abc123"
+    # Endpoint rotates: register3 → register
     assert [call["url"] for call in session.calls] == [
         GCM_REGISTER3_URL,
-        GCM_REGISTER3_URL,
+        GCM_REGISTER_URL,
     ]
+    # Sender stays legacy — no switch to numeric
     assert [call["data"]["sender"] for call in session.calls] == [
         GCM_SERVER_KEY_B64,
-        "1234567890123",
+        GCM_SERVER_KEY_B64,
     ]
 
 


### PR DESCRIPTION
[fix: don't switch GCM sender on PHONE_REGISTRATION_ERROR (upstream al…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/1034eff0ac1e39a4438e44a9474b130e644618ba) 

…ignment)

The GCM registration in gcm_register() immediately switched from the legacy
server key to the numeric sender on the first PHONE_REGISTRATION_ERROR.
The numeric sender then caused 404 on every subsequent attempt, burning
through all retries on a sender that never works.

Upstream GoogleFindMyTools (Issue https://github.com/jleinenbach/GoogleFindMy-HA/pull/90) treats PHONE_REGISTRATION_ERROR as
transient and retries with the same legacy key (GCM_SERVER_KEY_B64), which
eventually succeeds. This commit aligns our behavior:

- PHONE_REGISTRATION_ERROR: retry with same sender (no switch)
- 404/HTML responses: still trigger sender fallback (kept as-is)

Also adds fcm_credentials.json import for standalone CLI mode as a safety
net when GCM registration remains difficult.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)

[fix: remove _try_seed_fcm_credentials — FCM creds belong in secrets.json](https://github.com/jleinenbach/GoogleFindMy-HA/commit/d928e80e8ddaa8c12691a554197ef94d23b3e75e) 

FCM credentials should be stored in Auth/secrets.json under the
"fcm_credentials" key, not in a separate file. The existing _FileCache
already reads secrets.json, so _ensure_client_for_entry picks them up
automatically via cache.get("fcm_credentials").

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK