### PR TITLE
Fix CLI token staleness: clear stale ADM, remove standalone namespace…

### DIFF
--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -986,15 +986,19 @@ class AsyncTTLPolicy(TTLPolicy):
             threshold = self._jitter_sec(threshold, self.JITTER_SEC)
 
             if age >= threshold:
+                # Don't proactively invalidate the AAS token.  In CLI mode the
+                # OAuth cookie is single-use and consumed — destroying the AAS
+                # here would be fatal because no replacement can be obtained.
+                # Even in HA mode, premature invalidation is wasteful.  Instead,
+                # let gpsoauth validate the AAS on the next ADM refresh: if it's
+                # truly expired, InvalidAasTokenError propagates correctly.
                 self.log.info(
-                    "AAS token for %s reached measured threshold (%.1f hours) – "
-                    "proactively refreshing token chain.",
+                    "AAS token for %s past learned threshold (%.1f hours); "
+                    "will validate on next ADM refresh.",
                     self.username,
                     best_ttl / 3600,
                 )
-                await self.async_invalidate_aas_token()
-                # The next ADM refresh will trigger a fresh AAS token generation
-                return True
+                return False
         except (TypeError, ValueError) as e:
             self.log.debug("AAS proactive refresh check failed: %s", e)
 

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -214,7 +214,7 @@ def _register_file_cache() -> object:
     class _FileCache:
         """Minimal file-backed cache compatible with the TokenCache interface."""
 
-        entry_id: str = "standalone"
+        entry_id: str = ""
 
         # Keys that are hidden in memory but preserved in the backing file.
         # This mirrors HA's two-layer persistence (volatile TokenCache +
@@ -324,8 +324,8 @@ def _register_file_cache() -> object:
 
     # Register as a TokenCache instance so _resolve_cli_cache finds it.
     # mypy: _FileCache is duck-typed, not a real TokenCache subclass.
-    _register_instance("standalone", file_cache)  # type: ignore[arg-type]
-    _set_default_entry_id("standalone", force=True)
+    _register_instance("", file_cache)  # type: ignore[arg-type]
+    _set_default_entry_id("", force=True)
     return file_cache
 
 
@@ -480,6 +480,23 @@ async def _ensure_shared_key(cache: object) -> None:
     print("Encryption key saved.\n")
 
 
+async def _clear_stale_adm_token(cache: object) -> None:
+    """Clear cached ADM token so the first API request generates a fresh one.
+
+    Unlike Home Assistant (which has a coordinator polling regularly to keep
+    tokens fresh), the CLI process exits between uses.  The ADM token stored
+    in secrets.json from the previous session has most likely expired (~1 h
+    lifetime).  Clearing it here avoids a guaranteed 401 + lengthy retry
+    cascade on the very first request.
+    """
+    username_raw = await cache.get("username")  # type: ignore[attr-defined]
+    if not isinstance(username_raw, str) or not username_raw.strip():
+        return
+    user = username_raw.strip().lower()
+    for key in (f"adm_token_{user}", f"adm_token_issued_at_{user}"):
+        await cache.set(key, None)  # type: ignore[attr-defined]
+
+
 async def _setup_fcm_receiver(cache: object) -> Any:
     """Initialize the FCM push-notification receiver for standalone CLI use.
 
@@ -498,13 +515,13 @@ async def _setup_fcm_receiver(cache: object) -> Any:
     )
 
     fcm = FcmReceiverHA()
-    await fcm.async_initialize(entry_id="standalone", cache=cache)  # type: ignore[arg-type]
+    await fcm.async_initialize(entry_id="", cache=cache)  # type: ignore[arg-type]
 
     # Minimal coordinator stub so _select_manual_locate_entry finds an entry.
     # Must provide attributes that fcm_receiver_ha._write_coordinator_payload expects.
     _standalone_loc_data: dict[str, dict[str, object]] = {}
     coordinator_stub = SimpleNamespace(
-        config_entry=SimpleNamespace(entry_id="standalone"),
+        config_entry=SimpleNamespace(entry_id=""),
         cache=cache,
         is_device_present=lambda _cid: True,
         get_device_display_name=lambda _cid: None,
@@ -618,6 +635,7 @@ if __name__ == "__main__":
             # session is opened, so the exchange must happen immediately.
             await _ensure_aas_token(_file_cache)
             await _ensure_shared_key(_file_cache)
+            await _clear_stale_adm_token(_file_cache)
             fcm = await _setup_fcm_receiver(_file_cache)
             try:
                 await _async_cli_main(session=session)


### PR DESCRIPTION
[Fix CLI token staleness: clear stale ADM, remove standalone namespace…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/09f1a56befc6ee1bf1339aab8b25187081f08a33) 

…, defuse proactive AAS invalidation

F1: Clear the cached ADM token at CLI startup so the first API request
generates a fresh one via AAS→gpsoauth exchange. The CLI has no
coordinator to keep tokens fresh between sessions, so stale ADM tokens
(~1h lifetime) from previous sessions cause guaranteed 401 cascades.

F2: Replace proactive AAS token invalidation in
async_check_aas_proactive_refresh() with a log-only warning. The
proactive invalidation destroys the AAS based on a learned TTL
threshold, but in CLI mode the OAuth cookie is single-use and consumed —
no replacement AAS can be obtained. Let gpsoauth validate the AAS on
next use instead; InvalidAasTokenError propagates correctly if expired.

F3: Remove the "standalone" namespace from CLI mode entirely. The
namespace created duplicate cache keys (standalone:adm_token_user vs
adm_token_user) with inconsistent colon separators between
_key_variants() and _get_initial_token_async(), causing token refreshes
to miss stale keys. The CLI tokens in secrets.json need no namespace
isolation since there is only one account.

https://claude.ai/code/session_01AbaYDuXvxF65eFdErZPrMK