### PR TITLE
chore(coverage): bump floor to 66 % lockstep after Phase 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=64 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=66 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -339,11 +339,14 @@ omit = [
 [tool.coverage.report]
 show_missing = false
 skip_covered = true
-# Sprint baseline: measured 64.09 % after Phase 2 (#1073/#1074/#1075:
-# registry+identity+polling mixin branch-coverage). Target remains >= 95 % per
-# quality-scale rule test-coverage; this floor only prevents regressions
-# while incremental test expansion lands (60 -> 63 -> 64 -> 70 -> 80 -> 90 -> 95).
-fail_under = 64
+# Sprint baseline: measured 66.53 % after Phase 4 AP-J/AP-I/AP-L/AP-K
+# (#1079/#1080/#1081/#1082: coordinator/polling + api + config_flow + __init__
+# basics coverage). Target remains >= 95 % per quality-scale rule test-coverage;
+# this floor only prevents regressions while incremental test expansion lands
+# (60 -> 63 -> 64 -> 66 -> 70 -> 80 -> 90 -> 95). Bump bundles Phase-3 AP-LS1
+# and AP-LS2 (never executed) with Phase-4 AP-LS3 into one honest stairstep,
+# floor = empirical CI coverage minus 0.5 PP safety margin.
+fail_under = 66
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",

--- a/tests/test_platinum_compliance.py
+++ b/tests/test_platinum_compliance.py
@@ -192,10 +192,11 @@ def test_quality_scale_evidence_existence(integration_root: Path) -> None:
 
 
 # Sprint baseline for the test-coverage quality-scale rule.
-# Real coverage on scoped integration source was 64 % (CI run on b9ca59cd).
+# Real coverage on scoped integration source was 66.53 % after Phase 4
+# AP-J/AP-I/AP-L/AP-K (#1079/#1080/#1081/#1082).
 # The Platinum target remains >= 95 %; this floor only prevents regression
 # while incremental test expansion lands. Raise as the sprint phase-gates
-# advance (60 -> 65 -> 75 -> 85 -> 90 -> 95).
+# advance (60 -> 66 -> 70 -> 80 -> 90 -> 95).
 COVERAGE_SPRINT_FLOOR = 60
 COVERAGE_PLATINUM_TARGET = 95
 


### PR DESCRIPTION
## Summary

* Raise regression-coverage floor from **64 % to 66 %** across both gates (`pyproject.toml` engine side, `ci.yml` CI side).
* Rolls in Phase 3 AP-LS1 + AP-LS2 — documented but never executed because their per-AP thresholds (65.0 % / 66.5 %) were not crossed — together with Phase 4 AP-LS3.
* Floor derived from Phase 4 merged CI coverage **66.53 %** (run 27085419416 on the `#1082` merge commit) minus the plan's 0.5 PP safety margin → `66 %`, leaving a 0.53 PP cushion.

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `[tool.coverage.report] fail_under = 64 -> 66`; stairstep comment updated to `60 -> 63 -> 64 -> 66 -> 70 -> 80 -> 90 -> 95`; sprint-baseline note rewritten to reference Phase 4 CI measurement. |
| `.github/workflows/ci.yml` | `--cov-fail-under=64 -> 66` in the pytest invocation (CA-SYNC-001 lockstep). |
| `tests/test_platinum_compliance.py` | Sprint-baseline comment refreshed to `66.53 %` after Phase 4. The assertion logic (`60 <= floor <= 95` plus engine/CI symmetry) is unchanged and passes with the new value. |

## Test plan

- [ ] CI green on this branch (`Test (Python 3.13)` job enforces the new floor at runtime).
- [ ] `test_platinum_compliance.py::test_coverage_threshold_enforced` passes (verifies wiring + range + lockstep symmetry).
- [ ] No coverage-related test failures (current measured coverage 66.53 % > floor 66 %).
- [ ] Codex review clean.

## Plan references

- `PLAN_pr1073_phase4_coverage.md` AP-LS3 (Iteration 2: bump target lowered from 69 % to 66 % per the plan's conditional rule "empirical CI coverage minus 0.5 PP").
- `PLAN_pr1073_phase3_coverage.md` AP-LS1 / AP-LS2 (status updated to "rolled in").