### PR TITLE
fix: eagerly exchange OAuth cookie for AAS token before shared key flow

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -411,7 +411,11 @@ async def async_retrieve_identity_key(
     # Build key sources list (matches eid_resolver pattern: try owner + shared)
     key_sources: list[tuple[str, bytes]] = [("owner", owner_key_info.key)]
     try:
-        shared_key = await async_get_shared_key(cache=cache)
+        _cached_user = await cache.get(username_string)
+        shared_key = await async_get_shared_key(
+            cache=cache,
+            username=_cached_user if isinstance(_cached_user, str) else None,
+        )
         if shared_key is not None:
             key_sources.append(("shared", shared_key))
     except Exception:  # noqa: BLE001 - best-effort

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -406,6 +406,41 @@ def _ensure_authenticated() -> None:
     print("\nCredentials saved. Continuing...\n")
 
 
+async def _ensure_aas_token(cache: object) -> None:
+    """Eagerly exchange the OAuth cookie for an AAS master token.
+
+    The OAuth cookie obtained by ``_ensure_authenticated()`` is **single-use**
+    and has a very short TTL.  If we open Chrome again (e.g. for the shared
+    key vault flow) before exchanging it, the cookie is invalidated and the
+    AAS exchange fails with ``BadAuthentication``.
+
+    This function must be called **immediately** after ``_ensure_authenticated()``
+    and **before** any subsequent Chrome sessions.
+    """
+    # If an AAS token is already cached, nothing to do.
+    existing = await cache.get("aas_token")  # type: ignore[attr-defined]
+    if isinstance(existing, str) and existing.strip():
+        return
+    # If there's no OAuth token either, skip (auth wasn't needed).
+    oauth = await cache.get("oauth_token")  # type: ignore[attr-defined]
+    if not isinstance(oauth, str) or not oauth.strip():
+        return
+    try:
+        from custom_components.googlefindmy.Auth.aas_token_retrieval import (  # noqa: PLC0415
+            async_get_aas_token,
+        )
+
+        await async_get_aas_token(cache=cache)  # type: ignore[arg-type]
+    except Exception as exc:  # noqa: BLE001
+        import logging  # noqa: PLC0415
+
+        logging.getLogger(__name__).warning(
+            "Eager AAS token exchange failed: %s. "
+            "Will retry during API call.",
+            exc,
+        )
+
+
 async def _ensure_shared_key(cache: object) -> None:
     """Obtain the shared key from Google's vault if not already cached.
 
@@ -558,6 +593,11 @@ if __name__ == "__main__":
             session = aiohttp.ClientSession(
                 connector=aiohttp.TCPConnector(limit=16, enable_cleanup_closed=True)
             )
+            # Exchange the single-use OAuth cookie for an AAS master token
+            # BEFORE opening Chrome again for the shared key flow.  The OAuth
+            # cookie has a very short TTL and is invalidated once a new Chrome
+            # session is opened, so the exchange must happen immediately.
+            await _ensure_aas_token(_file_cache)
             await _ensure_shared_key(_file_cache)
             fcm = await _setup_fcm_receiver(_file_cache)
             try:


### PR DESCRIPTION
[fix: eagerly exchange OAuth cookie for AAS token before shared key flow](https://github.com/jleinenbach/GoogleFindMy-HA/commit/02ca6f3601ee72e4130399daf3cbbff41026dfd2) 

The OAuth cookie from _ensure_authenticated() is single-use and has a
very short TTL. Opening a second Chrome session (for the shared key
vault flow) invalidates it, causing BadAuthentication when the API
later tries to exchange it for an AAS token.

Add _ensure_aas_token() that runs immediately after authentication
and before _ensure_shared_key(), consuming the OAuth cookie while
it's still valid.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 27 minutes ago
[Pass username to async_get_shared_key in decrypt_locations for legacy…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/f8482fee9e390609000d4f9b5f2c10e3de6401be) 

… migration

The shared key retrieval call during decryption was missing the username
parameter, which prevented legacy user-scoped key migration from triggering.
While not blocking for fresh installs (startup already caches under the
canonical key), this makes the fallback path more robust.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK