### PR TITLE
fix: obtain shared key eagerly at CLI startup

### DIFF
--- a/custom_components/googlefindmy/KeyBackup/shared_key_retrieval.py
+++ b/custom_components/googlefindmy/KeyBackup/shared_key_retrieval.py
@@ -153,6 +153,12 @@ async def _interactive_flow_hex() -> str:
         return _decode_base64_like_32(s).hex()
 
 
+# Guard: only attempt the browser flow once per process to avoid opening
+# multiple Chrome windows on retry paths (e.g. blind refresh in
+# async_retrieve_identity_key).
+_browser_flow_attempted = False
+
+
 async def _retrieve_shared_key_hex() -> str:
     """Obtain a hex-encoded shared key (32 bytes) via the interactive browser flow.
 
@@ -164,15 +170,27 @@ async def _retrieve_shared_key_hex() -> str:
     the secrets bundle during ``async_setup_entry()``.  This function is only
     reached when the cache has no shared key.
 
+    A module-level guard prevents the browser from being opened more than once
+    per process lifetime, avoiding the "5 browser windows" problem when multiple
+    retry paths each trigger shared key retrieval.
+
     Returns:
         str: lowercase hex string of the 32-byte key.
 
     Raises:
         RuntimeError: if the key cannot be obtained.
     """
+    global _browser_flow_attempted  # noqa: PLW0603
+
     is_tty = sys.stdin and sys.stdin.isatty()
 
     if is_tty:
+        if _browser_flow_attempted:
+            raise RuntimeError(
+                "Shared key browser flow already attempted in this session. "
+                "Restart with --reauth to try again."
+            )
+        _browser_flow_attempted = True
         try:
             _LOGGER.info(
                 "Retrieving shared key via interactive browser flow (CLI mode)"

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -589,9 +589,10 @@ async def async_retrieve_identity_key(
             username = await cache.get(username_string)
             if isinstance(username, str) and username:
                 await cache.set(f"owner_key_{username}", None)
-            # Also clear shared key — if the owner key decryption fails
-            # because the shared key is stale, both must be refreshed.
-            await cache.set("shared_key", None)
+            # Note: shared_key is NOT cleared here. The shared key is stable
+            # and does not rotate with owner key versions. Clearing it would
+            # trigger the browser flow on retry, which fails on Windows due
+            # to ChromeDriver file locks and opens multiple browser windows.
         except Exception as cache_exc:  # noqa: BLE001
             _LOGGER.debug("Failed to clear cached keys: %s", cache_exc)
         try:

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -415,7 +415,53 @@ def create_driver(
     3. Fallback without specifying version
     4. Headless mode
     5. webdriver-manager fallback (standard Selenium)
+
+    On Windows, ``undetected_chromedriver`` may fail with ``WinError 32``
+    (file in use) if a previous ChromeDriver process hasn't fully released
+    its lock on ``chromedriver.exe``.  This function retries up to 3 times
+    with a short delay to handle transient file locks.
     """
+    for attempt in range(3):
+        try:
+            return _create_driver_inner(chrome_path=chrome_path, headless=headless)
+        except (PermissionError, OSError) as err:
+            # WinError 32 (file in use) or WinError 183 (file already exists)
+            err_str = str(err)
+            is_file_lock = "WinError 32" in err_str or "WinError 183" in err_str
+            if not is_file_lock or attempt >= 2:
+                raise
+            LOGGER.info(
+                "ChromeDriver file lock detected (attempt %d/3), "
+                "waiting for lock release...",
+                attempt + 1,
+            )
+            time.sleep(3)
+        except RuntimeError:
+            if attempt >= 2 or platform.system() != "Windows":
+                raise
+            # All strategies failed — on Windows this may be due to file locks;
+            # retry after a delay.
+            LOGGER.info(
+                "All ChromeDriver strategies failed (attempt %d/3), "
+                "retrying after delay...",
+                attempt + 1,
+            )
+            time.sleep(3)
+
+    # Should not reach here, but satisfy type checker
+    return _create_driver_inner(chrome_path=chrome_path, headless=headless)
+
+
+def _is_file_lock_error(err: BaseException) -> bool:
+    """Check if an exception is a Windows file lock error (WinError 32/183)."""
+    msg = str(err)
+    return "WinError 32" in msg or "WinError 183" in msg
+
+
+def _create_driver_inner(
+    chrome_path: str | None = None, *, headless: bool = False
+) -> WebDriver:
+    """Internal driver creation with multiple strategy fallbacks."""
     # Kill any existing Chrome processes to avoid conflicts
     _kill_existing_chrome_processes()
 
@@ -426,6 +472,9 @@ def create_driver(
         version_main = get_chrome_version(resolved_path)
         if version_main:
             LOGGER.debug("Detected Chrome version: %d", version_main)
+
+    # Track whether all failures are file-lock related (Windows)
+    _all_file_lock = True
 
     # Strategy 1: Default with version_main if detected
     driver: WebDriver | None = None
@@ -441,6 +490,8 @@ def create_driver(
         return driver
     except Exception as err:  # noqa: BLE001
         _quit_driver(driver)
+        if not _is_file_lock_error(err):
+            _all_file_lock = False
         LOGGER.warning("Strategy 1 (default) failed: %s", err)
 
     # Strategy 2: Use browser_executable_path parameter (if supported)
@@ -459,6 +510,8 @@ def create_driver(
             return driver
         except Exception as err:  # noqa: BLE001
             _quit_driver(driver)
+            if not _is_file_lock_error(err):
+                _all_file_lock = False
             LOGGER.warning("Strategy 2 (explicit path) failed: %s", err)
 
     # Strategy 3: Try without specifying version
@@ -473,6 +526,8 @@ def create_driver(
         return driver
     except Exception as err:  # noqa: BLE001
         _quit_driver(driver)
+        if not _is_file_lock_error(err):
+            _all_file_lock = False
         LOGGER.warning("Strategy 3 (no version) failed: %s", err)
 
     # Strategy 4: Try headless mode
@@ -492,12 +547,22 @@ def create_driver(
             return driver
         except Exception as err:  # noqa: BLE001
             _quit_driver(driver)
+            if not _is_file_lock_error(err):
+                _all_file_lock = False
             LOGGER.warning("Strategy 4 (headless) failed: %s", err)
 
     # Strategy 5: webdriver-manager fallback
     fallback_driver = _try_webdriver_manager_fallback()
     if fallback_driver is not None:
         return fallback_driver
+
+    # If all failures were file-lock related, raise PermissionError so the
+    # outer retry loop in create_driver() can wait and retry.
+    if _all_file_lock and platform.system() == "Windows":
+        raise PermissionError(
+            "All ChromeDriver strategies failed due to file lock (WinError 32/183). "
+            "A previous ChromeDriver process may still be running."
+        )
 
     # All strategies failed
     raise RuntimeError(

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -421,14 +421,15 @@ def create_driver(
     its lock on ``chromedriver.exe``.  This function retries up to 3 times
     with a short delay to handle transient file locks.
     """
-    for attempt in range(3):
+    max_retries = 3
+    for attempt in range(max_retries):
         try:
             return _create_driver_inner(chrome_path=chrome_path, headless=headless)
         except (PermissionError, OSError) as err:
             # WinError 32 (file in use) or WinError 183 (file already exists)
             err_str = str(err)
             is_file_lock = "WinError 32" in err_str or "WinError 183" in err_str
-            if not is_file_lock or attempt >= 2:
+            if not is_file_lock or attempt >= max_retries - 1:
                 raise
             LOGGER.info(
                 "ChromeDriver file lock detected (attempt %d/3), "
@@ -437,7 +438,7 @@ def create_driver(
             )
             time.sleep(3)
         except RuntimeError:
-            if attempt >= 2 or platform.system() != "Windows":
+            if attempt >= max_retries - 1 or platform.system() != "Windows":
                 raise
             # All strategies failed — on Windows this may be due to file locks;
             # retry after a delay.
@@ -458,7 +459,7 @@ def _is_file_lock_error(err: BaseException) -> bool:
     return "WinError 32" in msg or "WinError 183" in msg
 
 
-def _create_driver_inner(
+def _create_driver_inner(  # noqa: PLR0912, PLR0915
     chrome_path: str | None = None, *, headless: bool = False
 ) -> WebDriver:
     """Internal driver creation with multiple strategy fallbacks."""

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -413,13 +413,13 @@ async def _ensure_shared_key(cache: object) -> None:
     triggering the browser flow lazily during decryption, which can conflict
     with ChromeDriver file locks on Windows.
     """
-    existing = await cache.get("shared_key")  # type: ignore[union-attr]
+    existing = await cache.get("shared_key")  # type: ignore[attr-defined]
     if existing:
         return
     # Check user-scoped legacy key too
-    username = await cache.get("username")  # type: ignore[union-attr]
+    username = await cache.get("username")  # type: ignore[attr-defined]
     if isinstance(username, str) and username:
-        legacy = await cache.get(f"shared_key_{username}")  # type: ignore[union-attr]
+        legacy = await cache.get(f"shared_key_{username}")  # type: ignore[attr-defined]
         if legacy:
             return
     print("Retrieving encryption key from Google Key Backup vault...\n")

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -406,6 +406,34 @@ def _ensure_authenticated() -> None:
     print("\nCredentials saved. Continuing...\n")
 
 
+async def _ensure_shared_key(cache: object) -> None:
+    """Obtain the shared key from Google's vault if not already cached.
+
+    Called eagerly during CLI startup (before any location requests) to avoid
+    triggering the browser flow lazily during decryption, which can conflict
+    with ChromeDriver file locks on Windows.
+    """
+    existing = await cache.get("shared_key")  # type: ignore[union-attr]
+    if existing:
+        return
+    # Check user-scoped legacy key too
+    username = await cache.get("username")  # type: ignore[union-attr]
+    if isinstance(username, str) and username:
+        legacy = await cache.get(f"shared_key_{username}")  # type: ignore[union-attr]
+        if legacy:
+            return
+    print("Retrieving encryption key from Google Key Backup vault...\n")
+    from custom_components.googlefindmy.KeyBackup.shared_key_retrieval import (  # noqa: PLC0415
+        async_get_shared_key,
+    )
+
+    await async_get_shared_key(
+        cache=cache,  # type: ignore[arg-type]
+        username=username if isinstance(username, str) else None,
+    )
+    print("Encryption key saved.\n")
+
+
 async def _setup_fcm_receiver(cache: object) -> Any:
     """Initialize the FCM push-notification receiver for standalone CLI use.
 
@@ -530,6 +558,7 @@ if __name__ == "__main__":
             session = aiohttp.ClientSession(
                 connector=aiohttp.TCPConnector(limit=16, enable_cleanup_closed=True)
             )
+            await _ensure_shared_key(_file_cache)
             fcm = await _setup_fcm_receiver(_file_cache)
             try:
                 await _async_cli_main(session=session)


### PR DESCRIPTION
[fix: obtain shared key eagerly at CLI startup and prevent repeated br…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/111c304c310bc6ccd69df21733f1396aceab5bba) 

…owser opens

Three fixes for CLI location decryption on Windows:

1. Obtain shared key during CLI startup (_ensure_shared_key) before any
   location requests, avoiding ChromeDriver file lock conflicts when the
   browser flow is triggered lazily during decryption.

2. Add ChromeDriver file lock retry (3 attempts with 3s delay) in
   create_driver() for Windows WinError 32/183 - the OS may still hold
   locks on chromedriver.exe from a recently closed session.

3. Add single-attempt guard in _retrieve_shared_key_hex() to prevent
   the browser from opening multiple times per process when retry paths
   in async_retrieve_identity_key each trigger shared key retrieval.

4. Stop clearing shared_key during blind owner key refresh - the shared
   key is stable and does not rotate with owner key versions.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK