### PR TITLE
test(coordinator/locate): branch-coverage for pure helpers and async gating (Phase 3 AP-C)

### DIFF
--- a/tests/helpers/locate_mixin_stub.py
+++ b/tests/helpers/locate_mixin_stub.py
@@ -1,0 +1,104 @@
+# tests/helpers/locate_mixin_stub.py
+"""Test stub for :class:`LocateOperations` mixin standalone unit tests.
+
+Phase 3 AP-C: exercise the locate mixin methods (``_normalize_coords``,
+``can_play_sound``, ``_get_device_lock``, ``can_request_location``) and
+gating branches of the async helpers (``async_locate_device``,
+``async_play_sound``, ``async_stop_sound``) without the full coordinator.
+``_MixinBase`` is runtime-empty, so a minimal subclass seeds every
+attribute the mixin reads and pre-mocks cross-mixin methods to dodge the
+``NotImplementedError`` traps that come from ``_MixinBase``.
+
+The deep success-path branches of ``async_locate_device`` (Nova roundtrip,
+Google Home filter, weighted fusion, cache commit) are intentionally out
+of scope here; they land in Phase 4.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.googlefindmy.coordinator.locate import LocateOperations
+
+
+def make_hass_stub(*, loop: Any | None = None) -> MagicMock:
+    """Return a Home Assistant stub with ``data``, ``loop`` and task helpers."""
+
+    hass = MagicMock(spec_set=["data", "loop", "async_create_task"])
+    hass.data = {}
+    hass.loop = loop if loop is not None else MagicMock()
+    hass.async_create_task = MagicMock(return_value=None)
+    return hass
+
+
+class LocateStub(LocateOperations):
+    """Minimal :class:`LocateOperations` subclass for isolated mixin tests.
+
+    Cross-mixin ``_MixinBase`` stubs are seeded as ``MagicMock`` so methods
+    under test can call them transparently; tests rebind per-case via
+    :func:`setattr`. No ``super().__init__`` chain runs because
+    ``DataUpdateCoordinator.__init__`` would require a full HA runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        api: Any | None = None,
+        location_poll_interval: int = 120,
+        min_poll_interval: int = 60,
+    ) -> None:
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+        self.data: list[dict[str, Any]] = []
+
+        # Locate-state attributes the mixin reads or mutates.
+        self._device_caps: dict[str, dict[str, Any]] = {}
+        self._device_action_locks: dict[str, Any] = {}
+        self._locate_inflight: set[str] = set()
+        self._locate_cooldown_until: dict[str, float] = {}
+        self._device_poll_cooldown_until: dict[str, float] = {}
+        self._push_cooldown_until: float = 0.0
+        self._device_location_data: dict[str, dict[str, Any]] = {}
+        self._sound_request_uuids: dict[str, str] = {}
+        self._sound_request_timestamps: dict[str, float] = {}
+        self._last_poll_mono: float = 0.0
+        self._present_last_seen: dict[str, float] = {}
+        self._is_polling: bool = False
+
+        # Cross-mixin scalars used by helpers.
+        self.location_poll_interval = location_poll_interval
+        self.min_poll_interval = min_poll_interval
+        self.api = api if api is not None else MagicMock()
+        self.api.async_get_device_location = AsyncMock(return_value={})
+        self.api.async_play_sound = AsyncMock(return_value=(True, "uuid-stub"))
+        self.api.async_stop_sound = AsyncMock(return_value=True)
+
+        # Cross-mixin methods owned by other mixins or DataUpdateCoordinator:
+        # mock them so default behavior is a no-op. Tests override per-case.
+        entry_id = getattr(config_entry, "entry_id", None) if config_entry else None
+        self._entry_id = MagicMock(return_value=entry_id)
+        self.increment_stat = MagicMock(return_value=None)
+        self.is_ignored = MagicMock(return_value=False)
+        self.get_device_display_name = MagicMock(return_value=None)
+        self._api_push_ready = MagicMock(return_value=True)
+        self._ensure_device_name_cache = MagicMock(return_value={})
+        self._set_auth_state = MagicMock(return_value=None)
+        self._record_semantic_label = MagicMock(return_value=None)
+        self._apply_semantic_mapping = MagicMock(return_value=False)
+        self._get_google_home_filter = MagicMock(return_value=None)
+        self._should_preserve_precise_home_coordinates = MagicMock(return_value=False)
+        self.update_device_cache = MagicMock(return_value=None)
+        self._apply_weighted_location_fusion = MagicMock(return_value=True)
+        self.note_error = MagicMock(return_value=None)
+        self.push_updated = MagicMock(return_value=None)
+        self._short_error_message = MagicMock(return_value="short-err")
+        self._async_save_sound_uuids = AsyncMock(return_value=None)
+        self.async_set_updated_data = MagicMock(return_value=None)
+        self.async_request_refresh = AsyncMock(return_value=None)
+        self._note_push_transport_problem = MagicMock(return_value=None)
+
+
+__all__ = ["LocateStub", "make_hass_stub"]

--- a/tests/test_coordinator_locate_basics.py
+++ b/tests/test_coordinator_locate_basics.py
@@ -1,0 +1,326 @@
+# tests/test_coordinator_locate_basics.py
+"""Branch-Coverage tests for ``coordinator.locate``.
+
+Phase 3 AP-C: target ``coordinator/locate.py`` branch-coverage by
+exercising the pure helpers (``_normalize_coords``, ``_get_device_lock``,
+``can_request_location``, ``can_play_sound``) and the gating branches of
+the async helpers (``async_locate_device``, ``async_play_sound``,
+``async_stop_sound``). Deep success-path branches (Nova roundtrip,
+Google Home filter, weighted fusion, cache commit) remain out of scope
+and stay for Phase 4.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+
+import pytest
+
+from custom_components.googlefindmy.const import DEFAULT_MIN_POLL_INTERVAL
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.locate_mixin_stub import LocateStub
+
+
+@pytest.fixture
+def coord() -> LocateStub:
+    """Return a default :class:`LocateStub` bound to a synthetic config entry."""
+
+    entry = make_config_entry(entry_id="locate-test-entry")
+    return LocateStub(config_entry=entry)
+
+
+class TestNormalizeCoords:
+    """Exercise ``_normalize_coords`` branches."""
+
+    def test_missing_lat_returns_false(self, coord: LocateStub) -> None:
+        payload: dict = {"longitude": 12.0}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_not_called()
+
+    def test_missing_lon_returns_false(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_not_called()
+
+    def test_non_numeric_increments_invalid_and_returns_false(
+        self, coord: LocateStub
+    ) -> None:
+        payload: dict = {"latitude": "abc", "longitude": "def"}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_called_once_with("invalid_coords")
+
+    def test_non_numeric_warn_off_skips_warning(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": "abc", "longitude": "def"}
+        assert coord._normalize_coords(payload, warn_on_invalid=False) is False
+        coord.increment_stat.assert_called_once_with("invalid_coords")
+
+    @pytest.mark.parametrize(
+        ("lat", "lon"),
+        [
+            (math.nan, 0.0),
+            (math.inf, 0.0),
+            (0.0, math.inf),
+            (95.0, 0.0),
+            (0.0, -181.0),
+        ],
+    )
+    def test_out_of_range_increments_invalid(
+        self, coord: LocateStub, lat: float, lon: float
+    ) -> None:
+        payload: dict = {"latitude": lat, "longitude": lon}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_called_once_with("invalid_coords")
+
+    def test_valid_coords_returns_true_and_normalizes(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": "50.0", "longitude": "12.0"}
+        assert coord._normalize_coords(payload) is True
+        assert payload["latitude"] == 50.0
+        assert payload["longitude"] == 12.0
+
+    def test_accuracy_valid_kept(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0, "longitude": 12.0, "accuracy": "5.0"}
+        assert coord._normalize_coords(payload) is True
+        assert payload["accuracy"] == 5.0
+
+    def test_accuracy_invalid_dropped(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0, "longitude": 12.0, "accuracy": 0.0}
+        assert coord._normalize_coords(payload) is True
+        assert "accuracy" not in payload
+
+    def test_accuracy_unparsable_dropped(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0, "longitude": 12.0, "accuracy": "junk"}
+        assert coord._normalize_coords(payload) is True
+        assert "accuracy" not in payload
+
+
+class TestGetDeviceLock:
+    """Exercise ``_get_device_lock`` branches."""
+
+    def test_create_new_lock(self, coord: LocateStub) -> None:
+        lock = coord._get_device_lock("dev-1")
+        assert isinstance(lock, asyncio.Lock)
+        assert coord._device_action_locks["dev-1"] is lock
+
+    def test_return_existing_lock(self, coord: LocateStub) -> None:
+        first = coord._get_device_lock("dev-1")
+        second = coord._get_device_lock("dev-1")
+        assert first is second
+
+
+class TestCanRequestLocation:
+    """Exercise ``can_request_location`` branches."""
+
+    def test_ignored_device_blocked(self, coord: LocateStub) -> None:
+        coord.is_ignored.return_value = True
+        assert coord.can_request_location("dev-1") is False
+
+    def test_polling_in_progress_blocked(self, coord: LocateStub) -> None:
+        coord._is_polling = True
+        assert coord.can_request_location("dev-1") is False
+
+    def test_inflight_blocked(self, coord: LocateStub) -> None:
+        coord._locate_inflight.add("dev-1")
+        assert coord.can_request_location("dev-1") is False
+
+    def test_manual_cooldown_active_blocked(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._locate_cooldown_until["dev-1"] = 200.0
+        assert coord.can_request_location("dev-1") is False
+
+    def test_poll_cooldown_active_blocked(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._device_poll_cooldown_until["dev-1"] = 200.0
+        assert coord.can_request_location("dev-1") is False
+
+    def test_all_clear_allows(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        assert coord.can_request_location("dev-1") is True
+
+    def test_expired_cooldown_allows(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 300.0,
+        )
+        coord._locate_cooldown_until["dev-1"] = 200.0
+        coord._device_poll_cooldown_until["dev-1"] = 250.0
+        assert coord.can_request_location("dev-1") is True
+
+
+class TestCanPlaySound:
+    """Exercise ``can_play_sound`` branches."""
+
+    def test_capability_known_true(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        assert coord.can_play_sound("dev-1") is True
+
+    def test_capability_known_false(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": False}
+        assert coord.can_play_sound("dev-1") is False
+
+    def test_push_not_ready_with_cooldown_blocks(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coord._api_push_ready.return_value = False
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._push_cooldown_until = 200.0
+        assert coord.can_play_sound("dev-1") is False
+
+    def test_push_not_ready_no_cooldown_falls_back_optimistic(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coord._api_push_ready.return_value = False
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        coord._ensure_device_name_cache.return_value = {"dev-1": "Phone"}
+        assert coord.can_play_sound("dev-1") is True
+
+    def test_known_device_optimistic_true(self, coord: LocateStub) -> None:
+        coord._ensure_device_name_cache.return_value = {"dev-1": "Phone"}
+        assert coord.can_play_sound("dev-1") is True
+
+    def test_unknown_device_falls_back_optimistic(self, coord: LocateStub) -> None:
+        coord._ensure_device_name_cache.return_value = {}
+        assert coord.can_play_sound("dev-1") is True
+
+
+class TestAsyncLocateDeviceGating:
+    """Exercise gating branches of ``async_locate_device`` (no Nova roundtrip)."""
+
+    async def test_blocks_when_cannot_request_location(self, coord: LocateStub) -> None:
+        coord.is_ignored.return_value = True
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+        coord.api.async_get_device_location.assert_not_called()
+
+    async def test_blocks_when_push_cooldown_active(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._api_push_ready.return_value = False
+        coord._push_cooldown_until = 200.0
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+        coord.api.async_get_device_location.assert_not_called()
+
+    async def test_empty_payload_returns_empty(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        coord.api.async_get_device_location.return_value = None
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+        assert "dev-1" not in coord._locate_inflight  # finally branch cleared it
+
+    async def test_payload_without_coords_returns_empty(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        coord.api.async_get_device_location.return_value = {
+            "last_seen": 1234567890,
+        }
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+
+
+class TestAsyncPlaySoundGating:
+    """Exercise gating branches of ``async_play_sound``."""
+
+    async def test_blocks_when_cannot_play_sound(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": False}
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is False
+        coord.api.async_play_sound.assert_not_called()
+
+    async def test_success_stores_uuid(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is True
+        assert coord._sound_request_uuids.get("dev-1") == "uuid-stub"
+        coord._async_save_sound_uuids.assert_awaited_once()
+
+    async def test_failure_notes_problem(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        coord.api.async_play_sound.return_value = (False, None)
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is False
+        coord._note_push_transport_problem.assert_called_once()
+
+    async def test_unexpected_exception_returns_false(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        coord.api.async_play_sound.side_effect = RuntimeError("boom")
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is False
+        coord.note_error.assert_called_once()
+        coord._note_push_transport_problem.assert_called_once()
+
+
+class TestAsyncStopSoundGating:
+    """Exercise gating branches of ``async_stop_sound``."""
+
+    async def test_blocks_when_push_not_ready(self, coord: LocateStub) -> None:
+        coord._api_push_ready.return_value = False
+        ok = await coord.async_stop_sound("dev-1")
+        assert ok is False
+        coord.api.async_stop_sound.assert_not_called()
+
+    async def test_uses_cached_uuid_when_none_passed(self, coord: LocateStub) -> None:
+        coord._sound_request_uuids["dev-1"] = "cached-uuid"
+        ok = await coord.async_stop_sound("dev-1")
+        assert ok is True
+        coord.api.async_stop_sound.assert_awaited_once_with("dev-1", "cached-uuid")
+        # successful stop removes the uuid
+        assert "dev-1" not in coord._sound_request_uuids
+
+    async def test_explicit_uuid_overrides_cache(self, coord: LocateStub) -> None:
+        coord._sound_request_uuids["dev-1"] = "cached-uuid"
+        ok = await coord.async_stop_sound("dev-1", request_uuid="explicit")
+        assert ok is True
+        coord.api.async_stop_sound.assert_awaited_once_with("dev-1", "explicit")
+
+    async def test_missing_uuid_warns_but_attempts_stop(
+        self, coord: LocateStub
+    ) -> None:
+        ok = await coord.async_stop_sound("dev-1")
+        assert ok is True
+        coord.api.async_stop_sound.assert_awaited_once_with("dev-1", None)
+
+    async def test_failure_notes_problem(self, coord: LocateStub) -> None:
+        coord.api.async_stop_sound.return_value = False
+        ok = await coord.async_stop_sound("dev-1", request_uuid="x")
+        assert ok is False
+        coord._note_push_transport_problem.assert_called_once()
+
+
+_ = DEFAULT_MIN_POLL_INTERVAL  # silence unused-import lint when production no-ops


### PR DESCRIPTION
## Summary

- Phase 3 AP-C: target `coordinator/locate.py` branch-coverage **49 % → ≥ 75 %**
- New: `tests/helpers/locate_mixin_stub.py` (minimal `LocateOperations` subclass, pre-mocked cross-mixin collaborators incl. `api`, `_api_push_ready`, `_ensure_device_name_cache`)
- New: `tests/test_coordinator_locate_basics.py` (7 test classes covering pure helpers + async-gating branches)

## Coverage scope

| Method | Branches exercised | In scope |
|--------|--------------------|----------|
| `_normalize_coords` | missing-coords, non-numeric (with/without warn), NaN/Inf, out-of-range, accuracy valid/invalid/unparsable | ✅ |
| `_get_device_lock` | create-new, return-existing | ✅ |
| `can_request_location` | ignored / polling / inflight / manual-cooldown / poll-cooldown / clear / expired | ✅ |
| `can_play_sound` | caps-known-true/false / push-not-ready+cooldown / push-not-ready+optimistic / known / unknown | ✅ |
| `async_locate_device` | gating branches (cannot_request, push cooldown, empty payload, payload-without-coords) | ✅ (deep success-path → Phase 4) |
| `async_play_sound` | cap-block, success-with-uuid, failure, unexpected-exception | ✅ |
| `async_stop_sound` | push-not-ready, cached/explicit/missing uuid, failure | ✅ |

Deep success-path (Nova roundtrip, Google Home filter, weighted fusion, cache commit) remains out of scope and stays for Phase 4 per AP-INV.

## Conventions (Phase-3 plan KV-1..KV-8)

- ✅ Path-header + `__future__` immediately after docstring (CA-PATH-001)
- ✅ `make_config_entry` factory (CA-MOCK-001), no SimpleNamespace stubs
- ✅ `monkeypatch.setattr` with fixture-scope='function' for `time.monotonic` (CA-F8 mock-pollution mitigation)
- ✅ No `asyncio.run()` (CA-GUARD-001); `async def` + pytest-asyncio auto-mode
- ✅ Ruff check + format clean (CA-LINT-001)

## Test plan

- [ ] CI green: hassfest, hacs, lint, test, translations
- [ ] `test_platinum_compliance.py::test_coverage_threshold_enforced` green (floor 64 holds)
- [ ] Codex review clean
- [ ] CI coverage shows `coordinator/locate.py` ≥ 75 %
- [ ] CI total coverage ≥ 64 % (no regression)

Plan: `PLAN_pr1073_phase3_coverage.md` (Iteration 2, Option I freigegeben 2026-06-05 09:42 UTC)