### PR TITLE
fix: shared aiohttp session for standalone CLI + downgrade DIAG-ALERT…

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -464,6 +464,27 @@ async def async_retrieve_identity_key(
             "Tracker was encrypted with a stale owner key version."
         ) from last_exc
 
+    # Blind refresh: version check unavailable but key is clearly wrong.
+    # This mirrors the version-mismatch retry above but works when SPOT gRPC
+    # fails to provide current_owner_key_version (common in standalone CLI).
+    if not candidates and current_owner_key_version is None and _retry:
+        _LOGGER.info(
+            "EIK decryption failed and SPOT version check unavailable; "
+            "attempting blind owner key refresh."
+        )
+        try:
+            username = await cache.get(username_string)
+            if isinstance(username, str) and username:
+                await cache.set(f"owner_key_{username}", None)
+        except Exception as cache_exc:  # noqa: BLE001
+            _LOGGER.debug("Failed to clear cached owner key: %s", cache_exc)
+        try:
+            return await async_retrieve_identity_key(
+                device_registration, cache=cache, _retry=False
+            )
+        except Exception as refresh_exc:  # noqa: BLE001
+            _LOGGER.warning("Blind owner key refresh also failed: %s", refresh_exc)
+
     if candidates:
         return candidates
 
@@ -843,7 +864,11 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 identity_key_candidate_bytes = [identity_key_bytes]
                 identity_key = identity_key_bytes
         except Exception as exc:  # pragma: no cover - diagnostics only
-            _LOGGER.debug("[DECRYPT] Failed to unwrap: %s", exc)
+            _LOGGER.warning(
+                "[DECRYPT] Failed to unwrap 60-byte EIK: %s. "
+                "The owner key in secrets.json may be outdated.",
+                type(exc).__name__,
+            )
 
     if identity_key is None:
         raise DecryptionError("Identity key derivation returned no candidates.")

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -772,9 +772,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             and raw_encrypted_identity_key
             and len(raw_encrypted_identity_key) != _EIK_LEN
         ):
-            _LOGGER.warning(
-                "[DIAG-ALERT] Key length is %d (expected %d for raw EIK)."
-                " This suggests wrapping/encryption!",
+            _LOGGER.debug(
+                "[DIAG] Key length is %d (expected %d for raw EIK);"
+                " likely GCM-wrapped (normal for Moto Tag / Chipolo).",
                 len(raw_encrypted_identity_key),
                 _EIK_LEN,
             )
@@ -784,9 +784,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             and raw_encrypted_identity_key
             and len(raw_encrypted_identity_key) > _EIK_LEN
         ):
-            _LOGGER.warning(
-                "[DIAG-ALERT] Key length %d bytes exceeds expected raw EIK length (%d)."
-                " Probable wrapped key container or HKDF-required envelope.",
+            _LOGGER.debug(
+                "[DIAG] Key length %d bytes exceeds expected raw EIK length (%d);"
+                " probable GCM-wrapped key (will attempt unwrap).",
                 len(raw_encrypted_identity_key),
                 _EIK_LEN,
             )

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -15,6 +15,7 @@ from types import ModuleType
 from typing import Any, Protocol, cast, runtime_checkable
 
 import aiohttp
+from cryptography.exceptions import InvalidTag
 
 # Keep heavy/protobuf-related imports lazy (done inside functions/callbacks)
 from custom_components.googlefindmy.Auth.token_cache import TokenCache
@@ -47,8 +48,6 @@ from custom_components.googlefindmy.NovaApi.util import generate_random_uuid
 from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
     SpotApiEmptyResponseError,
 )
-from cryptography.exceptions import InvalidTag
-
 from custom_components.googlefindmy.SpotApi.spot_request import SpotAuthPermanentError
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -47,6 +47,8 @@ from custom_components.googlefindmy.NovaApi.util import generate_random_uuid
 from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
     SpotApiEmptyResponseError,
 )
+from cryptography.exceptions import InvalidTag
+
 from custom_components.googlefindmy.SpotApi.spot_request import SpotAuthPermanentError
 
 _LOGGER = logging.getLogger(__name__)
@@ -366,6 +368,7 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                     DecryptionError,
                     SpotApiEmptyResponseError,
                     SpotAuthPermanentError,
+                    InvalidTag,
                 ) as err:
                     _LOGGER.error(
                         "Failed to process location data for %s: %s", name, err

--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -233,19 +233,29 @@ def _resolve_cli_cache(entry_id_hint: str | None) -> tuple[TokenCache, str]:
     return cache, normalized
 
 
-async def _async_cli_main(entry_id: str | None = None) -> None:
+async def _async_cli_main(
+    entry_id: str | None = None,
+    *,
+    session: ClientSession | None = None,
+) -> None:
     """Asynchronous main function for the CLI experience (single event loop).
 
     This function provides an interactive command-line interface for fetching
     device locations or registering new microcontroller-based trackers.
     It is intended for development and testing purposes.
+
+    Args:
+        entry_id: Optional config entry ID to scope the CLI session.
+        session: Optional shared aiohttp session to avoid ephemeral per-request sessions.
     """
     cache, namespace = _resolve_cli_cache(
         entry_id or os.environ.get("GOOGLEFINDMY_ENTRY_ID")
     )
 
     print("Loading...")
-    result_hex = await async_request_device_list(cache=cache, namespace=namespace)
+    result_hex = await async_request_device_list(
+        cache=cache, namespace=namespace, session=session
+    )
 
     device_list = parse_device_list_protobuf(result_hex)
 
@@ -303,6 +313,7 @@ async def _async_cli_main(entry_id: str | None = None) -> None:
         await get_location_data_for_device(
             selected_canonic_id,
             selected_device_name,
+            session=session,
             cache=cache,
             namespace=namespace,
         )

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -505,12 +505,18 @@ if __name__ == "__main__":
         _file_cache = _register_file_cache()
 
         async def _cli_main() -> None:
+            import aiohttp  # noqa: PLC0415
+
+            session = aiohttp.ClientSession(
+                connector=aiohttp.TCPConnector(limit=16, enable_cleanup_closed=True)
+            )
             fcm = await _setup_fcm_receiver(_file_cache)
             try:
-                await _async_cli_main()
+                await _async_cli_main(session=session)
             finally:
                 with __import__("contextlib").suppress(Exception):
                     await fcm.async_stop()
+                await session.close()
 
         try:
             asyncio.run(_cli_main())


### PR DESCRIPTION
[fix: shared aiohttp session for standalone CLI + downgrade DIAG-ALERT…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/9aa93c41c5a5fe8663a899471d988edb1f38577b) 

… to debug

Standalone CLI fixes:
- Create a single shared aiohttp.ClientSession in _cli_main() and
  thread it through _async_cli_main → async_request_device_list and
  get_location_data_for_device. This eliminates 'Unclosed client
  session' warnings and 'Creating ephemeral aiohttp session' noise.
- Session is properly closed in the finally block.

DIAG-ALERT noise reduction:
- Downgrade two [DIAG-ALERT] EIK key-length warnings from warning to
  debug level. A 60-byte key is the expected GCM-wrapped format
  (12 IV + 32 CT + 16 tag) for Moto Tag / Chipolo devices, not an
  error condition. The warnings fired whenever the early unwrap
  returned None (e.g., owner key not yet cached), which is normal.