### PR TITLE
chore: bump version to 1.7.0-7 and document post-upgrade URL troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,13 @@ The integration provides a couple of Home Assistant Actions for use with automat
 - Check if devices have moved recently (Find My devices may not update GPS when stationary)
 - Check battery levels (low battery may disable GPS reporting)
 
+### Location updates stopped after an upgrade
+Location data is fetched **outbound** from Home Assistant to Google (FCM push plus Nova/SPOT polling); it does **not** depend on your Home Assistant internal or external URL configuration. If updates stop after upgrading the integration:
+1. **Reload the integration** (Settings → Devices & Services → Google Find My Device → ⋮ → Reload) or restart Home Assistant. This re-establishes the FCM connection and refreshes tokens, which resolves most post-upgrade stalls.
+2. If updates are still missing, review the logs for authentication errors and re-authenticate if prompted (see [Authentication Expires Repeatedly](#authentication-expires-repeatedly)).
+
+> **Note on the internal/external URL:** Your Home Assistant internal/external URL only affects the clickable **Map View links** on each device page, not location reception. Changing it can appear to "fix" updates because it triggers a reload or restart, but it is the restart that restores tracking, not the URL value. A configuration such as internal `http://ip-address:8123` plus external `https://your-domain:8123` is perfectly valid.
+
 ### FCM Connection Problems
 - Extended timeout allows up to 60 seconds for device response
 - Check firewall settings for Firebase Cloud Messaging

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -21,7 +21,7 @@ DATA_EID_RESOLVER: Final[Literal["eid_resolver"]] = "eid_resolver"
 # Latest config entry schema version handled by this integration.
 CONFIG_ENTRY_VERSION: int = 2
 # Keep the integration version aligned across the project (match manifest.json)
-INTEGRATION_VERSION: str = "1.7.0-6"
+INTEGRATION_VERSION: str = "1.7.0-7"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.0-6"
+  "version": "1.7.0-7"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "googlefindmy-ha"
-version = "1.7.0-6"
+version = "1.7.0-7"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
Prepares branch `1.7.0-7` by aligning the integration version and adding a documentation block that resolves a recurring user confusion.

### 1. Version bump 1.7.0-6 -> 1.7.0-7
Aligns the version across all three canonical locations (the only places carrying the integration's own version string):
- `custom_components/googlefindmy/manifest.json`
- `custom_components/googlefindmy/const.py` (`INTEGRATION_VERSION`)
- `pyproject.toml`

A repository-wide sweep confirmed no other live version markers: the remaining `1.7.0-3`/`1.7.0-5` strings in `docs/` and `README.md` are historical change references, and `poetry.lock`'s `1.7.0` is the unrelated `hass_nabucasa` dependency. `hacs.json` carries no version; there is no `CHANGELOG.md`.

### 2. README troubleshooting block (English)
Documents that location data is fetched outbound (FCM push plus Nova/SPOT polling) and does not depend on the Home Assistant internal/external URL. A reload or restart, not the URL value, restores tracking after an upgrade. Addresses the user report where changing the local URL appeared to fix updates but the restart was the actual cause.

## Verification
- `manifest.json` valid JSON, `pyproject.toml` parses (version `1.7.0-7`)
- grep gegenprobe: zero remaining `1.7.0-6`, exactly three `1.7.0-7`

Generated with Claude Code