### PR TITLE
Fix: coordinator stub and premature AAS token invalidation

### DIFF
--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -1515,9 +1515,12 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                             continue
 
                         if auth_retries_used == _AUTH_STEP_AAS_ADM_REFRESH:
-                            # Step 2: Second 401 - ADM refresh didn't help
-                            # Wait cooldown, then invalidate AAS and refresh entire chain
-                            # Set deadline for entire cooldown + refresh period
+                            # Step 2: Second 401 - ADM token may not have propagated yet.
+                            # Do NOT invalidate the AAS token here: gpsoauth already
+                            # validated it during Step 1's _do_refresh_async(). A second
+                            # 401 means propagation delay, not AAS invalidity.
+                            # If the AAS were truly rejected, Step 1 would have raised
+                            # NovaAuthPermanentError via InvalidAasTokenError.
                             await _cache_set(
                                 ns_deadline_key,
                                 time.time()
@@ -1527,13 +1530,11 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                             )
                             _LOGGER.info(
                                 "Nova API: 401 Unauthorized - ADM refresh unsuccessful. "
-                                "AAS token likely invalid. Waiting %.0fs before refreshing entire token chain.",
+                                "Waiting %.0fs before refreshing ADM token again.",
                                 _SHORT_COOLDOWN_S,
                             )
                             await asyncio.sleep(_SHORT_COOLDOWN_S)
-                            _LOGGER.info("Nova API: invalidating AAS token.")
-                            await policy.async_invalidate_aas_token()
-                            _LOGGER.info("Nova API: refreshing AAS+ADM token chain.")
+                            _LOGGER.info("Nova API: refreshing ADM token (AAS retained).")
                             try:
                                 await policy.async_on_401()
                             except NovaAuthPermanentError:

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -501,11 +501,19 @@ async def _setup_fcm_receiver(cache: object) -> Any:
     await fcm.async_initialize(entry_id="standalone", cache=cache)  # type: ignore[arg-type]
 
     # Minimal coordinator stub so _select_manual_locate_entry finds an entry.
+    # Must provide attributes that fcm_receiver_ha._write_coordinator_payload expects.
+    _standalone_loc_data: dict[str, dict[str, object]] = {}
     coordinator_stub = SimpleNamespace(
         config_entry=SimpleNamespace(entry_id="standalone"),
         cache=cache,
         is_device_present=lambda _cid: True,
         get_device_display_name=lambda _cid: None,
+        _device_location_data=_standalone_loc_data,
+        update_device_cache=lambda device_id, payload, **_kw: _standalone_loc_data.__setitem__(
+            device_id, payload
+        ),
+        increment_stat=lambda _name: None,
+        push_updated=lambda _ids: None,
     )
     fcm.register_coordinator(coordinator_stub)
 


### PR DESCRIPTION
[Fix coordinator stub and premature AAS token invalidation](https://github.com/jleinenbach/GoogleFindMy-HA/commit/468e654574a231dbdc5fb092578f5a4ce051fff0) 

Bug D: Add missing _device_location_data, update_device_cache,
increment_stat, and push_updated to the CLI coordinator stub so
fcm_receiver_ha._write_coordinator_payload no longer crashes with
"SimpleNamespace has no attribute '_device_location_data'".

Bug E: Remove premature AAS token invalidation in the 401 retry
sequence (Step 2). The AAS token is already validated by gpsoauth
during Step 1's _do_refresh_async(); if it were truly invalid,
InvalidAasTokenError -> NovaAuthPermanentError would have been raised.
A second 401 indicates propagation delay, not AAS invalidity.
This fix prevents destructive invalidation in CLI mode (where the
OAuth cookie is single-use) and avoids unnecessary re-auth cycles
in HA mode.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK