### PR TITLE
chore(coverage): bump floor to 64 % lockstep after Phase 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=63 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=64 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -339,11 +339,11 @@ omit = [
 [tool.coverage.report]
 show_missing = false
 skip_covered = true
-# Sprint baseline: measured 63.59 % after PR #1072 registry/subentry helpers
-# (was 60 in PR #1071 with 64 % headroom). Target remains >= 95 % per
+# Sprint baseline: measured 64.09 % after Phase 2 (#1073/#1074/#1075:
+# registry+identity+polling mixin branch-coverage). Target remains >= 95 % per
 # quality-scale rule test-coverage; this floor only prevents regressions
-# while incremental test expansion lands (60 -> 63 -> 70 -> 80 -> 90 -> 95).
-fail_under = 63
+# while incremental test expansion lands (60 -> 63 -> 64 -> 70 -> 80 -> 90 -> 95).
+fail_under = 64
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",


### PR DESCRIPTION
## Summary

- Lock the coverage floor at 64 % after Phase 2 (`test/coverage-phase-1-registry-lifecycle` carries PR #1073 / #1074 / #1075 which lifted measured coverage from 63.59 % to 64.09 %).
- Protects the headroom against silent regressions before Phase 3 lands.
- Synchronous bump on both gates as required by `tests/test_platinum_compliance.py::test_coverage_threshold_enforced`:
  - `pyproject.toml` `[tool.coverage.report] fail_under` → 64
  - `.github/workflows/ci.yml` `--cov-fail-under` → 64
- Stair-step progression in the inline comment now reads `60 -> 63 -> 64 -> 70 -> 80 -> 90 -> 95`.

## Test plan

- [x] Local `grep -n 'fail_under\|cov-fail-under' pyproject.toml .github/workflows/ci.yml` confirms both gates report `64`.
- [ ] CI green (`ci-success` aggregate covering hassfest, hacs, lint, test, translations).
- [ ] `tests/test_platinum_compliance.py::test_coverage_threshold_enforced` passes (asserts both gates agree).
- [ ] Codex review clean.

## Notes

- No production code or test code changes; pure floor lockstep bump.
- Follow-up: `PLAN_pr1073_phase3_coverage` will add further coverage to move toward the next stair-step at 70 %.