### PR TITLE
chore(ha-2026): drop _attr_source_type, declare PARALLEL_UPDATES, name fallback reload tasks

### DIFF
--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -76,6 +76,9 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Read-only mirror of coordinator state; no I/O performed per-entity.
+PARALLEL_UPDATES = 0
+
 CONNECTIVITY_DEVICE_CLASS = getattr(BinarySensorDeviceClass, "CONNECTIVITY", None)
 
 

--- a/custom_components/googlefindmy/button.py
+++ b/custom_components/googlefindmy/button.py
@@ -73,6 +73,9 @@ from .util_services import register_entity_service
 
 _LOGGER = logging.getLogger(__name__)
 
+# Buttons trigger coordinator actions (refresh, FCM restart); serialize them.
+PARALLEL_UPDATES = 1
+
 
 class _TrackerScope(NamedTuple):
     """Resolved tracker subentry scope for entity creation."""

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -2644,7 +2644,10 @@ class ConfigFlow(
                 else:
                     loop = getattr(hass, "loop", None)
                     if loop is not None:
-                        loop.create_task(_reload_and_normalize())
+                        loop.create_task(
+                            _reload_and_normalize(),
+                            name=f"{DOMAIN}.reload_after_discovery_update",
+                        )
             else:
                 _normalize_tracking_lists()
 
@@ -3318,7 +3321,10 @@ class ConfigFlow(
 
                     loop = getattr(self.hass, "loop", None)
                     if loop is not None:
-                        task = loop.create_task(reload_result_inner)
+                        task = loop.create_task(
+                            reload_result_inner,
+                            name=f"{DOMAIN}.deferred_reload_after_reconfigure",
+                        )
                         if hasattr(task, "add_done_callback"):
                             task.add_done_callback(_log_task_result)
                         return

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -28,7 +28,6 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from homeassistant.components.device_tracker import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_GPS_ACCURACY,
@@ -69,6 +68,9 @@ from .entity import (
 from .ha_typing import RestoreEntity, TrackerEntity, callback
 
 _LOGGER = logging.getLogger(__name__)
+
+# Read-only mirror of coordinator state; no I/O performed per-entity.
+PARALLEL_UPDATES = 0
 
 
 @dataclass
@@ -825,7 +827,6 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
     # Convention: trackers represent the device itself; the entity name
     # inherits from the device name via has_entity_name=True.
     _attr_has_entity_name = True
-    _attr_source_type = SourceType.GPS
     _attr_entity_category: EntityCategory | None = (
         None  # ensure tracker is not diagnostic
     )

--- a/custom_components/googlefindmy/quality_scale.yaml
+++ b/custom_components/googlefindmy/quality_scale.yaml
@@ -127,7 +127,10 @@ rules:
     - id: parallel-updates
       status: done
       evidence:
-        - "custom_components/googlefindmy/entity.py:GoogleFindMyEntity._attr_should_poll"
+        - "custom_components/googlefindmy/binary_sensor.py:PARALLEL_UPDATES"
+        - "custom_components/googlefindmy/button.py:PARALLEL_UPDATES"
+        - "custom_components/googlefindmy/device_tracker.py:PARALLEL_UPDATES"
+        - "custom_components/googlefindmy/sensor.py:PARALLEL_UPDATES"
     - id: reauthentication-flow
       status: done
       evidence:

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -67,6 +67,9 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Read-only mirror of coordinator state; no I/O performed per-entity.
+PARALLEL_UPDATES = 0
+
 
 class _Scope(NamedTuple):
     """Resolved subentry scope for entity creation."""


### PR DESCRIPTION
## Summary

HA 2026 deprecation and Platinum quality-scale cleanup, derived from an audit covering Home Assistant changelogs and developer-blog posts between 2025.9 and 2026.6.

- **D-1** Remove redundant `_attr_source_type = SourceType.GPS` from `device_tracker.py`. Upstream removed the same attribute from all built-in trackers in [home-assistant/core#171063](https://github.com/home-assistant/core/pull/171063) (shipped 2026.6) because `TrackerEntity` already defaults to `SourceType.GPS`. Dropping it lets the now-unused `SourceType` import disappear too.
- **Q-1** Add the `PARALLEL_UPDATES` module constant to all four platforms (`binary_sensor.py`, `button.py`, `device_tracker.py`, `sensor.py`). Read-only coordinator mirrors use `0`; `button.py` uses `1` because buttons trigger coordinator actions (refresh, FCM restart) that should serialize. Updates `quality_scale.yaml` evidence to point at the new constants instead of the unrelated `_attr_should_poll`.
- **Q-2** Name two fallback `loop.create_task` calls in `config_flow.py` so the resulting `asyncio.Task` shows up with a meaningful identifier in `Task exception was never retrieved` warnings.

## Audit coverage

Method: HA developer blog posts (Jan–May 2026) + release changelogs 2026.1–2026.6 + grep on `custom_components/googlefindmy/`. Verified non-issues:

- Config-entry-listener race (removal 2026.12): no `entry.add_update_listener` in the integration.
- `show_advanced_options` deprecation (removal 2027.6): not used.
- Legacy `device_tracker` platform API (removal 2027.5): integration uses `TrackerEntity` with `async_setup_entry` exclusively.
- Entity-ID domain mismatch (removal 2027.5): no manual `entity_id` assignment.
- OAuth2 helper errors (2026.3): integration uses `gpsoauth` directly.
- Labs `async_listen` (removal 2027.3): not used.
- Legacy template platform removal (2026.6): no templates in the repo.
- pyserial-asyncio blockade (2026.7): no serial usage.

## Why Q-2 stayed narrow

The original audit flagged seven `loop.create_task` / `asyncio.ensure_future` call sites. On detailed review, five are intentional and were left alone:
- `entity.py:240/241/243` are inside `_make_test_job_runner._run`, a defensive helper for test jobs without a `hass` owner; `loop` can legitimately be `None`.
- `entity.py:291` is the awaitable (not coroutine) fallback in `schedule_add_entities`; `hass.async_create_task` requires a coroutine, so `ensure_future` is the right tool.
- `Auth/fcm_receiver_ha.py:377/393` are already named (`f"{DOMAIN}.{label}"`) and registered with `_track_task`; this is the documented P0 thread-bridge pattern.

Only the two fallback paths in `config_flow.py` (Z. 2647 and 3324) were missing `name=` and got it added.

## Test plan

- [ ] `ruff check .` green (verified locally; HA 2026.4 minimum)
- [ ] `pytest tests/test_platinum_compliance.py -v` green
- [ ] `pytest tests/` green
- [ ] Reload the integration in a running HA instance, confirm `device_tracker.googlefindmy_*` entities still report `source_type: gps`

## Notes

- Two commits: D-1 + Q-1 + doc-co-change first, Q-2 second.
- Backups kept on operator NAS (`/mnt/nas/claude-webui/backups/gfm-ha-dep-cleanup/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)