### PR TITLE
fix: replace token regeneration buttons

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1916,6 +1916,68 @@ class FcmReceiverHA:
             if task:
                 task.cancel()
 
+    async def async_reregister_fcm(self, entry_id: str) -> bool:
+        """Public API: invalidate FCM tokens and re-register for a specific entry.
+
+        Preserves the GCM device identity (android_id/security_token) and
+        obtains fresh GCM + FCM tokens via ``reregister_keeping_identity()``.
+
+        Returns True if re-registration succeeded.
+        """
+        if entry_id not in self.pcs and entry_id not in self.creds:
+            _LOGGER.warning(
+                "[entry=%s] Cannot re-register FCM: entry not known to receiver",
+                entry_id,
+            )
+            return False
+
+        # 1. Invalidate FCM tokens (keeps GCM identity)
+        await self._invalidate_fcm_tokens(entry_id)
+
+        # 2. Stop the supervisor for this entry
+        stop_evt = self._stop_evts.get(entry_id)
+        if stop_evt is not None:
+            stop_evt.set()
+        task = self.supervisors.pop(entry_id, None)
+        if task is not None:
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=5.0)
+            except (TimeoutError, asyncio.CancelledError):
+                pass
+
+        # 3. Stop the client so it can be re-created
+        pc = self.pcs.pop(entry_id, None)
+        if pc is not None:
+            try:
+                await asyncio.wait_for(pc.stop(), timeout=5.0)
+            except (TimeoutError, ConnectionError, asyncio.CancelledError):
+                pass
+            except Exception:  # noqa: BLE001
+                pass
+
+        # 4. Reset the stop event and restart the supervisor
+        self._stop_evts[entry_id] = asyncio.Event()
+        cache = self._entry_caches.get(entry_id)
+        await self._start_supervisor_for_entry(entry_id, cache)
+
+        # 5. Wait briefly for the registration to complete
+        await asyncio.sleep(2.0)
+
+        # Check if we got a valid FCM token
+        token = self.get_fcm_token(entry_id)
+        if token:
+            _LOGGER.info(
+                "[entry=%s] FCM re-registration completed successfully", entry_id
+            )
+            return True
+
+        _LOGGER.warning(
+            "[entry=%s] FCM re-registration started but token not yet available",
+            entry_id,
+        )
+        return True  # Supervisor is running; registration may still be in progress
+
     async def async_stop(self, timeout: float = 5.0) -> None:
         """Stop all supervisors and clients (graceful, bounded)."""
         for eid, evt in self._stop_evts.items():

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1922,7 +1922,8 @@ class FcmReceiverHA:
         Preserves the GCM device identity (android_id/security_token) and
         obtains fresh GCM + FCM tokens via ``reregister_keeping_identity()``.
 
-        Returns True if re-registration succeeded.
+        Returns True if re-registration was initiated (supervisor restarted),
+        False if the entry is not known to this receiver.
         """
         if entry_id not in self.pcs and entry_id not in self.creds:
             _LOGGER.warning(
@@ -1946,7 +1947,11 @@ class FcmReceiverHA:
             except (TimeoutError, asyncio.CancelledError):
                 pass
 
-        # 3. Stop the client so it can be re-created
+        # 3. Reset the stop event BEFORE stopping the client to prevent
+        #    a race where concurrent code sees the old (set) event.
+        self._stop_evts[entry_id] = asyncio.Event()
+
+        # 4. Stop the client so it can be re-created
         pc = self.pcs.pop(entry_id, None)
         if pc is not None:
             try:
@@ -1956,27 +1961,16 @@ class FcmReceiverHA:
             except Exception:  # noqa: BLE001
                 pass
 
-        # 4. Reset the stop event and restart the supervisor
-        self._stop_evts[entry_id] = asyncio.Event()
+        # 5. Restart the supervisor (will re-register with fresh tokens)
         cache = self._entry_caches.get(entry_id)
         await self._start_supervisor_for_entry(entry_id, cache)
 
-        # 5. Wait briefly for the registration to complete
-        await asyncio.sleep(2.0)
-
-        # Check if we got a valid FCM token
-        token = self.get_fcm_token(entry_id)
-        if token:
-            _LOGGER.info(
-                "[entry=%s] FCM re-registration completed successfully", entry_id
-            )
-            return True
-
-        _LOGGER.warning(
-            "[entry=%s] FCM re-registration started but token not yet available",
+        _LOGGER.info(
+            "[entry=%s] FCM re-registration initiated; "
+            "supervisor restarted with invalidated tokens",
             entry_id,
         )
-        return True  # Supervisor is running; registration may still be in progress
+        return True
 
     async def async_stop(self, timeout: float = 5.0) -> None:
         """Stop all supervisors and clients (graceful, bounded)."""

--- a/custom_components/googlefindmy/Auth/token_refresh.py
+++ b/custom_components/googlefindmy/Auth/token_refresh.py
@@ -1,5 +1,5 @@
 # custom_components/googlefindmy/Auth/token_refresh.py
-"""Token refresh utilities for manual regeneration of AAS and ADM tokens.
+"""Token refresh utilities for manual regeneration of ADM and FCM tokens.
 
 This module provides entry-scoped token regeneration with:
 - Shared cooldown (3 minutes) across all token refresh operations
@@ -9,11 +9,13 @@ This module provides entry-scoped token regeneration with:
 Token dependency chain:
     OAuth Token -> AAS Token -> ADM Token
 
+FCM/GCM tokens are independent and can be regenerated at any time.
+
 When regenerating:
-- AAS Token: Invalidates both AAS and ADM, regenerates AAS (ADM will be
-  regenerated on next API call)
 - ADM Token: Invalidates only ADM, regenerates ADM (uses existing AAS if valid,
   otherwise triggers AAS regeneration)
+- FCM Token: Invalidates FCM tokens while preserving GCM device identity
+  (android_id/security_token), then re-registers to obtain fresh tokens
 """
 
 from __future__ import annotations
@@ -23,9 +25,11 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-from ..const import DATA_AAS_TOKEN, TOKEN_REFRESH_COOLDOWN_S
+from ..const import DOMAIN, TOKEN_REFRESH_COOLDOWN_S
 
 if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
     from .token_cache import TokenCache
 
 _LOGGER = logging.getLogger(__name__)
@@ -81,90 +85,78 @@ def _record_refresh(entry_id: str) -> None:
     _last_refresh_timestamps[entry_id] = time.time()
 
 
-async def async_regenerate_aas_token(
+async def async_regenerate_fcm_token(
     *,
-    cache: TokenCache,
-    username: str | None = None,
+    hass: HomeAssistant,
+    entry_id: str,
 ) -> bool:
-    """Regenerate the AAS token, invalidating both AAS and ADM tokens.
+    """Regenerate FCM/GCM tokens while preserving device identity.
 
-    Since ADM depends on AAS, invalidating AAS requires ADM to be regenerated
-    as well. This function:
+    This function:
     1. Checks and enforces the shared cooldown
-    2. Invalidates both AAS and ADM tokens in the cache
-    3. Triggers a fresh AAS token generation
+    2. Invalidates FCM tokens (keeps GCM android_id/security_token)
+    3. Triggers re-registration via the FCM receiver
 
     Args:
-        cache: Entry-scoped TokenCache instance
-        username: Optional username; resolved from cache if not provided
+        hass: Home Assistant instance
+        entry_id: Config entry ID
 
     Returns:
-        True if regeneration succeeded, False otherwise
-
-    Logs:
-        INFO level for button press and success/failure
+        True if regeneration succeeded or was started, False otherwise
     """
-    from .aas_token_retrieval import async_get_aas_token
-    from .username_provider import async_get_username
-
-    entry_id = await _get_entry_id(cache)
-
     async with _refresh_lock:
         on_cooldown, remaining = is_refresh_on_cooldown(entry_id)
         if on_cooldown:
             _LOGGER.info(
-                "AAS token regeneration blocked: cooldown active (%.1fs remaining)",
+                "FCM token regeneration blocked: cooldown active (%.1fs remaining)",
                 remaining,
             )
             return False
 
-        # Resolve username for logging
-        user = username
-        if not user:
-            user = await async_get_username(cache=cache)
-        masked_user = _mask_email(user)
-
         _LOGGER.info(
-            "AAS token regeneration requested for %s (entry: %s)",
-            masked_user,
+            "FCM token regeneration requested (entry: %s)",
             entry_id,
         )
 
         try:
-            # Invalidate AAS token
-            await cache.set(DATA_AAS_TOKEN, None)
-            _LOGGER.info("Invalidated AAS token for %s", masked_user)
-
-            # Invalidate ADM token (depends on AAS)
-            if user:
-                adm_key = f"adm_token_{user.strip().lower()}"
-                await cache.set(adm_key, None)
-                _LOGGER.info(
-                    "Invalidated ADM token for %s (AAS dependency)", masked_user
+            bucket = hass.data.get(DOMAIN)
+            if not bucket or not isinstance(bucket, dict):
+                _LOGGER.error(
+                    "FCM token regeneration failed: integration data not available"
                 )
+                return False
 
-            # Trigger AAS token regeneration
-            # The existing function handles retries and backoff internally
-            new_token = await async_get_aas_token(cache=cache)
+            receivers = bucket.get("fcm_receivers", {})
+            receiver = receivers.get(entry_id)
+            if receiver is None:
+                receiver = bucket.get("fcm_receiver")
+            if receiver is None:
+                _LOGGER.error(
+                    "FCM token regeneration failed: no FCM receiver found (entry: %s)",
+                    entry_id,
+                )
+                return False
 
-            if new_token:
+            success = await receiver.async_reregister_fcm(entry_id)
+
+            if success:
                 _record_refresh(entry_id)
                 _LOGGER.info(
-                    "AAS token regeneration successful for %s",
-                    masked_user,
+                    "FCM token regeneration successful (entry: %s)",
+                    entry_id,
                 )
                 return True
 
             _LOGGER.warning(
-                "AAS token regeneration returned empty token for %s",
-                masked_user,
+                "FCM token regeneration failed (entry: %s)",
+                entry_id,
             )
             return False
 
         except Exception as err:
             _LOGGER.error(
-                "AAS token regeneration failed for %s: %s",
-                masked_user,
+                "FCM token regeneration failed (entry: %s): %s",
+                entry_id,
                 err,
             )
             return False

--- a/custom_components/googlefindmy/button.py
+++ b/custom_components/googlefindmy/button.py
@@ -156,11 +156,11 @@ RESET_STATISTICS_DESCRIPTION = ButtonEntityDescription(
     icon="mdi:restart",
 )
 
-# Entity description for regenerating AAS token
-REGENERATE_AAS_TOKEN_DESCRIPTION = ButtonEntityDescription(
-    key="regenerate_aas_token",
-    translation_key="regenerate_aas_token",
-    icon="mdi:key-chain",
+# Entity description for regenerating FCM token
+REGENERATE_FCM_TOKEN_DESCRIPTION = ButtonEntityDescription(
+    key="regenerate_fcm_token",
+    translation_key="regenerate_fcm_token",
+    icon="mdi:cellphone-wireless",
     entity_category=EntityCategory.CONFIG,
 )
 
@@ -436,7 +436,7 @@ async def async_setup_entry(
 
         # Token regeneration buttons (disabled by default)
         for button_cls in (
-            GoogleFindMyRegenerateAasTokenButton,
+            GoogleFindMyRegenerateFcmTokenButton,
             GoogleFindMyRegenerateAdmTokenButton,
         ):
             token_button = button_cls(
@@ -1405,17 +1405,17 @@ class GoogleFindMyTokenRefreshButtonBase(
         return attrs
 
 
-class GoogleFindMyRegenerateAasTokenButton(GoogleFindMyTokenRefreshButtonBase):
-    """Button to regenerate the AAS (Android AuthSub) token.
+class GoogleFindMyRegenerateFcmTokenButton(GoogleFindMyTokenRefreshButtonBase):
+    """Button to regenerate FCM/GCM tokens.
 
-    Regenerating the AAS token will also invalidate the ADM token since
-    ADM depends on AAS. The ADM token will be regenerated on the next API call.
+    Preserves the GCM device identity (android_id/security_token) and
+    obtains fresh GCM + FCM registration tokens via re-registration.
     """
 
-    _attr_entity_description = REGENERATE_AAS_TOKEN_DESCRIPTION
-    _attr_icon = REGENERATE_AAS_TOKEN_DESCRIPTION.icon
-    _attr_translation_key = REGENERATE_AAS_TOKEN_DESCRIPTION.translation_key
-    _token_type = "AAS"
+    _attr_entity_description = REGENERATE_FCM_TOKEN_DESCRIPTION
+    _attr_icon = REGENERATE_FCM_TOKEN_DESCRIPTION.icon
+    _attr_translation_key = REGENERATE_FCM_TOKEN_DESCRIPTION.translation_key
+    _token_type = "FCM"
 
     def __init__(
         self,
@@ -1434,53 +1434,47 @@ class GoogleFindMyRegenerateAasTokenButton(GoogleFindMyTokenRefreshButtonBase):
             DOMAIN,
             entry_id,
             subentry_identifier,
-            "regenerate_aas_token",
+            "regenerate_fcm_token",
             separator="_",
         )
 
     async def async_press(self) -> None:
-        """Handle the button press to regenerate AAS token."""
-        from .Auth.token_refresh import async_regenerate_aas_token
+        """Handle the button press to regenerate FCM token."""
+        from .Auth.token_refresh import async_regenerate_fcm_token
 
         entry_id = self.entry_id or "unknown"
 
         if not self.available:
             _LOGGER.info(
-                "AAS token regeneration button pressed but cooldown active (entry: %s)",
+                "FCM token regeneration button pressed but cooldown active (entry: %s)",
                 entry_id,
             )
             return
 
         _LOGGER.info(
-            "AAS token regeneration button pressed (entry: %s)",
+            "FCM token regeneration button pressed (entry: %s)",
             entry_id,
         )
 
-        # Get the token cache from runtime data
-        config_entry = getattr(self.coordinator, "config_entry", None)
-        runtime_data = getattr(config_entry, "runtime_data", None)
-        cache = getattr(runtime_data, "token_cache", None)
-        if cache is None:
-            cache = getattr(self.coordinator, "cache", None)
-
-        if cache is None:
+        hass = self.hass
+        if hass is None:
             _LOGGER.error(
-                "AAS token regeneration failed: no token cache available (entry: %s)",
+                "FCM token regeneration failed: no hass instance available (entry: %s)",
                 entry_id,
             )
             return
 
-        success = await async_regenerate_aas_token(cache=cache)
+        success = await async_regenerate_fcm_token(hass=hass, entry_id=entry_id)
 
         if success:
             self._update_last_pressed()
             _LOGGER.info(
-                "AAS token regeneration completed successfully (entry: %s)",
+                "FCM token regeneration completed successfully (entry: %s)",
                 entry_id,
             )
         else:
             _LOGGER.warning(
-                "AAS token regeneration failed (entry: %s)",
+                "FCM token regeneration failed (entry: %s)",
                 entry_id,
             )
 

--- a/custom_components/googlefindmy/icons.json
+++ b/custom_components/googlefindmy/icons.json
@@ -43,8 +43,8 @@
       "reset_statistics": {
         "default": "mdi:restart"
       },
-      "regenerate_aas_token": {
-        "default": "mdi:key-chain"
+      "regenerate_fcm_token": {
+        "default": "mdi:cellphone-wireless"
       },
       "regenerate_adm_token": {
         "default": "mdi:key-change"

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Reset Statistics"
       },
-      "regenerate_aas_token": {
-        "name": "Regenerate AAS Token",
+      "regenerate_fcm_token": {
+        "name": "Regenerate FCM Token",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Cooldown period (s)"

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Statistiken zurücksetzen"
       },
-      "regenerate_aas_token": {
-        "name": "AAS-Token neu generieren",
+      "regenerate_fcm_token": {
+        "name": "FCM-Token neu generieren",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Abklingzeit (s)"

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Reset Statistics"
       },
-      "regenerate_aas_token": {
-        "name": "Regenerate AAS Token",
+      "regenerate_fcm_token": {
+        "name": "Regenerate FCM Token",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Cooldown period (s)"

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Restablecer estadísticas"
       },
-      "regenerate_aas_token": {
-        "name": "Regenerar token AAS",
+      "regenerate_fcm_token": {
+        "name": "Regenerar token FCM",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Período de espera (s)"

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Réinitialiser les statistiques"
       },
-      "regenerate_aas_token": {
-        "name": "Régénérer le jeton AAS",
+      "regenerate_fcm_token": {
+        "name": "Régénérer le jeton FCM",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Période de refroidissement (s)"

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Reimposta statistiche"
       },
-      "regenerate_aas_token": {
-        "name": "Rigenera token AAS",
+      "regenerate_fcm_token": {
+        "name": "Rigenera token FCM",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Periodo di attesa (s)"

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Statistieken resetten"
       },
-      "regenerate_aas_token": {
-        "name": "AAS-token opnieuw genereren",
+      "regenerate_fcm_token": {
+        "name": "FCM-token opnieuw genereren",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Afkoelperiode (s)"

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Resetuj statystyki"
       },
-      "regenerate_aas_token": {
-        "name": "Regeneruj token AAS",
+      "regenerate_fcm_token": {
+        "name": "Regeneruj token FCM",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Okres oczekiwania (s)"

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Redefinir estatísticas"
       },
-      "regenerate_aas_token": {
-        "name": "Regenerar token AAS",
+      "regenerate_fcm_token": {
+        "name": "Regenerar token FCM",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Período de espera (s)"

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -422,8 +422,8 @@
       "reset_statistics": {
         "name": "Redefinir estatísticas"
       },
-      "regenerate_aas_token": {
-        "name": "Regenerar token AAS",
+      "regenerate_fcm_token": {
+        "name": "Regenerar token FCM",
         "state_attributes": {
           "cooldown_seconds": {
             "name": "Período de espera (s)"


### PR DESCRIPTION
[fix: replace non-functional AAS token regeneration with FCM token reg…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/2e508ecaf8803a1dc15646b3ad6d802a3c389aec) 

…eneration

The AAS token cannot be regenerated after initial setup because the OAuth
cookie is single-use. Remove the misleading AAS regeneration button and
replace it with an FCM token regeneration button that actually works by
calling reregister_keeping_identity() to obtain fresh GCM+FCM tokens
while preserving the device identity (android_id/security_token).

Changes:
- Remove GoogleFindMyRegenerateAasTokenButton and async_regenerate_aas_token()
- Add GoogleFindMyRegenerateFcmTokenButton with async_regenerate_fcm_token()
- Add async_reregister_fcm() public method to FcmReceiverHA
- Update all 11 translation/icon files (strings.json, icons.json, 9 languages)

https://claude.ai/code/session_01VZyUsTNEWNK7AxrxdQTRhG
@[claude](https://github.com/jleinenbach/GoogleFindMy-HA/commits?author=claude)

[fix: race condition with stop event and remove blocking sleep in asyn…](https://github.com/jleinenbach/GoogleFindMy-HA/commit/60a49c3f56e0df74fff785f8d0bcbfa30328e1c5) 

…c_reregister_fcm

- Move stop event reset before pc.stop() to prevent concurrent code from
  seeing the old (already-set) event during the await
- Remove asyncio.sleep(2.0) that unnecessarily blocked the shared refresh
  lock and gave unreliable results
- Simplify return logic: True = re-registration initiated, False = unknown entry

https://claude.ai/code/session_01VZyUsTNEWNK7AxrxdQTRhG