### PR TITLE
fix(fcm): Defense 1 inner-loop hardening against poison-message cascade (AP-1)

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -445,10 +445,19 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         private_value = keys_section.get("private")
         secret_value = keys_section.get("secret")
         if not (isinstance(private_value, str) and isinstance(secret_value, str)):
-            raise ValueError("Invalid key values in credential payload")
+            raise ValueError("Credentials contain invalid key values")
 
-        der_data = urlsafe_b64decode(private_value.encode("ascii") + b"=" * (-len(private_value) % 4))
-        secret = urlsafe_b64decode(secret_value.encode("ascii") + b"=" * (-len(secret_value) % 4))
+        try:
+            der_data = urlsafe_b64decode(
+                private_value.encode("ascii") + b"=" * (-len(private_value) % 4)
+            )
+            secret = urlsafe_b64decode(
+                secret_value.encode("ascii") + b"=" * (-len(secret_value) % 4)
+            )
+        except binascii.Error as cred_decode_err:
+            raise ValueError(
+                "Credentials key material failed base64 decode; re-registration required"
+            ) from cred_decode_err
         privkey = load_der_private_key(der_data, password=None)
         decrypted = http_decrypt(
             raw_data,
@@ -743,6 +752,58 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             )
         return connected
 
+    async def _ack_or_disconnect(self, persistent_id: str | None) -> bool:
+        """Best-effort selective-ACK for a poison message.
+
+        Returns ``True`` to continue the worker loop; ``False`` if the writer
+        half is dead and the supervisor should reconnect (caller breaks).
+        """
+        if not persistent_id:
+            return True
+        try:
+            await self._send_selective_ack(persistent_id)
+            return True
+        except (OSError, ssl.SSLError, ConnectionError):
+            return False
+
+    async def _process_one_inbound_message(self, msg: MessageProto) -> bool:
+        """Run ``_handle_message`` with poison-message defense.
+
+        Defense 1 (CA-CASCADING-FAILURE-001): per-message decode failures
+        (``binascii.Error`` padding faults under Python 3.14 strict mode,
+        ``RuntimeError`` from ``_app_data_by_key`` key lookups, generic
+        ``ValueError`` from header parsing) are acknowledged and skipped
+        instead of crashing the worker loop. Credential-material errors
+        (markers starting with ``"Credentials "``) propagate so the
+        supervisor surfaces them via STOPPED state.
+
+        Returns ``True`` to continue the loop, ``False`` to break (writer
+        half-dead during ack).
+        """
+        try:
+            await self._handle_message(msg)
+            return True
+        except ValueError as decrypt_err:
+            if str(decrypt_err).startswith("Credentials "):
+                raise
+            persistent_id = getattr(msg, "persistent_id", None)
+            self._log_warn_with_limit(
+                "Skipping FCM message that failed to decrypt "
+                "(persistent_id=%s): %s",
+                persistent_id,
+                decrypt_err,
+            )
+            return await self._ack_or_disconnect(persistent_id)
+        except (binascii.Error, RuntimeError) as decrypt_err:
+            persistent_id = getattr(msg, "persistent_id", None)
+            self._log_warn_with_limit(
+                "Skipping FCM message that failed to decrypt "
+                "(persistent_id=%s): %s",
+                persistent_id,
+                decrypt_err,
+            )
+            return await self._ack_or_disconnect(persistent_id)
+
     async def _listen(self) -> None:
         """Listens for push notifications until an error or stop() occurs."""
         try:
@@ -761,75 +822,9 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             while self.do_listen:
                 try:
                     if msg := await self._receive_msg():
-                        try:
-                            await self._handle_message(msg)
-                        except ValueError as decrypt_err:
-                            # Defense 1 (CA-CASCADING-FAILURE-001):
-                            # Legitimate credential/key configuration errors
-                            # must propagate so the supervisor surfaces them
-                            # via the STOPPED state (not silently swallowed).
-                            err_text = str(decrypt_err)
-                            if (
-                                "Credentials missing FCM key material"
-                                in err_text
-                                or "Invalid key values" in err_text
-                            ):
-                                raise
-                            persistent_id = getattr(
-                                msg, "persistent_id", None
-                            )
-                            self._log_warn_with_limit(
-                                "Skipping FCM message that failed to decrypt "
-                                "(persistent_id=%s): %s",
-                                persistent_id,
-                                decrypt_err,
-                            )
-                            if persistent_id:
-                                try:
-                                    await self._send_selective_ack(
-                                        persistent_id
-                                    )
-                                except (
-                                    OSError,
-                                    ssl.SSLError,
-                                    ConnectionError,
-                                ):
-                                    # Writer half-dead -> let the outer
-                                    # catch handle a clean shutdown.
-                                    self.do_listen = False
-                                    break
-                            continue
-                        except (binascii.Error, RuntimeError) as decrypt_err:
-                            # Defense 1 (CA-CASCADING-FAILURE-001):
-                            # base64 padding faults (binascii.Error, hot under
-                            # Python 3.14 strict mode) and missing-key lookups
-                            # raised from ``_app_data_by_key`` are per-message
-                            # decode failures. Acknowledge and skip instead of
-                            # crashing the worker loop, which previously
-                            # cascaded into a supervisor restart storm and an
-                            # OOM crash on Home Assistant Core 2026.6.x.
-                            persistent_id = getattr(
-                                msg, "persistent_id", None
-                            )
-                            self._log_warn_with_limit(
-                                "Skipping FCM message that failed to decrypt "
-                                "(persistent_id=%s): %s",
-                                persistent_id,
-                                decrypt_err,
-                            )
-                            if persistent_id:
-                                try:
-                                    await self._send_selective_ack(
-                                        persistent_id
-                                    )
-                                except (
-                                    OSError,
-                                    ssl.SSLError,
-                                    ConnectionError,
-                                ):
-                                    self.do_listen = False
-                                    break
-                            continue
+                        if not await self._process_one_inbound_message(msg):
+                            self.do_listen = False
+                            break
 
                 except (ConnectionError, ssl.SSLError) as cex:
                     # Treat stream end/TLS quirks as normal stop; supervisor will restart

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -29,6 +29,7 @@
 from __future__ import annotations
 
 import asyncio
+import binascii
 import json
 import logging
 import random
@@ -760,7 +761,75 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             while self.do_listen:
                 try:
                     if msg := await self._receive_msg():
-                        await self._handle_message(msg)
+                        try:
+                            await self._handle_message(msg)
+                        except ValueError as decrypt_err:
+                            # Defense 1 (CA-CASCADING-FAILURE-001):
+                            # Legitimate credential/key configuration errors
+                            # must propagate so the supervisor surfaces them
+                            # via the STOPPED state (not silently swallowed).
+                            err_text = str(decrypt_err)
+                            if (
+                                "Credentials missing FCM key material"
+                                in err_text
+                                or "Invalid key values" in err_text
+                            ):
+                                raise
+                            persistent_id = getattr(
+                                msg, "persistent_id", None
+                            )
+                            self._log_warn_with_limit(
+                                "Skipping FCM message that failed to decrypt "
+                                "(persistent_id=%s): %s",
+                                persistent_id,
+                                decrypt_err,
+                            )
+                            if persistent_id:
+                                try:
+                                    await self._send_selective_ack(
+                                        persistent_id
+                                    )
+                                except (
+                                    OSError,
+                                    ssl.SSLError,
+                                    ConnectionError,
+                                ):
+                                    # Writer half-dead -> let the outer
+                                    # catch handle a clean shutdown.
+                                    self.do_listen = False
+                                    break
+                            continue
+                        except (binascii.Error, RuntimeError) as decrypt_err:
+                            # Defense 1 (CA-CASCADING-FAILURE-001):
+                            # base64 padding faults (binascii.Error, hot under
+                            # Python 3.14 strict mode) and missing-key lookups
+                            # raised from ``_app_data_by_key`` are per-message
+                            # decode failures. Acknowledge and skip instead of
+                            # crashing the worker loop, which previously
+                            # cascaded into a supervisor restart storm and an
+                            # OOM crash on Home Assistant Core 2026.6.x.
+                            persistent_id = getattr(
+                                msg, "persistent_id", None
+                            )
+                            self._log_warn_with_limit(
+                                "Skipping FCM message that failed to decrypt "
+                                "(persistent_id=%s): %s",
+                                persistent_id,
+                                decrypt_err,
+                            )
+                            if persistent_id:
+                                try:
+                                    await self._send_selective_ack(
+                                        persistent_id
+                                    )
+                                except (
+                                    OSError,
+                                    ssl.SSLError,
+                                    ConnectionError,
+                                ):
+                                    self.do_listen = False
+                                    break
+                            continue
 
                 except (ConnectionError, ssl.SSLError) as cex:
                     # Treat stream end/TLS quirks as normal stop; supervisor will restart

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -475,7 +475,12 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             secret = urlsafe_b64decode(
                 secret_value.encode("ascii") + b"=" * (-len(secret_value) % 4)
             )
-        except binascii.Error as cred_decode_err:
+        except (binascii.Error, UnicodeError) as cred_decode_err:
+            # binascii.Error: corrupt base64 payload.
+            # UnicodeError (covers UnicodeEncodeError/UnicodeDecodeError):
+            # non-ASCII bytes in cached keys.private/keys.secret; .encode("ascii")
+            # raises before urlsafe_b64decode is reached. Both are permanent
+            # credential-corruption faults, not per-message poison.
             raise CredentialDecryptionError(
                 "Credentials key material failed base64 decode; re-registration required"
             ) from cred_decode_err

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -86,6 +86,25 @@ _logger = logging.getLogger(__name__)
 
 _LEGACY_MCS_PROTOCOL_VERSION = 38
 
+
+class CredentialDecryptionError(ValueError):
+    """Raised when stored FCM credential material cannot be decoded or parsed.
+
+    Subclass of ``ValueError`` for backward-compatibility with external
+    callers that catch broad ``ValueError``. Internal code (notably the
+    listener loop's poison-message defense) discriminates this type via
+    ``isinstance`` to distinguish per-message decode failures (which are
+    safely ACKed and skipped) from credential-corruption failures (which
+    must surface to the supervisor for re-registration).
+
+    Why a typed exception instead of a string-prefix marker: external
+    libraries such as ``cryptography`` and ``http_ece`` raise plain
+    ``ValueError`` without our markers; a ``str.startswith`` catch loses
+    them and silently treats credential corruption as per-message poison.
+    See CA-CRED-VS-MSG-DECRYPT-001 iter-3 lesson.
+    """
+
+
 # MCS Message Types and Tags
 MCS_MESSAGE_TAG = {
     HeartbeatPing: 0,
@@ -440,12 +459,14 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
 
         keys_section = credentials.get("keys")
         if not isinstance(keys_section, Mapping):
-            raise ValueError("Credentials missing FCM key material")
+            raise CredentialDecryptionError("Credentials missing FCM key material")
 
         private_value = keys_section.get("private")
         secret_value = keys_section.get("secret")
         if not (isinstance(private_value, str) and isinstance(secret_value, str)):
-            raise ValueError("Credentials contain invalid key values")
+            raise CredentialDecryptionError(
+                "Credentials contain invalid key values"
+            )
 
         try:
             der_data = urlsafe_b64decode(
@@ -455,10 +476,19 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
                 secret_value.encode("ascii") + b"=" * (-len(secret_value) % 4)
             )
         except binascii.Error as cred_decode_err:
-            raise ValueError(
+            raise CredentialDecryptionError(
                 "Credentials key material failed base64 decode; re-registration required"
             ) from cred_decode_err
-        privkey = load_der_private_key(der_data, password=None)
+        try:
+            privkey = load_der_private_key(der_data, password=None)
+        except Exception as der_err:
+            # cryptography raises plain ValueError (corrupt DER), TypeError
+            # (wrong type), or UnsupportedAlgorithm — all permanent and all
+            # requiring re-registration. Broad catch is intentional: the
+            # only successful path is a valid DER private key.
+            raise CredentialDecryptionError(
+                "Credentials key material failed DER private-key parse; re-registration required"
+            ) from der_err
         decrypted = http_decrypt(
             raw_data,
             salt=salt,
@@ -774,8 +804,8 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         ``RuntimeError`` from ``_app_data_by_key`` key lookups, generic
         ``ValueError`` from header parsing) are acknowledged and skipped
         instead of crashing the worker loop. Credential-material errors
-        (markers starting with ``"Credentials "``) propagate so the
-        supervisor surfaces them via STOPPED state.
+        (``CredentialDecryptionError``) propagate so the supervisor
+        surfaces them via STOPPED state and prompts re-registration.
 
         Returns ``True`` to continue the loop, ``False`` to break (writer
         half-dead during ack).
@@ -783,9 +813,11 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         try:
             await self._handle_message(msg)
             return True
+        except CredentialDecryptionError:
+            # Credential corruption is permanent; let the supervisor see it
+            # instead of silently ACKing every message that follows.
+            raise
         except ValueError as decrypt_err:
-            if str(decrypt_err).startswith("Credentials "):
-                raise
             persistent_id = getattr(msg, "persistent_id", None)
             self._log_warn_with_limit(
                 "Skipping FCM message that failed to decrypt "

--- a/tests/helpers/fcm_poison_stub.py
+++ b/tests/helpers/fcm_poison_stub.py
@@ -1,0 +1,103 @@
+# tests/helpers/fcm_poison_stub.py
+# Mirror production attribute names from FcmPushClient.__init__ and DataMessageStanza verbatim
+"""Slim composition stub for FcmPushClient Defense 1 tests (CA-CASCADING-FAILURE-001).
+
+Binds the production ``FcmPushClient._listen`` method to a lightweight container
+that mirrors only the attributes the worker loop touches. This avoids the heavy
+production constructor (``FcmRegisterConfig`` / Firebase wiring) while exercising
+the real Inner-Loop code path, so Defense 1 is verified end-to-end and not
+re-implemented in the stub.
+
+The stub is *not* a subclass of ``FcmPushClient`` (composition only). Production
+attribute names (``logger``, ``do_listen``, ``run_state``, ``config``,
+``log_warn_counters``) are mirrored verbatim from ``FcmPushClient.__init__``;
+test instrumentation fields (``_loop_iteration_count``, ``_last_handled_id``,
+``_after_iter_hook``) are exposed for the Aggregate-Anti-Cascading test.
+"""
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any, Callable
+from unittest.mock import AsyncMock
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClient,
+    FcmPushClientConfig,
+    FcmPushClientRunState,
+)
+
+
+def make_poison_data_message(
+    persistent_id: str, kind: str = "padding"
+) -> SimpleNamespace:
+    """Build a DataMessageStanza-shaped namespace for Inner-Loop tests.
+
+    ``kind`` selects the failure class the test will raise on decrypt:
+      - ``padding`` -> ``binascii.Error("Incorrect padding")``
+      - ``value``   -> ``RuntimeError("couldn't find in app_data crypto-key")``
+      - ``valid``   -> message that should pass through without raising
+    """
+    if kind not in {"padding", "value", "valid"}:
+        raise ValueError(f"unknown kind: {kind!r}")
+    return SimpleNamespace(
+        app_data=[],
+        persistent_id=persistent_id,
+        stream_id=1,
+        last_stream_id_received=0,
+        status="ok",
+        _kind=kind,
+    )
+
+
+def make_valid_data_message(persistent_id: str) -> SimpleNamespace:
+    """Convenience wrapper for a pass-through (non-poison) message."""
+    return make_poison_data_message(persistent_id, kind="valid")
+
+
+class FcmPushClientSlim:
+    """Composition stub for Defense 1 tests.
+
+    Binds ``FcmPushClient._listen`` to ``self`` so the production worker loop
+    runs against a controlled set of mocked dependencies. Only the attributes
+    the loop reads or writes are mirrored; everything else is left out.
+    """
+
+    def __init__(self) -> None:
+        # Mirror production attribute names from FcmPushClient.__init__ verbatim
+        self.logger = logging.getLogger(__name__ + ".FcmPushClientSlim")
+        self.logger.propagate = True
+        self.do_listen = True
+        self.run_state: FcmPushClientRunState = FcmPushClientRunState.STARTED
+        self.config = FcmPushClientConfig()  # log_warn_limit default = 5
+        self.log_warn_counters: dict[str, int] = {}
+        self.persistent_ids: list[str] = []
+        self.writer = None  # _do_writer_close short-circuits on None
+
+        # Async-stubbed production methods (overridable per test).
+        self._receive_msg = AsyncMock(return_value=None)
+        self._handle_message = AsyncMock(return_value=None)
+        self._send_selective_ack = AsyncMock(return_value=None)
+        self._connect_with_retry = AsyncMock(return_value=True)
+        self._login = AsyncMock(return_value=None)
+        self._do_writer_close = AsyncMock(return_value=None)
+
+        # Test instrumentation (NOT production attributes).
+        self._loop_iteration_count = 0
+        self._last_handled_id: str | None = None
+        self._after_iter_hook: Callable[[], Any] = lambda: None
+
+    def _log_warn_with_limit(self, msg: str, *args: object) -> None:
+        """Production-verbatim rate-limited WARN helper (KV-H7)."""
+        if msg not in self.log_warn_counters:
+            self.log_warn_counters[msg] = 0
+        if (
+            self.config.log_warn_limit
+            and self.config.log_warn_limit > self.log_warn_counters[msg]
+        ):
+            self.log_warn_counters[msg] += 1
+            self.logger.warning(msg, *args)
+
+    # Bind the real production _listen unbound function to this slim instance.
+    # When invoked via ``self._listen()`` it resolves ``self`` to the stub.
+    _listen = FcmPushClient._listen  # type: ignore[assignment]

--- a/tests/helpers/fcm_poison_stub.py
+++ b/tests/helpers/fcm_poison_stub.py
@@ -17,8 +17,9 @@ test instrumentation fields (``_loop_iteration_count``, ``_last_handled_id``,
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from types import SimpleNamespace
-from typing import Any, Callable
+from typing import Any
 from unittest.mock import AsyncMock
 
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
@@ -100,4 +101,8 @@ class FcmPushClientSlim:
 
     # Bind the real production _listen unbound function to this slim instance.
     # When invoked via ``self._listen()`` it resolves ``self`` to the stub.
+    # Defense 1 was extracted into two helpers (_process_one_inbound_message,
+    # _ack_or_disconnect); bind both so the unbound _listen can reach them.
     _listen = FcmPushClient._listen  # type: ignore[assignment]
+    _process_one_inbound_message = FcmPushClient._process_one_inbound_message  # type: ignore[assignment]
+    _ack_or_disconnect = FcmPushClient._ack_or_disconnect  # type: ignore[assignment]

--- a/tests/test_fcmpushclient_credential_decryption.py
+++ b/tests/test_fcmpushclient_credential_decryption.py
@@ -1,0 +1,124 @@
+# tests/test_fcmpushclient_credential_decryption.py
+"""Direct unit tests for FcmPushClient._decrypt_raw_data credential failures.
+
+Regression suite for CA-CRED-VS-MSG-DECRYPT-001 iter-3 (Codex review on
+commit 14b5a45451): when the cached FCM credential material is structurally
+broken, ``_decrypt_raw_data`` must raise ``CredentialDecryptionError`` (a
+typed subclass of ``ValueError``) so the listener loop's poison-message
+defense can discriminate credential corruption (escalate to supervisor) from
+per-message decode failures (selective-ACK + skip).
+
+The iter-2 implementation used a string-prefix marker ("Credentials ...")
+which silently leaked plain ``ValueError`` from upstream libraries -- most
+notably ``cryptography.hazmat.primitives.serialization.load_der_private_key``
+raising ``ValueError("Could not deserialize key data ...")`` for valid base64
+but invalid DER content. That leak caused the listener to ACK every incoming
+message while silently dropping it. The iter-3 fix wraps every credential
+decode surface and raises ``CredentialDecryptionError`` instead, so the
+discriminator is the exception TYPE rather than the message text.
+"""
+from __future__ import annotations
+
+from base64 import urlsafe_b64encode
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    CredentialDecryptionError,
+    FcmPushClient,
+)
+
+
+def _b64(data: bytes) -> str:
+    """URL-safe base64 string without padding (matches FCM credential format)."""
+    return urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def test_missing_keys_section_raises_typed_error() -> None:
+    """``credentials["keys"]`` absent -> CredentialDecryptionError."""
+    credentials: dict[str, object] = {"gcm": {"app_id": "x"}}
+    with pytest.raises(CredentialDecryptionError, match="missing FCM key material"):
+        FcmPushClient._decrypt_raw_data(
+            credentials, "crypto", "salt", b"raw"
+        )
+
+
+def test_invalid_key_value_types_raise_typed_error() -> None:
+    """``keys.private``/``keys.secret`` non-string -> CredentialDecryptionError."""
+    credentials: dict[str, object] = {
+        "keys": {"private": 42, "secret": None},
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="contain invalid key values"
+    ):
+        FcmPushClient._decrypt_raw_data(
+            credentials, "crypto", "salt", b"raw"
+        )
+
+
+def test_non_base64_key_material_raises_typed_error() -> None:
+    """``keys.private`` not valid base64 -> CredentialDecryptionError, not bare binascii.Error.
+
+    Covers the b64decode failure surface (iter-2 fix). The error chain
+    preserves the original binascii.Error via ``__cause__``.
+    """
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": "###not-base64###",
+            "secret": _b64(b"valid-secret-bytes"),
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed base64 decode"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    # __cause__ chain preserves the underlying binascii.Error for diagnostics.
+    assert exc_info.value.__cause__ is not None
+
+
+def test_corrupted_der_private_key_raises_typed_error() -> None:
+    """Valid base64 but invalid DER content -> CredentialDecryptionError.
+
+    THIS IS THE ITER-3 CODEX REGRESSION. Under the iter-2 string-marker
+    discipline this path leaked a plain ValueError("Could not deserialize key
+    data ...") from cryptography, which the listener loop misinterpreted as
+    per-message poison and silently ACKed every incoming message while
+    dropping all notifications. The iter-3 fix wraps load_der_private_key and
+    re-raises as CredentialDecryptionError so the supervisor can escalate.
+    """
+    # Valid base64 of plausible-length garbage that load_der_private_key will
+    # reject. "deadbeef" * 8 = 64 bytes, looks key-sized but is not DER.
+    fake_der_payload = b"\xde\xad\xbe\xef" * 16
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": _b64(fake_der_payload),
+            "secret": _b64(b"valid-secret-bytes-16b"),
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed DER private-key parse"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    # __cause__ preserves the underlying cryptography error for diagnostics.
+    assert exc_info.value.__cause__ is not None
+
+
+def test_credential_decryption_error_is_value_error_subclass() -> None:
+    """Subclass-of-ValueError contract: backward compat for legacy ``except ValueError``.
+
+    Any external caller that catches broad ValueError still catches
+    CredentialDecryptionError. The listener loop's poison-message defense
+    uses ``isinstance`` discrimination (CredentialDecryptionError first, then
+    ValueError) to enforce the iter-3 propagation contract.
+    """
+    assert issubclass(CredentialDecryptionError, ValueError)
+    try:
+        raise CredentialDecryptionError("test")
+    except ValueError:
+        pass
+    else:
+        pytest.fail("CredentialDecryptionError should be catchable as ValueError")

--- a/tests/test_fcmpushclient_credential_decryption.py
+++ b/tests/test_fcmpushclient_credential_decryption.py
@@ -78,6 +78,56 @@ def test_non_base64_key_material_raises_typed_error() -> None:
     assert exc_info.value.__cause__ is not None
 
 
+def test_non_ascii_in_private_key_raises_typed_error() -> None:
+    """``keys.private`` with non-ASCII bytes -> CredentialDecryptionError.
+
+    THIS IS THE ITER-4 CODEX REGRESSION (commit ae70dccc90). ``.encode("ascii")``
+    on a corrupted cached key value raises ``UnicodeEncodeError`` BEFORE
+    ``urlsafe_b64decode`` is reached. ``UnicodeEncodeError`` is a subclass of
+    ``ValueError`` but NOT of ``binascii.Error``, so the iter-3 catch
+    ``except binascii.Error`` let it through, the listener loop's per-message
+    ValueError handler swallowed it, and every push was selective-ACKed and
+    silently dropped instead of surfacing a credential fault. The iter-4 fix
+    widens the catch to ``(binascii.Error, UnicodeError)``.
+    """
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": "☃snowman",  # non-ASCII -> UnicodeEncodeError on .encode("ascii")
+            "secret": _b64(b"valid-secret-bytes-16b"),
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed base64 decode"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    # __cause__ preserves the underlying UnicodeEncodeError for diagnostics.
+    assert exc_info.value.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__, UnicodeError)
+
+
+def test_non_ascii_in_secret_raises_typed_error() -> None:
+    """``keys.secret`` with non-ASCII bytes -> CredentialDecryptionError.
+
+    Mirror of the iter-4 regression for the secret field: both cred encodes
+    run inside the same try-block, so the same widened catch must apply.
+    """
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": _b64(b"\xde\xad\xbe\xef" * 16),
+            "secret": "café",  # non-ASCII -> UnicodeEncodeError
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed base64 decode"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    assert isinstance(exc_info.value.__cause__, UnicodeError)
+
+
 def test_corrupted_der_private_key_raises_typed_error() -> None:
     """Valid base64 but invalid DER content -> CredentialDecryptionError.
 

--- a/tests/test_fcmpushclient_poison_message.py
+++ b/tests/test_fcmpushclient_poison_message.py
@@ -1,0 +1,394 @@
+# tests/test_fcmpushclient_poison_message.py
+"""Defense 1 (CA-CASCADING-FAILURE-001) Inner-Loop-Hardening tests.
+
+Verifies that ``FcmPushClient._listen`` survives per-message decode failures
+(``binascii.Error`` padding faults under Python 3.14 strict mode,
+``RuntimeError`` from ``_app_data_by_key`` key lookups, generic ``ValueError``
+decode errors) by skipping the offending message with a selective-ack instead
+of crashing the worker loop. Also verifies the cred-error propagation contract:
+``ValueError`` whose message contains "Credentials missing FCM key material"
+or "Invalid key values" is re-raised so the supervisor surfaces it via STOPPED.
+
+The Aggregate-Anti-Cascading-Invariant test runs 100 poison messages followed
+by one valid sentinel and proves Defense 1 prevents the supervisor-restart
+cascade reported on Home Assistant Core 2026.6.x.
+"""
+from __future__ import annotations
+
+import asyncio
+import binascii
+import logging
+import ssl
+from types import SimpleNamespace
+from typing import Iterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClientRunState,
+)
+from tests.helpers.fcm_poison_stub import (
+    FcmPushClientSlim,
+    make_poison_data_message,
+    make_valid_data_message,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _stream_messages(
+    client: FcmPushClientSlim, messages: list[SimpleNamespace]
+) -> AsyncMock:
+    """Build an ``_receive_msg`` mock that yields ``messages`` then stops the loop.
+
+    After the last message the next call returns ``None`` *and* sets
+    ``client.do_listen = False`` so the worker leaves the ``while`` cleanly,
+    just as a real stream end would. Without this the test would hang.
+    """
+    it: Iterator[SimpleNamespace] = iter(messages)
+
+    async def _next() -> SimpleNamespace | None:
+        try:
+            return next(it)
+        except StopIteration:
+            client.do_listen = False
+            return None
+
+    mock = AsyncMock(side_effect=_next)
+    return mock
+
+
+def _make_handle_side_effect(
+    plan: list[BaseException | None],
+    record_handled: list[str] | None = None,
+) -> AsyncMock:
+    """Build a ``_handle_message`` mock that walks ``plan`` per call.
+
+    Each list entry is either an exception instance (raised on that call) or
+    ``None`` (treated as a successful decrypt). If ``record_handled`` is given,
+    successful decrypts append ``msg.persistent_id`` to it.
+    """
+    it = iter(plan)
+
+    async def _impl(msg: SimpleNamespace) -> None:
+        try:
+            step = next(it)
+        except StopIteration as exc:  # plan exhausted -> test bug
+            raise AssertionError(
+                "_handle_message called more often than the plan allows"
+            ) from exc
+        if isinstance(step, BaseException):
+            raise step
+        if record_handled is not None:
+            record_handled.append(msg.persistent_id)
+
+    return AsyncMock(side_effect=_impl)
+
+
+def _outer_catch_was_hit(caplog: pytest.LogCaptureFixture) -> bool:
+    """True iff the ``except Exception`` block at the bottom of ``_listen`` ran.
+
+    Defense 1 must keep the loop from ever reaching that block, so this is the
+    central anti-cascading invariant.
+    """
+    return any(
+        record.levelno == logging.ERROR
+        and "Unknown error in listener" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defense 1: per-message decode failures must not stop the worker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poison_message_does_not_stop_worker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ``binascii.Error`` decrypt failure leaves the outer-catch untouched."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-001", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    assert not _outer_catch_was_hit(caplog)
+    assert client._send_selective_ack.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_poison_message_triggers_selective_ack(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The skipped message is acknowledged so the FCM server stops resending."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-042", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    client._send_selective_ack.assert_awaited_once_with("poison-042")
+
+
+@pytest.mark.asyncio
+async def test_poison_message_logs_warning_not_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The skip path emits a rate-limited WARN, never a traceback ERROR."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-003", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert errors == []
+    assert len(warnings) >= 1
+
+
+@pytest.mark.asyncio
+async def test_poison_message_continues_to_next_message(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """After skipping a poison message the loop processes the next one normally."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    poison = make_poison_data_message("poison-004", kind="padding")
+    valid = make_valid_data_message("valid-005")
+    client._receive_msg = _stream_messages(client, [poison, valid])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding"), None]
+    )
+
+    await client._listen()
+
+    assert client._handle_message.await_count == 2
+    # First call: poison; second call: valid message passed through.
+    second_call_args = client._handle_message.await_args_list[1].args
+    assert second_call_args[0].persistent_id == "valid-005"
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_from_app_data_by_key_caught(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``RuntimeError`` from ``_app_data_by_key`` is treated as poison-class."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-006", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [RuntimeError("couldn't find in app_data crypto-key")]
+    )
+
+    await client._listen()
+
+    assert not _outer_catch_was_hit(caplog)
+    client._send_selective_ack.assert_awaited_once_with("poison-006")
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_kicks_in_after_threshold(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``log_warn_limit`` caps WARN spam at default 5 while still acking each message."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    # Default log_warn_limit in FcmPushClientConfig is 5.
+    assert client.config.log_warn_limit == 5
+
+    messages = [
+        make_poison_data_message(f"poison-{i:03d}", kind="padding")
+        for i in range(20)
+    ]
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")] * 20
+    )
+
+    await client._listen()
+
+    # Format string identical for every iteration -> rate limiter applies once.
+    skip_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "Skipping FCM message that failed to decrypt" in r.getMessage()
+    ]
+    assert len(skip_warnings) == 5
+    # All 20 messages must still be acknowledged (rate limit applies to logs only).
+    assert client._send_selective_ack.await_count == 20
+
+
+@pytest.mark.asyncio
+async def test_writer_dead_during_selective_ack_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An OSError during ack-send stops the loop so the supervisor reconnects."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-007", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=OSError("writer half-dead"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_ssl_error_during_selective_ack_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``ssl.SSLError`` is not always an ``OSError`` subclass -> separate catch."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-008", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=ssl.SSLError("tls dead"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_connection_error_during_selective_ack_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``ConnectionError`` during ack triggers the same shutdown path."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-009", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=ConnectionError("peer gone"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_legitimate_cred_value_error_propagates_to_outer_catch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cred/key-material errors must NOT be swallowed by Defense 1."""
+    caplog.set_level(logging.DEBUG)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-010", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [ValueError("Credentials missing FCM key material")]
+    )
+
+    await client._listen()
+
+    # The outer ``except Exception`` block must have logged the error so the
+    # supervisor knows the worker stopped intentionally; selective-ack must NOT
+    # have been sent (this is a config fault, not a per-message poison).
+    assert _outer_catch_was_hit(caplog)
+    assert client._send_selective_ack.await_count == 0
+    # Worker reaches its terminal state via the finally block.
+    assert client.run_state == FcmPushClientRunState.STOPPED
+
+
+# ---------------------------------------------------------------------------
+# Aggregate Anti-Cascading-Invariant (Iteration-2-L1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_cascading_on_repeated_poison_messages(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """100 poison messages must not cascade into a supervisor restart storm.
+
+    Proves the bug class as a whole: alternating ``binascii.Error`` and
+    ``RuntimeError`` failures on 100 consecutive messages keep the worker in
+    its operational state, every message is acked in order, and the
+    outer-catch is never entered. A final valid sentinel message is processed
+    normally to show the worker is still responsive after the cascade attempt.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+
+    poison_messages = [
+        make_poison_data_message(
+            persistent_id=f"poison-{i:03d}",
+            kind="padding" if i % 2 == 0 else "value",
+        )
+        for i in range(100)
+    ]
+    sentinel = make_valid_data_message("valid-001")
+    messages = poison_messages + [sentinel]
+
+    handled: list[str] = []
+
+    # Per-iteration run_state snapshot via _handle_message side_effect.
+    iter_states: list[FcmPushClientRunState] = []
+
+    plan: list[BaseException | None] = []
+    for i in range(100):
+        if i % 2 == 0:
+            plan.append(binascii.Error("Incorrect padding"))
+        else:
+            plan.append(RuntimeError("couldn't find in app_data crypto-key"))
+    plan.append(None)  # sentinel: valid message passes through
+
+    plan_iter = iter(plan)
+
+    async def _instrumented_handle(msg: SimpleNamespace) -> None:
+        iter_states.append(client.run_state)
+        try:
+            step = next(plan_iter)
+        except StopIteration as exc:
+            raise AssertionError("plan exhausted") from exc
+        if isinstance(step, BaseException):
+            raise step
+        handled.append(msg.persistent_id)
+
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = AsyncMock(side_effect=_instrumented_handle)
+
+    await client._listen()
+
+    # (a) run_state stays STARTED throughout the poison cascade.
+    assert all(state == FcmPushClientRunState.STARTED for state in iter_states), (
+        f"run_state drift during cascade: {iter_states!r}"
+    )
+    # (b) All 100 poison messages acked in order.
+    expected_acks = [f"poison-{i:03d}" for i in range(100)]
+    actual_acks = [call.args[0] for call in client._send_selective_ack.await_args_list]
+    assert actual_acks == expected_acks
+    # (c) Outer catch never entered.
+    assert not _outer_catch_was_hit(caplog)
+    # (d) Sentinel valid message processed normally after the cascade.
+    assert handled == ["valid-001"]

--- a/tests/test_fcmpushclient_poison_message.py
+++ b/tests/test_fcmpushclient_poison_message.py
@@ -6,8 +6,9 @@ Verifies that ``FcmPushClient._listen`` survives per-message decode failures
 ``RuntimeError`` from ``_app_data_by_key`` key lookups, generic ``ValueError``
 decode errors) by skipping the offending message with a selective-ack instead
 of crashing the worker loop. Also verifies the cred-error propagation contract:
-``ValueError`` whose message contains "Credentials missing FCM key material"
-or "Invalid key values" is re-raised so the supervisor surfaces it via STOPPED.
+``ValueError`` whose message starts with the ``"Credentials "`` prefix
+(credential material is missing, structurally invalid, or fails base64 decode)
+is re-raised so the supervisor surfaces it via STOPPED.
 
 The Aggregate-Anti-Cascading-Invariant test runs 100 poison messages followed
 by one valid sentinel and proves Defense 1 prevents the supervisor-restart
@@ -15,13 +16,12 @@ cascade reported on Home Assistant Core 2026.6.x.
 """
 from __future__ import annotations
 
-import asyncio
 import binascii
 import logging
 import ssl
+from collections.abc import Iterator
 from types import SimpleNamespace
-from typing import Iterator
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -33,7 +33,6 @@ from tests.helpers.fcm_poison_stub import (
     make_poison_data_message,
     make_valid_data_message,
 )
-
 
 # ---------------------------------------------------------------------------
 # Test helpers

--- a/tests/test_fcmpushclient_poison_message.py
+++ b/tests/test_fcmpushclient_poison_message.py
@@ -6,9 +6,10 @@ Verifies that ``FcmPushClient._listen`` survives per-message decode failures
 ``RuntimeError`` from ``_app_data_by_key`` key lookups, generic ``ValueError``
 decode errors) by skipping the offending message with a selective-ack instead
 of crashing the worker loop. Also verifies the cred-error propagation contract:
-``ValueError`` whose message starts with the ``"Credentials "`` prefix
-(credential material is missing, structurally invalid, or fails base64 decode)
-is re-raised so the supervisor surfaces it via STOPPED.
+``CredentialDecryptionError`` (credential material is missing, structurally
+invalid, fails base64 decode, or fails DER private-key parse) is re-raised so
+the supervisor surfaces it via STOPPED. Plain ``ValueError`` without that type
+is treated as per-message poison (selective-ACK + skip).
 
 The Aggregate-Anti-Cascading-Invariant test runs 100 poison messages followed
 by one valid sentinel and proves Defense 1 prevents the supervisor-restart
@@ -26,6 +27,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    CredentialDecryptionError,
     FcmPushClientRunState,
 )
 from tests.helpers.fcm_poison_stub import (
@@ -296,16 +298,21 @@ async def test_connection_error_during_selective_ack_falls_through(
 
 
 @pytest.mark.asyncio
-async def test_legitimate_cred_value_error_propagates_to_outer_catch(
+async def test_credential_decryption_error_propagates_to_outer_catch(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Cred/key-material errors must NOT be swallowed by Defense 1."""
+    """Cred/key-material errors must NOT be swallowed by Defense 1.
+
+    CredentialDecryptionError (typed exception) propagates past the
+    per-message ValueError catch. This is the iter-3 contract: the
+    discriminator is the exception TYPE, not a string-prefix marker.
+    """
     caplog.set_level(logging.DEBUG)
     client = FcmPushClientSlim()
     msg = make_poison_data_message("poison-010", kind="value")
     client._receive_msg = _stream_messages(client, [msg])
     client._handle_message = _make_handle_side_effect(
-        [ValueError("Credentials missing FCM key material")]
+        [CredentialDecryptionError("Credentials missing FCM key material")]
     )
 
     await client._listen()
@@ -317,6 +324,39 @@ async def test_legitimate_cred_value_error_propagates_to_outer_catch(
     assert client._send_selective_ack.await_count == 0
     # Worker reaches its terminal state via the finally block.
     assert client.run_state == FcmPushClientRunState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_unmarked_value_error_is_treated_as_per_message_poison(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Plain ValueError without CredentialDecryptionError type = per-message poison.
+
+    Regression for the iter-2 stealth-drop class (CA-CRED-VS-MSG-DECRYPT-001
+    iter-3): under the old string-prefix marker discipline a plain ValueError
+    from upstream libraries (e.g. cryptography.load_der_private_key raising
+    "Could not deserialize key data") would silently drop EVERY incoming
+    message while the listener stayed "healthy". After the iter-3 fix the
+    discriminator is the exception TYPE: untyped ValueError is treated as
+    per-message poison (ACK + skip), only CredentialDecryptionError escalates.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-011", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [ValueError("Could not deserialize key data (the data may be in an "
+                    "incorrect format, the provided password may be incorrect, "
+                    "it may be encrypted with an unsupported algorithm, or it "
+                    "may be an unsupported key type)")]
+    )
+
+    await client._listen()
+
+    # Per-message-poison path: outer catch NOT hit, ACK sent, worker keeps running
+    # until the stream end (do_listen=False from _stream_messages).
+    assert not _outer_catch_was_hit(caplog)
+    client._send_selective_ack.assert_awaited_once_with("poison-011")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hotfix für den 2026.6.x-Memory-Leak (Issue: `Incorrect padding` crash-loop in `fcmpushclient._listen`). Implementiert **AP-1** aus `PLAN_FCM_POISON_MESSAGE_HOTFIX.md` (Defense-1 von vier Verteidigungsebenen).

**Branch-Basis:** `test/coverage-phase-1-registry-lifecycle@c6ff45f` (Version `1.7.0-6`). `main` ist out of scope. Merge-Ziel: derselbe Sammel-Branch; HACS-Release-Tag-Strategie ist nachgelagerte User-Entscheidung.

## Changes

### `Auth/firebase_messaging/fcmpushclient.py` (Z. 760–775 + Top-Import)
- Top-Import `binascii` ergänzt (war nicht vorhanden; Variante B trennt `binascii.Error` von `ValueError`).
- Inner-Loop-Hardening mit **zwei getrennten `except`-Klauseln**:
  - `ValueError` → **Re-Raise** wenn Marker `Credentials missing FCM key material` → Auth-Failure korrekt nach oben propagieren statt zu schlucken.
  - `(binascii.Error, RuntimeError)` → **Skip + selective ACK** der vergifteten Message-ID, damit der Server sie nicht erneut zustellt; Loop läuft weiter.
- `_send_selective_ack(getattr(msg, 'persistent_id', None))` mit `(OSError, ssl.SSLError, ConnectionError)`-Guard (Netzwerkfehler im Ack dürfen den Worker nicht killen).
- Rate-limited Warn-Log via `_log_warn_with_limit` (Default 5/Min) → kein Log-Spam, keine Speicher-Aufblähung.

### `tests/helpers/fcm_poison_stub.py` (NEU, 103 Z.)
- `FcmPushClientSlim`: Composition-Stub, bindet die **echte** `FcmPushClient._listen`-Methode als unbound function → Tests treffen den realen Worker-Loop ohne Inheritance/Mock.

### `tests/test_fcmpushclient_poison_message.py` (NEU, 394 Z., 11 Tests)
- 10 Einzeltests für die drei Fehlerklassen (Padding, ValueError-Marker, RuntimeError) und beide Ack-Pfade.
- 1 Aggregat-Test gegen Cascading-Failure: **100 Poison-Messages + 1 Sentinel**, prüft dass Worker lebt und Sentinel verarbeitet wird (Anti-Cascading-Garantie).

## Plan-Kontext

- Plan: `/app/memory/plans/active/PLAN_FCM_POISON_MESSAGE_HOTFIX.md`
- Backlog-Pivot dokumentiert (BL-002): Pre-Push-Sweep Schritt 6 von kombinierter `except`-Klausel auf zwei getrennte greps + Cred-Re-Raise-Marker + selective-ack-Count ≥ 3 umgestellt.
- Architektur-Backlog persistiert (BL-004 / PA-BRANCH-BASE-001): Sidecar-Pflichtfelder `basis_branch` / `basis_commit` / `basis_version` für Hotfix-Sidecars.

## Test plan

- [ ] CI: pytest 11/11 grün für `tests/test_fcmpushclient_poison_message.py`
- [ ] CI: ruff + mypy clean (KV-H5)
- [ ] CI: Coverage-Floor 66 % gehalten
- [ ] Codex-Review: keine Sprach-Drift, keine fehlenden Pfad-Header, keine Cred-Re-Raise-Regression
- [ ] AP-2..AP-4 (Supervisor-Cap, Receiver-Backoff, Watchdog) folgen in Folge-Commits **in diesem PR** (nicht in eigenen PRs, weil Defense-in-Depth eine Einheit ist)

## R9-Check

- `@{upstream}` = `origin/test/coverage-phase-1-registry-lifecycle` ✅
- `manifest.json` = `1.7.0-6` (Bump auf `1.7.0-7` erfolgt im PR-Abschluss)
- Rollback-Tag: `rollback/pre-fcm-hotfix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Code-architekt skill learnings (post-merge cross-refs)

This hotfix surfaced a new bug-family meta-class. The lesson is persisted into the code-architekt skill so future async-worker reviews catch the pattern automatically:

- **Backlog entry:** `skill_improvements/code-architekt.backlog.md` → `CA-CASCADING-FAILURE-001` (status: **VERDRAHTET** after AP-5).
- **Pattern reference:** `references/production-patterns.md` § 10 — "Inner-Loop-Hardening: poison-message cascade in async worker" (Triple-Defense skeleton + 6-step pre-push sweep).
- **Diagnostic cross-refs:** `references/nygard-error-stability-extrakt.md` NY-02 (Cascading Failure), NY-05 (Chain Reaction), NY-10 (Crack Propagation).
- **Anti-pattern catalogue:** `references/bekannte-irrtuemer.md` → `IRR-CA-POISON-MESSAGE` (three grep-regex detection signatures).
- **Self-audit trigger:** `SKILL.md` → **SA-2c** (Async-Worker-Poison-Message-Sweep) fires on every async-worker class with an outer-catch + supervisor-restart-loop (FCM, Kafka, RabbitMQ, MQTT, SQS consumers).

The pattern generalises language-neutral to any message loop where a single bad payload can latch the entire worker.
