### PR TITLE
fix: remove report-type cooldown, add FCM 401/404 recovery, fix backo…

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -164,6 +164,8 @@ _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
 _BACKOFF_WARNING_THRESHOLD_S = 1024.0
+_MAX_FATAL_AUTH_RETRIES = 3       # 401: max retries (60s, 120s, then give up)
+_MAX_FATAL_ENDPOINT_RETRIES = 7   # 404: max retries (30s-300s, Google rotates endpoints)
 
 
 async def _call_in_executor(
@@ -256,6 +258,7 @@ class FcmReceiverHA:
 
         self._fatal_error: str | None = None
         self._fatal_errors: dict[str, str] = {}
+        self._fatal_retry_counts: dict[str, int] = {}  # "entry:auth"|"entry:endpoint" -> count
 
         # Aggregate telemetry
         self.last_start_monotonic: float = 0.0
@@ -725,10 +728,9 @@ class FcmReceiverHA:
                         ok_reg = await self._register_for_fcm_entry(entry_id)
                     except FatalRegistrationError as err:
                         message = str(err) or "FCM registration failed"
-                        self._fatal_error = message
                         self._fatal_errors[entry_id] = message
                         _LOGGER.error(
-                            "[entry=%s] FCM registration failed permanently; credentials may be invalid: %s",
+                            "[entry=%s] FCM registration failed: %s",
                             entry_id,
                             message,
                         )
@@ -739,7 +741,72 @@ class FcmReceiverHA:
                         finally:
                             async with self._lock:
                                 self.pcs.pop(entry_id, None)
-                        break
+
+                        is_auth = getattr(err, "is_auth_error", False)
+                        counter_key = (
+                            f"{entry_id}:auth"
+                            if is_auth
+                            else f"{entry_id}:endpoint"
+                        )
+                        fatal_count = (
+                            self._fatal_retry_counts.get(counter_key, 0) + 1
+                        )
+                        self._fatal_retry_counts[counter_key] = fatal_count
+
+                        if is_auth:
+                            # 401: Token renewal while preserving android_id
+                            max_retries = _MAX_FATAL_AUTH_RETRIES
+                            if fatal_count >= max_retries:
+                                self._fatal_error = message
+                                _LOGGER.error(
+                                    "[entry=%s] FCM auth failed %d "
+                                    "consecutive times; giving up. "
+                                    "Re-authentication may be required.",
+                                    entry_id,
+                                    fatal_count,
+                                )
+                                break
+
+                            await self._invalidate_fcm_tokens(entry_id)
+
+                            delay = 60.0 * fatal_count
+                            _LOGGER.warning(
+                                "[entry=%s] FCM auth error 401 (%d/%d); "
+                                "renewing tokens (android_id preserved), "
+                                "retry in %.0fs",
+                                entry_id,
+                                fatal_count,
+                                max_retries,
+                                delay,
+                            )
+                            await asyncio.sleep(delay)
+                            continue
+                        else:
+                            # 404: Endpoint rotation — just retry
+                            max_retries = _MAX_FATAL_ENDPOINT_RETRIES
+                            if fatal_count >= max_retries:
+                                self._fatal_error = message
+                                _LOGGER.error(
+                                    "[entry=%s] FCM endpoint 404 "
+                                    "persisted for %d attempts; "
+                                    "giving up.",
+                                    entry_id,
+                                    fatal_count,
+                                )
+                                break
+
+                            delay = min(300.0, 30.0 * fatal_count)
+                            _LOGGER.warning(
+                                "[entry=%s] FCM endpoint 404 (%d/%d); "
+                                "retrying in %.0fs (likely Google "
+                                "endpoint rotation)",
+                                entry_id,
+                                fatal_count,
+                                max_retries,
+                                delay,
+                            )
+                            await asyncio.sleep(delay)
+                            continue
 
                     if not ok_reg:
                         try:
@@ -793,12 +860,11 @@ class FcmReceiverHA:
                         self._update_last_activity_for_entry(
                             entry_id, pc, time.monotonic()
                         )
+                        backoff = 1.0  # reset only after a successful start
                     except Exception as err:
                         _LOGGER.info(
                             "[entry=%s] FCM client failed to start: %s", entry_id, err
                         )
-
-                    backoff = 1.0  # reset after a successful start
 
                     while not stop_evt.is_set():
                         await asyncio.sleep(max(FCM_MONITOR_INTERVAL_S, 0.5))
@@ -892,13 +958,61 @@ class FcmReceiverHA:
         self.supervisors[entry_id] = task
         _LOGGER.info("Started FCM supervisor for entry %s", entry_id)
 
+    async def _invalidate_fcm_tokens(self, entry_id: str) -> None:
+        """Clear renewable FCM tokens while preserving GCM device identity.
+
+        After this, the next registration attempt will use
+        ``reregister_keeping_identity()`` to get fresh FCM tokens with
+        the same android_id/security_token.
+        """
+        creds = self.creds.get(entry_id)
+        if creds and isinstance(creds, dict):
+            # Remove FCM-related parts, keep GCM device identity
+            creds.pop("fcm", None)
+            creds.pop("keys", None)
+            gcm = creds.get("gcm")
+            if isinstance(gcm, dict):
+                gcm.pop("token", None)
+                gcm.pop("app_id", None)
+
+            # Persist partial credentials so restarts also trigger re-register
+            entry_cache = self._entry_caches.get(entry_id)
+            if entry_cache is not None:
+                try:
+                    await entry_cache.set("fcm_credentials", creds)
+                except Exception:
+                    pass
+
+            _LOGGER.info(
+                "[entry=%s] Invalidated FCM tokens; "
+                "android_id/security_token preserved for re-registration",
+                entry_id,
+            )
+
     async def _register_for_fcm_entry(self, entry_id: str) -> bool:
         """Single registration attempt for a specific entry."""
         pc = self.pcs.get(entry_id)
         if not pc:
             return False
         try:
-            token_or_creds = await pc.checkin_or_register()
+            creds = getattr(pc, "credentials", None)
+            # If FCM tokens were invalidated (partial creds with only GCM
+            # identity), re-register while preserving android_id.
+            needs_reregister = (
+                isinstance(creds, dict)
+                and "gcm" in creds
+                and "fcm" not in creds
+            )
+            if needs_reregister:
+                _LOGGER.info(
+                    "[entry=%s] Partial credentials detected; "
+                    "re-registering with existing device identity",
+                    entry_id,
+                )
+                token_or_creds = await pc.reregister_keeping_identity()
+            else:
+                token_or_creds = await pc.checkin_or_register()
+
             if token_or_creds:
                 _LOGGER.info("[entry=%s] FCM registered successfully", entry_id)
                 token = self.get_fcm_token(entry_id)
@@ -908,6 +1022,9 @@ class FcmReceiverHA:
                 self._clear_fatal_error_for_entry(
                     entry_id, reason="Registration succeeded"
                 )
+                # Reset fatal retry counters on success
+                self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
+                self._fatal_retry_counts.pop(f"{entry_id}:endpoint", None)
                 return True
             _LOGGER.warning("[entry=%s] FCM registration returned no token", entry_id)
             return False
@@ -922,11 +1039,25 @@ class FcmReceiverHA:
             except (TypeError, ValueError):
                 status_int = None
 
-            if status_int in {401, 404}:
-                message = f"GCM Registration failed ({status_int}): Credentials invalid"
-                self._fatal_error = message
+            if status_int == 401:
+                message = (
+                    f"FCM registration auth failed ({status_int}): "
+                    "token renewal needed"
+                )
                 self._fatal_errors[entry_id] = message
-                raise FatalRegistrationError(message) from err
+                raise FatalRegistrationError(
+                    message, is_auth_error=True
+                ) from err
+
+            if status_int == 404:
+                message = (
+                    f"FCM registration endpoint not found ({status_int}): "
+                    "may be transient"
+                )
+                self._fatal_errors[entry_id] = message
+                raise FatalRegistrationError(
+                    message, is_auth_error=False
+                ) from err
 
             _LOGGER.error(
                 "[entry=%s] FCM registration client error (status=%s): %s",

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -166,6 +166,8 @@ _T = TypeVar("_T")
 _BACKOFF_WARNING_THRESHOLD_S = 1024.0
 _MAX_FATAL_AUTH_RETRIES = 3       # 401: max retries (60s, 120s, then give up)
 _MAX_FATAL_ENDPOINT_RETRIES = 7   # 404: max retries (30s-300s, Google rotates endpoints)
+_HTTP_UNAUTHORIZED = 401
+_HTTP_NOT_FOUND = 404
 
 
 async def _call_in_executor(
@@ -989,6 +991,40 @@ class FcmReceiverHA:
                 entry_id,
             )
 
+    @staticmethod
+    def _raise_if_fatal_client_error(
+        entry_id: str, err: ClientError
+    ) -> None:
+        """Raise ``FatalRegistrationError`` for 401/404 client errors."""
+        status_raw = getattr(err, "status", None)
+        if status_raw is None:
+            status_raw = getattr(err, "status_code", None)
+        try:
+            status_int = int(cast(int | str, status_raw))
+        except (TypeError, ValueError):
+            status_int = None
+
+        if status_int == _HTTP_UNAUTHORIZED:
+            raise FatalRegistrationError(
+                f"FCM registration auth failed ({status_int}): "
+                "token renewal needed",
+                is_auth_error=True,
+            ) from err
+
+        if status_int == _HTTP_NOT_FOUND:
+            raise FatalRegistrationError(
+                f"FCM registration endpoint not found ({status_int}): "
+                "may be transient",
+                is_auth_error=False,
+            ) from err
+
+        _LOGGER.error(
+            "[entry=%s] FCM registration client error (status=%s): %s",
+            entry_id,
+            status_raw,
+            err,
+        )
+
     async def _register_for_fcm_entry(self, entry_id: str) -> bool:
         """Single registration attempt for a specific entry."""
         pc = self.pcs.get(entry_id)
@@ -1031,40 +1067,7 @@ class FcmReceiverHA:
         except FatalRegistrationError:
             raise
         except ClientError as err:
-            status_raw = getattr(err, "status", None)
-            if status_raw is None:
-                status_raw = getattr(err, "status_code", None)
-            try:
-                status_int = int(cast(int | str, status_raw))
-            except (TypeError, ValueError):
-                status_int = None
-
-            if status_int == 401:
-                message = (
-                    f"FCM registration auth failed ({status_int}): "
-                    "token renewal needed"
-                )
-                self._fatal_errors[entry_id] = message
-                raise FatalRegistrationError(
-                    message, is_auth_error=True
-                ) from err
-
-            if status_int == 404:
-                message = (
-                    f"FCM registration endpoint not found ({status_int}): "
-                    "may be transient"
-                )
-                self._fatal_errors[entry_id] = message
-                raise FatalRegistrationError(
-                    message, is_auth_error=False
-                ) from err
-
-            _LOGGER.error(
-                "[entry=%s] FCM registration client error (status=%s): %s",
-                entry_id,
-                status_raw,
-                err,
-            )
+            self._raise_if_fatal_client_error(entry_id, err)
             return False
         except (TimeoutError, RuntimeError, Exception) as err:  # noqa: BLE001
             # Transient errors (TimeoutError, RuntimeError from firebase_messaging)

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -832,6 +832,41 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             if self.register is register:
                 self.register = None
 
+    async def reregister_keeping_identity(self) -> str:
+        """Re-register FCM tokens while preserving GCM device identity.
+
+        :return: The FCM token.
+        """
+        register = FcmRegister(
+            self.fcm_config,
+            self.credentials,
+            self.credentials_updated_callback,
+            http_client_session=self._http_client_session,
+        )
+        self.register = register
+
+        try:
+            credentials = await register.reregister_keeping_identity()
+            self.credentials = credentials
+
+            fcm_section = credentials.get("fcm")
+            registration_token: str | None = None
+            if isinstance(fcm_section, Mapping):
+                registration_section = fcm_section.get("registration")
+                if isinstance(registration_section, Mapping):
+                    token_candidate = registration_section.get("token")
+                    if isinstance(token_candidate, str):
+                        registration_token = token_candidate
+
+            if registration_token is None:
+                raise RuntimeError("FCM registration token missing from credentials.")
+
+            return registration_token
+        finally:
+            await register.close()
+            if self.register is register:
+                self.register = None
+
     async def _start_heartbeat_sender(self) -> None:
         """Send client heartbeats at a fixed interval while started."""
         interval = self.config.client_heartbeat_interval or 0

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -793,6 +793,23 @@ class FcmRegister:
             raise RuntimeError("Registration did not yield credentials")
         return credentials
 
+    async def _fallback_full_register(
+        self, reason: str
+    ) -> MutableJSONMapping:
+        """Run a full ``register()`` as fallback and notify the callback."""
+        _logger.warning("%s; falling back to full register()", reason)
+        self.credentials = await self.register()
+        if self.credentials_updated_callback and self.credentials:
+            try:
+                self.credentials_updated_callback(self.credentials)
+            except Exception as e:
+                _logger.debug(
+                    "credentials_updated_callback raised", exc_info=e
+                )
+        if self.credentials is None:
+            raise RuntimeError("Fallback registration did not yield credentials")
+        return self.credentials
+
     async def reregister_keeping_identity(self) -> MutableJSONMapping:
         """Re-register FCM tokens while preserving GCM device identity.
 
@@ -803,18 +820,9 @@ class FcmRegister:
         :return: The full credentials dict with same android_id but fresh tokens.
         """
         if not self.credentials or "gcm" not in self.credentials:
-            _logger.warning(
-                "No existing GCM identity; falling back to full register()"
+            return await self._fallback_full_register(
+                "No existing GCM identity"
             )
-            self.credentials = await self.register()
-            if self.credentials_updated_callback and self.credentials:
-                try:
-                    self.credentials_updated_callback(self.credentials)
-                except Exception as e:
-                    _logger.debug(
-                        "credentials_updated_callback raised", exc_info=e
-                    )
-            return self.credentials
 
         android_id = self.credentials["gcm"]["android_id"]
         security_token = self.credentials["gcm"]["security_token"]
@@ -823,34 +831,15 @@ class FcmRegister:
         try:
             gcm_response = await self.gcm_check_in(android_id, security_token)
         except Exception as e:
-            _logger.warning(
-                "Check-in with existing identity failed; "
-                "falling back to full register()",
-                exc_info=e,
+            _logger.debug("Check-in exception detail", exc_info=e)
+            return await self._fallback_full_register(
+                "Check-in with existing identity failed"
             )
-            self.credentials = await self.register()
-            if self.credentials_updated_callback and self.credentials:
-                try:
-                    self.credentials_updated_callback(self.credentials)
-                except Exception as cb_err:
-                    _logger.debug(
-                        "credentials_updated_callback raised", exc_info=cb_err
-                    )
-            return self.credentials
 
         if not gcm_response:
-            _logger.warning(
-                "Check-in returned empty; falling back to full register()"
+            return await self._fallback_full_register(
+                "Check-in returned empty response"
             )
-            self.credentials = await self.register()
-            if self.credentials_updated_callback and self.credentials:
-                try:
-                    self.credentials_updated_callback(self.credentials)
-                except Exception as e:
-                    _logger.debug(
-                        "credentials_updated_callback raised", exc_info=e
-                    )
-            return self.credentials
 
         # Step 2: Re-register GCM token (uses same android_id/security_token)
         gcm_data = await self.gcm_register(gcm_response)

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -793,6 +793,104 @@ class FcmRegister:
             raise RuntimeError("Registration did not yield credentials")
         return credentials
 
+    async def reregister_keeping_identity(self) -> MutableJSONMapping:
+        """Re-register FCM tokens while preserving GCM device identity.
+
+        Performs a check-in with the existing android_id/security_token,
+        then obtains fresh GCM and FCM tokens.  Falls back to full
+        ``register()`` if the identity is no longer valid.
+
+        :return: The full credentials dict with same android_id but fresh tokens.
+        """
+        if not self.credentials or "gcm" not in self.credentials:
+            _logger.warning(
+                "No existing GCM identity; falling back to full register()"
+            )
+            self.credentials = await self.register()
+            if self.credentials_updated_callback and self.credentials:
+                try:
+                    self.credentials_updated_callback(self.credentials)
+                except Exception as e:
+                    _logger.debug(
+                        "credentials_updated_callback raised", exc_info=e
+                    )
+            return self.credentials
+
+        android_id = self.credentials["gcm"]["android_id"]
+        security_token = self.credentials["gcm"]["security_token"]
+
+        # Step 1: Check-in with existing device identity
+        try:
+            gcm_response = await self.gcm_check_in(android_id, security_token)
+        except Exception as e:
+            _logger.warning(
+                "Check-in with existing identity failed; "
+                "falling back to full register()",
+                exc_info=e,
+            )
+            self.credentials = await self.register()
+            if self.credentials_updated_callback and self.credentials:
+                try:
+                    self.credentials_updated_callback(self.credentials)
+                except Exception as cb_err:
+                    _logger.debug(
+                        "credentials_updated_callback raised", exc_info=cb_err
+                    )
+            return self.credentials
+
+        if not gcm_response:
+            _logger.warning(
+                "Check-in returned empty; falling back to full register()"
+            )
+            self.credentials = await self.register()
+            if self.credentials_updated_callback and self.credentials:
+                try:
+                    self.credentials_updated_callback(self.credentials)
+                except Exception as e:
+                    _logger.debug(
+                        "credentials_updated_callback raised", exc_info=e
+                    )
+            return self.credentials
+
+        # Step 2: Re-register GCM token (uses same android_id/security_token)
+        gcm_data = await self.gcm_register(gcm_response)
+        if not gcm_data:
+            raise RuntimeError(
+                "GCM re-registration failed with existing identity"
+            )
+
+        # Step 3: Generate fresh keys and re-register FCM
+        keys = self.generate_keys()
+        fcm_data = await self.fcm_install_and_register(gcm_data, keys)
+        if not fcm_data:
+            raise RuntimeError("FCM re-registration failed")
+
+        res: dict[str, Any] = {
+            "keys": keys,
+            "gcm": gcm_data,
+            "fcm": fcm_data,
+            "config": {
+                "bundle_id": self.config.bundle_id,
+                "project_id": self.config.project_id,
+                "vapid_key": self.config.vapid_key,
+            },
+        }
+
+        self.credentials = res
+        if self.credentials_updated_callback:
+            try:
+                self.credentials_updated_callback(res)
+            except Exception as e:
+                _logger.debug(
+                    "credentials_updated_callback raised", exc_info=e
+                )
+
+        _logger.info(
+            "Re-registered FCM with existing device identity "
+            "(android_id preserved)"
+        )
+        return res
+
     async def register(self) -> JSONDict:
         """Register GCM and FCM tokens for configured sender_id/app.
 

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -374,25 +374,15 @@ class CacheOperations(_MixinBase):
         fused_applied = slot.pop("_fused_applied", False)
 
         status = slot.get("status")
-        is_stationary_logic = (
-            status in ("Fused (Weighted)", "Stationary (at Anchor)") or is_replay
-        )
 
         # Track fused update statistics
         if fused_applied and status == "Fused (Weighted)":
             self.increment_stat("fused_updates")
 
-        # Apply report type cooldown for stationary updates
-        if is_stationary_logic:
-            apply_cooldown = getattr(self, "_apply_report_type_cooldown", None)
-            if callable(apply_cooldown):
-                apply_cooldown(device_id, report_hint)
-        else:
-            _LOGGER.debug(
-                "Skipping throttle cooldown for %s despite '%s' hint (movement detected)",
-                device_id,
-                report_hint,
-            )
+        # Report-type cooldown removed: location_poll_interval (default 300s)
+        # already provides sufficient protection against excessive polling.
+        # The previous 600s cooldown for crowdsourced reports caused a feedback
+        # loop where replays kept extending the cooldown indefinitely.
 
         # Track crowd-sourced updates when hint is present
         if report_hint:

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -422,9 +422,9 @@ class LocateOperations(_MixinBase):
                 slot = dict(location_data)
                 slot.setdefault("last_updated", time.time())
 
-                # Apply type-aware cooldowns based on internal hint (if any), then strip it.
+                # Report-type cooldown removed: location_poll_interval already
+                # regulates polling frequency; the 600s cooldown caused stale updates.
                 report_hint = slot.get("_report_hint")
-                self._apply_report_type_cooldown(device_id, report_hint)
 
                 # Track crowd-sourced updates when hint is present
                 if report_hint:

--- a/custom_components/googlefindmy/exceptions.py
+++ b/custom_components/googlefindmy/exceptions.py
@@ -55,5 +55,8 @@ class MissingNamespaceError(HomeAssistantError):
 class FatalRegistrationError(HomeAssistantError):
     """Raised when FCM registration fails with a fatal status code."""
 
-    def __init__(self, message: str) -> None:
+    def __init__(
+        self, message: str, *, is_auth_error: bool = False
+    ) -> None:
         super().__init__(message)
+        self.is_auth_error = is_auth_error


### PR DESCRIPTION
…ff reset

Bug 1: Remove the report-type cooldown mechanism that caused a feedback loop where replay data kept extending the 600s cooldown indefinitely. Polling now runs purely on location_poll_interval (default 300s). Removed cooldown calls in both cache.py (polling path) and locate.py (FCM push/locate path).

Bug 2: Replace the permanent supervisor death on FatalRegistrationError with differentiated 401/404 handling:
- 401 (auth): Invalidate FCM tokens while preserving android_id/security_token (device identity), then re-register with reregister_keeping_identity(). Max 3 retries at 60s/120s intervals.
- 404 (endpoint): Retry with existing credentials (Google endpoint rotation). Max 7 retries at 30s-300s intervals. Add FcmRegister.reregister_keeping_identity() that performs check-in with existing GCM identity then gets fresh GCM/FCM tokens.

Bug 3: Move backoff = 1.0 inside the try block so it only resets after a successful pc.start(), not after failures.

https://claude.ai/code/session_01PmKUK9G2CTYQWq4uYbmA17
