### PR TITLE
Fix: silent CLI exit after location request and Chrome cleanup on Windows

### DIFF
--- a/custom_components/googlefindmy/Auth/auth_flow.py
+++ b/custom_components/googlefindmy/Auth/auth_flow.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from selenium.webdriver.support.ui import WebDriverWait
 
-from custom_components.googlefindmy.chrome_driver import create_driver
+from custom_components.googlefindmy.chrome_driver import create_driver, safe_quit_driver
 
 if TYPE_CHECKING:
     from selenium.webdriver.remote.webdriver import WebDriver
@@ -79,8 +79,8 @@ def request_oauth_account_token_flow(
         return oauth_token_value, email
 
     finally:
-        # Close the browser
-        driver.quit()
+        # Close the browser (safe_quit handles WinError 6 on Windows)
+        safe_quit_driver(driver)
 
 
 def _extract_email_from_session(driver: WebDriver) -> str | None:

--- a/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
+++ b/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
@@ -14,7 +14,7 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.ui import WebDriverWait
 
-from custom_components.googlefindmy.chrome_driver import create_driver
+from custom_components.googlefindmy.chrome_driver import create_driver, safe_quit_driver
 from custom_components.googlefindmy.KeyBackup.response_parser import (
     get_fmdn_shared_key,
 )
@@ -102,8 +102,7 @@ def request_shared_key_flow() -> str | None:
         LOGGER.exception("Shared key flow terminated unexpectedly")
         return None
     finally:
-        if driver is not None:
-            driver.quit()
+        safe_quit_driver(driver)
 
 
 if __name__ == "__main__":

--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -310,13 +310,42 @@ async def _async_cli_main(
             "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request"
         ).get_location_data_for_device
 
-        await get_location_data_for_device(
+        locations = await get_location_data_for_device(
             selected_canonic_id,
             selected_device_name,
             session=session,
             cache=cache,
             namespace=namespace,
         )
+
+        if locations:
+            import datetime as _dt  # noqa: PLC0415
+
+            for loc in locations:
+                lat = loc.get("latitude")
+                lon = loc.get("longitude")
+                if lat is not None and lon is not None:
+                    print(f"\nLocation: {lat}, {lon}")
+                    acc = loc.get("accuracy")
+                    if acc is not None:
+                        print(f"Accuracy: {acc}m")
+                    last_seen = loc.get("last_seen")
+                    if last_seen is not None:
+                        dt = _dt.datetime.fromtimestamp(
+                            float(last_seen), tz=_dt.UTC
+                        )
+                        print(f"Last seen: {dt:%Y-%m-%d %H:%M:%S UTC}")
+                    print(
+                        f"Google Maps: https://www.google.com/maps/search/"
+                        f"?api=1&query={lat},{lon}"
+                    )
+                elif loc.get("semantic_name"):
+                    print(f"\nSemantic location: {loc['semantic_name']}")
+        else:
+            print(
+                "\nNo location data received. "
+                "The tracker may be out of range or the request timed out."
+            )
 
 
 def list_devices() -> None:

--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -254,7 +254,7 @@ def _print_locations(locations: list[dict[str, object]]) -> None:
                 print(f"Accuracy: {acc}m")
             last_seen = loc.get("last_seen")
             if last_seen is not None:
-                dt = _dt.datetime.fromtimestamp(float(last_seen), tz=_dt.UTC)
+                dt = _dt.datetime.fromtimestamp(float(str(last_seen)), tz=_dt.UTC)
                 print(f"Last seen: {dt:%Y-%m-%d %H:%M:%S UTC}")
             print(
                 f"Google Maps: https://www.google.com/maps/search/"

--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -233,6 +233,37 @@ def _resolve_cli_cache(entry_id_hint: str | None) -> tuple[TokenCache, str]:
     return cache, normalized
 
 
+def _print_locations(locations: list[dict[str, object]]) -> None:
+    """Pretty-print location results to the console."""
+    if not locations:
+        print(
+            "\nNo location data received. "
+            "The tracker may be out of range or the request timed out."
+        )
+        return
+
+    import datetime as _dt  # noqa: PLC0415
+
+    for loc in locations:
+        lat = loc.get("latitude")
+        lon = loc.get("longitude")
+        if lat is not None and lon is not None:
+            print(f"\nLocation: {lat}, {lon}")
+            acc = loc.get("accuracy")
+            if acc is not None:
+                print(f"Accuracy: {acc}m")
+            last_seen = loc.get("last_seen")
+            if last_seen is not None:
+                dt = _dt.datetime.fromtimestamp(float(last_seen), tz=_dt.UTC)
+                print(f"Last seen: {dt:%Y-%m-%d %H:%M:%S UTC}")
+            print(
+                f"Google Maps: https://www.google.com/maps/search/"
+                f"?api=1&query={lat},{lon}"
+            )
+        elif loc.get("semantic_name"):
+            print(f"\nSemantic location: {loc['semantic_name']}")
+
+
 async def _async_cli_main(
     entry_id: str | None = None,
     *,
@@ -279,73 +310,54 @@ async def _async_cli_main(
     for idx, (device_name, canonic_id) in enumerate(canonic_ids, start=1):
         print(f"{idx}. {device_name}: {canonic_id}")
 
-    selected_value = input(
-        "\nIf you want to see locations of a tracker, type the number of the tracker and press 'Enter'.\n"
-        "If you want to register a new ESP32- or Zephyr-based tracker, type 'r' and press 'Enter': "
-    )
-
-    if selected_value == "r":
-        print("Loading...")
-
-        def _register_esp32_cli() -> None:
-            """Synchronous helper to register a new ESP32 device."""
-            # Lazy import to avoid touching spot token logic at HA startup
-            register_esp32 = import_module(
-                "custom_components.googlefindmy.SpotApi.CreateBleDevice.create_ble_device"
-            ).register_esp32
-
-            register_esp32(cache=cache)
-
-        # Run potential blocking/IO work in a worker thread to avoid blocking the loop.
-        await asyncio.to_thread(_register_esp32_cli)
-    else:
-        selected_idx = int(selected_value) - 1
-        selected_device_name = canonic_ids[selected_idx][0]
-        selected_canonic_id = canonic_ids[selected_idx][1]
-
-        print("Fetching location...")
-
-        # Lazy import: only needed for the CLI branch
-        get_location_data_for_device = import_module(
-            "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request"
-        ).get_location_data_for_device
-
-        locations = await get_location_data_for_device(
-            selected_canonic_id,
-            selected_device_name,
-            session=session,
-            cache=cache,
-            namespace=namespace,
+    while True:
+        selected_value = input(
+            "\nType the number of a tracker to locate it, 'r' to register a new tracker, or 'q' to quit: "
         )
 
-        if locations:
-            import datetime as _dt  # noqa: PLC0415
+        if selected_value.strip().lower() == "q":
+            print("Goodbye!")
+            break
 
-            for loc in locations:
-                lat = loc.get("latitude")
-                lon = loc.get("longitude")
-                if lat is not None and lon is not None:
-                    print(f"\nLocation: {lat}, {lon}")
-                    acc = loc.get("accuracy")
-                    if acc is not None:
-                        print(f"Accuracy: {acc}m")
-                    last_seen = loc.get("last_seen")
-                    if last_seen is not None:
-                        dt = _dt.datetime.fromtimestamp(
-                            float(last_seen), tz=_dt.UTC
-                        )
-                        print(f"Last seen: {dt:%Y-%m-%d %H:%M:%S UTC}")
-                    print(
-                        f"Google Maps: https://www.google.com/maps/search/"
-                        f"?api=1&query={lat},{lon}"
-                    )
-                elif loc.get("semantic_name"):
-                    print(f"\nSemantic location: {loc['semantic_name']}")
+        if selected_value == "r":
+            print("Loading...")
+
+            def _register_esp32_cli() -> None:
+                """Synchronous helper to register a new ESP32 device."""
+                # Lazy import to avoid touching spot token logic at HA startup
+                register_esp32 = import_module(
+                    "custom_components.googlefindmy.SpotApi.CreateBleDevice.create_ble_device"
+                ).register_esp32
+
+                register_esp32(cache=cache)
+
+            # Run potential blocking/IO work in a worker thread to avoid blocking the loop.
+            await asyncio.to_thread(_register_esp32_cli)
         else:
-            print(
-                "\nNo location data received. "
-                "The tracker may be out of range or the request timed out."
+            try:
+                selected_idx = int(selected_value) - 1
+                selected_device_name = canonic_ids[selected_idx][0]
+                selected_canonic_id = canonic_ids[selected_idx][1]
+            except (ValueError, IndexError):
+                print("Invalid selection. Please try again.")
+                continue
+
+            print("Fetching location...")
+
+            # Lazy import: only needed for the CLI branch
+            get_location_data_for_device = import_module(
+                "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request"
+            ).get_location_data_for_device
+
+            locations = await get_location_data_for_device(
+                selected_canonic_id,
+                selected_device_name,
+                session=session,
+                cache=cache,
+                namespace=namespace,
             )
+
+            _print_locations(locations)
 
 
 def list_devices() -> None:

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -14,6 +14,7 @@ from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 
 from selenium.webdriver.chrome.webdriver import WebDriver
+from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 # Platform-specific import for Windows registry access
 _winreg: ModuleType | None = None
@@ -359,12 +360,12 @@ def _try_webdriver_manager_fallback() -> WebDriver | None:
         return None
 
 
-def safe_quit_driver(driver: WebDriver | None) -> None:
+def safe_quit_driver(driver: RemoteWebDriver | None) -> None:
     """Safely quit the Chrome driver, handling WinError 6 and other errors.
 
     Parameters
     ----------
-    driver: WebDriver | None
+    driver: RemoteWebDriver | None
         The WebDriver instance to quit, or None.
     """
     if driver is None:

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -416,6 +416,11 @@ async def _ensure_aas_token(cache: object) -> None:
 
     This function must be called **immediately** after ``_ensure_authenticated()``
     and **before** any subsequent Chrome sessions.
+
+    If no AAS token is available and the exchange fails (e.g. because the
+    OAuth cookie is stale from a previous session), the process exits with
+    a clear re-authentication prompt instead of continuing only to fail
+    later during the first API call.
     """
     # If an AAS token is already cached, nothing to do.
     existing = await cache.get("aas_token")  # type: ignore[attr-defined]
@@ -431,14 +436,20 @@ async def _ensure_aas_token(cache: object) -> None:
         )
 
         await async_get_aas_token(cache=cache)  # type: ignore[arg-type]
-    except Exception as exc:  # noqa: BLE001
-        import logging  # noqa: PLC0415
-
-        logging.getLogger(__name__).warning(
-            "Eager AAS token exchange failed: %s. "
-            "Will retry during API call.",
-            exc,
+    except Exception:  # noqa: BLE001
+        # The OAuth cookie is single-use and already consumed/expired.
+        # Without an AAS token the CLI cannot make any API calls, so
+        # continuing would just produce the same error later.  Exit
+        # immediately with a clear message.
+        print(
+            "\nError: Could not obtain an AAS authentication token.\n"
+            "The OAuth cookie in secrets.json is stale (single-use, already consumed).\n"
+            "\n"
+            "Please re-authenticate:\n"
+            "  python main.py --reauth\n",
+            file=sys.stderr,
         )
+        sys.exit(1)
 
 
 async def _ensure_shared_key(cache: object) -> None:

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -6,7 +6,11 @@ omits that attribute, causing class creation to fail before tests import the
 integration. Provide a lightweight placeholder so the annotations resolve.
 """
 
-import pycares
+try:
+    import pycares
+except ModuleNotFoundError:
+    # pycares is not installed (e.g. mypy-only CI run); nothing to patch.
+    pycares = None  # type: ignore[assignment]
 
 _ARES_RESULT_TYPES = {
     "ares_query_a_result",
@@ -25,7 +29,8 @@ _ARES_RESULT_TYPES = {
     "ares_nameinfo_result",
 }
 
-for _result_name in _ARES_RESULT_TYPES:
-    if not hasattr(pycares, _result_name):
-        placeholder = type(_result_name, (), {})
-        setattr(pycares, _result_name, placeholder)
+if pycares is not None:
+    for _result_name in _ARES_RESULT_TYPES:
+        if not hasattr(pycares, _result_name):
+            placeholder = type(_result_name, (), {})
+            setattr(pycares, _result_name, placeholder)


### PR DESCRIPTION
[Abort CLI startup when AAS token exchange fails with stale OAuth cookie](https://github.com/jleinenbach/GoogleFindMy-HA/commit/b97fba871a5317b280e928b3c4bcf8367dd252cc) 

When secrets.json contains a consumed/expired OAuth token but no AAS token
(e.g. from a previous session where the exchange never succeeded), the CLI
would silently continue and fail later during the API call with the same
BadAuthentication error. Now it exits immediately with a clear message
directing the user to re-authenticate with --reauth.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 38 minutes ago
[Fix silent CLI exit after location request and Chrome cleanup on Windows](https://github.com/jleinenbach/GoogleFindMy-HA/commit/c3f19cf33e064c1f99df12c9a84e8d64d42be52f) 

Two bugs fixed:

1. CLI silently exits after "Fetching location..." without showing results.
   The return value of get_location_data_for_device() was discarded.
   Now prints coordinates, accuracy, timestamp, and Google Maps link.

2. Chrome window stays open after shared key vault flow on Windows.
   Both shared_key_flow.py and auth_flow.py used bare driver.quit()
   which fails with WinError 6 during garbage collection. Now uses
   safe_quit_driver() which handles this gracefully.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)
claude committed 7 minutes ago
[Loop CLI back to tracker selection after each location query](https://github.com/jleinenbach/GoogleFindMy-HA/commit/fd8bb5a44b4bbf14504ac75171da7d7ef7949e9d) 

Match upstream GoogleFindMyTools behavior: after displaying location
results, the CLI returns to the tracker menu instead of exiting.
Added 'q' option to quit, and input validation for invalid selections.

Extracted _print_locations() helper to keep _async_cli_main() within
ruff complexity limits.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK