### PR TITLE
fix(coordinator/polling): demote FCM-connected timeout to INFO

### DIFF
--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1332,7 +1332,7 @@ class PollingOperations(_MixinBase):
 
                     except TimeoutError as terr:
                         if self.is_fcm_connected:
-                            _LOGGER.warning(
+                            _LOGGER.info(
                                 "Poll timed out for %s (FCM connected); ignoring error to keep status healthy.",
                                 dev_name,
                             )


### PR DESCRIPTION
## Summary
- Demote `_LOGGER.warning` to `_LOGGER.info` in the FCM-connected timeout branch of `polling.py` (one line).
- The message itself says "ignoring error to keep status healthy" — by Python logging convention (WARNING = unexpected, still working) this is not warning-worthy.
- Restores severity symmetry: the parallel FCM-disconnected branch already logs INFO for the same `TimeoutError`.

## Why
- In a 24-hour window on a healthy installation, this single line produced ~22 WARNINGs that surface in HA Notifications and inflate the Recorder log without representing any real problem.
- The disconnected branch (the *actually concerning* case) logs at INFO. The asymmetry inverted reality: the harmless branch shouted while the real failure whispered.

## Test plan
- [ ] HA restart with patched component -> no WARNING from the FCM-connected timeout branch in `home-assistant.log` over 24 h
- [ ] INFO for the same event remains visible at INFO log level
- [ ] `self.increment_stat("timeouts")` still fires (timeout counter unchanged in diagnostics)
- [ ] FCM-disconnected branch untouched -- same INFO behavior as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)