### PR TITLE
fix: soft-invalidate AAS token in standalone mode instead of deleting

### DIFF
--- a/custom_components/googlefindmy/Auth/AGENTS.md
+++ b/custom_components/googlefindmy/Auth/AGENTS.md
@@ -43,6 +43,12 @@ Chrome Cookie (oauth2_4/***, single-use, consumed after first exchange)
 * **AAS master token:** Long-lived. Only invalidated by password change, manual revocation in Google account settings, or Google security heuristics. Can generate unlimited scoped ADM tokens via `perform_oauth()`.
 * **ADM scoped token:** Short-lived (~1 hour, measured adaptively by `TTLPolicy` in `nova_request.py`). Regenerated automatically from the AAS token on expiry.
 
+### Architecture note: OAuth fallback lives in the ADM layer
+
+When `gpsoauth.perform_oauth()` rejects the AAS token (`InvalidAasTokenError`), the retry logic in `adm_token_retrieval.py:449-482` attempts an **OAuth fallback**: it reads `CONF_OAUTH_TOKEN`, switches `DATA_AUTH_METHOD` to `"individual_tokens"`, and retries — which causes the next iteration to call `async_get_aas_token()` → `_generate_aas_token()` → `gpsoauth.exchange_token(oauth_cookie)` to produce a fresh AAS token from the Chrome cookie.
+
+This is architecturally an **AAS regeneration** triggered from the ADM layer. It works for HA where the Chrome cookie may still be fresh (e.g., during initial config validation), but is ineffective in standalone mode where the cookie is already consumed. A future refactor could move this fallback into `aas_token_retrieval.py` where it logically belongs; for now it is documented here so contributors understand the cross-layer dependency.
+
 ### HA vs standalone persistence
 
 | Layer | HA mode | Standalone CLI (`main.py`) |

--- a/custom_components/googlefindmy/Auth/AGENTS.md
+++ b/custom_components/googlefindmy/Auth/AGENTS.md
@@ -24,12 +24,63 @@ When multiple modules need the same small utility (for example, `_mask_email_for
 
 The FCM supervisor uses a shared activity-health helper (freshness window + snapshot structure) to decide when a client is healthy, stale, or needs a restart. Reuse the existing helper and timestamp fields (`last_activity_monotonic`, freshness window constants, snapshot shape) rather than introducing new window values or parallel health calculations so diagnostics and coordinator state remain consistent across entries.
 
+## Token lifecycle & standalone persistence
+
+### Token hierarchy
+
+The integration uses a three-tier token chain derived from Google Play Services authentication:
+
+```
+Chrome Cookie (oauth2_4/***, single-use, consumed after first exchange)
+  → gpsoauth.exchange_token()
+  → AAS / Master Token (aas_et/***, quasi-permanent)
+    → gpsoauth.perform_oauth(service=...) — repeatable indefinitely
+    → ADM / Scoped Token (ya29.***, ~1 hour TTL)
+      → Nova API requests
+```
+
+* **Chrome OAuth cookie:** Obtained once via `accounts.google.com/EmbeddedSetup` (see `auth_flow.py`). It is **single-use** — after `exchange_token()` consumes it, the cookie is worthless. Never overwrite `CONF_OAUTH_TOKEN` with an AAS token; `adm_token_retrieval.py:450-454` guards the OAuth-fallback path with `not startswith("aas_et/")`.
+* **AAS master token:** Long-lived. Only invalidated by password change, manual revocation in Google account settings, or Google security heuristics. Can generate unlimited scoped ADM tokens via `perform_oauth()`.
+* **ADM scoped token:** Short-lived (~1 hour, measured adaptively by `TTLPolicy` in `nova_request.py`). Regenerated automatically from the AAS token on expiry.
+
+### HA vs standalone persistence
+
+| Layer | HA mode | Standalone CLI (`main.py`) |
+|-------|---------|----------------------------|
+| **Volatile** | `TokenCache` (in-memory dict) | `_FileCache._data` (in-memory dict) |
+| **Persistent** | `entry.data` (HA database) — survives `cache.set(key, None)` and is re-seeded on every restart (`__init__.py:6897-6901`) | `secrets.json` — **only store**; a naive `set(key, None)` would permanently delete the value |
+
+### Soft invalidation (standalone)
+
+To bridge the architectural gap, `_FileCache` applies **soft invalidation** for the `aas_token` key (see `_SOFT_INVALIDATE_KEYS`). When `cache.set("aas_token", None)` is called during a runtime 401 recovery:
+
+1. The key is added to `_soft_invalidated` (in-memory set).
+2. `get("aas_token")` returns `None` for the remainder of the process — the runtime sees the token as invalidated and can attempt regeneration or fail fast.
+3. `_save()` is **not** called — `secrets.json` still contains the AAS token.
+4. On the next process start, `_soft_invalidated` is empty, so `get("aas_token")` returns the value from the file, effectively recovering the token.
+
+This mirrors HA's two-layer model where `entry.data` preserves the AAS token even after the volatile `TokenCache` is cleared.
+
+### When re-authentication is required
+
+If Google genuinely revokes the AAS master token (password change, security event), no cached value can recover it. The standalone CLI logs an explicit error:
+
+```
+AAS token exchange failed with a likely-expired OAuth cookie.
+The Chrome OAuth cookie is single-use and cannot be reused.
+Please re-authenticate: python -m custom_components.googlefindmy --reauth
+```
+
+In HA mode, the equivalent path raises `ConfigEntryAuthFailed`, which triggers the reconfiguration UI.
+
 ## Cache key conventions
 
 Android IDs and related identifiers stored in `TokenCache` must follow predictable, per-user keys so helpers avoid collisions between accounts:
 
 * **AAS/FCM Android IDs:** `android_id_<username>` — always the normalized username string (entry-scoped) as the suffix.
 * **FCM credential bundle:** `fcm_credentials` — contains the `gcm.android_id` value that downstream helpers normalize and cache under the key above.
+* **AAS token:** `aas_token` (`DATA_AAS_TOKEN`) — the master token. In standalone mode this key is **soft-invalidated** (hidden in memory but preserved in `secrets.json`). Do not add it to hard-delete flows.
+* **OAuth token:** `oauth_token` (`CONF_OAUTH_TOKEN`) — the original Chrome cookie. Must remain as-is after initial storage; never overwrite with an AAS token value.
 
 When adding new cache-backed helpers under this directory, reuse these patterns (prefix + username suffix) so multi-account setups remain isolated and future helpers can retrieve existing values without guessing.
 

--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -389,7 +389,22 @@ async def _generate_aas_token(*, cache: TokenCache) -> str:  # noqa: PLR0912, PL
                 "Failed to persist normalized username from gpsoauth: %s", _clip(err)
             )
 
-    return str(resp["Token"])
+    aas_token = str(resp["Token"])
+
+    # 5) Persist the AAS token back as the OAuth slot so that future calls
+    #    hit the ``startswith("aas_et/")`` shortcut (line 333) instead of
+    #    re-attempting gpsoauth.exchange_token with a stale one-time-use
+    #    cookie.  This mirrors HA's config_flow behaviour where entry.data
+    #    stores the AAS token under CONF_OAUTH_TOKEN.
+    if aas_token.startswith("aas_et/"):
+        try:
+            await cache.set(CONF_OAUTH_TOKEN, aas_token)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Failed to persist AAS token into oauth_token slot: %s", _clip(err)
+            )
+
+    return aas_token
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -278,6 +278,11 @@ async def _exchange_oauth_for_aas(
             error_details or "(none)",
             resp_keys,
             _mask_email_for_logs(username),
+            extra={
+                "error_field_present": bool(error_value),
+                "response_keys": resp_keys,
+                "user": _mask_email_for_logs(username),
+            },
         )
         raise RuntimeError(
             f"Missing 'Token' in gpsoauth response (Error={error_value or '(none)'})"

--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -269,20 +269,19 @@ async def _exchange_oauth_for_aas(
             f"Invalid response from gpsoauth: {_summarize_response(resp)}"
         )
     if "Token" not in resp:
-        resp_keys: list[str] | str = "N/A"
-        error_details_present = False
-        if isinstance(resp, dict):
-            resp_keys = list(resp.keys())
-            error_details_present = bool(resp.get("ErrorDetails") or resp.get("Error"))
+        error_value = resp.get("Error", "") if isinstance(resp, dict) else ""
+        error_details = resp.get("ErrorDetails", "") if isinstance(resp, dict) else ""
+        resp_keys = list(resp.keys()) if isinstance(resp, dict) else "N/A"
         _LOGGER.warning(
-            "gpsoauth response missing token; response details recorded in extras.",
-            extra={
-                "error_field_present": error_details_present,
-                "response_keys": resp_keys,
-                "user": _mask_email_for_logs(username),
-            },
+            "gpsoauth response missing token. Error=%s, ErrorDetails=%s, keys=%s, user=%s",
+            error_value or "(none)",
+            error_details or "(none)",
+            resp_keys,
+            _mask_email_for_logs(username),
         )
-        raise RuntimeError("Missing 'Token' in gpsoauth response")
+        raise RuntimeError(
+            f"Missing 'Token' in gpsoauth response (Error={error_value or '(none)'})"
+        )
     return resp
 
 

--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -378,7 +378,17 @@ async def _generate_aas_token(*, cache: TokenCache) -> str:  # noqa: PLR0912, PL
     android_id = await _get_or_generate_android_id(username, cache=cache)
 
     # 3) Exchange OAuth → AAS (blocking call executed in executor).
-    resp = await _exchange_oauth_for_aas(username, oauth_token, android_id)
+    try:
+        resp = await _exchange_oauth_for_aas(username, oauth_token, android_id)
+    except RuntimeError:
+        if not oauth_token.startswith("aas_et/"):
+            _LOGGER.error(
+                "AAS token exchange failed with a likely-expired OAuth cookie. "
+                "The Chrome OAuth cookie is single-use and cannot be reused. "
+                "Please re-authenticate: "
+                "python -m custom_components.googlefindmy --reauth",
+            )
+        raise
 
     # 4) Persist normalized email if gpsoauth returns it (keeps cache consistent).
     if isinstance(resp.get("Email"), str) and resp["Email"]:
@@ -389,22 +399,7 @@ async def _generate_aas_token(*, cache: TokenCache) -> str:  # noqa: PLR0912, PL
                 "Failed to persist normalized username from gpsoauth: %s", _clip(err)
             )
 
-    aas_token = str(resp["Token"])
-
-    # 5) Persist the AAS token back as the OAuth slot so that future calls
-    #    hit the ``startswith("aas_et/")`` shortcut (line 333) instead of
-    #    re-attempting gpsoauth.exchange_token with a stale one-time-use
-    #    cookie.  This mirrors HA's config_flow behaviour where entry.data
-    #    stores the AAS token under CONF_OAUTH_TOKEN.
-    if aas_token.startswith("aas_et/"):
-        try:
-            await cache.set(CONF_OAUTH_TOKEN, aas_token)
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug(
-                "Failed to persist AAS token into oauth_token slot: %s", _clip(err)
-            )
-
-    return aas_token
+    return str(resp["Token"])
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -216,9 +216,17 @@ def _register_file_cache() -> object:
 
         entry_id: str = "standalone"
 
+        # Keys that are hidden in memory but preserved in the backing file.
+        # This mirrors HA's two-layer persistence (volatile TokenCache +
+        # persistent entry.data) for standalone mode where secrets.json is
+        # the only store.  The AAS master token must survive runtime
+        # invalidation so it can be recovered on the next process start.
+        _SOFT_INVALIDATE_KEYS: frozenset[str] = frozenset({"aas_token"})
+
         def __init__(self, path: Path) -> None:
             self._path = path
             self._data: dict[str, object] = {}
+            self._soft_invalidated: set[str] = set()
             self._load_failed = False
             if path.is_file():
                 try:
@@ -247,23 +255,33 @@ def _register_file_cache() -> object:
         # --- async interface expected by nbe_list_devices / nova_request ---
 
         async def get(self, name: str) -> object:
+            if name in self._soft_invalidated:
+                return None
             return self._data.get(name)
 
         async def set(self, name: str, value: object) -> None:
             if value is None:
+                if name in self._SOFT_INVALIDATE_KEYS and name in self._data:
+                    # Soft-invalidate: hide from in-memory reads but keep in
+                    # the backing file so the value survives process restarts.
+                    self._soft_invalidated.add(name)
+                    return  # intentionally skip _save()
                 self._data.pop(name, None)
             else:
                 self._data[name] = value
+                self._soft_invalidated.discard(name)
             self._save()
 
         async def async_get_cached_value(self, name: str) -> object:
+            if name in self._soft_invalidated:
+                return None
             return self._data.get(name)
 
         async def async_set_cached_value(self, name: str, value: object) -> None:
             await self.set(name, value)
 
         async def async_get_cached_value_or_set(self, name: str, generator):  # type: ignore[no-untyped-def]
-            existing = self._data.get(name)
+            existing = await self.get(name)
             if existing is not None:
                 return existing
             import asyncio  # noqa: PLC0415


### PR DESCRIPTION
[fix: log gpsoauth error details directly instead of only in extras](https://github.com/jleinenbach/GoogleFindMy-HA/commit/76cb12b2ee6eeee2a57af664c093ab33f4475f2e) 

When gpsoauth returns a response without 'Token', the actual Error and
ErrorDetails fields were only logged in extra={} which is invisible in
standard logging output. Users saw "response details recorded in extras"
with no actionable information.

Now the Error, ErrorDetails, and response keys are logged directly in
the warning message, and the RuntimeError includes the error type so
higher-level retry/abort decisions can reference it.

This primarily affects standalone CLI mode where standard logging is
used (HA mode benefits from structured logging formatters that can
display extras).

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 54 minutes ago
[fix: persist AAS token into oauth_token slot after successful gpsoaut…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/984df32b717a2eec768b2288d050f8a7084a059b) 

…h exchange

After a successful gpsoauth.exchange_token call, the resulting AAS token
(aas_et/...) is now written back to the CONF_OAUTH_TOKEN cache slot. This
ensures that subsequent calls (including after a 401-triggered invalidation
of DATA_AAS_TOKEN) hit the startswith("aas_et/") shortcut and reuse the
AAS token directly — instead of re-attempting gpsoauth.exchange_token with
the stale one-time-use Chrome OAuth cookie.

This mirrors HA's config_flow behaviour where entry.data persists the AAS
token under CONF_OAUTH_TOKEN so that async_setup_entry can re-seed it on
every restart.

Root cause: In standalone CLI mode, a 401 response invalidated the cached
aas_token (set to None). On the next start, the only remaining credential
was the original oauth_token cookie — which is single-use and already
expired. gpsoauth.exchange_token then returned {"Error": "..."} without
a Token key, causing the infinite "Missing 'Token' in gpsoauth response"
retry loop.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 35 minutes ago
[fix: soft-invalidate AAS token in standalone mode instead of deleting](https://github.com/jleinenbach/GoogleFindMy-HA/commit/85eff5917703dc679d57c47c57c6bc8825223d15) 

Replace the oauth_token overwrite approach (commit https://github.com/jleinenbach/GoogleFindMy-HA/commit/984df32b717a2eec768b2288d050f8a7084a059b) with a
proper soft-invalidation mechanism in _FileCache that mirrors HA's
two-layer persistence model.

Problem: In standalone CLI mode, a 401-triggered AAS invalidation
permanently deleted the AAS master token from secrets.json.  The
Chrome OAuth cookie is single-use (consumed after the first exchange),
so gpsoauth.exchange_token could never regenerate the AAS token on
the next start — causing an infinite "Missing 'Token'" error loop.

HA avoids this because entry.data (persistent) survives TokenCache
invalidation (volatile) and is re-seeded on every restart.

Solution:
- _FileCache now soft-invalidates the aas_token key: set(key, None)
  hides the value in memory but preserves it in secrets.json.  On
  the next process start, the value is recovered from the file.
- Revert the oauth_token overwrite — CONF_OAUTH_TOKEN must keep the
  original Chrome cookie because adm_token_retrieval.py:450-454
  guards the OAuth fallback path with not startswith("aas_et/").
- Add fail-fast logging when gpsoauth exchange fails with a stale
  Chrome cookie, directing users to run --reauth.
- Document token lifecycle, HA vs standalone persistence, and the
  soft-invalidation contract in Auth/AGENTS.md.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK