### PR TITLE
fix: resolve unclosed aiohttp sessions and FCM readiness race

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -2011,6 +2011,32 @@ class FcmReceiverHA:
 
             self._update_token_routing(token, {entry_id})
             await self._persist_routing_token(entry_id, token)
+
+            # Wait for the FCM client to be actively listening before sending
+            # the location request.  Without this, the push notification from
+            # Google may arrive before the MCS connection is established.
+            pc = self.pcs.get(entry_id)
+            if pc is not None:
+                _MAX_READY_WAIT_S = 15.0
+                _POLL_INTERVAL_S = 0.3
+                waited = 0.0
+                while waited < _MAX_READY_WAIT_S:
+                    run_state = getattr(pc, "run_state", None)
+                    if (
+                        FcmPushClientRunState is not None
+                        and run_state == FcmPushClientRunState.STARTED
+                    ):
+                        break
+                    await asyncio.sleep(_POLL_INTERVAL_S)
+                    waited += _POLL_INTERVAL_S
+                else:
+                    _LOGGER.warning(
+                        "[entry=%s] FCM client not in STARTED state after %.1fs; "
+                        "location request may time out",
+                        entry_id,
+                        _MAX_READY_WAIT_S,
+                    )
+
             _LOGGER.info(
                 "[entry=%s] Manual locate registration ready for %s",
                 entry_id,

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -800,15 +800,18 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         :return: The FCM token which is used to identify you with the push end
             point application.
         """
-        self.register = FcmRegister(
+        # Capture in a local variable so concurrent calls on the same instance
+        # cannot overwrite ``self.register`` and leak the previous session.
+        register = FcmRegister(
             self.fcm_config,
             self.credentials,
             self.credentials_updated_callback,
             http_client_session=self._http_client_session,
         )
+        self.register = register
 
         try:
-            credentials = await self.register.checkin_or_register()
+            credentials = await register.checkin_or_register()
             self.credentials = credentials
 
             fcm_section = credentials.get("fcm")
@@ -825,9 +828,8 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
 
             return registration_token
         finally:
-            register = self.register
-            if register is not None:
-                await register.close()
+            await register.close()
+            if self.register is register:
                 self.register = None
 
     async def _start_heartbeat_sender(self) -> None:


### PR DESCRIPTION
[fix: resolve unclosed aiohttp sessions and FCM readiness race in stan…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/3fa19b1204a21a5ae040df1596f66e41b1c33245) 

…dalone CLI

Two bugs in standalone mode (python main.py):

1. "Unclosed client session" warnings: FcmPushClient.checkin_or_register()
   stored the FcmRegister on self.register. Concurrent calls (supervisor +
   location request) could overwrite it, leaking the previous session.
   Fix: capture FcmRegister in a local variable so the finally block always
   closes the correct instance.

2. "No location response received (timeout: 30s)": The location request was
   sent before the FCM client finished connecting to Google's MCS endpoint.
   Fix: async_register_for_location_updates() now polls until the FCM client
   reaches STARTED state (up to 15s) before returning the token.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK