### PR TITLE
fix: cap FCM supervisor backoff at 120s, reduce degraded-mode log spa…

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -163,7 +163,8 @@ type MutableJSONMapping = MutableMapping[str, Any]
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
-_BACKOFF_WARNING_THRESHOLD_S = 1024.0
+_MAX_SUPERVISOR_BACKOFF_S = 120.0    # cap retry delay at 2 minutes (was 4096s)
+_BACKOFF_WARNING_THRESHOLD_S = 64.0  # warn after ~6 failed attempts
 _MAX_FATAL_AUTH_RETRIES = 3       # 401: max retries (60s, 120s, then give up)
 _MAX_FATAL_ENDPOINT_RETRIES = 7   # 404: max retries (30s-300s, Google rotates endpoints)
 _HTTP_UNAUTHORIZED = 401
@@ -287,6 +288,9 @@ class FcmReceiverHA:
 
         # Active background tasks for exception tracking (P0 fix)
         self._active_tasks: set[asyncio.Task[Any]] = set()
+
+        # Per-entry nudge events: allows coordinator to wake up a sleeping supervisor
+        self._retry_nudge_evts: dict[str, asyncio.Event] = {}
 
     def _clear_fatal_error_for_entry(
         self, entry_id: str, *, reason: str | None = None
@@ -550,6 +554,27 @@ class FcmReceiverHA:
 
     ready = is_ready  # alias used by callers
 
+    def nudge_retry(self, entry_id: str | None = None) -> bool:
+        """Wake a sleeping supervisor so it retries FCM connection immediately.
+
+        Called by the polling coordinator when it enters degraded mode and wants
+        the supervisor to attempt reconnection sooner than the backoff timer.
+        Returns True if a nudge event was set.
+        """
+        key = entry_id or self._default_entry_id
+        if not key:
+            # Nudge all entries
+            nudged = False
+            for evt in self._retry_nudge_evts.values():
+                evt.set()
+                nudged = True
+            return nudged
+        evt = self._retry_nudge_evts.get(key)
+        if evt is not None:
+            evt.set()
+            return True
+        return False
+
     def get_last_connected_wall_time(self, entry_id: str | None) -> float | None:
         """Return the last wall-clock timestamp when the entry marked healthy."""
 
@@ -717,13 +742,29 @@ class FcmReceiverHA:
         stop_evt = self._stop_evts.setdefault(entry_id, asyncio.Event())
 
         async def _supervisor() -> None:  # noqa: PLR0912, PLR0915
+            nudge_evt = self._retry_nudge_evts.setdefault(
+                entry_id, asyncio.Event()
+            )
+
+            async def _nudge_sleep(seconds: float) -> bool:
+                """Sleep up to *seconds*, returning True if nudged early."""
+                nudge_evt.clear()
+                try:
+                    await asyncio.wait_for(nudge_evt.wait(), timeout=seconds)
+                    return True  # nudged
+                except TimeoutError:
+                    return False
+
             backoff = 1.0
             try:
                 while not stop_evt.is_set():
                     pc = await self._ensure_client_for_entry(entry_id, cache)
                     if not pc:
-                        await asyncio.sleep(backoff)
-                        backoff = min(backoff * 2, 4096.0)
+                        nudged = await _nudge_sleep(backoff)
+                        if nudged:
+                            backoff = 1.0
+                        else:
+                            backoff = min(backoff * 2, _MAX_SUPERVISOR_BACKOFF_S)
                         continue
 
                     try:
@@ -841,8 +882,11 @@ class FcmReceiverHA:
                                 entry_id,
                                 delay,
                             )
-                        await asyncio.sleep(delay)
-                        backoff = min(backoff * 2, 4096.0)
+                        nudged = await _nudge_sleep(delay)
+                        if nudged:
+                            backoff = 1.0
+                        else:
+                            backoff = min(backoff * 2, _MAX_SUPERVISOR_BACKOFF_S)
                         continue
 
                     # Telemetry (aggregate counters)
@@ -943,8 +987,11 @@ class FcmReceiverHA:
                         _LOGGER.info(
                             "[entry=%s] Restarting FCM client in %.1fs", entry_id, delay
                         )
-                        await asyncio.sleep(delay)
-                        backoff = min(backoff * 2, 4096.0)
+                        nudged = await _nudge_sleep(delay)
+                        if nudged:
+                            backoff = 1.0
+                        else:
+                            backoff = min(backoff * 2, _MAX_SUPERVISOR_BACKOFF_S)
             except asyncio.CancelledError:
                 _LOGGER.debug("[entry=%s] FCM supervisor cancelled", entry_id)
                 raise
@@ -953,6 +1000,7 @@ class FcmReceiverHA:
             finally:
                 _LOGGER.info("[entry=%s] FCM supervisor stopped", entry_id)
                 self._update_entry_health(entry_id, False)
+                self._retry_nudge_evts.pop(entry_id, None)
 
         task = asyncio.create_task(
             _supervisor(), name=f"{DOMAIN}.fcm_supervisor[{entry_id}]"

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -696,6 +696,7 @@ class GoogleFindMyCoordinator(
         # Push readiness deferral/escalation bookkeeping
         self._fcm_defer_started_mono: float = 0.0
         self._fcm_last_stage: int = 0  # 0=none, 1=warned, 2=errored
+        self._degraded_mode_warned: bool = False
 
         # Push readiness memoization and cooldown after transport errors
         self._push_ready_memo: bool | None = None

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -471,7 +471,21 @@ class PollingOperations(_MixinBase):
             _LOGGER.info("FCM/push is ready; resuming scheduled polling.")
         self._fcm_defer_started_mono = 0.0
         self._fcm_last_stage = 0
+        self._degraded_mode_warned = False
         self._set_fcm_status(FcmStatus.CONNECTED)
+
+    def _nudge_fcm_supervisor(self) -> None:
+        """Ask the FCM supervisor to wake up and retry connection immediately."""
+        try:
+            fcm = self.hass.data.get(DOMAIN, {}).get("fcm_receiver")
+            if fcm is None:
+                return
+            nudge_fn = getattr(fcm, "nudge_retry", None)
+            if callable(nudge_fn):
+                entry_id = self._entry_id()
+                nudge_fn(entry_id)
+        except Exception:  # noqa: BLE001
+            pass
 
     # -------------------- Poll timing prediction --------------------
     def _get_predicted_poll_time(self) -> float | None:
@@ -913,10 +927,17 @@ class PollingOperations(_MixinBase):
 
                 if fcm_ready or force_poll:
                     if force_poll:
-                        _LOGGER.warning(
-                            "Push transport unavailable for %ds; forcing poll cycle.",
-                            _PUSH_NOT_READY_TIMEOUT_S,
-                        )
+                        if not self._degraded_mode_warned:
+                            _LOGGER.warning(
+                                "Push transport unavailable for %ds; forcing poll cycle.",
+                                _PUSH_NOT_READY_TIMEOUT_S,
+                            )
+                        else:
+                            _LOGGER.debug(
+                                "Push transport still unavailable; forcing poll cycle.",
+                            )
+                        # Nudge FCM supervisor to retry connection sooner
+                        self._nudge_fcm_supervisor()
                     _LOGGER.debug(
                         "Scheduling background polling cycle (devices=%d, interval=%ds)",
                         len(devices_to_poll),
@@ -1033,9 +1054,15 @@ class PollingOperations(_MixinBase):
                     self._note_fcm_deferral(time.monotonic())
                     self._schedule_short_retry(5.0)
                     return
-                _LOGGER.warning(
-                    "Starting poll cycle without push transport; continuing in degraded mode."
-                )
+                if not self._degraded_mode_warned:
+                    _LOGGER.warning(
+                        "Starting poll cycle without push transport; continuing in degraded mode."
+                    )
+                    self._degraded_mode_warned = True
+                else:
+                    _LOGGER.debug(
+                        "Poll cycle still without push transport (degraded mode)."
+                    )
             elif self._fcm_defer_started_mono:
                 # If we were deferring previously, clear the escalation timeline.
                 self._clear_fcm_deferral()


### PR DESCRIPTION
…m, add nudge mechanism

The FCM supervisor used exponential backoff up to 4096s (~68 min), preventing self-healing when the push transport went down temporarily. The "degraded mode" warning also fired every poll cycle (~2 min), creating log spam.

Changes:
- Cap supervisor backoff from 4096s to 120s (_MAX_SUPERVISOR_BACKOFF_S)
- Lower _BACKOFF_WARNING_THRESHOLD_S from 1024s to 64s (now reachable)
- Add nudge_retry() to FcmReceiverHA so the coordinator can wake a sleeping supervisor immediately, resetting its backoff
- Replace asyncio.sleep() with nudge-aware waits in all three supervisor backoff paths (client creation, registration, monitor restart)
- Log degraded-mode WARNING only once per outage, then DEBUG for repeats
- Reset _degraded_mode_warned when FCM recovers

https://claude.ai/code/session_01C66qmzPUdADmh3J9C5fNWi
