### PR TITLE
fix(fcm): Defense 2 — supervisor short-run crash cap (PLAN_HOTFIX AP-2)

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -412,6 +412,16 @@ class FcmReceiverHA:
         # see no visible fatal state in between (Codex defense-2 iter-8
         # second finding).
         self._short_run_cap_latched: set[str] = set()
+        # Defense 2 iter-16 (Codex follow-up): persistent snapshot of the
+        # cap-fire message per entry. Populated when the cap fires and used
+        # by ``_clear_fatal_error_for_entry`` to restore the cap fatal after
+        # a non-cap fatal (e.g. a terminal 401/404 from a subsequent
+        # re-registration) was cleared. Cleared in the same two places that
+        # release the latch: the healthy-run cleanup branch and any
+        # ``force=True`` teardown. This keeps the per-entry fatal visible to
+        # the coordinator and the diagnostic binary sensor for the entire
+        # latch lifetime, even across non-cap fatal overwrites.
+        self._short_run_cap_messages: dict[str, str] = {}
 
     def _clear_fatal_error_for_entry(
         self,
@@ -470,6 +480,14 @@ class FcmReceiverHA:
             # unrelated fatal but KEEP the cap latch and Repairs UI artefact
             # intact, so the user-visible cap warning is not silently
             # invalidated by an unrelated recovery path.
+            #
+            # Defense 2 iter-16 (Codex follow-up): the per-entry cap-fire
+            # message snapshot (``_short_run_cap_messages``) must be
+            # re-written into ``_fatal_errors`` so the coordinator and the
+            # diagnostic binary sensor continue to see the cap-fatal state
+            # during the recovery/retry window. Otherwise the latch would
+            # silently invalidate the per-entry fatal even though the
+            # in-memory latch and the Repairs UI artefact remain set.
             _LOGGER.debug(
                 "[entry=%s] Cap latch active; clearing non-cap fatal "
                 "(reason=%s) while preserving cap latch and repair issue",
@@ -477,11 +495,18 @@ class FcmReceiverHA:
                 reason or "unspecified",
             )
             self._fatal_errors.pop(entry_id, None)
+            cap_message = self._short_run_cap_messages.get(entry_id)
+            if cap_message is not None:
+                self._fatal_errors[entry_id] = cap_message
             self._fatal_error = next(iter(self._fatal_errors.values()), None)
             return
 
         if force:
             self._short_run_cap_latched.discard(entry_id)
+            # Iter-16: drop the cap-fire snapshot in lockstep with the latch
+            # so a forced teardown also retires the message that the
+            # pass-through branch would otherwise restore.
+            self._short_run_cap_messages.pop(entry_id, None)
 
         removed = False
         if entry_id in self._fatal_errors:
@@ -1274,6 +1299,13 @@ class FcmReceiverHA:
                             # before a real healthy supervisor run proves the
                             # poison message is gone).
                             self._short_run_cap_latched.add(entry_id)
+                            # Iter-16 (Codex follow-up): snapshot the
+                            # cap-fire message so the pass-through clear
+                            # branch in ``_clear_fatal_error_for_entry`` can
+                            # restore it after a non-cap fatal overwrote
+                            # ``_fatal_errors[entry_id]``. Released in the
+                            # same two places that release the latch.
+                            self._short_run_cap_messages[entry_id] = message
                             if self._hass:
                                 ir.async_create_issue(
                                     self._hass,
@@ -1337,6 +1369,11 @@ class FcmReceiverHA:
                         cap_was_latched = entry_id in self._short_run_cap_latched
                         if cap_was_latched:
                             self._short_run_cap_latched.discard(entry_id)
+                            # Iter-16: a healthy run is also the moment to
+                            # retire the cap-fire snapshot so the
+                            # pass-through clear branch cannot re-introduce
+                            # it after the latch is gone.
+                            self._short_run_cap_messages.pop(entry_id, None)
                             cap_message = self._fatal_errors.get(entry_id)
                             if cap_message and cap_message.startswith(
                                 CRASH_LOOP_FATAL_PREFIX

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -167,6 +167,13 @@ _MAX_SUPERVISOR_BACKOFF_S = 120.0    # cap retry delay at 2 minutes (was 4096s)
 _BACKOFF_WARNING_THRESHOLD_S = 64.0  # warn after ~6 failed attempts
 _MAX_FATAL_AUTH_RETRIES = 3       # 401: max retries (60s, 120s, then give up)
 _MAX_FATAL_ENDPOINT_RETRIES = 7   # 404: max retries (30s-300s, Google rotates endpoints)
+# Defense 2: supervisor-level crash cap as a bulkhead around the inner-loop
+# poison-message filter (``fcmpushclient._listen`` Defense 1+3). When the FCM
+# client connects but loses the run-loop within ``_SHORT_RUN_THRESHOLD_S``
+# repeatedly, a persistent poison condition is suspected and the supervisor
+# stops looping to prevent unbounded retry pressure on Google + log spam.
+_MAX_CONSECUTIVE_SHORT_RUNS = 10
+_SHORT_RUN_THRESHOLD_S = 30.0  # strictly < 30s between pc.start() and STOPPED = short run
 _HTTP_UNAUTHORIZED = 401
 _HTTP_NOT_FOUND = 404
 
@@ -756,6 +763,12 @@ class FcmReceiverHA:
                     return False
 
             backoff = 1.0
+            # Defense 2: per-supervisor closure state for the short-run
+            # crash cap. Kept closure-local (not on ``self``) so a
+            # re-registration that cancels this supervisor and spawns a
+            # new one cannot inherit a stale counter (CA-Audit B1).
+            short_run_counter: int = 0
+            entry_start: float = 0.0
             try:
                 while not stop_evt.is_set():
                     pc = await self._ensure_client_for_entry(entry_id, cache)
@@ -919,6 +932,12 @@ class FcmReceiverHA:
                             "[entry=%s] FCM client failed to start: %s", entry_id, err
                         )
 
+                    # Defense 2 snapshot: timestamp the entry into the
+                    # monitor loop. A start-failure-immediate-exit is still
+                    # counted, because the body below breaks out and runs
+                    # the short-run check with ``run_duration ~= 0``.
+                    entry_start = time.monotonic()
+
                     while not stop_evt.is_set():
                         await asyncio.sleep(max(FCM_MONITOR_INTERVAL_S, 0.5))
                         state = getattr(pc, "run_state", None)
@@ -978,6 +997,63 @@ class FcmReceiverHA:
                                 monotonic_now - last_activity,
                             )
                             break
+
+                    # Defense 2: short-run crash cap. Counts consecutive
+                    # monitor exits with ``run_duration <
+                    # _SHORT_RUN_THRESHOLD_S``. After
+                    # ``_MAX_CONSECUTIVE_SHORT_RUNS`` such runs, surface a
+                    # non-fixable repair issue and stop the loop. The
+                    # comparison is strictly ``<`` (a 30.0s run counts as
+                    # healthy and resets the counter).
+                    run_duration = time.monotonic() - entry_start
+                    if run_duration < _SHORT_RUN_THRESHOLD_S:
+                        short_run_counter += 1
+                        # Test hook: expose the closure counter to stubs
+                        # without leaking it onto ``self``.
+                        observe = getattr(pc, "_observe_counter", None)
+                        if callable(observe):
+                            try:
+                                observe(short_run_counter)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        if short_run_counter >= _MAX_CONSECUTIVE_SHORT_RUNS:
+                            message = (
+                                f"FCM short-run crash loop: "
+                                f"{_MAX_CONSECUTIVE_SHORT_RUNS} consecutive "
+                                f"runs ended within "
+                                f"{_SHORT_RUN_THRESHOLD_S:.0f}s "
+                                f"(persistent poison message suspected)"
+                            )
+                            _LOGGER.error("[entry=%s] %s", entry_id, message)
+                            self._fatal_errors[entry_id] = message
+                            if self._hass:
+                                ir.async_create_issue(
+                                    self._hass,
+                                    DOMAIN,
+                                    f"fcm_short_run_crash_loop_{entry_id}",
+                                    is_fixable=False,
+                                    severity=ir.IssueSeverity.ERROR,
+                                    translation_key="fcm_short_run_crash_loop",
+                                )
+                            # Cleanup the client before breaking out so
+                            # the loop exit doesn't leave a half-stopped pc.
+                            try:
+                                await pc.stop()
+                            except Exception:  # noqa: BLE001
+                                pass
+                            finally:
+                                async with self._lock:
+                                    self.pcs.pop(entry_id, None)
+                                self._update_entry_health(entry_id, False)
+                            break
+                    else:
+                        short_run_counter = 0  # healthy run resets the counter
+                        observe = getattr(pc, "_observe_counter", None)
+                        if callable(observe):
+                            try:
+                                observe(short_run_counter)
+                            except Exception:  # noqa: BLE001
+                                pass
 
                     # Cleanup before restart
                     try:

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -160,6 +160,44 @@ else:
 
 _LOGGER = logging.getLogger(__name__)
 
+
+# Iter-12 (Codex follow-up): the short-run crash cap needs to know
+# whether the FCM client ever reached ``FcmPushClientRunState.STARTED``
+# during a run, even when the entire CREATED -> STARTED -> CRASH
+# lifecycle happens between two monitor polls (``FCM_MONITOR_INTERVAL_S``
+# >= 0.5s). Sampling alone is too coarse for the very poison-message
+# loop the cap is meant to stop. A subclass with a ``__setattr__`` hook
+# latches ``_has_been_started`` the moment the vendored library assigns
+# ``run_state = STARTED`` -- independent of any polling cadence and
+# without modifying the vendored library itself. See
+# CA-DEFENSE-OBSERVABILITY-001.
+if HAVE_FCM_PUSH_CLIENT and FcmPushClientRunState is not None:
+
+    class _ObservableFcmPushClient(FcmPushClient):  # type: ignore[misc, valid-type]
+        """FcmPushClient subclass with a run_state observer latch."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            # Seed the latch before super().__init__ so any attribute
+            # assignment performed by the parent's constructor still
+            # routes through our ``__setattr__`` without raising.
+            object.__setattr__(self, "_has_been_started", False)
+            super().__init__(*args, **kwargs)
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            super().__setattr__(name, value)
+            if (
+                name == "run_state"
+                and FcmPushClientRunState is not None
+                and value == FcmPushClientRunState.STARTED
+            ):
+                # ``object.__setattr__`` to avoid recursion through this hook.
+                object.__setattr__(self, "_has_been_started", True)
+
+    _FcmPushClientFactory: type[Any] = _ObservableFcmPushClient
+else:  # pragma: no cover - exercised only when the vendored library is absent
+    _FcmPushClientFactory = FcmPushClient
+
+
 type JSONDict = dict[str, Any]
 type MutableJSONMapping = MutableMapping[str, Any]
 
@@ -813,7 +851,7 @@ class FcmReceiverHA:
                     "CredentialsUpdatedCallable[MutableJSONMapping]",
                     _on_creds_updated_entry,
                 )
-                pc = FcmPushClient(
+                pc = _FcmPushClientFactory(
                     lambda payload,
                     persistent_id,
                     context,
@@ -1062,6 +1100,19 @@ class FcmReceiverHA:
                                 became_started = True
                         elif state == FcmPushClientRunState.STARTED:
                             became_started = True
+                        # Iter-12 (Codex follow-up): sampling-gap defense.
+                        # When the full lifecycle ``CREATED -> STARTED ->
+                        # CRASH`` happens between two monitor polls (>=0.5s),
+                        # this loop reads STOPPED/!do_listen and ``became_started``
+                        # would remain false. The vendored client's
+                        # ``__setattr__`` hook latches ``_has_been_started``
+                        # the moment the library assigns ``run_state =
+                        # STARTED``, independent of polling cadence; mirror
+                        # that observation here so the cap branch correctly
+                        # classifies micro-window poison-message crashes.
+                        became_started = became_started or bool(
+                            getattr(pc, "_has_been_started", False)
+                        )
                         healthy = (
                             (
                                 FcmPushClientRunState is None

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1119,6 +1119,22 @@ class FcmReceiverHA:
                                 async with self._lock:
                                     self.pcs.pop(entry_id, None)
                                 self._update_entry_health(entry_id, False)
+                            # Defense 2 iter-9 (Codex follow-up): the cap is
+                            # a TERMINAL state for this supervisor. ``break``
+                            # alone only exits the inner monitor loop and
+                            # falls through to the per-iteration restart
+                            # block (``if not stop_evt.is_set(): ...
+                            # _nudge_sleep(delay)``), which would spawn a
+                            # fresh FCM client and continue the retry
+                            # pressure / log spam the cap is meant to stop.
+                            # Set the stop event so the outer ``while not
+                            # stop_evt.is_set()`` exits, and pop the entry
+                            # from ``_stop_evts`` so a legitimate
+                            # re-registration / reload (which constructs a
+                            # fresh event via ``setdefault``) is not
+                            # short-circuited by the now-consumed event.
+                            stop_evt.set()
+                            self._stop_evts.pop(entry_id, None)
                             break
                     else:
                         short_run_counter = 0  # healthy run resets the counter

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -255,6 +255,22 @@ _SHORT_RUN_THRESHOLD_S = 30.0  # strictly < 30s between pc.start() and STOPPED =
 _HTTP_UNAUTHORIZED = 401
 _HTTP_NOT_FOUND = 404
 
+# Defense 2 iter-14 (Codex follow-up): the supervisor-level crash cap writes
+# its terminal state into ``_fatal_errors[entry_id]`` so the binary_sensor
+# diagnostic attribute and the "is FCM ready" check in
+# ``coordinator/polling.py`` see the listener as unavailable. However, the
+# coordinator's re-auth escalation in ``coordinator/polling.py`` also consumes
+# that map and, after _FCM_ERROR_RETRY_THRESHOLD consecutive update cycles,
+# raises ``ConfigEntryAuthFailed`` for ANY non-auth fatal it does not
+# explicitly classify. The crash-loop fatal is NOT an auth problem
+# (the user must reload / regenerate credentials per the repair issue, not
+# re-authenticate). To prevent users from being pushed into Home Assistant's
+# re-auth flow for what is really a poison-message defense, the cap-fire
+# branch tags its message with this prefix and the polling-side consumer
+# excludes it from the re-auth escalation. This module is the SSOT for the
+# prefix; the polling-side consumer imports it from here.
+CRASH_LOOP_FATAL_PREFIX = "FCM short-run crash loop:"
+
 
 async def _call_in_executor[**P, T](
     func: Callable[P, T], /, *args: P.args, **kwargs: P.kwargs
@@ -434,13 +450,13 @@ class FcmReceiverHA:
         dropped.
         """
 
-        cap_message_prefix = "FCM short-run crash loop:"
-
         if not force and entry_id in self._short_run_cap_latched:
             current_fatal = self._fatal_errors.get(entry_id)
             # No fatal stored, or the stored fatal IS the cap message:
             # preserve everything (latch, message, Repairs UI artefact).
-            if current_fatal is None or current_fatal.startswith(cap_message_prefix):
+            if current_fatal is None or current_fatal.startswith(
+                CRASH_LOOP_FATAL_PREFIX
+            ):
                 _LOGGER.debug(
                     "[entry=%s] Skipping fatal-error clear; short-run cap latch "
                     "active (reason=%s). Latch will be released by a healthy "
@@ -1243,7 +1259,7 @@ class FcmReceiverHA:
                                 pass
                         if short_run_counter >= _MAX_CONSECUTIVE_SHORT_RUNS:
                             message = (
-                                f"FCM short-run crash loop: "
+                                f"{CRASH_LOOP_FATAL_PREFIX} "
                                 f"{_MAX_CONSECUTIVE_SHORT_RUNS} consecutive "
                                 f"runs ended within "
                                 f"{_SHORT_RUN_THRESHOLD_S:.0f}s "
@@ -1323,7 +1339,7 @@ class FcmReceiverHA:
                             self._short_run_cap_latched.discard(entry_id)
                             cap_message = self._fatal_errors.get(entry_id)
                             if cap_message and cap_message.startswith(
-                                "FCM short-run crash loop:"
+                                CRASH_LOOP_FATAL_PREFIX
                             ):
                                 self._fatal_errors.pop(entry_id, None)
                                 self._fatal_error = next(

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -302,7 +302,16 @@ class FcmReceiverHA:
     def _clear_fatal_error_for_entry(
         self, entry_id: str, *, reason: str | None = None
     ) -> None:
-        """Clear any latched fatal registration error for a config entry."""
+        """Clear any latched fatal registration error for a config entry.
+
+        Also removes the Defense 2 short-run-crash-loop repair issue from the
+        Home Assistant Issue Registry. The fatal-error map and the Issue
+        Registry entry are a CREATE/DELETE pair: any recovery path that clears
+        the in-memory latch must also delete the user-visible UI artefact, or
+        the Repairs panel keeps a stale non-fixable error after the underlying
+        condition is gone (e.g. user re-registers credentials and FCM starts
+        successfully again).
+        """
 
         removed = False
         if entry_id in self._fatal_errors:
@@ -318,6 +327,18 @@ class FcmReceiverHA:
 
         if removed:
             self._fatal_error = next(iter(self._fatal_errors.values()), None)
+
+        if self._hass is not None:
+            try:
+                ir.async_delete_issue(
+                    self._hass, DOMAIN, f"fcm_short_run_crash_loop_{entry_id}"
+                )
+            except Exception:  # noqa: BLE001 - best-effort UI cleanup
+                _LOGGER.debug(
+                    "[entry=%s] Failed to delete short-run repair issue",
+                    entry_id,
+                    exc_info=True,
+                )
 
     @staticmethod
     def _ensure_cache_entry_id(cache: Any, entry_id: str) -> None:
@@ -1052,6 +1073,19 @@ class FcmReceiverHA:
                         if callable(observe):
                             try:
                                 observe(short_run_counter)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        # Mirror the counter reset in the Issue Registry: if
+                        # the cap had previously fired on a prior supervisor
+                        # incarnation, a healthy run is the user-visible
+                        # signal that the condition is gone.
+                        if self._hass is not None:
+                            try:
+                                ir.async_delete_issue(
+                                    self._hass,
+                                    DOMAIN,
+                                    f"fcm_short_run_crash_loop_{entry_id}",
+                                )
                             except Exception:  # noqa: BLE001
                                 pass
 

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -299,8 +299,32 @@ class FcmReceiverHA:
         # Per-entry nudge events: allows coordinator to wake up a sleeping supervisor
         self._retry_nudge_evts: dict[str, asyncio.Event] = {}
 
+        # Defense 2 iter-8: persistent short-run cap latch.
+        #
+        # When the cap fires the entry is in a *poison-message crash loop*
+        # that only a real healthy supervisor run (>= _SHORT_RUN_THRESHOLD_S)
+        # can prove gone. A successful FCM re-registration alone is NOT a
+        # proof: registration only contacts the GCM endpoint, it does not
+        # show that the subsequent listener stays up long enough to drain
+        # the poisoned notification.
+        #
+        # The latch is therefore set together with the user-visible repair
+        # issue at cap-fire time and is the *only* thing that gates whether
+        # ``_clear_fatal_error_for_entry`` (which gets called from every
+        # registration-success path) is allowed to drop the fatal-error map
+        # entry and the Repairs UI artefact. Without this latch, any reload
+        # or credential update would clear the cap-related fatal state, the
+        # supervisor would start a fresh 10-run burst, and the user would
+        # see no visible fatal state in between (Codex defense-2 iter-8
+        # second finding).
+        self._short_run_cap_latched: set[str] = set()
+
     def _clear_fatal_error_for_entry(
-        self, entry_id: str, *, reason: str | None = None
+        self,
+        entry_id: str,
+        *,
+        reason: str | None = None,
+        force: bool = False,
     ) -> None:
         """Clear any latched fatal registration error for a config entry.
 
@@ -311,7 +335,29 @@ class FcmReceiverHA:
         the Repairs panel keeps a stale non-fixable error after the underlying
         condition is gone (e.g. user re-registers credentials and FCM starts
         successfully again).
+
+        Defense 2 iter-8 (Codex second finding): a successful FCM
+        re-registration is NOT a recovery proof for the short-run crash cap.
+        While ``_short_run_cap_latched`` contains *entry_id* this method is a
+        no-op (the cap latch and the Repairs UI artefact persist), so users
+        keep seeing the fatal state until a real healthy supervisor run
+        (>= _SHORT_RUN_THRESHOLD_S) drops the latch from the monitor loop.
+        Hard-reset callers (entry unregister, test cleanup, integration
+        teardown) must opt in with ``force=True``.
         """
+
+        if not force and entry_id in self._short_run_cap_latched:
+            _LOGGER.debug(
+                "[entry=%s] Skipping fatal-error clear; short-run cap latch "
+                "active (reason=%s). Latch will be released by a healthy "
+                "supervisor run.",
+                entry_id,
+                reason or "unspecified",
+            )
+            return
+
+        if force:
+            self._short_run_cap_latched.discard(entry_id)
 
         removed = False
         if entry_id in self._fatal_errors:
@@ -1047,6 +1093,13 @@ class FcmReceiverHA:
                             )
                             _LOGGER.error("[entry=%s] %s", entry_id, message)
                             self._fatal_errors[entry_id] = message
+                            # Defense 2 iter-8: latch the cap state. While
+                            # this latch is set, ``_clear_fatal_error_for_entry``
+                            # is a no-op (registration / credential-update paths
+                            # cannot clear the fatal map or the Repairs issue
+                            # before a real healthy supervisor run proves the
+                            # poison message is gone).
+                            self._short_run_cap_latched.add(entry_id)
                             if self._hass:
                                 ir.async_create_issue(
                                     self._hass,
@@ -1079,6 +1132,34 @@ class FcmReceiverHA:
                         # the cap had previously fired on a prior supervisor
                         # incarnation, a healthy run is the user-visible
                         # signal that the condition is gone.
+                        #
+                        # Defense 2 iter-8: a healthy run is the ONLY proof
+                        # the system has that the poison-message condition is
+                        # gone, so this is also the only callsite that may
+                        # drop the cap latch. After dropping the latch, the
+                        # cap-related ``_fatal_errors`` entry is removed and
+                        # the aggregate ``_fatal_error`` re-derived (so the
+                        # System Health surface stops showing the stale
+                        # message). The Repairs delete below stays inside
+                        # ``self._hass is not None`` and intentionally also
+                        # runs when no latch was set (cheap idempotent UI
+                        # cleanup).
+                        cap_was_latched = entry_id in self._short_run_cap_latched
+                        if cap_was_latched:
+                            self._short_run_cap_latched.discard(entry_id)
+                            cap_message = self._fatal_errors.get(entry_id)
+                            if cap_message and cap_message.startswith(
+                                "FCM short-run crash loop:"
+                            ):
+                                self._fatal_errors.pop(entry_id, None)
+                                self._fatal_error = next(
+                                    iter(self._fatal_errors.values()), None
+                                )
+                                _LOGGER.info(
+                                    "[entry=%s] FCM short-run cap latch released "
+                                    "by healthy supervisor run",
+                                    entry_id,
+                                )
                         if self._hass is not None:
                             try:
                                 ir.async_delete_issue(
@@ -1441,7 +1522,12 @@ class FcmReceiverHA:
             else:
                 self._entry_caches.pop(entry_id, None)
                 self._purge_entry_tokens(entry_id)
-                self._clear_fatal_error_for_entry(entry_id, reason="Entry unregistered")
+                # Hard-reset on unregister: the entry is going away, so the
+                # short-run cap latch must be released together with the
+                # fatal-error map and the Repairs issue (force=True).
+                self._clear_fatal_error_for_entry(
+                    entry_id, reason="Entry unregistered", force=True
+                )
 
     # -------------------- Incoming notifications --------------------
 

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -172,9 +172,18 @@ _LOGGER = logging.getLogger(__name__)
 # without modifying the vendored library itself. See
 # CA-DEFENSE-OBSERVABILITY-001.
 if HAVE_FCM_PUSH_CLIENT and FcmPushClientRunState is not None:
+    # Snapshot of the original class for runtime identity comparison.
+    # Tests substitute the module-level ``FcmPushClient`` symbol via
+    # monkeypatch (the documented seam) to inject test doubles; the
+    # factory below honours that substitution by class identity, not by
+    # subclass relation. See CA-SUBCLASS-IDENTITY-001.
+    _OriginalFcmPushClient: type[Any] | None = FcmPushClient
 
-    class _ObservableFcmPushClient(FcmPushClient):  # type: ignore[misc, valid-type]
-        """FcmPushClient subclass with a run_state observer latch."""
+    class _ObservableFcmPushClient(FcmPushClient[Any]):
+        """FcmPushClient subclass with a run_state observer latch.
+
+        See CA-DEFENSE-OBSERVABILITY-001.
+        """
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             # Seed the latch before super().__init__ so any attribute
@@ -193,9 +202,40 @@ if HAVE_FCM_PUSH_CLIENT and FcmPushClientRunState is not None:
                 # ``object.__setattr__`` to avoid recursion through this hook.
                 object.__setattr__(self, "_has_been_started", True)
 
-    _FcmPushClientFactory: type[Any] = _ObservableFcmPushClient
+    _ObservableFcmPushClientCls: type[Any] | None = _ObservableFcmPushClient
 else:  # pragma: no cover - exercised only when the vendored library is absent
-    _FcmPushClientFactory = FcmPushClient
+    _OriginalFcmPushClient = None
+    _ObservableFcmPushClientCls = None
+
+
+def _FcmPushClientFactory(*args: Any, **kwargs: Any) -> FcmPushClient[Any]:
+    """Construct an FCM client at call time, honouring test substitutions.
+
+    Production: prefers the ``_ObservableFcmPushClient`` subclass so the
+    short-run crash cap can observe ``run_state -> STARTED`` transitions
+    that happen between monitor polls (CA-DEFENSE-OBSERVABILITY-001).
+
+    Tests: when the module-level ``FcmPushClient`` symbol has been
+    monkeypatched away from the original class (the documented test
+    seam), the factory instantiates the patched class DIRECTLY rather
+    than the production subclass. This preserves ``isinstance`` identity
+    for test doubles (CA-SUBCLASS-IDENTITY-001) instead of returning a
+    subclass that diverges from the patched symbol.
+    """
+
+    current = globals().get("FcmPushClient")
+    if (
+        _ObservableFcmPushClientCls is not None
+        and _OriginalFcmPushClient is not None
+        and current is _OriginalFcmPushClient
+    ):
+        return cast(
+            "FcmPushClient[Any]",
+            _ObservableFcmPushClientCls(*args, **kwargs),
+        )
+    if current is None:  # pragma: no cover - vendored library missing
+        raise RuntimeError("FcmPushClient is not available")
+    return cast("FcmPushClient[Any]", current(*args, **kwargs))
 
 
 type JSONDict = dict[str, Any]

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -338,22 +338,52 @@ class FcmReceiverHA:
 
         Defense 2 iter-8 (Codex second finding): a successful FCM
         re-registration is NOT a recovery proof for the short-run crash cap.
-        While ``_short_run_cap_latched`` contains *entry_id* this method is a
-        no-op (the cap latch and the Repairs UI artefact persist), so users
-        keep seeing the fatal state until a real healthy supervisor run
-        (>= _SHORT_RUN_THRESHOLD_S) drops the latch from the monitor loop.
-        Hard-reset callers (entry unregister, test cleanup, integration
-        teardown) must opt in with ``force=True``.
+        While ``_short_run_cap_latched`` contains *entry_id* this method must
+        protect the cap state (latched fatal message + Repairs UI artefact)
+        from being silently cleared, so users keep seeing the fatal state
+        until a real healthy supervisor run (>= _SHORT_RUN_THRESHOLD_S) drops
+        the latch from the monitor loop. Hard-reset callers (entry unregister,
+        test cleanup, integration teardown) must opt in with ``force=True``.
+
+        Defense 2 iter-10 (Codex follow-up): the latch guard is intentionally
+        narrow. It is a no-op ONLY when the currently stored fatal IS the
+        cap-related message (``FCM short-run crash loop: ...``). Non-cap fatal
+        errors (e.g. a terminal 401/404 from a subsequent re-registration that
+        overwrote ``_fatal_errors[entry_id]``) must clear normally so a
+        credentials recovery is not blocked by an unrelated latch. The cap
+        latch, any cap-related fatal it still protects, and the Repairs UI
+        artefact remain in place in that case; only the unrelated fatal is
+        dropped.
         """
 
+        cap_message_prefix = "FCM short-run crash loop:"
+
         if not force and entry_id in self._short_run_cap_latched:
+            current_fatal = self._fatal_errors.get(entry_id)
+            # No fatal stored, or the stored fatal IS the cap message:
+            # preserve everything (latch, message, Repairs UI artefact).
+            if current_fatal is None or current_fatal.startswith(cap_message_prefix):
+                _LOGGER.debug(
+                    "[entry=%s] Skipping fatal-error clear; short-run cap latch "
+                    "active (reason=%s). Latch will be released by a healthy "
+                    "supervisor run.",
+                    entry_id,
+                    reason or "unspecified",
+                )
+                return
+
+            # Non-cap fatal stored while the cap latch is active. Clear the
+            # unrelated fatal but KEEP the cap latch and Repairs UI artefact
+            # intact, so the user-visible cap warning is not silently
+            # invalidated by an unrelated recovery path.
             _LOGGER.debug(
-                "[entry=%s] Skipping fatal-error clear; short-run cap latch "
-                "active (reason=%s). Latch will be released by a healthy "
-                "supervisor run.",
+                "[entry=%s] Cap latch active; clearing non-cap fatal "
+                "(reason=%s) while preserving cap latch and repair issue",
                 entry_id,
                 reason or "unspecified",
             )
+            self._fatal_errors.pop(entry_id, None)
+            self._fatal_error = next(iter(self._fatal_errors.values()), None)
             return
 
         if force:

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1030,10 +1030,20 @@ class FcmReceiverHA:
                         )
 
                     # Defense 2 snapshot: timestamp the entry into the
-                    # monitor loop. A start-failure-immediate-exit is still
-                    # counted, because the body below breaks out and runs
-                    # the short-run check with ``run_duration ~= 0``.
+                    # monitor loop.
+                    #
+                    # Iter-11 (Codex follow-up): per-run latch tracking
+                    # whether the client ever reached a connected/listening
+                    # state. The cap is meant to detect a poison-message
+                    # crash loop (client connects, decodes, dies, repeat),
+                    # NOT ordinary connectivity outages where ``_listen()``
+                    # exhausts its 5 connection retries (~15-20s) without
+                    # ever reaching ``STARTED``. Without this gate, a normal
+                    # MCS-unreachable / Google outage would cap the
+                    # supervisor after 10 brief connection-failure runs and
+                    # permanently disable FCM push until reload.
                     entry_start = time.monotonic()
+                    became_started = False
 
                     while not stop_evt.is_set():
                         await asyncio.sleep(max(FCM_MONITOR_INTERVAL_S, 0.5))
@@ -1044,6 +1054,14 @@ class FcmReceiverHA:
                             entry_id, pc, monotonic_now
                         )
                         stale_after = max(self._activity_stale_after_s, 0.0)
+                        # Iter-11: track ``became_started`` symmetrically to
+                        # the health probe (same fallback for libraries that
+                        # do not expose a ``run_state`` enum).
+                        if FcmPushClientRunState is None:
+                            if do_listen:
+                                became_started = True
+                        elif state == FcmPushClientRunState.STARTED:
+                            became_started = True
                         healthy = (
                             (
                                 FcmPushClientRunState is None
@@ -1097,13 +1115,32 @@ class FcmReceiverHA:
 
                     # Defense 2: short-run crash cap. Counts consecutive
                     # monitor exits with ``run_duration <
-                    # _SHORT_RUN_THRESHOLD_S``. After
+                    # _SHORT_RUN_THRESHOLD_S`` THAT ALSO reached
+                    # ``STARTED`` at least once during the run. After
                     # ``_MAX_CONSECUTIVE_SHORT_RUNS`` such runs, surface a
                     # non-fixable repair issue and stop the loop. The
                     # comparison is strictly ``<`` (a 30.0s run counts as
                     # healthy and resets the counter).
+                    #
+                    # Iter-11 (Codex follow-up): the ``became_started`` gate
+                    # ensures the cap is specific to the poison-message
+                    # scenario (client connects, decodes, dies, repeat) and
+                    # excludes pre-start connection/login failures. A burst
+                    # of MCS-unreachable failures (5 retries x ~3-4s each)
+                    # would otherwise be counted as short-run crashes and
+                    # permanently disable FCM push after one ordinary
+                    # network outage. Pre-start failures leave the counter
+                    # AND the latch UNTOUCHED so that (a) a poison-message
+                    # cascade interleaved with outages still accumulates
+                    # correctly, and (b) a long pre-start hang does not
+                    # falsely clear a real cap latch (no healthy proof).
                     run_duration = time.monotonic() - entry_start
-                    if run_duration < _SHORT_RUN_THRESHOLD_S:
+                    if not became_started:
+                        # Pre-start failure (no connected/listening state
+                        # observed during this run). Do NOT touch the
+                        # short-run counter or the cap latch.
+                        pass
+                    elif run_duration < _SHORT_RUN_THRESHOLD_S:
                         short_run_counter += 1
                         # Test hook: expose the closure counter to stubs
                         # without leaking it onto ``self``.

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -155,6 +155,7 @@ class PollingOperations(_MixinBase):
     _fcm_status_changed_at: float | None
     _force_device_list_reason: str | None
     _short_retry_cancel: Callable[[], None] | None
+    _fcm_error_count: int
     _fcm_last_error: str | None
     _last_transient_auth_error: str | None
     _is_polling: bool

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -45,6 +45,7 @@ from homeassistant.core import Event
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from ..Auth.fcm_receiver_ha import CRASH_LOOP_FATAL_PREFIX
 from ..const import (
     DEVICE_LIST_POLL_INTERVAL,
     DOMAIN,
@@ -79,6 +80,42 @@ from .helpers.update import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# Iter-14 (Codex follow-up): re-auth-escalation classification SSOT.
+# The FCM receiver's ``_fatal_errors`` map is a shared channel: it carries
+# both classic auth fatals (401/404 with credentials issues, raise
+# ``ConfigEntryAuthFailed`` immediately or after _FCM_ERROR_RETRY_THRESHOLD
+# cycles) and supervisor-level "short-run crash loop" fatals (poison
+# message defense; user must reload / regenerate credentials per the
+# repair issue, NOT re-authenticate). Without this classification the
+# crash-loop fatal would be reclassified as an auth fatal after 3 cycles
+# and push users into HA's re-auth flow. Keep this as a free function so
+# branch-coverage tests can pin the classification contract without
+# spinning up the full update coroutine.
+_FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED = "crash_loop_excluded"
+_FCM_FATAL_CLASS_AUTH_IMMEDIATE = "auth_immediate"
+_FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD = "auth_after_threshold"
+
+
+def _classify_fcm_fatal(fatal_error: str) -> str:
+    """Classify a non-empty FCM fatal error for the re-auth escalation.
+
+    Returns one of:
+      - ``_FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED``: supervisor-level
+        short-run cap; excluded from re-auth (repair issue carries the
+        user-visible guidance).
+      - ``_FCM_FATAL_CLASS_AUTH_IMMEDIATE``: classic auth fatal that
+        should raise ``ConfigEntryAuthFailed`` immediately.
+      - ``_FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD``: unclassified non-cap
+        fatal; count and escalate after _FCM_ERROR_RETRY_THRESHOLD
+        consecutive update cycles.
+    """
+    if fatal_error.startswith(CRASH_LOOP_FATAL_PREFIX):
+        return _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+    if _is_fatal_fcm_auth_error_impl(fatal_error):
+        return _FCM_FATAL_CLASS_AUTH_IMMEDIATE
+    return _FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD
 
 # Cooldown constants for crowdsourced reports
 _COOLDOWN_MIN_IN_ALL_AREAS_S = 10 * 60  # 10 minutes
@@ -576,43 +613,65 @@ class PollingOperations(_MixinBase):
                     fatal_error = fatal_by_entry.get(entry_id)
 
             if isinstance(fatal_error, str) and fatal_error:
-                # Check if this is a fatal auth error that should fail immediately
-                # (e.g., 404/401 with credentials issues - no point retrying)
-                is_fatal_auth = _is_fatal_fcm_auth_error_impl(fatal_error)
+                # Iter-14 (Codex follow-up, channel-confusion): the FCM
+                # receiver's supervisor-level "short-run crash loop" cap
+                # publishes its terminal state into the SAME ``_fatal_errors``
+                # map this re-auth escalation consumes. That defense is a
+                # poison-message bulkhead (the user has to reload or
+                # regenerate credentials per the repair issue, NOT
+                # re-authenticate). Classify the fatal first so a cap-fired
+                # listener-lifecycle fatal does not get reclassified as an
+                # auth fatal after _FCM_ERROR_RETRY_THRESHOLD cycles and
+                # push users into Home Assistant's re-auth flow.
+                fatal_class = _classify_fcm_fatal(fatal_error)
 
-                if is_fatal_auth:
-                    # Fatal auth errors - fail immediately, no retry
-                    _LOGGER.error(
-                        "Fatal FCM authentication error: %s. Triggering re-authentication.",
-                        fatal_error,
-                    )
-                    self._set_auth_state(failed=True, reason=fatal_error)
-                    raise ConfigEntryAuthFailed(fatal_error)
-
-                # Track consecutive FCM errors for transient issues
-                if fatal_error != self._fcm_last_error:
-                    # New error type, reset counter
-                    self._fcm_error_count = 1
-                    self._fcm_last_error = fatal_error
+                if fatal_class == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED:
+                    # Reset any partial auth-error count so a later,
+                    # unrelated auth fatal starts from zero rather than
+                    # inheriting a stale count from the crash-loop window.
+                    if self._fcm_error_count > 0:
+                        _LOGGER.debug(
+                            "FCM crash-loop fatal observed; resetting auth-"
+                            "error counter (was %d). Repair issue surfaces "
+                            "guidance, no re-auth.",
+                            self._fcm_error_count,
+                        )
+                        self._fcm_error_count = 0
+                        self._fcm_last_error = None
                 else:
-                    self._fcm_error_count += 1
+                    if fatal_class == _FCM_FATAL_CLASS_AUTH_IMMEDIATE:
+                        # Fatal auth errors - fail immediately, no retry
+                        _LOGGER.error(
+                            "Fatal FCM authentication error: %s. Triggering re-authentication.",
+                            fatal_error,
+                        )
+                        self._set_auth_state(failed=True, reason=fatal_error)
+                        raise ConfigEntryAuthFailed(fatal_error)
 
-                # Only trigger re-auth after _FCM_ERROR_RETRY_THRESHOLD consecutive failures
-                if self._fcm_error_count >= _FCM_ERROR_RETRY_THRESHOLD:
-                    _LOGGER.error(
-                        "FCM error persisted after %d attempts: %s. Triggering re-authentication.",
-                        self._fcm_error_count,
-                        fatal_error,
-                    )
-                    self._set_auth_state(failed=True, reason=fatal_error)
-                    raise ConfigEntryAuthFailed(fatal_error)
-                else:
-                    _LOGGER.warning(
-                        "FCM error detected (%d/%d): %s. Will retry before triggering re-auth.",
-                        self._fcm_error_count,
-                        _FCM_ERROR_RETRY_THRESHOLD,
-                        fatal_error,
-                    )
+                    # Track consecutive FCM errors for transient issues
+                    if fatal_error != self._fcm_last_error:
+                        # New error type, reset counter
+                        self._fcm_error_count = 1
+                        self._fcm_last_error = fatal_error
+                    else:
+                        self._fcm_error_count += 1
+
+                    # Only trigger re-auth after _FCM_ERROR_RETRY_THRESHOLD consecutive failures
+                    if self._fcm_error_count >= _FCM_ERROR_RETRY_THRESHOLD:
+                        _LOGGER.error(
+                            "FCM error persisted after %d attempts: %s. Triggering re-authentication.",
+                            self._fcm_error_count,
+                            fatal_error,
+                        )
+                        self._set_auth_state(failed=True, reason=fatal_error)
+                        raise ConfigEntryAuthFailed(fatal_error)
+                    else:
+                        _LOGGER.warning(
+                            "FCM error detected (%d/%d): %s. Will retry before triggering re-auth.",
+                            self._fcm_error_count,
+                            _FCM_ERROR_RETRY_THRESHOLD,
+                            fatal_error,
+                        )
             # No error - reset counter on successful check
             elif self._fcm_error_count > 0:
                 _LOGGER.debug(

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM Push Crash Loop Detected",
+      "description": "The FCM push client repeatedly disconnects within seconds of connecting (short-run crash loop). This is most often caused by a persistent poison notification on the inbound queue that cannot be decoded.\n\n1. Reload the integration to clear the run state.\n2. If the issue returns, regenerate your `secrets.json` (Google may have rotated credentials)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM-Push-Abbruchschleife erkannt",
+      "description": "Der FCM-Push-Client trennt die Verbindung wiederholt innerhalb weniger Sekunden nach dem Verbindungsaufbau (Short-Run-Crash-Schleife). Üblicherweise wird das durch eine persistente, nicht dekodierbare Push-Nachricht in der eingehenden Warteschlange ausgelöst.\n\n1. Laden Sie die Integration neu, um den Laufzustand zurückzusetzen.\n2. Falls das Problem erneut auftritt: Erneuern Sie Ihre `secrets.json` (Google könnte Anmeldedaten rotiert haben)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM Push Crash Loop Detected",
+      "description": "The FCM push client repeatedly disconnects within seconds of connecting (short-run crash loop). This is most often caused by a persistent poison notification on the inbound queue that cannot be decoded.\n\n1. Reload the integration to clear the run state.\n2. If the issue returns, regenerate your `secrets.json` (Google may have rotated credentials)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Bucle de fallos de FCM Push detectado",
+      "description": "El cliente push de FCM se desconecta repetidamente a los pocos segundos de conectarse (bucle de fallos cortos). Esto suele estar causado por una notificación corrupta persistente en la cola entrante que no se puede decodificar.\n\n1. Recarga la integración para limpiar el estado de ejecución.\n2. Si el problema vuelve, regenera tu `secrets.json` (Google podría haber rotado las credenciales)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Boucle de plantage FCM Push détectée",
+      "description": "Le client push FCM se déconnecte à plusieurs reprises quelques secondes après s’être connecté (boucle de plantage court). Cela est généralement causé par une notification persistante corrompue dans la file d’attente entrante qui ne peut pas être décodée.\n\n1. Rechargez l’intégration pour réinitialiser l’état d’exécution.\n2. Si le problème revient, régénérez votre `secrets.json` (Google peut avoir rotaté les identifiants)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "לולאת קריסה של FCM Push זוהתה",
+      "description": "לקוח ה-FCM Push מתנתק שוב ושוב תוך שניות לאחר ההתחברות (לולאת קריסה קצרה). הסיבה השכיחה היא הודעה פגומה מתמשכת בתור הנכנס שלא ניתן לפענח.\n\n1. טען מחדש את האינטגרציה כדי לנקות את מצב הריצה.\n2. אם הבעיה חוזרת, חולל מחדש את `secrets.json` (ייתכן ש-Google סובב את האישורים)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Rilevato ciclo di crash di FCM Push",
+      "description": "Il client push FCM si disconnette ripetutamente entro pochi secondi dalla connessione (ciclo di crash brevi). La causa più comune è una notifica persistente corrotta nella coda in arrivo che non può essere decodificata.\n\n1. Ricarica l’integrazione per ripristinare lo stato di esecuzione.\n2. Se il problema si ripresenta, rigenera il tuo `secrets.json` (Google potrebbe aver ruotato le credenziali)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM Push crash-lus gedetecteerd",
+      "description": "De FCM push-client verbreekt herhaaldelijk binnen enkele seconden na het verbinden de verbinding (short-run crash-lus). Dit wordt meestal veroorzaakt door een aanhoudende beschadigde melding in de inkomende wachtrij die niet kan worden gedecodeerd.\n\n1. Laad de integratie opnieuw om de looptijdstatus te wissen.\n2. Als het probleem terugkeert, regenereer je `secrets.json` (Google kan de inloggegevens hebben gerouleerd)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Wykryto pętlę awarii FCM Push",
+      "description": "Klient push FCM wielokrotnie rozłącza się w ciągu kilku sekund od połączenia (pętla krótkich awarii). Najczęstszą przyczyną jest trwałe uszkodzone powiadomienie w kolejce przychodzącej, którego nie można zdekodować.\n\n1. Załaduj ponownie integrację, aby wyczyścić stan działania.\n2. Jeśli problem powraca, wygeneruj ponownie plik `secrets.json` (Google mógł zmienić dane uwierzytelniające)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Detectado ciclo de falhas no FCM Push",
+      "description": "O cliente push do FCM se desconecta repetidamente segundos após conectar (ciclo de falhas curtas). Geralmente isso é causado por uma notificação persistente corrompida na fila de entrada que não pode ser decodificada.\n\n1. Recarregue a integração para limpar o estado de execução.\n2. Se o problema voltar, regenere seu `secrets.json` (o Google pode ter rotacionado as credenciais)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Detetado ciclo de falhas do FCM Push",
+      "description": "O cliente push do FCM desliga-se repetidamente segundos após a ligação (ciclo de falhas curtas). Normalmente é causado por uma notificação persistente corrompida na fila de entrada que não pode ser descodificada.\n\n1. Recarregue a integração para limpar o estado de execução.\n2. Se o problema voltar, regenere o seu `secrets.json` (a Google pode ter rodado as credenciais)."
     }
   },
   "exceptions": {

--- a/tests/test_coordinator_polling_fatal_channel.py
+++ b/tests/test_coordinator_polling_fatal_channel.py
@@ -1,0 +1,102 @@
+# tests/test_coordinator_polling_fatal_channel.py
+"""Channel-confusion regression tests for ``coordinator.polling``.
+
+Iter-14 (Codex follow-up): the FCM receiver's supervisor-level "short-run
+crash loop" cap publishes its terminal state into the SAME ``_fatal_errors``
+map that the coordinator's re-auth escalation consumes. Without explicit
+classification the crash-loop fatal would be reclassified as an auth fatal
+after ``_FCM_ERROR_RETRY_THRESHOLD`` consecutive update cycles and push users
+into Home Assistant's re-auth flow for what is structurally a listener-
+lifecycle fatal (the repair issue carries the actual user-visible guidance).
+
+This module pins three contracts:
+
+1. ``_classify_fcm_fatal`` (free function, branch-coverage friendly):
+   - crash-loop prefix => ``_FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED``
+   - classic auth fatal (401/404/credentials text) =>
+     ``_FCM_FATAL_CLASS_AUTH_IMMEDIATE``
+   - any other non-empty fatal => ``_FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD``
+2. The polling-side fatal-classification call is the SSOT consumer for the
+   crash-loop prefix exported by ``Auth.fcm_receiver_ha``.
+3. The crash-loop prefix matches the message produced by the cap-fire
+   branch in ``Auth.fcm_receiver_ha`` (cross-module wire contract).
+"""
+
+from __future__ import annotations
+
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
+    _MAX_CONSECUTIVE_SHORT_RUNS,
+    _SHORT_RUN_THRESHOLD_S,
+    CRASH_LOOP_FATAL_PREFIX,
+)
+from custom_components.googlefindmy.coordinator.polling import (
+    _FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD,
+    _FCM_FATAL_CLASS_AUTH_IMMEDIATE,
+    _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED,
+    _classify_fcm_fatal,
+)
+
+
+class TestClassifyFcmFatal:
+    """Branch coverage for the channel-confusion fix."""
+
+    def test_crash_loop_prefix_is_excluded(self) -> None:
+        """A cap-fired crash-loop fatal must never escalate to re-auth."""
+        cap_message = (
+            f"{CRASH_LOOP_FATAL_PREFIX} 10 consecutive runs ended within 30s "
+            f"(persistent poison message suspected)"
+        )
+
+        assert (
+            _classify_fcm_fatal(cap_message) == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+        )
+
+    def test_bare_prefix_is_also_excluded(self) -> None:
+        """Defense is on the prefix alone, not the full message body."""
+        assert (
+            _classify_fcm_fatal(CRASH_LOOP_FATAL_PREFIX)
+            == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+        )
+
+    def test_classic_auth_fatal_is_immediate(self) -> None:
+        """A 401 credentials fatal must classify as auth_immediate.
+
+        ``is_fatal_fcm_auth_error`` matches plain ``"401"`` substrings, so a
+        message that contains ``"HTTP 401"`` classifies as the immediate
+        auth-fatal path.
+        """
+        msg = "FCM auth failed: invalid credentials (HTTP 401)"
+
+        assert _classify_fcm_fatal(msg) == _FCM_FATAL_CLASS_AUTH_IMMEDIATE
+
+    def test_unrelated_transient_fatal_uses_threshold_path(self) -> None:
+        """An unrecognised non-crash-loop fatal goes through the counter."""
+        # A network error that does not match auth patterns AND does not
+        # start with the crash-loop prefix.
+        msg = "Transient FCM error: connection reset"
+
+        assert (
+            _classify_fcm_fatal(msg) == _FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD
+        )
+
+    def test_wire_contract_cap_message_matches_prefix(self) -> None:
+        """The cap-fire branch must produce a message the classifier excludes.
+
+        This pins the cross-module wire contract: if the cap-fire branch in
+        ``Auth.fcm_receiver_ha`` ever changes its message template, this test
+        fails fast and forces the change to be propagated through
+        ``CRASH_LOOP_FATAL_PREFIX`` rather than diverging silently.
+        """
+        # Reproduce the cap-fire branch's f-string template literally.
+        cap_message = (
+            f"{CRASH_LOOP_FATAL_PREFIX} "
+            f"{_MAX_CONSECUTIVE_SHORT_RUNS} consecutive "
+            f"runs ended within "
+            f"{_SHORT_RUN_THRESHOLD_S:.0f}s "
+            f"(persistent poison message suspected)"
+        )
+
+        assert cap_message.startswith(CRASH_LOOP_FATAL_PREFIX)
+        assert (
+            _classify_fcm_fatal(cap_message) == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+        )

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -1,0 +1,495 @@
+# tests/test_fcm_receiver_ha_short_run_cap.py
+"""Defense-2 regression tests for the FCM supervisor short-run crash cap.
+
+Covers PLAN_HOTFIX_FCM_CASCADING_FAILURE AP-2 (`fcm_receiver_ha.py`):
+- 7 building-block tests (threshold trigger, break, reset, re-registration,
+  per-entry independence, orthogonality to `_fatal_retry_counts`, unload-cleanup)
+- 1 boundary test that pins `<` vs. `<=` drift on `_SHORT_RUN_THRESHOLD_S`
+- 1 cross-locale symmetry test for the `fcm_short_run_crash_loop` translation key
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth import fcm_receiver_ha
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
+    _MAX_CONSECUTIVE_SHORT_RUNS,
+    _SHORT_RUN_THRESHOLD_S,
+    DOMAIN,
+    FcmReceiverHA,
+)
+
+
+class _MonoClock:
+    """Stateful auto-increment monotonic clock for deterministic run-duration math.
+
+    Each call returns ``value`` then advances by ``step``. ``jump(seconds)``
+    skips ahead without consuming a call slot (used to simulate a long run
+    between ``entry_start`` and the run-duration check).
+    """
+
+    def __init__(self, step: float = 0.01) -> None:
+        self.value = 0.0
+        self.step = step
+
+    def __call__(self) -> float:
+        v = self.value
+        self.value += self.step
+        return v
+
+    def jump(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class _SupervisorPushClientStub:
+    """Lightweight ``FcmPushClient`` substitute for supervisor-loop tests.
+
+    Mirrors only the surface the supervisor reads/writes (``start``, ``stop``,
+    ``run_state``, ``do_listen``, ``_observe_counter``). Each ``start()`` call
+    can optionally trigger a clock jump (to simulate the elapsed wall time of
+    the run before STOPPED), and ``run_state`` defaults to STOPPED so the
+    monitor loop exits on the first iteration.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: _MonoClock | None = None,
+        jump_on_start: float = 0.0,
+    ) -> None:
+        self.clock = clock
+        self.jump_on_start = jump_on_start
+        self.do_listen = True
+        self.run_state = None  # forces ``state is None`` break path
+        self.start_calls = 0
+        self.stop_calls = 0
+        self._observed_short_run_counter: int | None = None
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        if self.clock is not None and self.jump_on_start:
+            self.clock.jump(self.jump_on_start)
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+
+    def _observe_counter(self, counter: int) -> None:
+        # Last writer wins so tests observe the most recent supervisor pass.
+        self._observed_short_run_counter = counter
+
+
+def _install_supervisor_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    receiver: FcmReceiverHA,
+    *,
+    clock: _MonoClock,
+    ensure_clients: list,
+) -> AsyncMock:
+    """Wire the common supervisor-loop mock surface and return the register mock."""
+
+    monkeypatch.setattr(fcm_receiver_ha.time, "monotonic", clock)
+
+    ensure_iter = iter(ensure_clients)
+
+    async def _ensure(entry_id: str, cache):  # noqa: ARG001
+        try:
+            return next(ensure_iter)
+        except StopIteration:
+            return None
+
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
+
+    register_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        fcm_receiver_ha.random, "uniform", lambda *_a, **_kw: 0.0
+    )
+
+    real_wait_for = asyncio.wait_for
+
+    async def _instant_wait_for(fut, *, timeout=None):
+        if timeout is not None and timeout > 0:
+            coro_name = getattr(fut, "__name__", "") or getattr(
+                getattr(fut, "cr_code", None), "co_name", ""
+            )
+            if coro_name == "wait":
+                if asyncio.iscoroutine(fut):
+                    fut.close()
+                raise TimeoutError
+        return await real_wait_for(fut, timeout=timeout)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "wait_for", _instant_wait_for)
+    return register_mock
+
+
+def _install_ir_capture(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, MagicMock]:
+    """Capture ``ir.async_create_issue`` and ``ir.async_delete_issue`` calls."""
+
+    create_issue = MagicMock()
+    delete_issue = MagicMock()
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_delete_issue", delete_issue)
+    monkeypatch.setattr(
+        fcm_receiver_ha.ir,
+        "IssueSeverity",
+        SimpleNamespace(WARNING="warning", ERROR="error"),
+    )
+    return create_issue, delete_issue
+
+
+# --------------------------------------------------------------------------
+# Building blocks
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_short_run_triggers_repair_issue_after_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """10 short runs in one supervisor pass produce exactly one ERROR repair issue."""
+    entry_id = "entry-trigger"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)  # 1ms per call -> every run is short
+    clients = [_SupervisorPushClientStub(clock=clock) for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert register_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS
+    assert create_issue.call_count == 1
+    call = create_issue.call_args
+    assert call.args[1] == DOMAIN
+    assert call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    assert call.kwargs["is_fixable"] is False
+    assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.ERROR
+    assert call.kwargs["translation_key"] == "fcm_short_run_crash_loop"
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_short_run_break_after_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The supervisor task completes after the 10th short run (no further iters)."""
+    entry_id = "entry-break"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # Provide more clients than the threshold to detect "loop kept going".
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS + 5)
+    ]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert receiver.supervisors[entry_id].done()
+    assert register_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS
+
+
+@pytest.mark.asyncio
+async def test_long_run_resets_closure_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """9 short + 1 long + 9 short runs must not trigger the threshold."""
+    entry_id = "entry-reset"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # Build 19 clients: short, short, ..., LONG at index 9, short, short, ...
+    clients = []
+    for idx in range(19):
+        if idx == 9:
+            clients.append(
+                _SupervisorPushClientStub(clock=clock, jump_on_start=60.0)
+            )
+        else:
+            clients.append(_SupervisorPushClientStub(clock=clock))
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # No repair issue: the long run at index 9 resets the counter, so the
+    # remaining 9 short runs never reach the threshold of 10.
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+    assert register_mock.await_count == 19
+
+
+@pytest.mark.asyncio
+async def test_re_registration_does_not_inherit_old_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled supervisor's counter must not bleed into a fresh supervisor."""
+    entry_id = "entry-rereg"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # First supervisor: 9 short runs then we cancel.
+    clients_first = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(9)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients_first
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    # Run the first supervisor to natural completion (runs out of clients).
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+    # Pre-condition: 9 short runs did NOT trigger the cap.
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+    # Remove the spent stop_evt so a fresh supervisor can start.
+    receiver._stop_evts.pop(entry_id, None)
+    receiver.supervisors.pop(entry_id, None)
+
+    # Second supervisor: 9 more short runs. If the counter were shared, the
+    # combined 18 runs would have crossed the threshold and re-fired.
+    clients_second = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(9)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients_second
+    )
+    create_issue_b, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue_b.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+
+@pytest.mark.asyncio
+async def test_per_entry_supervisors_independent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entry A crash-loops, entry B stays healthy: only A produces a repair issue."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock_a = _MonoClock(step=0.001)
+    clock_b = _MonoClock(step=0.001)
+    # Entry A: 10 short runs (will trip the cap).
+    clients_a = [_SupervisorPushClientStub(clock=clock_a) for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)]
+    # Entry B: 5 healthy long runs (well above threshold).
+    clients_b = [
+        _SupervisorPushClientStub(clock=clock_b, jump_on_start=60.0)
+        for _ in range(5)
+    ]
+
+    # Single shared monkeypatch fixture but per-receiver wiring.
+    # We can't run both supervisors against the same monkeypatched function,
+    # so we sequence A then B.
+    register_a = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock_a, ensure_clients=clients_a
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry("entry-a", None)
+    await asyncio.wait_for(receiver.supervisors["entry-a"], timeout=5.0)
+
+    register_b = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock_b, ensure_clients=clients_b
+    )
+    await receiver._start_supervisor_for_entry("entry-b", None)
+    await asyncio.wait_for(receiver.supervisors["entry-b"], timeout=5.0)
+
+    # Exactly one issue was raised, and it targets entry A.
+    assert create_issue.call_count == 1
+    assert create_issue.call_args.args[2] == "fcm_short_run_crash_loop_entry-a"
+    assert receiver._fatal_errors.get("entry-a", "").startswith(
+        "FCM short-run crash loop"
+    )
+    assert "entry-b" not in receiver._fatal_errors
+    assert register_a.await_count == _MAX_CONSECUTIVE_SHORT_RUNS
+    assert register_b.await_count == 5
+
+
+@pytest.mark.asyncio
+async def test_fatal_retry_counts_orthogonal_to_short_run_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_fatal_retry_counts` and the closure-counter advance independently.
+
+    A short run pumps the closure counter; a `FatalRegistrationError` from
+    the registration path pumps `_fatal_retry_counts`. They share no state
+    and must not double-fire the short-run repair issue.
+    """
+    from custom_components.googlefindmy.exceptions import FatalRegistrationError
+
+    entry_id = "entry-orthogonal"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [_SupervisorPushClientStub(clock=clock) for _ in range(6)]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    # Override register: first 5 successes (short runs), 6th raises fatal endpoint.
+    side_effects: list = [True, True, True, True, True]
+    err = FatalRegistrationError("registration failed")
+    err.is_auth_error = False  # endpoint path, not auth
+    side_effects.append(err)
+    register_mock = AsyncMock(side_effect=side_effects)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    # 6th iteration's FatalRegistrationError triggers endpoint path
+    # which retries up to _MAX_FATAL_ENDPOINT_RETRIES (7) before giving up.
+    # Refill register with the same error so the endpoint counter exhausts.
+    side_effects.extend([err] * 6)
+
+    # Bounded run via wait_for to avoid hanging on register-retry backoff.
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    try:
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+    except TimeoutError:  # noqa: PERF203 - test bounded fallback
+        receiver._stop_evts[entry_id].set()
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # The short-run counter reached 5 (< 10), so no short-run issue.
+    short_run_calls = [
+        c for c in create_issue.call_args_list
+        if c.args[2].startswith("fcm_short_run_crash_loop_")
+    ]
+    assert len(short_run_calls) == 0
+    # _fatal_retry_counts was incremented at least once by the endpoint path.
+    counter_key = f"{entry_id}:endpoint"
+    assert receiver._fatal_retry_counts.get(counter_key, 0) >= 1
+
+
+def test_unload_clears_fatal_errors() -> None:
+    """`_clear_fatal_error_for_entry` (called from unload) removes the latched key."""
+    receiver = FcmReceiverHA()
+    receiver._fatal_errors["entry-unload"] = "FCM short-run crash loop: ..."
+    receiver._fatal_error = "FCM short-run crash loop: ..."
+
+    receiver._clear_fatal_error_for_entry("entry-unload", reason="Entry unregistered")
+
+    assert "entry-unload" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+
+
+# --------------------------------------------------------------------------
+# Boundary test (Iteration-2-L3)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_long_run_boundary_exactly_30s_does_not_count_as_short(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`<` vs. `<=` drift sentry: run_duration == 30.0 must NOT count as short."""
+    assert _SHORT_RUN_THRESHOLD_S == 30.0  # pin the constant against silent drift
+
+    entry_id = "entry-boundary"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # A single client that jumps exactly the threshold on start(): the
+    # supervisor's ``run_duration = time.monotonic() - entry_start`` then
+    # equals 30.0 (the very small additional ``step`` reads in between
+    # are also captured by the jump because the snapshot happens AFTER
+    # ``start()`` returned).
+    stub = _SupervisorPushClientStub(clock=clock, jump_on_start=30.0)
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=[stub]
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # The else-branch was hit (counter reset to 0), not the short-run branch.
+    assert stub._observed_short_run_counter == 0, (
+        f"Boundary 30.0s was counted as short — `<` drifted to `<=`? "
+        f"Counter={stub._observed_short_run_counter}"
+    )
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+
+# --------------------------------------------------------------------------
+# Cross-locale symmetry (Iteration-2-L2)
+# --------------------------------------------------------------------------
+
+
+def test_translation_key_present_in_all_locales(integration_root: Path) -> None:
+    """`fcm_short_run_crash_loop` exists in every locale file under `issues`."""
+    key = "fcm_short_run_crash_loop"
+    files = {
+        "strings.json": integration_root / "strings.json",
+        "de.json": integration_root / "translations" / "de.json",
+        "en.json": integration_root / "translations" / "en.json",
+        "es.json": integration_root / "translations" / "es.json",
+        "fr.json": integration_root / "translations" / "fr.json",
+        "he.json": integration_root / "translations" / "he.json",
+        "it.json": integration_root / "translations" / "it.json",
+        "nl.json": integration_root / "translations" / "nl.json",
+        "pl.json": integration_root / "translations" / "pl.json",
+        "pt-BR.json": integration_root / "translations" / "pt-BR.json",
+        "pt.json": integration_root / "translations" / "pt.json",
+    }
+
+    titles: dict[str, str] = {}
+    descriptions: dict[str, str] = {}
+    for label, path in files.items():
+        assert path.exists(), f"locale file missing: {path}"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "issues" in data, f"{label}: no issues section"
+        assert key in data["issues"], f"{label}: missing key {key!r}"
+        entry = data["issues"][key]
+        assert isinstance(entry, dict), f"{label}: {key!r} must be a dict"
+        assert entry.get("title", "").strip(), f"{label}: empty title for {key!r}"
+        assert (
+            entry.get("description", "").strip()
+        ), f"{label}: empty description for {key!r}"
+        assert len(entry["description"]) >= 50, (
+            f"{label}: description too short ({len(entry['description'])} chars) "
+            f"for a repair-issue body"
+        )
+        titles[label] = entry["title"]
+        descriptions[label] = entry["description"]
+
+    # No copy-paste drift between German and English description.
+    assert descriptions["de.json"] != descriptions["en.json"], (
+        "Copy-paste drift: de.json description matches en.json — translation missing"
+    )
+    # Strings.json (master) matches en.json (English locale)
+    assert descriptions["strings.json"] == descriptions["en.json"], (
+        "strings.json description must mirror en.json"
+    )

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -1223,8 +1223,8 @@ def test_observable_subclass_latches_started_transition() -> None:
     monotonic (set on STARTED, never cleared) and ignores non-STARTED
     state assignments.
     """
-    pc_cls = fcm_receiver_ha._FcmPushClientFactory
-    if pc_cls is fcm_receiver_ha.FcmPushClient:
+    pc_cls = fcm_receiver_ha._ObservableFcmPushClientCls
+    if pc_cls is None:
         pytest.skip("Vendored library not available; subclass not active")
 
     from custom_components.googlefindmy.Auth.firebase_messaging import (
@@ -1371,3 +1371,104 @@ async def test_mixed_burst_micro_window_and_pre_start_failures(
     cap_issue_call = create_issue.call_args
     assert cap_issue_call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
     assert entry_id in receiver._short_run_cap_latched
+
+
+# --------------------------------------------------------------------------
+# CI follow-up (PR #1086 iter-13): Class-Identity substitution defense
+#
+# Iter-12 added _ObservableFcmPushClient as a subclass of FcmPushClient. The
+# production factory must construct that subclass. Tests, however, may
+# substitute the module-level FcmPushClient symbol via monkeypatch (the
+# documented seam) to inject test doubles -- e.g. test_receiver_reuses_
+# hass_managed_session in tests/test_fcm_receiver_guard.py asserts
+# ``isinstance(created, DummyPushClient)``. A factory that always returns
+# the production subclass would break isinstance identity against the
+# patched symbol because the subclass inherits from the ORIGINAL class,
+# not from the patched one. The factory therefore checks at CALL TIME
+# whether the module symbol still points at the snapshot of the original
+# class, and instantiates the patched class directly when not.
+# (CA-SUBCLASS-IDENTITY-001)
+# --------------------------------------------------------------------------
+
+
+def test_factory_uses_observable_subclass_in_production() -> None:
+    """When the FcmPushClient symbol is untouched the factory returns the subclass.
+
+    Pins the production path: the runtime check
+    ``current is _OriginalFcmPushClient`` is true, so the factory MUST
+    instantiate ``_ObservableFcmPushClient`` (not the plain library class).
+    """
+    if fcm_receiver_ha._ObservableFcmPushClientCls is None:
+        pytest.skip("Vendored library not available; subclass not active")
+
+    from custom_components.googlefindmy.Auth.firebase_messaging import (
+        FcmPushClientConfig,
+        FcmRegisterConfig,
+    )
+
+    config = FcmPushClientConfig()
+    register_cfg = FcmRegisterConfig(
+        project_id="p",
+        app_id="a",
+        api_key="k",
+        messaging_sender_id="s",
+    )
+
+    async def _noop_cb(*_args: object, **_kw: object) -> None:
+        return None
+
+    pc = fcm_receiver_ha._FcmPushClientFactory(
+        _noop_cb,
+        register_cfg,
+        {},
+        _noop_cb,
+        config=config,
+    )
+
+    assert isinstance(pc, fcm_receiver_ha._ObservableFcmPushClientCls)
+    # Latch was seeded before super().__init__ so it is observable here.
+    assert pc._has_been_started is False
+
+
+def test_factory_honours_monkeypatched_fcm_push_client_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Substituting FcmPushClient via monkeypatch is the documented seam.
+
+    Regression pin for CA-SUBCLASS-IDENTITY-001: when tests patch the
+    module-level ``FcmPushClient`` symbol to inject a test double, the
+    factory MUST instantiate the patched class DIRECTLY -- not a subclass
+    of the original library class. Otherwise ``isinstance`` assertions on
+    the patched symbol (as used by tests in tests/test_fcm_receiver_guard
+    .py) fail because the production subclass diverges from the patched
+    class hierarchy.
+    """
+
+    captured: dict[str, object] = {}
+
+    class _PatchedClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "FcmPushClient",
+        _PatchedClient,
+    )
+
+    pc = fcm_receiver_ha._FcmPushClientFactory(
+        "callback",
+        "config",
+        {"creds": True},
+        "creds_cb",
+        http_client_session="session",
+    )
+
+    # The factory honoured the patch: identity matches the patched class,
+    # not the production subclass and not the original library class.
+    assert isinstance(pc, _PatchedClient)
+    if fcm_receiver_ha._ObservableFcmPushClientCls is not None:
+        assert not isinstance(pc, fcm_receiver_ha._ObservableFcmPushClientCls)
+    assert captured["args"][0] == "callback"
+    assert captured["kwargs"]["http_client_session"] == "session"

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -744,3 +744,129 @@ def test_translation_key_present_in_all_locales(integration_root: Path) -> None:
     assert descriptions["strings.json"] == descriptions["en.json"], (
         "strings.json description must mirror en.json"
     )
+
+
+# --------------------------------------------------------------------------
+# Defense 2 iter-9 (Codex PR #1086 follow-up):
+# Cap-fire must TERMINATE the supervisor; the inner-loop ``break`` alone
+# falls through to the per-iteration restart block and keeps spawning fresh
+# FCM clients (retry pressure + log spam continue indefinitely despite the
+# cap latch). See CA-DEFENSE-TERMINATION-001.
+#
+# These tests deliberately do NOT rely on the helper's
+# StopIteration->stop_evt.set() emergency brake (CA-TEST-TERMINATION-001):
+# they install their own ``_ensure_client_for_entry`` mock that fails the
+# test the moment the supervisor calls it AFTER the cap should have fired.
+# That isolates the production-side termination contract from the test-helper
+# safety net.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cap_fire_terminates_outer_loop_without_helper_safety_net(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cap-fire must stop the supervisor in production, not via the test helper.
+
+    Codex iter-9 (PR #1086): ``break`` after the cap fires only exits the
+    inner monitor loop; the outer ``while not stop_evt.is_set()`` keeps
+    spinning and ``_ensure_client_for_entry`` is called for an 11th client.
+    The production fix sets ``stop_evt`` and pops ``_stop_evts[entry_id]``
+    inside the cap-fire branch, so the outer loop exits before any further
+    ensure call.
+    """
+    entry_id = "entry-cap-terminates"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS + 5)
+    ]
+    ensure_iter = iter(clients)
+    ensure_call_count = 0
+
+    async def _ensure(entry_id_inner: str, cache):  # noqa: ARG001
+        # NOTE: no StopIteration->stop_evt.set() escape hatch here. If the
+        # production cap fails to terminate the supervisor, this returns the
+        # 11th client and we explicitly fail the test below.
+        nonlocal ensure_call_count
+        ensure_call_count += 1
+        return next(ensure_iter)
+
+    monkeypatch.setattr(fcm_receiver_ha.time, "monotonic", clock)
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
+    register_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        fcm_receiver_ha.random, "uniform", lambda *_a, **_kw: 0.0
+    )
+
+    real_wait_for = asyncio.wait_for
+
+    async def _instant_wait_for(fut, *, timeout=None):
+        if timeout is not None and timeout > 0:
+            coro_name = getattr(fut, "__name__", "") or getattr(
+                getattr(fut, "cr_code", None), "co_name", ""
+            )
+            if coro_name == "wait":
+                if asyncio.iscoroutine(fut):
+                    fut.close()
+                raise TimeoutError
+        return await real_wait_for(fut, timeout=timeout)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "wait_for", _instant_wait_for)
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Production-side termination contract: exactly _MAX ensure calls.
+    # An 11th call would mean the outer loop kept running after cap-fire.
+    assert ensure_call_count == _MAX_CONSECUTIVE_SHORT_RUNS, (
+        f"Supervisor kept spinning after cap-fire: ensure was called "
+        f"{ensure_call_count} times (expected {_MAX_CONSECUTIVE_SHORT_RUNS}). "
+        f"Defense 2 cap is a paper tiger."
+    )
+    assert receiver.supervisors[entry_id].done()
+    assert entry_id in receiver._short_run_cap_latched
+
+
+@pytest.mark.asyncio
+async def test_cap_fire_pops_stop_evt_for_legitimate_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After cap-fire, ``_stop_evts[entry_id]`` is gone so a reload restarts cleanly.
+
+    The cap-fire branch calls ``stop_evt.set()`` AND
+    ``self._stop_evts.pop(entry_id, None)``. Without the pop, the next
+    legitimate restart via ``_start_supervisor_for_entry`` would reuse the
+    already-set event through ``setdefault`` and the new supervisor would
+    terminate immediately.
+    """
+    entry_id = "entry-cap-pop"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # After cap-fire the stop event has been consumed AND removed so that a
+    # legitimate ``_register_for_fcm_entry`` or reload constructs a fresh one.
+    assert entry_id not in receiver._stop_evts, (
+        "Stale stop event lingers in _stop_evts after cap-fire; a "
+        "legitimate restart would short-circuit because setdefault would "
+        "reuse the already-set event."
+    )

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -587,6 +587,123 @@ async def test_cap_latch_survives_registration_success_path(
     assert receiver._fatal_errors[entry_id] == pre_message
 
 
+# --------------------------------------------------------------------------
+# Defense 2 iter-10: cap-latch guard granularity (Codex follow-up finding)
+# --------------------------------------------------------------------------
+#
+# Codex objected that the iter-8 latch guard was unconditional and blocked
+# every later ``_clear_fatal_error_for_entry`` call while the latch was set.
+# Scenario: the cap fires, then the user reloads or re-registers; the new
+# registration hits a terminal 401/404 and overwrites ``_fatal_errors[entry_id]``
+# with a non-cap message; a credentials recovery later tries to clear that
+# fatal but is blocked by the latch guard, so the coordinator keeps seeing
+# the stale auth-fatal even after the underlying problem is fixed.
+#
+# CA-GUARD-GRANULARITY-001: the latch guard is now SELECTIVE:
+#
+#   * Latch active AND stored fatal IS the cap message
+#     -> full no-op (cap state + Repairs UI artefact preserved).
+#   * Latch active AND stored fatal is a NON-cap message
+#     -> clear the non-cap fatal, but keep the latch and the Repairs UI
+#        artefact (cap warning stays visible until a healthy run releases it).
+#   * Latch active AND no fatal stored
+#     -> full no-op (treat as cap-only state).
+#   * Latch not active OR force=True
+#     -> normal clear-all path (unchanged).
+
+
+def test_clear_clears_non_cap_fatal_while_cap_latched() -> None:
+    """Non-cap fatals must clear normally even while the cap latch is active.
+
+    Defense 2 iter-10 (Codex follow-up): the iter-8 guard was too broad and
+    blocked every clear-call, so a terminal 401/404 written into
+    ``_fatal_errors`` by a re-registration attempt after cap-fire could never
+    be dropped by a subsequent credentials recovery. The guard now blocks
+    only when the stored fatal IS the cap message; non-cap fatals are
+    dropped while latch and Repairs UI artefact stay in place.
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    # Cap is latched (set by an earlier cap-fire); a subsequent
+    # re-registration then overwrote the fatal map with a non-cap auth error.
+    receiver._short_run_cap_latched.add("entry-mixed")
+    receiver._fatal_errors["entry-mixed"] = (
+        "FCM registration failed: HTTP 401 Unauthorized"
+    )
+    receiver._fatal_error = "FCM registration failed: HTTP 401 Unauthorized"
+
+    # Credentials recovery path: ``_register_for_fcm_entry`` calls this after
+    # a new successful registration. The non-cap fatal MUST clear so the
+    # coordinator does not see a stale auth-fatal.
+    receiver._clear_fatal_error_for_entry(
+        "entry-mixed", reason="Credentials updated for entry"
+    )
+
+    # Non-cap fatal cleared.
+    assert "entry-mixed" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    # Cap latch SURVIVES: only a real healthy supervisor run may drop it.
+    assert "entry-mixed" in receiver._short_run_cap_latched
+
+
+def test_clear_preserves_repair_issue_when_clearing_non_cap_fatal() -> None:
+    """Clearing a non-cap fatal while latched must not delete the Repairs issue.
+
+    The Repairs UI artefact (``fcm_short_run_crash_loop_<entry_id>``) is the
+    user-visible cap warning. Dropping it during an unrelated credentials
+    recovery would invalidate the cap warning before the listener proves the
+    poison message is gone (the very failure mode iter-8 pinned).
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    deleted_issues: list[tuple[str, str]] = []
+
+    def fake_async_delete_issue(hass, domain: str, issue_id: str) -> None:
+        deleted_issues.append((domain, issue_id))
+
+    monkey = pytest.MonkeyPatch()
+    try:
+        monkey.setattr(
+            fcm_receiver_ha.ir, "async_delete_issue", fake_async_delete_issue
+        )
+
+        receiver._short_run_cap_latched.add("entry-keep-issue")
+        receiver._fatal_errors["entry-keep-issue"] = (
+            "FCM registration failed: HTTP 404 Not Found"
+        )
+        receiver._fatal_error = "FCM registration failed: HTTP 404 Not Found"
+
+        receiver._clear_fatal_error_for_entry(
+            "entry-keep-issue", reason="Credentials updated for entry"
+        )
+    finally:
+        monkey.undo()
+
+    # Non-cap fatal cleared but the Repairs UI artefact must remain (no
+    # ``async_delete_issue`` call for the cap issue id).
+    assert "entry-keep-issue" not in receiver._fatal_errors
+    assert deleted_issues == []
+    assert "entry-keep-issue" in receiver._short_run_cap_latched
+
+
+def test_clear_no_stored_fatal_while_latched_is_full_noop() -> None:
+    """Latch active and no fatal stored: full no-op, latch survives."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    receiver._short_run_cap_latched.add("entry-no-fatal")
+    # No entry in ``_fatal_errors``.
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-no-fatal", reason="Registration succeeded"
+    )
+
+    assert "entry-no-fatal" in receiver._short_run_cap_latched
+    assert "entry-no-fatal" not in receiver._fatal_errors
+
+
 @pytest.mark.asyncio
 async def test_healthy_run_releases_cap_latch_and_fatal_state(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -437,16 +437,211 @@ async def test_fatal_retry_counts_orthogonal_to_short_run_path(
     assert receiver._fatal_retry_counts.get(counter_key, 0) >= 1
 
 
-def test_unload_clears_fatal_errors() -> None:
-    """`_clear_fatal_error_for_entry` (called from unload) removes the latched key."""
+def test_unload_clears_fatal_errors_via_force() -> None:
+    """`_clear_fatal_error_for_entry(force=True)` (unload path) releases the latch.
+
+    Defense 2 iter-8: the unregister path must clear the cap latch alongside
+    the fatal-error map because the entry itself goes away. Without ``force``
+    the clear-path is a no-op while the latch is set (Codex second finding).
+    """
     receiver = FcmReceiverHA()
     receiver._fatal_errors["entry-unload"] = "FCM short-run crash loop: ..."
     receiver._fatal_error = "FCM short-run crash loop: ..."
+    receiver._short_run_cap_latched.add("entry-unload")
 
-    receiver._clear_fatal_error_for_entry("entry-unload", reason="Entry unregistered")
+    receiver._clear_fatal_error_for_entry(
+        "entry-unload", reason="Entry unregistered", force=True
+    )
 
     assert "entry-unload" not in receiver._fatal_errors
+    assert "entry-unload" not in receiver._short_run_cap_latched
     assert receiver._fatal_error is None
+
+
+# --------------------------------------------------------------------------
+# Defense 2 iter-8: cap-latch lifecycle (Codex second finding)
+# --------------------------------------------------------------------------
+#
+# Codex objected that the cap state lives in the same ``_fatal_errors`` map
+# that ``_register_for_fcm_entry`` unconditionally clears after a successful
+# registration. Registration is NOT a recovery proof for a poison-message
+# crash loop: only a real healthy supervisor run (>= 30s) shows that the
+# poisoned notification is gone. The tests below pin the new lifecycle
+# contract (CA-STATE-LIFECYCLE-ASYMMETRY-001):
+#
+#   * ``_short_run_cap_latched`` is set at cap-fire time alongside the
+#     ``_fatal_errors`` entry and the Repairs issue.
+#   * ``_clear_fatal_error_for_entry`` is a no-op while the latch is set
+#     (unless ``force=True`` is passed, which only the unregister path does).
+#   * Only the healthy-run branch of the supervisor loop releases the latch,
+#     pops the cap-related ``_fatal_errors`` entry, and re-derives the
+#     aggregate ``_fatal_error``.
+
+
+def test_clear_fatal_error_is_noop_while_cap_latched() -> None:
+    """Registration-success paths cannot drop the latch (Codex iter-8 finding 2)."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._fatal_errors["entry-latched"] = "FCM short-run crash loop: ..."
+    receiver._fatal_error = "FCM short-run crash loop: ..."
+    receiver._short_run_cap_latched.add("entry-latched")
+
+    # ``force`` defaults to ``False``: this is the path that
+    # ``_register_for_fcm_entry`` and the credential-update handler take.
+    receiver._clear_fatal_error_for_entry(
+        "entry-latched", reason="Registration succeeded"
+    )
+
+    # Nothing changed: the latch, the fatal-error map, and the aggregate
+    # all survive because the registration did not prove a healthy run.
+    assert "entry-latched" in receiver._short_run_cap_latched
+    assert receiver._fatal_errors["entry-latched"].startswith(
+        "FCM short-run crash loop"
+    )
+    assert receiver._fatal_error == "FCM short-run crash loop: ..."
+
+
+def test_clear_without_latch_still_clears_fatal_errors() -> None:
+    """Without an active cap latch, the clear-path behaves idempotently."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._fatal_errors["entry-clean"] = "FCM auth failed ..."
+    receiver._fatal_error = "FCM auth failed ..."
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-clean", reason="Registration succeeded"
+    )
+
+    assert "entry-clean" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+
+
+@pytest.mark.asyncio
+async def test_cap_fire_sets_short_run_cap_latched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cap-fire installs the latch alongside the fatal-error map and the issue."""
+    entry_id = "entry-cap-latch"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue.call_count == 1
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_cap_latch_survives_registration_success_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A simulated registration-success path cannot drop the latch.
+
+    Defense 2 iter-8 (Codex second finding): without the latch, a reload or
+    credential update after cap-fire would clear the fatal-error map and the
+    Repairs issue before the supervisor proved the poison message is gone,
+    leaving the user blind during the next 10-run burst.
+    """
+    entry_id = "entry-survive"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert entry_id in receiver._short_run_cap_latched
+    pre_message = receiver._fatal_errors[entry_id]
+
+    # Simulate ``_register_for_fcm_entry`` success path (Z. 1260) and the
+    # credential-update path (Z. 2069). Neither must release the latch.
+    receiver._clear_fatal_error_for_entry(
+        entry_id, reason="Registration succeeded"
+    )
+    receiver._clear_fatal_error_for_entry(
+        entry_id, reason="Credentials updated for entry"
+    )
+
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id] == pre_message
+
+
+@pytest.mark.asyncio
+async def test_healthy_run_releases_cap_latch_and_fatal_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A healthy run (>= 30s) clears the latch, the fatal map entry, and the issue."""
+    entry_id = "entry-recover"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # 10 short runs trip the cap; one healthy run afterwards must release it.
+    # The healthy run is modelled as a long supervisor pass (jump after the
+    # ``entry_start`` snapshot via ``jump_on_run_state_read``).
+    short_clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    healthy_client = _SupervisorPushClientStub(
+        clock=clock, jump_on_run_state_read=60.0
+    )
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock,
+        ensure_clients=[*short_clients, healthy_client],
+    )
+    create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    # Phase 1: 10 short runs trip the cap and stop the supervisor.
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue.call_count == 1
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+    # Phase 2: simulate a reload (fresh stop_evt + fresh supervisor task).
+    receiver._stop_evts.pop(entry_id, None)
+    receiver.supervisors.pop(entry_id, None)
+
+    # The healthy run drops the latch from inside the supervisor loop's
+    # else branch (counter reset path).
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert entry_id not in receiver._short_run_cap_latched
+    assert entry_id not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    # The Repairs issue is deleted at least once on the healthy path.
+    delete_calls_for_entry = [
+        call
+        for call in delete_issue.call_args_list
+        if call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    ]
+    assert delete_calls_for_entry, (
+        "expected a delete_issue call for the short-run crash loop key"
+    )
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -124,9 +124,19 @@ def _install_supervisor_mocks(
     ensure_iter = iter(ensure_clients)
 
     async def _ensure(entry_id: str, cache):  # noqa: ARG001
+        # Codex Iter-7 (PR #1086): modelling exhaustion as ``None`` mirrors
+        # production's ``if not pc`` path, which is designed to back off and
+        # retry **forever**. The non-cap tests (long-run reset,
+        # re-registration, entry-B independence, 30s boundary) all rely on
+        # natural supervisor completion after the configured client list is
+        # exhausted, so we MUST stop the supervisor explicitly here instead
+        # of falling into the retry-forever branch (CA-TEST-TERMINATION-001).
         try:
             return next(ensure_iter)
         except StopIteration:
+            stop_evt = receiver._stop_evts.get(entry_id)
+            if stop_evt is not None:
+                stop_evt.set()
             return None
 
     monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -739,6 +739,117 @@ def test_clear_no_stored_fatal_while_latched_is_full_noop() -> None:
     assert "entry-no-fatal" not in receiver._fatal_errors
 
 
+# --------------------------------------------------------------------------
+# Iter-16 regression: latch-restoration on pass-through clear
+# (Codex 8cfd5b25 follow-up)
+# --------------------------------------------------------------------------
+#
+# Pinning contract for ``_short_run_cap_messages``:
+#   * Populated by the real cap-fire branch in ``_supervisor`` (snapshot of
+#     the user-visible cap message).
+#   * Restored into ``_fatal_errors[entry_id]`` by the pass-through clear
+#     branch in ``_clear_fatal_error_for_entry`` so the per-entry fatal
+#     stays visible to the coordinator/diag binary sensor across non-cap
+#     overwrites.
+#   * Dropped in lockstep with the latch in the two release paths:
+#       (a) ``force=True`` teardown
+#       (b) healthy-run cleanup branch in ``_supervisor``
+#
+# These are unit-tests of the helper contract (no supervisor loop).
+
+
+def test_iter16_pass_through_restores_cap_message_from_snapshot() -> None:
+    """Pass-through clear must restore the cap-fire snapshot.
+
+    Iter-16 (Codex follow-up on commit 8cfd5b25): without restoration the
+    coordinator and the diagnostic binary sensor lose visibility of the
+    cap-fatal state during the recovery/retry window even though
+    ``_short_run_cap_latched`` is still set.
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    cap_message = (
+        "FCM short-run crash loop: 10 consecutive runs ended within 30s "
+        "(persistent poison message suspected)"
+    )
+
+    # Simulate the state right after a cap fire + a later non-cap fatal
+    # overwriting the per-entry fatal map slot.
+    receiver._short_run_cap_latched.add("entry-restore")
+    receiver._short_run_cap_messages["entry-restore"] = cap_message
+    receiver._fatal_errors["entry-restore"] = (
+        "FCM registration failed: HTTP 401 Unauthorized"
+    )
+    receiver._fatal_error = "FCM registration failed: HTTP 401 Unauthorized"
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-restore", reason="Credentials updated for entry"
+    )
+
+    # The non-cap fatal is gone, the cap snapshot is restored, the latch
+    # and the snapshot cache survive (only a healthy run or force=True may
+    # drop them).
+    assert receiver._fatal_errors["entry-restore"] == cap_message
+    assert receiver._fatal_error == cap_message
+    assert "entry-restore" in receiver._short_run_cap_latched
+    assert receiver._short_run_cap_messages["entry-restore"] == cap_message
+
+
+def test_iter16_force_true_clear_drops_cap_message_snapshot() -> None:
+    """A force=True teardown must also drop the cap-fire snapshot."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    receiver._short_run_cap_latched.add("entry-force")
+    receiver._short_run_cap_messages["entry-force"] = (
+        "FCM short-run crash loop: ..."
+    )
+    receiver._fatal_errors["entry-force"] = (
+        "FCM short-run crash loop: ..."
+    )
+    receiver._fatal_error = "FCM short-run crash loop: ..."
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-force", reason="Unload", force=True
+    )
+
+    assert "entry-force" not in receiver._short_run_cap_latched
+    assert "entry-force" not in receiver._short_run_cap_messages
+    assert "entry-force" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+
+
+def test_iter16_pass_through_with_empty_snapshot_falls_back_to_iter10() -> None:
+    """When no snapshot was captured the iter-10 behaviour must survive.
+
+    Edge case: a stale latch is set manually (test harness) or the snapshot
+    was already dropped while the latch remained. The pass-through clear
+    must NOT fabricate a cap message - it simply clears the non-cap fatal
+    and lets the latch keep blocking future cap-fatal clears.
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    receiver._short_run_cap_latched.add("entry-empty-snapshot")
+    # NO entry in ``_short_run_cap_messages`` for this entry_id.
+    receiver._fatal_errors["entry-empty-snapshot"] = (
+        "FCM registration failed: HTTP 401 Unauthorized"
+    )
+    receiver._fatal_error = "FCM registration failed: HTTP 401 Unauthorized"
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-empty-snapshot", reason="Credentials updated for entry"
+    )
+
+    # Iter-10 contract: non-cap fatal cleared, latch survives, no
+    # restoration because nothing was snapshotted.
+    assert "entry-empty-snapshot" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    assert "entry-empty-snapshot" in receiver._short_run_cap_latched
+    assert "entry-empty-snapshot" not in receiver._short_run_cap_messages
+
+
 @pytest.mark.asyncio
 async def test_healthy_run_releases_cap_latch_and_fatal_state(
     monkeypatch: pytest.MonkeyPatch,
@@ -785,6 +896,10 @@ async def test_healthy_run_releases_cap_latch_and_fatal_state(
     assert entry_id not in receiver._short_run_cap_latched
     assert entry_id not in receiver._fatal_errors
     assert receiver._fatal_error is None
+    # Iter-16: the healthy-run cleanup branch must also retire the
+    # cap-fire snapshot so a later non-cap fatal cannot accidentally
+    # restore a stale cap message.
+    assert entry_id not in receiver._short_run_cap_messages
     # The Repairs issue is deleted at least once on the healthy path.
     delete_calls_for_entry = [
         call

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -244,11 +244,17 @@ async def test_long_run_resets_closure_counter(
 
     clock = _MonoClock(step=0.001)
     # Build 19 clients: short, short, ..., LONG at index 9, short, short, ...
+    # The LONG run must use ``jump_on_run_state_read`` (not ``jump_on_start``)
+    # so the 60s elapse AFTER the supervisor captures ``entry_start`` at
+    # Z. 960; otherwise the jump is consumed by the snapshot itself and
+    # ``run_duration`` collapses to ~0, making this run count as short.
     clients = []
     for idx in range(19):
         if idx == 9:
             clients.append(
-                _SupervisorPushClientStub(clock=clock, jump_on_start=60.0)
+                _SupervisorPushClientStub(
+                    clock=clock, jump_on_run_state_read=60.0
+                )
             )
         else:
             clients.append(_SupervisorPushClientStub(clock=clock))
@@ -329,8 +335,12 @@ async def test_per_entry_supervisors_independent(
     # Entry A: 10 short runs (will trip the cap).
     clients_a = [_SupervisorPushClientStub(clock=clock_a) for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)]
     # Entry B: 5 healthy long runs (well above threshold).
+    # ``jump_on_run_state_read`` (not ``jump_on_start``) is required so the
+    # 60s elapse AFTER ``entry_start`` snapshot at Z. 960 and actually mark
+    # each run as a long run; otherwise the test passes only by accident
+    # because 5 short runs also stay below the cap of 10.
     clients_b = [
-        _SupervisorPushClientStub(clock=clock_b, jump_on_start=60.0)
+        _SupervisorPushClientStub(clock=clock_b, jump_on_run_state_read=60.0)
         for _ in range(5)
     ]
 

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -84,11 +84,26 @@ class _SupervisorPushClientStub:
         jump_on_start: float = 0.0,
         jump_on_run_state_read: float = 0.0,
         become_started: bool = True,
+        has_been_started: bool | None = None,
     ) -> None:
         self.clock = clock
         self.jump_on_start = jump_on_start
         self.jump_on_run_state_read = jump_on_run_state_read
         self.become_started = become_started
+        # Iter-12 ``has_been_started``: mirrors the production subclass'
+        # ``_has_been_started`` latch which is set by the vendored
+        # library the moment ``run_state = STARTED`` is assigned,
+        # independent of polling cadence. Default mirrors
+        # ``become_started`` so existing tests behave as before; pass
+        # explicitly to model the micro-window crash scenario
+        # (``become_started=False, has_been_started=True``: client
+        # reached STARTED and crashed before the first monitor poll)
+        # or a true pre-start failure
+        # (``become_started=False, has_been_started=False``: client
+        # never reached STARTED at all).
+        if has_been_started is None:
+            has_been_started = become_started
+        self._has_been_started = has_been_started
         self.do_listen = True
         self.start_calls = 0
         self.stop_calls = 0
@@ -1184,3 +1199,175 @@ async def test_long_pre_start_does_not_release_cap_latch(
         f"Long pre-start deleted the cap Repairs issue without a healthy "
         f"run; cap_deletes={cap_deletes}"
     )
+
+
+# --------------------------------------------------------------------------
+# Iter-12 (Codex follow-up): sampling-gap defense
+#
+# When the full lifecycle CREATED -> STARTED -> CRASH happens between two
+# monitor polls (>=0.5s), the supervisor's monitor loop NEVER reads
+# ``state == STARTED`` and ``became_started`` would remain false. The
+# vendored ``_ObservableFcmPushClient`` subclass latches
+# ``_has_been_started`` via a ``__setattr__`` hook the moment the library
+# assigns ``run_state = STARTED`` -- independent of polling cadence.
+# The supervisor's cap branch consults this latch before deciding whether
+# a short run advances the counter. (CA-DEFENSE-OBSERVABILITY-001)
+# --------------------------------------------------------------------------
+
+
+def test_observable_subclass_latches_started_transition() -> None:
+    """The ``__setattr__`` hook latches ``_has_been_started`` on STARTED.
+
+    Unit-tests the observer mechanic in isolation: bypass the library
+    ``__init__`` and only exercise the attribute hook. The latch is
+    monotonic (set on STARTED, never cleared) and ignores non-STARTED
+    state assignments.
+    """
+    pc_cls = fcm_receiver_ha._FcmPushClientFactory
+    if pc_cls is fcm_receiver_ha.FcmPushClient:
+        pytest.skip("Vendored library not available; subclass not active")
+
+    from custom_components.googlefindmy.Auth.firebase_messaging import (
+        FcmPushClientRunState,
+    )
+
+    # Bypass library ``__init__`` -- we only exercise the ``__setattr__``
+    # hook. Seed the latch the same way the subclass' ``__init__`` does.
+    pc = pc_cls.__new__(pc_cls)
+    object.__setattr__(pc, "_has_been_started", False)
+
+    # Non-STARTED transitions do NOT set the latch.
+    pc.run_state = FcmPushClientRunState.CREATED
+    assert pc._has_been_started is False
+    pc.run_state = FcmPushClientRunState.STARTING_LOGIN
+    assert pc._has_been_started is False
+
+    # STARTED sets the latch.
+    pc.run_state = FcmPushClientRunState.STARTED
+    assert pc._has_been_started is True
+
+    # Latch is monotonic -- subsequent non-STARTED transitions do NOT
+    # clear it (the cap needs evidence the client was EVER started, not
+    # whether it is started right now).
+    pc.run_state = FcmPushClientRunState.STOPPING
+    assert pc._has_been_started is True
+    pc.run_state = FcmPushClientRunState.STOPPED
+    assert pc._has_been_started is True
+
+
+@pytest.mark.asyncio
+async def test_micro_window_crash_advances_cap_via_observable_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Micro-window CREATED -> STARTED -> CRASH between polls still counts.
+
+    Models the exact scenario the cap is meant to detect: the client
+    connects, decodes a poison message, and crashes before the supervisor's
+    first ``await asyncio.sleep(FCM_MONITOR_INTERVAL_S)`` sample. The
+    monitor loop reads STOPPED/!do_listen and ``became_started`` would
+    remain false WITHOUT the subclass latch. The latch
+    (``_has_been_started=True``, set by the vendored ``__setattr__`` hook
+    during ``pc.start()``) lets the cap correctly classify the run as a
+    short crash and advance the counter. 10 such micro-window crashes
+    fire the cap.
+    """
+    entry_id = "entry-micro-window"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # become_started=False: the monitor loop never reads ``run_state ==
+    # STARTED`` (state read returns None on the first call, forcing the
+    # ``state is None`` break path immediately).
+    # has_been_started=True: the subclass latch was set during the
+    # library's CREATED -> STARTED transition that completed BEFORE the
+    # first monitor poll.
+    clients = [
+        _SupervisorPushClientStub(
+            clock=clock, become_started=False, has_been_started=True
+        )
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Cap fired despite the supervisor monitor loop never reading STARTED.
+    assert register_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS, (
+        f"Expected exactly {_MAX_CONSECUTIVE_SHORT_RUNS} register calls "
+        f"(one per micro-window crash); got {register_mock.await_count}. "
+        f"Without the subclass latch, became_started=False would keep the "
+        f"cap from firing and the supervisor would retry indefinitely."
+    )
+    assert create_issue.call_count == 1
+    cap_issue_call = create_issue.call_args
+    assert cap_issue_call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith(
+        "FCM short-run crash loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_burst_micro_window_and_pre_start_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-start failures interleaved with micro-window crashes count only the latter.
+
+    Cascade: 5 micro-window crashes (has_been_started=True) + 3 true
+    pre-start failures (has_been_started=False) + 5 micro-window crashes.
+    The cap MUST fire at exactly 10 cumulative micro-window crashes
+    (counter reaches threshold on the 13th supervisor pass). Pre-start
+    failures leave the counter AND the latch UNTOUCHED. This pins the
+    orthogonality of the sampling-gap defense to the pre-start-failure
+    gate from iter-11 (CA-DEFENSE-SPECIFICITY-001).
+    """
+    entry_id = "entry-mixed-burst"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    cascade = (
+        [
+            _SupervisorPushClientStub(
+                clock=clock, become_started=False, has_been_started=True
+            )
+            for _ in range(5)
+        ]
+        + [
+            _SupervisorPushClientStub(
+                clock=clock, become_started=False, has_been_started=False
+            )
+            for _ in range(3)
+        ]
+        + [
+            _SupervisorPushClientStub(
+                clock=clock, become_started=False, has_been_started=True
+            )
+            for _ in range(5)
+        ]
+    )
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=cascade
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Cap fired on the 13th iteration (5 + 3 + 5 = 13 stubs total, cap
+    # advances on micro-window crashes only).
+    assert register_mock.await_count == 13, (
+        f"Expected 13 register calls (5 + 3 + 5 cascade); got "
+        f"{register_mock.await_count}. Pre-start failures must NOT count "
+        f"toward the cap (iter-11), but real micro-window crashes MUST "
+        f"(iter-12)."
+    )
+    assert create_issue.call_count == 1
+    cap_issue_call = create_issue.call_args
+    assert cap_issue_call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    assert entry_id in receiver._short_run_cap_latched

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -51,10 +51,22 @@ class _SupervisorPushClientStub:
     """Lightweight ``FcmPushClient`` substitute for supervisor-loop tests.
 
     Mirrors only the surface the supervisor reads/writes (``start``, ``stop``,
-    ``run_state``, ``do_listen``, ``_observe_counter``). Each ``start()`` call
-    can optionally trigger a clock jump (to simulate the elapsed wall time of
-    the run before STOPPED), and ``run_state`` defaults to STOPPED so the
-    monitor loop exits on the first iteration.
+    ``run_state``, ``do_listen``, ``_observe_counter``).
+
+    Two clock-injection hooks model the supervisor's snapshot boundary
+    correctly:
+
+    * ``jump_on_start`` advances the clock inside ``start()`` BEFORE the
+      supervisor takes the ``entry_start`` snapshot (Z. 960). It models
+      pre-monitor elapsed time and does NOT influence ``run_duration``.
+    * ``jump_on_run_state_read`` advances the clock on the first
+      ``pc.run_state`` access INSIDE the monitor loop (Z. 964), which is
+      AFTER the ``entry_start`` snapshot. It is the only correct way to
+      inject elapsed-run time that ``run_duration = time.monotonic() -
+      entry_start`` actually observes. Use this for boundary math.
+
+    ``run_state`` defaults to ``None`` so the monitor loop exits on the
+    first iteration (``state is None`` break path).
     """
 
     def __init__(
@@ -62,14 +74,28 @@ class _SupervisorPushClientStub:
         *,
         clock: _MonoClock | None = None,
         jump_on_start: float = 0.0,
+        jump_on_run_state_read: float = 0.0,
     ) -> None:
         self.clock = clock
         self.jump_on_start = jump_on_start
+        self.jump_on_run_state_read = jump_on_run_state_read
         self.do_listen = True
-        self.run_state = None  # forces ``state is None`` break path
         self.start_calls = 0
         self.stop_calls = 0
         self._observed_short_run_counter: int | None = None
+        self._run_state_reads = 0
+
+    @property
+    def run_state(self):  # noqa: D401 - mirror attribute access
+        self._run_state_reads += 1
+        if (
+            self._run_state_reads == 1
+            and self.clock is not None
+            and self.jump_on_run_state_read
+        ):
+            self.clock.jump(self.jump_on_run_state_read)
+        # Implicit ``None`` return forces the ``state is None`` break path
+        # in the supervisor monitor loop (Z. 984-989).
 
     async def start(self) -> None:
         self.start_calls += 1
@@ -419,13 +445,21 @@ async def test_long_run_boundary_exactly_30s_does_not_count_as_short(
     receiver = FcmReceiverHA()
     receiver.attach_hass(SimpleNamespace())
 
-    clock = _MonoClock(step=0.001)
-    # A single client that jumps exactly the threshold on start(): the
-    # supervisor's ``run_duration = time.monotonic() - entry_start`` then
-    # equals 30.0 (the very small additional ``step`` reads in between
-    # are also captured by the jump because the snapshot happens AFTER
-    # ``start()`` returned).
-    stub = _SupervisorPushClientStub(clock=clock, jump_on_start=30.0)
+    # Frozen clock (``step=0.0``): every ``time.monotonic()`` call returns
+    # the same value unless ``.jump(seconds)`` is invoked. This is the only
+    # way to drive ``run_duration`` to *exactly* 30.0 — any auto-increment
+    # would push the read at Z. 1008 past the boundary by a few ``step``s
+    # and let an off-by-one bug (`<=` instead of `<`) hide inside the noise.
+    clock = _MonoClock(step=0.0)
+
+    # Critical ordering (Codex Iter-5 finding):
+    # ``jump_on_start`` would fire BEFORE the supervisor records
+    # ``entry_start = time.monotonic()`` (Z. 960), so the jump is baked
+    # into the snapshot and ``run_duration`` ends up ~0s. Instead, hook
+    # the jump on the first ``pc.run_state`` read (Z. 964), which is the
+    # first clock-observable event INSIDE the monitor loop, AFTER the
+    # snapshot. Then ``time.monotonic() - entry_start == 30.0`` exactly.
+    stub = _SupervisorPushClientStub(clock=clock, jump_on_run_state_read=30.0)
     _install_supervisor_mocks(
         monkeypatch, receiver, clock=clock, ensure_clients=[stub]
     )
@@ -435,6 +469,8 @@ async def test_long_run_boundary_exactly_30s_does_not_count_as_short(
     await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
 
     # The else-branch was hit (counter reset to 0), not the short-run branch.
+    # If `<` ever drifts to `<=`, ``run_duration == 30.0`` falls into the
+    # short-run path and ``_observed_short_run_counter`` becomes 1.
     assert stub._observed_short_run_counter == 0, (
         f"Boundary 30.0s was counted as short — `<` drifted to `<=`? "
         f"Counter={stub._observed_short_run_counter}"

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -65,8 +65,16 @@ class _SupervisorPushClientStub:
       inject elapsed-run time that ``run_duration = time.monotonic() -
       entry_start`` actually observes. Use this for boundary math.
 
-    ``run_state`` defaults to ``None`` so the monitor loop exits on the
-    first iteration (``state is None`` break path).
+    Iter-11 ``become_started``: defaults to ``True`` so the first
+    ``run_state`` read returns ``FcmPushClientRunState.STARTED`` (setting
+    the supervisor's per-run ``became_started`` latch) and the second
+    read returns ``None`` (forcing the ``state is None`` break path on
+    the next iteration with ``last_activity is None``). This mirrors the
+    poison-message scenario the cap is designed to catch: client
+    connects, decodes, dies, repeat. Set ``become_started=False`` to
+    model a pre-start failure (MCS unreachable / login failed) where the
+    client NEVER reaches ``STARTED`` and the cap MUST NOT advance the
+    counter.
     """
 
     def __init__(
@@ -75,10 +83,12 @@ class _SupervisorPushClientStub:
         clock: _MonoClock | None = None,
         jump_on_start: float = 0.0,
         jump_on_run_state_read: float = 0.0,
+        become_started: bool = True,
     ) -> None:
         self.clock = clock
         self.jump_on_start = jump_on_start
         self.jump_on_run_state_read = jump_on_run_state_read
+        self.become_started = become_started
         self.do_listen = True
         self.start_calls = 0
         self.stop_calls = 0
@@ -94,8 +104,18 @@ class _SupervisorPushClientStub:
             and self.jump_on_run_state_read
         ):
             self.clock.jump(self.jump_on_run_state_read)
+        if self.become_started and self._run_state_reads == 1:
+            from custom_components.googlefindmy.Auth.firebase_messaging import (
+                FcmPushClientRunState,
+            )
+
+            return FcmPushClientRunState.STARTED
         # Implicit ``None`` return forces the ``state is None`` break path
-        # in the supervisor monitor loop (Z. 984-989).
+        # in the supervisor monitor loop on the next iteration. With
+        # ``become_started=True`` this also gives ``last_activity is
+        # None`` break exactly one iteration AFTER ``STARTED`` was
+        # observed, which is the poison-message run shape (client
+        # connects, no message processed, restart).
 
     async def start(self) -> None:
         self.start_calls += 1
@@ -986,4 +1006,181 @@ async def test_cap_fire_pops_stop_evt_for_legitimate_restart(
         "Stale stop event lingers in _stop_evts after cap-fire; a "
         "legitimate restart would short-circuit because setdefault would "
         "reuse the already-set event."
+    )
+
+
+# --------------------------------------------------------------------------
+# Iter-11: Defense-Specificity (pre-start failures excluded from cap)
+# --------------------------------------------------------------------------
+# Pins the ``became_started`` per-run latch contract:
+# - Pre-start failures (MCS unreachable / login failed, client never
+#   reaches STARTED) MUST NOT advance the short-run counter and MUST
+#   NOT clear an existing cap latch.
+# - Real poison-message short-runs (became_started=True + run<30s) MUST
+#   still advance the counter as before. The cap stays specific to the
+#   scenario it was designed for.
+# - A mixed cascade (poison-message runs interleaved with transient
+#   outages) still accumulates correctly: the outages are no-ops, the
+#   poison-message runs add up to the cap at iteration N+M_short.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_start_failure_does_not_advance_cap_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """15 pre-start failures (no STARTED reached) must NOT fire the cap.
+
+    Models the Codex iter-11 scenario: an ordinary network/Google outage
+    where ``_listen()`` exhausts its 5 connection retries (~15-20s) and
+    the client never reaches ``STARTED``. Before the gate, 10 such
+    bursts would have permanently capped the supervisor and disabled
+    FCM push until reload.
+    """
+    entry_id = "entry-pre-start"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # 15 stubs that NEVER set become_started -> run_state stays None on
+    # every read -> ``became_started`` stays False in the supervisor.
+    clients = [
+        _SupervisorPushClientStub(clock=clock, become_started=False)
+        for _ in range(15)
+    ]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # The supervisor only terminates when the helper exhausts the client
+    # list (StopIteration -> stop_evt.set()). We MUST see all 15 registration
+    # attempts -- none was prematurely cut off by a cap fire.
+    assert register_mock.await_count == 15, (
+        f"Pre-start failures advanced the cap counter and terminated "
+        f"early -- expected 15 attempts, got {register_mock.await_count}"
+    )
+    assert create_issue.call_count == 0, (
+        "Cap repair issue was created from pre-start failures; the "
+        "``became_started`` gate is broken."
+    )
+    assert entry_id not in receiver._fatal_errors
+    assert entry_id not in receiver._short_run_cap_latched
+
+
+@pytest.mark.asyncio
+async def test_mixed_burst_only_counts_real_short_runs_toward_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """5 real short-runs + 3 pre-start failures + 5 real short-runs -> cap fires at 10 real.
+
+    Pins the "counter unchanged across pre-start failures" semantics: a
+    poison-message cascade interleaved with outages must still
+    accumulate correctly. The outages are no-ops, the real short-runs
+    accumulate 5+5=10 and the cap fires on the 10th REAL short-run.
+    """
+    entry_id = "entry-mixed"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients: list[_SupervisorPushClientStub] = []
+    # 5 real poison-message-style short-runs (became_started=True, run<30s)
+    for _ in range(5):
+        clients.append(_SupervisorPushClientStub(clock=clock))
+    # 3 transient outages (become_started=False) -- must be ignored by the cap
+    for _ in range(3):
+        clients.append(
+            _SupervisorPushClientStub(clock=clock, become_started=False)
+        )
+    # 5 more real short-runs -- together with the first 5 these are the 10
+    # consecutive REAL short-runs that fire the cap.
+    for _ in range(5):
+        clients.append(_SupervisorPushClientStub(clock=clock))
+    # Extra clients beyond the cap-fire would expose "loop kept going".
+    for _ in range(3):
+        clients.append(_SupervisorPushClientStub(clock=clock))
+
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Cap fires after the 13th client (5 real + 3 outage + 5th real = 13).
+    # Anything beyond 13 indicates the cap miscounted or did not terminate.
+    assert register_mock.await_count == 13, (
+        f"Mixed burst miscounted -- expected 13 client attempts "
+        f"(5 real + 3 outage + 5 real, cap on the 13th), got "
+        f"{register_mock.await_count}"
+    )
+    assert create_issue.call_count == 1
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_long_pre_start_does_not_release_cap_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Long-running pre-start failure (run>=30s) does NOT clear the cap latch.
+
+    Models a slow-to-fail connection attempt that hangs in pre-start for
+    more than 30s. Before the gate, the supervisor would have hit the
+    ``else`` branch (long run) and released the cap latch + Repairs UI
+    issue without ever proving the listener can stay up. The
+    ``became_started`` gate makes this a no-op so the latch remains.
+    """
+    entry_id = "entry-long-prestart"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    # Pre-seed the latch as if a prior cap-fire was still active. This
+    # mirrors the production state right after iter-9 termination but
+    # before any healthy run has cleared it.
+    receiver._short_run_cap_latched.add(entry_id)
+    receiver._fatal_errors[entry_id] = (
+        "FCM short-run crash loop: 10 consecutive runs ended within 30s "
+        "(persistent poison message suspected)"
+    )
+
+    clock = _MonoClock(step=0.0)
+    # become_started=False AND a 60s jump after the snapshot. Without the
+    # gate, the supervisor would see run_duration >= 30s and hit the
+    # ``else`` branch, releasing the latch.
+    stub = _SupervisorPushClientStub(
+        clock=clock, jump_on_run_state_read=60.0, become_started=False
+    )
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=[stub]
+    )
+    _create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Latch survives the long pre-start (no healthy proof was observed).
+    assert entry_id in receiver._short_run_cap_latched, (
+        "Long pre-start failure cleared the cap latch without ever "
+        "proving a healthy run -- gate is broken."
+    )
+    assert entry_id in receiver._fatal_errors
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+    # Repairs UI issue for the short-run cap was NOT deleted by the long
+    # pre-start. (The supervisor may issue unrelated ``fcm_stuck`` delete
+    # calls after a successful registration; we filter on the specific
+    # ``fcm_short_run_crash_loop_*`` key.)
+    cap_issue_key = f"fcm_short_run_crash_loop_{entry_id}"
+    cap_deletes = [
+        call for call in delete_issue.call_args_list
+        if len(call.args) >= 3 and call.args[2] == cap_issue_key
+    ]
+    assert cap_deletes == [], (
+        f"Long pre-start deleted the cap Repairs issue without a healthy "
+        f"run; cap_deletes={cap_deletes}"
     )


### PR DESCRIPTION
## Summary
- Implements PLAN_HOTFIX_FCM_CASCADING_FAILURE **AP-2 (Defense 2)** as the supervisor-level bulkhead around Defense 1 (PR #1084) and Defense 3 (PR #1085).
- New module constants `_MAX_CONSECUTIVE_SHORT_RUNS = 10` and `_SHORT_RUN_THRESHOLD_S = 30.0` in `Auth/fcm_receiver_ha.py`. Closure-local counter+timestamp inside `_start_supervisor_for_entry._supervisor` (CA-Audit B1 race-safe across re-registration).
- After the monitor loop exits, if `run_duration < _SHORT_RUN_THRESHOLD_S` (strict `<`) the counter bumps; at 10 consecutive short runs the supervisor surfaces a non-fixable ERROR repair issue `fcm_short_run_crash_loop_<entry_id>`, latches `_fatal_errors[entry_id]`, stops the client, and breaks the loop. A healthy run resets the counter.
- Translation key `fcm_short_run_crash_loop` added to **all 11 locale files** (plan-ownership extension over the spec's de+en, because the repo pattern is full native translations matching `fcm_connection_stuck`).
- 9 regression tests: 7 building blocks (threshold trigger, break, reset, re-registration isolation, per-entry independence, orthogonality to `_fatal_retry_counts`, unload cleanup), 1 boundary test (`<` vs. `<=` drift sentry on `_SHORT_RUN_THRESHOLD_S == 30.0`), 1 cross-locale symmetry test.
- Local `_MonoClock` (auto-incrementing monotonic with `jump(seconds)` for long-run simulation) + dedicated `_SupervisorPushClientStub` (orthogonal to AP-1's `FcmPushClientSlim`).

## Why this layer
- **Defense 1** (PR #1084 merged) wraps every per-message decode failure in `_listen` (cred-vs-message discriminator via typed `CredentialDecryptionError`).
- **Defense 3** (PR #1085 merged) hardens the base64 surface itself against Python 3.14 `binascii.a2b_base64(strict_mode=True)`.
- **Defense 2** (this PR) is the supervisor-level bulkhead: if some *future* poison class bypasses Defense 1+3 and the inner loop crashes hard while the supervisor reconnects in <30 s, the short-run counter caps the cascade at 10 iterations (≈300 s worst case) and surfaces a clear repair issue to the user instead of burning RAM + log volume unbounded (the original bug-report symptom on HA Core 2026.6.x).

## Background
- Branch base: `test/coverage-phase-1-registry-lifecycle@596f4d05` (the PR #1085 merge). Not `main` (out of scope for this sammel-branch).
- `_fatal_errors[entry_id]` cleanup on unload was already covered by `_clear_fatal_error_for_entry` (Z. 1334); the new `test_unload_clears_fatal_errors` verifies this structural guarantee.
- Closure-local state (not class dict) means a cancelled supervisor leaves no stale counter for the next one — prevents a false-positive repair issue after a legitimate reload.

## Verification
- `ruff check .` repo-wide: All checks passed.
- Cross-locale symmetry: 11 files, 10 distinct titles, all valid (de description ≠ en, strings == en).
- Defense-2 constants grep: 12 expected hits in `fcm_receiver_ha.py`.
- File-header sweep ✅ (`# tests/test_fcm_receiver_ha_short_run_cap.py`).
- Language gate ✅ (0 `[äöüÄÖÜß]` or German function words in production/test Python).
- pytest local skipped (container Py 3.11 cannot compile repo's PEP-695 `type` syntax) — CI verifies.

## Test plan
- [ ] CI green on `pytest tests/test_fcm_receiver_ha_short_run_cap.py` (9 tests, including boundary + i18n symmetry).
- [ ] CI green on `ruff check .` + `ruff format --check`.
- [ ] Codex review: watch for cred-vs-message discriminator regressions, exception-hierarchy assumptions, or sweep-class evasions analogous to the AP-1 iter cycle.
- [ ] No regression in `test_fcm_backoff_escalation` (same `_start_supervisor_for_entry` surface).

## Related
- PR #1084 (Defense 1, merged) — inner-loop poison-message hardening
- PR #1085 (Defense 3, merged) — base64 surface hardening
- Plan: `memory/plans/active/PLAN_HOTFIX_FCM_CASCADING_FAILURE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Code-architekt skill learnings (post-merge cross-refs)

This hotfix surfaced a new bug-family meta-class. The lesson is persisted into the code-architekt skill so future async-worker reviews catch the pattern automatically:

- **Backlog entry:** `skill_improvements/code-architekt.backlog.md` → `CA-CASCADING-FAILURE-001` (status: **VERDRAHTET** after AP-5).
- **Pattern reference:** `references/production-patterns.md` § 10 — "Inner-Loop-Hardening: poison-message cascade in async worker" (Triple-Defense skeleton + 6-step pre-push sweep).
- **Diagnostic cross-refs:** `references/nygard-error-stability-extrakt.md` NY-02 (Cascading Failure), NY-05 (Chain Reaction), NY-10 (Crack Propagation).
- **Anti-pattern catalogue:** `references/bekannte-irrtuemer.md` → `IRR-CA-POISON-MESSAGE` (three grep-regex detection signatures).
- **Self-audit trigger:** `SKILL.md` → **SA-2c** (Async-Worker-Poison-Message-Sweep) fires on every async-worker class with an outer-catch + supervisor-restart-loop (FCM, Kafka, RabbitMQ, MQTT, SQS consumers).

The pattern generalises language-neutral to any message loop where a single bad payload can latch the entire worker.

## LIFECYCLE discipline: 12 Codex/CI iterations on one defense

PR #1086 went through 12 consecutive Codex review iterations (iter-5..iter-16) plus 4 CI-cascade follow-ups on the same meta-class "lifecycle discipline of a defense". Each axis is now an inline RV-G3j..RV-G3t sub-check in `references/code-review-checkliste.md`:

| Iter | Axis | Type | Inline check |
|------|------|------|--------------|
| 5 | Snapshot ordering | temporal | RV-G3j |
| 6 | Hook-refactor sweep | refactoring | RV-G3k |
| 7 | Sentinel-as-termination | causal | RV-G3l |
| 8 | Set/Clear asymmetry | semantic | RV-G3m |
| 9 | Defense-termination loop | structural | RV-G3n |
| 10 | Guard granularity per payload | payload-structural | RV-G3o |
| 11 | Pre-start vs. became-started | scenario-specific | RV-G3p |
| 12 | Observability sampling gap | sampling-mechanistic | RV-G3q |
| 13 | Class identity + PEP 695 generic | type-system (CI follow-up) | RV-G3r |
| 14 | Cap-fatal channel vs. re-auth | channel confusion | RV-G3s |
| 15 | Mixin forward-declaration | mypy strict (CI follow-up) | RV-G3t |
| 16 | Latch restoration on pass-through clear | visibility preservation | RV-G3u |

12 iterations on one meta-class is the operative threshold for a dedicated `[LIFECYCLE-AUDIT]` mode in code-architekt v1.18+. Plan-architect escalation pending; the RV-G3 inline sub-checks are the operative discipline in v1.17–v1.26.

A separate Codex-marker verification reflex (RV-G3t / `_store/feedback_codex_outdated_marker_verifikation.md`) was added: GitHub's `outdated:false` flag on an inline review comment means **the diff position still exists**, not **the bug is unresolved**. Always cross-check against `original_commit_id` + HEAD diff before re-applying a finding.
