### PR TITLE
fix(i18n): correct contributor_mode default direction (Codex follow-up)

### DIFF
--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -274,7 +274,7 @@
           "show_location_age": "When enabled (default), a 'location_age' attribute (rounded to 1 minute) is added to each tracker entity. Disable to eliminate all database writes for stationary devices. The absolute 'last_seen' attribute and sensor.*_last_seen entities are always available.",
           "delete_caches_on_remove": "Remove cached tokens and device metadata when this entry is deleted.",
           "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire.",
-          "contributor_mode": "Choose how your device contributes to Google's network (High-traffic areas by default, or All areas for crowdsourced reporting).",
+          "contributor_mode": "Choose how your device contributes to Google's network (All areas by default for crowdsourced reporting, or High-traffic areas only).",
           "subentry": "Store these options on the selected feature group. See [Subentries and feature groups]({subentries_docs_url}) for examples."
         }
       },

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -274,7 +274,7 @@
           "show_location_age": "When enabled (default), a 'location_age' attribute (rounded to 1 minute) is added to each tracker entity. Disable to eliminate all database writes for stationary devices. The absolute 'last_seen' attribute and sensor.*_last_seen entities are always available.",
           "delete_caches_on_remove": "Remove cached tokens and device metadata when this entry is deleted.",
           "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire.",
-          "contributor_mode": "Choose how your device contributes to Google's network (High-traffic areas by default, or All areas for crowdsourced reporting).",
+          "contributor_mode": "Choose how your device contributes to Google's network (All areas by default for crowdsourced reporting, or High-traffic areas only).",
           "subentry": "Store these options on the selected feature group. See [Subentries and feature groups]({subentries_docs_url}) for examples."
         }
       },


### PR DESCRIPTION
## Summary
Codex review on PR #174 (commit `50a1d9be`) caught that the English `contributor_mode` help text describes the wrong default. The actual code default in `custom_components/googlefindmy/const.py:219` is `CONTRIBUTOR_MODE_IN_ALL_AREAS` (`"in_all_areas"`) since `d6ba9c5b` (2025-10-23), but `strings.json` was rewritten on 2025-11-24 (`87ccef22`) to claim "High-traffic areas by default". My earlier `c3d041a3` then mirrored the broken `strings.json` into `en.json` instead of restoring the original direction.

This PR fixes both `strings.json` and `en.json` to match the code. The nine non-English locales already describe the default correctly ("All areas by default" / equivalent translations) and remain untouched.

## Diagnosis
| Source | Says | Verdict |
|---|---|---|
| `const.py:219` | `DEFAULT_CONTRIBUTOR_MODE = CONTRIBUTOR_MODE_IN_ALL_AREAS` | Code truth (Oct 23, 2025) |
| `strings.json` (before) | "High-traffic areas by default, or All areas for crowdsourced reporting" | Wrong (drift from Nov 24, 2025) |
| `en.json` (before) | identical to `strings.json` | Wrong (my earlier mirror) |
| 9 other locales | translated equivalents of "All areas by default" | Correct |

## Changes
- `custom_components/googlefindmy/strings.json`: corrected help text
- `custom_components/googlefindmy/translations/en.json`: resynced via `script/sync_translations.py`

## Verification
- `python3 script/translation_key_check.py`: 10/10 OK
- `python3 script/sync_translations.py --check`: no drift
- JSON validity: 10/10 + strings.json
- Grep `"All areas by default"`: 2 hits (`strings.json` + `en.json`)
- Grep `"High-traffic areas by default"`: 0 hits

## Credits
Reported by [@codex](https://github.com/apps/chatgpt-codex-connector) on PR #174.