### PR TITLE
fix: remove endpoint rotation

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -59,7 +59,6 @@ from .const import (
     FCM_SEND_URL,
     GCM_CHECKIN_URL,
     GCM_REGISTER3_URL,
-    GCM_REGISTER_URL,
     GCM_SERVER_KEY_B64,
     SDK_VERSION,
 )
@@ -376,71 +375,23 @@ class FcmRegister:
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
-        sender_candidates: list[str] = []
-
-        # Always use the legacy server key — upstream GoogleFindMyTools only
-        # ever uses GCM_SERVER_KEY_B64 and never falls back to the numeric
-        # sender.  The numeric sender causes persistent 404 responses, wasting
-        # retries.  See upstream Issue #90.
-        sender_candidates.append(GCM_SERVER_KEY_B64)
-
         body = {
             "app": self.config.chrome_id,
             "X-subtype": gcm_app_id,
             "device": android_id,
-            "sender": sender_candidates[0],
+            "sender": GCM_SERVER_KEY_B64,
         }
 
         last_error: str | Exception | None = None
         attempt = 1
-        endpoints = (GCM_REGISTER3_URL, GCM_REGISTER_URL)
-        endpoint_index = 0
-
-        def sender_mode(sender: str) -> str:
-            """Return a human readable label for the active sender."""
-
-            if sender == GCM_SERVER_KEY_B64:
-                return "legacy server key"
-            if sender == self.config.messaging_sender_id:
-                return "configured numeric sender"
-            return "custom sender"
-
-        def log_endpoint_switch(
-            reason: str, current_index: int, next_index: int
-        ) -> None:
-            """Log when we switch between /register3 and /register endpoints."""
-
-            current_indicator = (
-                "/c2dm/register3"
-                if endpoints[current_index] == GCM_REGISTER3_URL
-                else "/c2dm/register"
-            )
-            next_indicator = (
-                "/c2dm/register3"
-                if endpoints[next_index] == GCM_REGISTER3_URL
-                else "/c2dm/register"
-            )
-            _logger.warning(
-                "GCM register switching endpoint %s -> %s due to %s; sender=%s (%s)",
-                current_indicator,
-                next_indicator,
-                reason,
-                body["sender"],
-                sender_mode(body["sender"]),
-            )
 
         while attempt <= retries:
-            url = endpoints[endpoint_index]
-            indicator = (
-                "/c2dm/register3" if url == GCM_REGISTER3_URL else "/c2dm/register"
-            )
 
             if self._log_debug_verbose:
                 _logger.debug(
-                    "GCM Registration request attempt %d/%d via %s: app=%s, X-subtype=%s, device=%s, sender=%s",
+                    "GCM Registration request attempt %d/%d via /c2dm/register3: app=%s, X-subtype=%s, device=%s, sender=%s",
                     attempt,
                     retries,
-                    indicator,
                     body["app"],
                     self._redact(body["X-subtype"]),
                     self._redact(body["device"]),
@@ -449,7 +400,7 @@ class FcmRegister:
 
             try:
                 async with self._session.post(
-                    url=url,
+                    url=GCM_REGISTER3_URL,
                     headers=headers,
                     data=body,
                     timeout=self.CLIENT_TIMEOUT,
@@ -460,20 +411,12 @@ class FcmRegister:
             except Exception as exc:  # network or aiohttp failure
                 last_error = exc
                 _logger.warning(
-                    "GCM register request failed via %s (attempt %d/%d): %s",
-                    indicator,
+                    "GCM register request failed via /c2dm/register3 (attempt %d/%d): %s",
                     attempt,
                     retries,
                     exc,
                 )
                 if attempt < retries:
-                    next_index = (endpoint_index + 1) % len(endpoints)
-                    log_endpoint_switch(
-                        f"exception={exc.__class__.__name__}",
-                        endpoint_index,
-                        next_index,
-                    )
-                    endpoint_index = next_index
                     await asyncio.sleep(1)
                 attempt += 1
                 continue
@@ -485,19 +428,14 @@ class FcmRegister:
             if status == HTTPStatus.NOT_FOUND or html_like:
                 snippet = response_text[:200]
                 last_error = f"Unexpected register response (status={status}, ctype={content_type}): {snippet}"
+                _logger.warning(
+                    "GCM register 404/HTML via /c2dm/register3 (attempt %d/%d, status=%s)",
+                    attempt,
+                    retries,
+                    status,
+                )
                 if attempt < retries:
-                    next_index = (endpoint_index + 1) % len(endpoints)
-                    log_endpoint_switch(
-                        f"HTTP {status}", endpoint_index, next_index
-                    )
-                    endpoint_index = next_index
                     await asyncio.sleep(1)
-                else:
-                    _logger.warning(
-                        "GCM register 404/HTML via %s (status=%s); no retries left.",
-                        indicator,
-                        status,
-                    )
                 attempt += 1
                 continue
 
@@ -514,12 +452,10 @@ class FcmRegister:
 
             if token:
                 _logger.info(
-                    "GCM register succeeded via %s on attempt %d/%d using sender=%s (%s)",
-                    indicator,
+                    "GCM register succeeded via /c2dm/register3 on attempt %d/%d using sender=%s (legacy server key)",
                     attempt,
                     retries,
                     body["sender"],
-                    sender_mode(body["sender"]),
                 )
                 return {
                     "token": token,
@@ -536,17 +472,15 @@ class FcmRegister:
                     # retries without switching sender, which eventually succeeds.
                     _logger.info(
                         "GCM register %s (transient, attempt %d/%d); "
-                        "retrying with same sender=%s (%s)",
+                        "retrying with same sender=%s (legacy server key)",
                         error_code,
                         attempt,
                         retries,
                         body["sender"],
-                        sender_mode(body["sender"]),
                     )
                 else:
                     _logger.warning(
-                        "GCM register error via %s (attempt %d/%d): %s",
-                        indicator,
+                        "GCM register error via /c2dm/register3 (attempt %d/%d): %s",
                         attempt,
                         retries,
                         last_error,
@@ -557,22 +491,13 @@ class FcmRegister:
                     snippet += " [html]"
                 last_error = f"Unexpected register response (status={status}, ctype={content_type}): {snippet}"
                 _logger.warning(
-                    "GCM register unexpected response via %s (attempt %d/%d): %s",
-                    indicator,
+                    "GCM register unexpected response via /c2dm/register3 (attempt %d/%d): %s",
                     attempt,
                     retries,
                     last_error,
                 )
 
             if attempt < retries:
-                rotation_reason = (
-                    f"HTTP {status}" if status else last_error or "unknown"
-                )
-                if error_code:
-                    rotation_reason = f"error_code={error_code}"
-                next_index = (endpoint_index + 1) % len(endpoints)
-                log_endpoint_switch(rotation_reason, endpoint_index, next_index)
-                endpoint_index = next_index
                 await asyncio.sleep(1)
             attempt += 1
 

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -363,6 +363,23 @@ def _ensure_authenticated() -> None:
 
     data["oauth_token"] = oauth_token
 
+    # Clear stale derived tokens — they were generated from the old OAuth
+    # token and will be regenerated from the new one. The _FileCache
+    # auto-saves on every set() call, so fresh AAS/ADM tokens produced
+    # during the first successful Nova API request are persisted back
+    # to secrets.json automatically.
+    for key in list(data.keys()):
+        if key.startswith(
+            (
+                "adm_token_",
+                "adm_token_issued_at_",
+                "aas_token_issued_at_",
+                "adm_probe_",
+            )
+        ):
+            del data[key]
+    data.pop("aas_token", None)
+
     # 3) Persist to secrets.json
     secrets_path.parent.mkdir(parents=True, exist_ok=True)
     with open(secrets_path, "w", encoding="utf-8") as fh:
@@ -418,14 +435,72 @@ async def _setup_fcm_receiver(cache: object) -> Any:
     return fcm
 
 
+def _clear_stale_tokens_for_reauth() -> None:
+    """Clear cached tokens from secrets.json to force re-authentication.
+
+    Called when ``--reauth`` is passed on the CLI. Removes ``oauth_token``,
+    ``aas_token``, and all derived ``adm_token_*`` / timestamp keys so that
+    ``_ensure_authenticated()`` triggers the Chrome login flow.
+    """
+    import json  # noqa: PLC0415
+
+    secrets_path = _this_dir / "Auth" / "secrets.json"
+    if not secrets_path.is_file():
+        return
+
+    try:
+        with open(secrets_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            return
+    except Exception:  # noqa: BLE001
+        return
+
+    keys_to_remove = [
+        k
+        for k in data
+        if k.startswith(
+            (
+                "oauth_token",
+                "aas_token",
+                "adm_token_",
+                "adm_token_issued_at_",
+                "aas_token_issued_at_",
+                "adm_probe_",
+            )
+        )
+    ]
+    if not keys_to_remove:
+        return
+
+    for k in keys_to_remove:
+        del data[k]
+
+    with open(secrets_path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+
+    print(f"Cleared {len(keys_to_remove)} cached token(s). Re-authentication required.\n")
+
+
 if __name__ == "__main__":
+    import argparse  # noqa: PLC0415
     import asyncio  # noqa: PLC0415
 
     from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import (  # noqa: E402, PLC0415
         _async_cli_main,
     )
 
+    _cli_parser = argparse.ArgumentParser(description="Google Find My Device CLI")
+    _cli_parser.add_argument(
+        "--reauth",
+        action="store_true",
+        help="Force re-authentication by clearing cached tokens and running Chrome login",
+    )
+    _cli_args = _cli_parser.parse_args()
+
     if _standalone:
+        if _cli_args.reauth:
+            _clear_stale_tokens_for_reauth()
         _ensure_authenticated()
         _file_cache = _register_file_cache()
 

--- a/tests/test_fcm_register.py
+++ b/tests/test_fcm_register.py
@@ -13,7 +13,6 @@ import pytest
 
 from custom_components.googlefindmy.Auth.firebase_messaging.const import (
     GCM_REGISTER3_URL,
-    GCM_REGISTER_URL,
     GCM_SERVER_KEY_B64,
 )
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
@@ -87,7 +86,7 @@ def test_gcm_register_prefers_legacy_sender_first(
 def test_gcm_register_html_response_rotates_endpoint_not_sender(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """HTML/404 responses rotate the endpoint but never switch sender (upstream alignment)."""
+    """HTML/404 responses retry on the same endpoint without switching sender (upstream alignment)."""
 
     responses = [
         _FakeResponse(404, "<!doctype html>not found", {"Content-Type": "text/html"}),
@@ -115,10 +114,10 @@ def test_gcm_register_html_response_rotates_endpoint_not_sender(
 
     assert result["token"] == "abc123"
     assert result["android_id"] == 42
-    # Endpoint rotates, but sender stays as legacy key
+    # Both attempts use the same endpoint — no rotation (upstream alignment)
     assert [call["url"] for call in session.calls] == [
         GCM_REGISTER3_URL,
-        GCM_REGISTER_URL,
+        GCM_REGISTER3_URL,
     ]
     assert [call["data"]["sender"] for call in session.calls] == [
         GCM_SERVER_KEY_B64,
@@ -126,48 +125,10 @@ def test_gcm_register_html_response_rotates_endpoint_not_sender(
     ]
 
 
-def test_gcm_register_rotation_logs_reason_and_sender(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Endpoint rotation still logs details when no fallback sender is available."""
-
-    responses = [
-        _FakeResponse(404, "<!doctype html>not found", {"Content-Type": "text/html"}),
-        _FakeResponse(200, "token=abc123", {"Content-Type": "text/plain"}),
-    ]
-    session = _FakeSession(responses)
-    config = FcmRegisterConfig(
-        project_id="proj",
-        app_id="app",
-        api_key="key",
-        messaging_sender_id=GCM_SERVER_KEY_B64,
-        bundle_id="bundle",
-    )
-    register = FcmRegister(config, http_client_session=session)
-
-    async def fast_sleep(_: float) -> None:
-        return None
-
-    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
-
-    with caplog.at_level(logging.WARNING):
-        result = asyncio.run(
-            register.gcm_register({"androidId": 11, "securityToken": 22})
-        )
-
-    assert result["token"] == "abc123"
-    assert any(
-        "GCM register switching endpoint /c2dm/register3 -> /c2dm/register due to HTTP 404"
-        in record.getMessage()
-        and f"sender={GCM_SERVER_KEY_B64} (legacy server key)" in record.getMessage()
-        for record in caplog.records
-    )
-
-
 def test_gcm_register_404_retries_with_same_sender(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A 404 rotates endpoint but keeps the same legacy sender."""
+    """A 404 retries on the same endpoint with the same legacy sender."""
 
     responses = [
         _FakeResponse(404, "<!doctype html>not found", {"Content-Type": "text/html"}),
@@ -191,10 +152,10 @@ def test_gcm_register_404_retries_with_same_sender(
     result = asyncio.run(register.gcm_register({"androidId": 11, "securityToken": 22}))
 
     assert result["token"] == "abc123"
-    # Endpoint rotates: register3 → register
+    # No endpoint rotation — always /c2dm/register3 (upstream alignment)
     assert [call["url"] for call in session.calls] == [
         GCM_REGISTER3_URL,
-        GCM_REGISTER_URL,
+        GCM_REGISTER3_URL,
     ]
     # Sender stays legacy — no switch to numeric
     assert [call["data"]["sender"] for call in session.calls] == [


### PR DESCRIPTION
[fix: remove endpoint rotation — use only /c2dm/register3 (upstream al…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/77a543646d5574fdbd7e89c22f4f5ae44a257433) 

…ignment)

The dead /c2dm/register endpoint always returns 404, wasting every other
retry. Upstream GoogleFindMyTools uses only /c2dm/register3. This removes
the endpoints tuple, endpoint_index, log_endpoint_switch() helper, and
all rotation logic from gcm_register().

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 43 minutes ago
[fix: clear stale tokens on re-auth + add --reauth CLI flag](https://github.com/jleinenbach/GoogleFindMy-HA/commit/9a1abd90b5484b69b5ff5b11cf60b2f89a265f80) 

When _ensure_authenticated() stores a new OAuth token, clear old
aas_token, adm_token_*, and related timestamps from secrets.json.
This prevents the Nova API retry sequence from wasting 75+ seconds
on stale cached tokens before generating fresh ones.

Add --reauth CLI flag that forces re-authentication by clearing all
cached tokens from secrets.json, triggering the Chrome login flow.
Fresh AAS/ADM tokens are auto-saved by _FileCache on first success.