### PR TITLE
fix(deps): move grpclib to main dependency group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2232,7 +2232,7 @@ version = "0.4.9"
 description = "Pure-Python gRPC implementation for asyncio"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e"},
     {file = "grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46"},
@@ -2263,7 +2263,7 @@ version = "4.3.0"
 description = "Pure-Python HTTP/2 protocol implementation"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
     {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
@@ -2500,7 +2500,7 @@ version = "4.1.0"
 description = "Pure-Python HPACK header encoding"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
     {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
@@ -2610,7 +2610,7 @@ version = "6.1.0"
 description = "Pure-Python HTTP/2 framing"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
     {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
@@ -7639,4 +7639,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13.2"
-content-hash = "e9ce543b98f4f1bdaf4f36c11ec3456490685c0eb95b1d86219f7be5335c14d7"
+content-hash = "d8f65e6488915fd24832aa67dcabb6dfe0197531fafafc289eaa97dcd80d4918"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ beautifulsoup4 = ">=4.12.3"
 cryptography = ">=43.0.3"
 ecdsa = ">=0.19.1"
 gpsoauth = ">=2.0.0"
+grpclib = ">=0.4.7"
 h2 = ">=4.1.0"
 http-ece = ">=1.2.1"
 httpx = { version = ">=0.28.0", extras = ["http2"] }
@@ -49,7 +50,6 @@ pip-audit = ">=2.6"
 
 # Additional dev tools
 pyyaml = ">=6.0.2"
-grpclib = ">=0.4.7"
 pycares = ">=4.4.0"
 certifi = ">=2024.7.4"
 


### PR DESCRIPTION
## Problem

`grpclib` is a Home Assistant **runtime** requirement: it is declared in `custom_components/googlefindmy/manifest.json` and imported at integration load time (`__init__.py` → `SpotApi/spot_grpc_transport.py`, top-level `from grpclib.client import Channel`).

However it was misplaced under `[tool.poetry.group.dev.dependencies]` ("Additional dev tools"). It was the **only** one of the 13 manifest requirements missing from the `main` group. Consequence: a production install (`poetry install --only main`) yields an integration that raises `ModuleNotFoundError: grpclib` at load time.

This stays hidden in normal operation because HA/HACS install via `manifest.json`, not Poetry — but any Poetry-based main-only install (and a slim production dependency closure) is broken.

## Fix

- Move `grpclib = ">=0.4.7"` from the `dev` group to `[tool.poetry.dependencies]`.
- Regenerate `poetry.lock` (Poetry 2.3.2): `grpclib` groups `dev` → `main`; its transitives `h2`/`hpack`/`hyperframe` drop the now-redundant `dev` tag. **No version changes.**

## Verification

- `poetry check --lock` passes.
- `poetry export --only main` now contains `grpclib==0.4.9` (was absent before).
- Minimal diff: 5 insertions / 5 deletions in `poetry.lock`, 1 line moved in `pyproject.toml`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>