### PR TITLE
Forward-port Class-A coverage suite + #1086 FCM hardening, recalibrate coverage floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=63 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=67 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -160,6 +160,84 @@ else:
 
 _LOGGER = logging.getLogger(__name__)
 
+
+# Iter-12 (Codex follow-up): the short-run crash cap needs to know
+# whether the FCM client ever reached ``FcmPushClientRunState.STARTED``
+# during a run, even when the entire CREATED -> STARTED -> CRASH
+# lifecycle happens between two monitor polls (``FCM_MONITOR_INTERVAL_S``
+# >= 0.5s). Sampling alone is too coarse for the very poison-message
+# loop the cap is meant to stop. A subclass with a ``__setattr__`` hook
+# latches ``_has_been_started`` the moment the vendored library assigns
+# ``run_state = STARTED`` -- independent of any polling cadence and
+# without modifying the vendored library itself. See
+# CA-DEFENSE-OBSERVABILITY-001.
+if HAVE_FCM_PUSH_CLIENT and FcmPushClientRunState is not None:
+    # Snapshot of the original class for runtime identity comparison.
+    # Tests substitute the module-level ``FcmPushClient`` symbol via
+    # monkeypatch (the documented seam) to inject test doubles; the
+    # factory below honours that substitution by class identity, not by
+    # subclass relation. See CA-SUBCLASS-IDENTITY-001.
+    _OriginalFcmPushClient: type[Any] | None = FcmPushClient
+
+    class _ObservableFcmPushClient(FcmPushClient[Any]):
+        """FcmPushClient subclass with a run_state observer latch.
+
+        See CA-DEFENSE-OBSERVABILITY-001.
+        """
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            # Seed the latch before super().__init__ so any attribute
+            # assignment performed by the parent's constructor still
+            # routes through our ``__setattr__`` without raising.
+            object.__setattr__(self, "_has_been_started", False)
+            super().__init__(*args, **kwargs)
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            super().__setattr__(name, value)
+            if (
+                name == "run_state"
+                and FcmPushClientRunState is not None
+                and value == FcmPushClientRunState.STARTED
+            ):
+                # ``object.__setattr__`` to avoid recursion through this hook.
+                object.__setattr__(self, "_has_been_started", True)
+
+    _ObservableFcmPushClientCls: type[Any] | None = _ObservableFcmPushClient
+else:  # pragma: no cover - exercised only when the vendored library is absent
+    _OriginalFcmPushClient = None
+    _ObservableFcmPushClientCls = None
+
+
+def _FcmPushClientFactory(*args: Any, **kwargs: Any) -> FcmPushClient[Any]:
+    """Construct an FCM client at call time, honouring test substitutions.
+
+    Production: prefers the ``_ObservableFcmPushClient`` subclass so the
+    short-run crash cap can observe ``run_state -> STARTED`` transitions
+    that happen between monitor polls (CA-DEFENSE-OBSERVABILITY-001).
+
+    Tests: when the module-level ``FcmPushClient`` symbol has been
+    monkeypatched away from the original class (the documented test
+    seam), the factory instantiates the patched class DIRECTLY rather
+    than the production subclass. This preserves ``isinstance`` identity
+    for test doubles (CA-SUBCLASS-IDENTITY-001) instead of returning a
+    subclass that diverges from the patched symbol.
+    """
+
+    current = globals().get("FcmPushClient")
+    if (
+        _ObservableFcmPushClientCls is not None
+        and _OriginalFcmPushClient is not None
+        and current is _OriginalFcmPushClient
+    ):
+        return cast(
+            "FcmPushClient[Any]",
+            _ObservableFcmPushClientCls(*args, **kwargs),
+        )
+    if current is None:  # pragma: no cover - vendored library missing
+        raise RuntimeError("FcmPushClient is not available")
+    return cast("FcmPushClient[Any]", current(*args, **kwargs))
+
+
 type JSONDict = dict[str, Any]
 type MutableJSONMapping = MutableMapping[str, Any]
 
@@ -167,8 +245,31 @@ _MAX_SUPERVISOR_BACKOFF_S = 120.0    # cap retry delay at 2 minutes (was 4096s)
 _BACKOFF_WARNING_THRESHOLD_S = 64.0  # warn after ~6 failed attempts
 _MAX_FATAL_AUTH_RETRIES = 3       # 401: max retries (60s, 120s, then give up)
 _MAX_FATAL_ENDPOINT_RETRIES = 7   # 404: max retries (30s-300s, Google rotates endpoints)
+# Defense 2: supervisor-level crash cap as a bulkhead around the inner-loop
+# poison-message filter (``fcmpushclient._listen`` Defense 1+3). When the FCM
+# client connects but loses the run-loop within ``_SHORT_RUN_THRESHOLD_S``
+# repeatedly, a persistent poison condition is suspected and the supervisor
+# stops looping to prevent unbounded retry pressure on Google + log spam.
+_MAX_CONSECUTIVE_SHORT_RUNS = 10
+_SHORT_RUN_THRESHOLD_S = 30.0  # strictly < 30s between pc.start() and STOPPED = short run
 _HTTP_UNAUTHORIZED = 401
 _HTTP_NOT_FOUND = 404
+
+# Defense 2 iter-14 (Codex follow-up): the supervisor-level crash cap writes
+# its terminal state into ``_fatal_errors[entry_id]`` so the binary_sensor
+# diagnostic attribute and the "is FCM ready" check in
+# ``coordinator/polling.py`` see the listener as unavailable. However, the
+# coordinator's re-auth escalation in ``coordinator/polling.py`` also consumes
+# that map and, after _FCM_ERROR_RETRY_THRESHOLD consecutive update cycles,
+# raises ``ConfigEntryAuthFailed`` for ANY non-auth fatal it does not
+# explicitly classify. The crash-loop fatal is NOT an auth problem
+# (the user must reload / regenerate credentials per the repair issue, not
+# re-authenticate). To prevent users from being pushed into Home Assistant's
+# re-auth flow for what is really a poison-message defense, the cap-fire
+# branch tags its message with this prefix and the polling-side consumer
+# excludes it from the re-auth escalation. This module is the SSOT for the
+# prefix; the polling-side consumer imports it from here.
+CRASH_LOOP_FATAL_PREFIX = "FCM short-run crash loop:"
 
 
 async def _call_in_executor[**P, T](
@@ -292,10 +393,120 @@ class FcmReceiverHA:
         # Per-entry nudge events: allows coordinator to wake up a sleeping supervisor
         self._retry_nudge_evts: dict[str, asyncio.Event] = {}
 
+        # Defense 2 iter-8: persistent short-run cap latch.
+        #
+        # When the cap fires the entry is in a *poison-message crash loop*
+        # that only a real healthy supervisor run (>= _SHORT_RUN_THRESHOLD_S)
+        # can prove gone. A successful FCM re-registration alone is NOT a
+        # proof: registration only contacts the GCM endpoint, it does not
+        # show that the subsequent listener stays up long enough to drain
+        # the poisoned notification.
+        #
+        # The latch is therefore set together with the user-visible repair
+        # issue at cap-fire time and is the *only* thing that gates whether
+        # ``_clear_fatal_error_for_entry`` (which gets called from every
+        # registration-success path) is allowed to drop the fatal-error map
+        # entry and the Repairs UI artefact. Without this latch, any reload
+        # or credential update would clear the cap-related fatal state, the
+        # supervisor would start a fresh 10-run burst, and the user would
+        # see no visible fatal state in between (Codex defense-2 iter-8
+        # second finding).
+        self._short_run_cap_latched: set[str] = set()
+        # Defense 2 iter-16 (Codex follow-up): persistent snapshot of the
+        # cap-fire message per entry. Populated when the cap fires and used
+        # by ``_clear_fatal_error_for_entry`` to restore the cap fatal after
+        # a non-cap fatal (e.g. a terminal 401/404 from a subsequent
+        # re-registration) was cleared. Cleared in the same two places that
+        # release the latch: the healthy-run cleanup branch and any
+        # ``force=True`` teardown. This keeps the per-entry fatal visible to
+        # the coordinator and the diagnostic binary sensor for the entire
+        # latch lifetime, even across non-cap fatal overwrites.
+        self._short_run_cap_messages: dict[str, str] = {}
+
     def _clear_fatal_error_for_entry(
-        self, entry_id: str, *, reason: str | None = None
+        self,
+        entry_id: str,
+        *,
+        reason: str | None = None,
+        force: bool = False,
     ) -> None:
-        """Clear any latched fatal registration error for a config entry."""
+        """Clear any latched fatal registration error for a config entry.
+
+        Also removes the Defense 2 short-run-crash-loop repair issue from the
+        Home Assistant Issue Registry. The fatal-error map and the Issue
+        Registry entry are a CREATE/DELETE pair: any recovery path that clears
+        the in-memory latch must also delete the user-visible UI artefact, or
+        the Repairs panel keeps a stale non-fixable error after the underlying
+        condition is gone (e.g. user re-registers credentials and FCM starts
+        successfully again).
+
+        Defense 2 iter-8 (Codex second finding): a successful FCM
+        re-registration is NOT a recovery proof for the short-run crash cap.
+        While ``_short_run_cap_latched`` contains *entry_id* this method must
+        protect the cap state (latched fatal message + Repairs UI artefact)
+        from being silently cleared, so users keep seeing the fatal state
+        until a real healthy supervisor run (>= _SHORT_RUN_THRESHOLD_S) drops
+        the latch from the monitor loop. Hard-reset callers (entry unregister,
+        test cleanup, integration teardown) must opt in with ``force=True``.
+
+        Defense 2 iter-10 (Codex follow-up): the latch guard is intentionally
+        narrow. It is a no-op ONLY when the currently stored fatal IS the
+        cap-related message (``FCM short-run crash loop: ...``). Non-cap fatal
+        errors (e.g. a terminal 401/404 from a subsequent re-registration that
+        overwrote ``_fatal_errors[entry_id]``) must clear normally so a
+        credentials recovery is not blocked by an unrelated latch. The cap
+        latch, any cap-related fatal it still protects, and the Repairs UI
+        artefact remain in place in that case; only the unrelated fatal is
+        dropped.
+        """
+
+        if not force and entry_id in self._short_run_cap_latched:
+            current_fatal = self._fatal_errors.get(entry_id)
+            # No fatal stored, or the stored fatal IS the cap message:
+            # preserve everything (latch, message, Repairs UI artefact).
+            if current_fatal is None or current_fatal.startswith(
+                CRASH_LOOP_FATAL_PREFIX
+            ):
+                _LOGGER.debug(
+                    "[entry=%s] Skipping fatal-error clear; short-run cap latch "
+                    "active (reason=%s). Latch will be released by a healthy "
+                    "supervisor run.",
+                    entry_id,
+                    reason or "unspecified",
+                )
+                return
+
+            # Non-cap fatal stored while the cap latch is active. Clear the
+            # unrelated fatal but KEEP the cap latch and Repairs UI artefact
+            # intact, so the user-visible cap warning is not silently
+            # invalidated by an unrelated recovery path.
+            #
+            # Defense 2 iter-16 (Codex follow-up): the per-entry cap-fire
+            # message snapshot (``_short_run_cap_messages``) must be
+            # re-written into ``_fatal_errors`` so the coordinator and the
+            # diagnostic binary sensor continue to see the cap-fatal state
+            # during the recovery/retry window. Otherwise the latch would
+            # silently invalidate the per-entry fatal even though the
+            # in-memory latch and the Repairs UI artefact remain set.
+            _LOGGER.debug(
+                "[entry=%s] Cap latch active; clearing non-cap fatal "
+                "(reason=%s) while preserving cap latch and repair issue",
+                entry_id,
+                reason or "unspecified",
+            )
+            self._fatal_errors.pop(entry_id, None)
+            cap_message = self._short_run_cap_messages.get(entry_id)
+            if cap_message is not None:
+                self._fatal_errors[entry_id] = cap_message
+            self._fatal_error = next(iter(self._fatal_errors.values()), None)
+            return
+
+        if force:
+            self._short_run_cap_latched.discard(entry_id)
+            # Iter-16: drop the cap-fire snapshot in lockstep with the latch
+            # so a forced teardown also retires the message that the
+            # pass-through branch would otherwise restore.
+            self._short_run_cap_messages.pop(entry_id, None)
 
         removed = False
         if entry_id in self._fatal_errors:
@@ -311,6 +522,18 @@ class FcmReceiverHA:
 
         if removed:
             self._fatal_error = next(iter(self._fatal_errors.values()), None)
+
+        if self._hass is not None:
+            try:
+                ir.async_delete_issue(
+                    self._hass, DOMAIN, f"fcm_short_run_crash_loop_{entry_id}"
+                )
+            except Exception:  # noqa: BLE001 - best-effort UI cleanup
+                _LOGGER.debug(
+                    "[entry=%s] Failed to delete short-run repair issue",
+                    entry_id,
+                    exc_info=True,
+                )
 
     @staticmethod
     def _ensure_cache_entry_id(cache: Any, entry_id: str) -> None:
@@ -709,7 +932,7 @@ class FcmReceiverHA:
                     "CredentialsUpdatedCallable[MutableJSONMapping]",
                     _on_creds_updated_entry,
                 )
-                pc = FcmPushClient(
+                pc = _FcmPushClientFactory(
                     lambda payload,
                     persistent_id,
                     context,
@@ -756,6 +979,12 @@ class FcmReceiverHA:
                     return False
 
             backoff = 1.0
+            # Defense 2: per-supervisor closure state for the short-run
+            # crash cap. Kept closure-local (not on ``self``) so a
+            # re-registration that cancels this supervisor and spawns a
+            # new one cannot inherit a stale counter (CA-Audit B1).
+            short_run_counter: int = 0
+            entry_start: float = 0.0
             try:
                 while not stop_evt.is_set():
                     pc = await self._ensure_client_for_entry(entry_id, cache)
@@ -919,6 +1148,22 @@ class FcmReceiverHA:
                             "[entry=%s] FCM client failed to start: %s", entry_id, err
                         )
 
+                    # Defense 2 snapshot: timestamp the entry into the
+                    # monitor loop.
+                    #
+                    # Iter-11 (Codex follow-up): per-run latch tracking
+                    # whether the client ever reached a connected/listening
+                    # state. The cap is meant to detect a poison-message
+                    # crash loop (client connects, decodes, dies, repeat),
+                    # NOT ordinary connectivity outages where ``_listen()``
+                    # exhausts its 5 connection retries (~15-20s) without
+                    # ever reaching ``STARTED``. Without this gate, a normal
+                    # MCS-unreachable / Google outage would cap the
+                    # supervisor after 10 brief connection-failure runs and
+                    # permanently disable FCM push until reload.
+                    entry_start = time.monotonic()
+                    became_started = False
+
                     while not stop_evt.is_set():
                         await asyncio.sleep(max(FCM_MONITOR_INTERVAL_S, 0.5))
                         state = getattr(pc, "run_state", None)
@@ -928,6 +1173,27 @@ class FcmReceiverHA:
                             entry_id, pc, monotonic_now
                         )
                         stale_after = max(self._activity_stale_after_s, 0.0)
+                        # Iter-11: track ``became_started`` symmetrically to
+                        # the health probe (same fallback for libraries that
+                        # do not expose a ``run_state`` enum).
+                        if FcmPushClientRunState is None:
+                            if do_listen:
+                                became_started = True
+                        elif state == FcmPushClientRunState.STARTED:
+                            became_started = True
+                        # Iter-12 (Codex follow-up): sampling-gap defense.
+                        # When the full lifecycle ``CREATED -> STARTED ->
+                        # CRASH`` happens between two monitor polls (>=0.5s),
+                        # this loop reads STOPPED/!do_listen and ``became_started``
+                        # would remain false. The vendored client's
+                        # ``__setattr__`` hook latches ``_has_been_started``
+                        # the moment the library assigns ``run_state =
+                        # STARTED``, independent of polling cadence; mirror
+                        # that observation here so the cap branch correctly
+                        # classifies micro-window poison-message crashes.
+                        became_started = became_started or bool(
+                            getattr(pc, "_has_been_started", False)
+                        )
                         healthy = (
                             (
                                 FcmPushClientRunState is None
@@ -978,6 +1244,158 @@ class FcmReceiverHA:
                                 monotonic_now - last_activity,
                             )
                             break
+
+                    # Defense 2: short-run crash cap. Counts consecutive
+                    # monitor exits with ``run_duration <
+                    # _SHORT_RUN_THRESHOLD_S`` THAT ALSO reached
+                    # ``STARTED`` at least once during the run. After
+                    # ``_MAX_CONSECUTIVE_SHORT_RUNS`` such runs, surface a
+                    # non-fixable repair issue and stop the loop. The
+                    # comparison is strictly ``<`` (a 30.0s run counts as
+                    # healthy and resets the counter).
+                    #
+                    # Iter-11 (Codex follow-up): the ``became_started`` gate
+                    # ensures the cap is specific to the poison-message
+                    # scenario (client connects, decodes, dies, repeat) and
+                    # excludes pre-start connection/login failures. A burst
+                    # of MCS-unreachable failures (5 retries x ~3-4s each)
+                    # would otherwise be counted as short-run crashes and
+                    # permanently disable FCM push after one ordinary
+                    # network outage. Pre-start failures leave the counter
+                    # AND the latch UNTOUCHED so that (a) a poison-message
+                    # cascade interleaved with outages still accumulates
+                    # correctly, and (b) a long pre-start hang does not
+                    # falsely clear a real cap latch (no healthy proof).
+                    run_duration = time.monotonic() - entry_start
+                    if not became_started:
+                        # Pre-start failure (no connected/listening state
+                        # observed during this run). Do NOT touch the
+                        # short-run counter or the cap latch.
+                        pass
+                    elif run_duration < _SHORT_RUN_THRESHOLD_S:
+                        short_run_counter += 1
+                        # Test hook: expose the closure counter to stubs
+                        # without leaking it onto ``self``.
+                        observe = getattr(pc, "_observe_counter", None)
+                        if callable(observe):
+                            try:
+                                observe(short_run_counter)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        if short_run_counter >= _MAX_CONSECUTIVE_SHORT_RUNS:
+                            message = (
+                                f"{CRASH_LOOP_FATAL_PREFIX} "
+                                f"{_MAX_CONSECUTIVE_SHORT_RUNS} consecutive "
+                                f"runs ended within "
+                                f"{_SHORT_RUN_THRESHOLD_S:.0f}s "
+                                f"(persistent poison message suspected)"
+                            )
+                            _LOGGER.error("[entry=%s] %s", entry_id, message)
+                            self._fatal_errors[entry_id] = message
+                            # Defense 2 iter-8: latch the cap state. While
+                            # this latch is set, ``_clear_fatal_error_for_entry``
+                            # is a no-op (registration / credential-update paths
+                            # cannot clear the fatal map or the Repairs issue
+                            # before a real healthy supervisor run proves the
+                            # poison message is gone).
+                            self._short_run_cap_latched.add(entry_id)
+                            # Iter-16 (Codex follow-up): snapshot the
+                            # cap-fire message so the pass-through clear
+                            # branch in ``_clear_fatal_error_for_entry`` can
+                            # restore it after a non-cap fatal overwrote
+                            # ``_fatal_errors[entry_id]``. Released in the
+                            # same two places that release the latch.
+                            self._short_run_cap_messages[entry_id] = message
+                            if self._hass:
+                                ir.async_create_issue(
+                                    self._hass,
+                                    DOMAIN,
+                                    f"fcm_short_run_crash_loop_{entry_id}",
+                                    is_fixable=False,
+                                    severity=ir.IssueSeverity.ERROR,
+                                    translation_key="fcm_short_run_crash_loop",
+                                )
+                            # Cleanup the client before breaking out so
+                            # the loop exit doesn't leave a half-stopped pc.
+                            try:
+                                await pc.stop()
+                            except Exception:  # noqa: BLE001
+                                pass
+                            finally:
+                                async with self._lock:
+                                    self.pcs.pop(entry_id, None)
+                                self._update_entry_health(entry_id, False)
+                            # Defense 2 iter-9 (Codex follow-up): the cap is
+                            # a TERMINAL state for this supervisor. ``break``
+                            # alone only exits the inner monitor loop and
+                            # falls through to the per-iteration restart
+                            # block (``if not stop_evt.is_set(): ...
+                            # _nudge_sleep(delay)``), which would spawn a
+                            # fresh FCM client and continue the retry
+                            # pressure / log spam the cap is meant to stop.
+                            # Set the stop event so the outer ``while not
+                            # stop_evt.is_set()`` exits, and pop the entry
+                            # from ``_stop_evts`` so a legitimate
+                            # re-registration / reload (which constructs a
+                            # fresh event via ``setdefault``) is not
+                            # short-circuited by the now-consumed event.
+                            stop_evt.set()
+                            self._stop_evts.pop(entry_id, None)
+                            break
+                    else:
+                        short_run_counter = 0  # healthy run resets the counter
+                        observe = getattr(pc, "_observe_counter", None)
+                        if callable(observe):
+                            try:
+                                observe(short_run_counter)
+                            except Exception:  # noqa: BLE001
+                                pass
+                        # Mirror the counter reset in the Issue Registry: if
+                        # the cap had previously fired on a prior supervisor
+                        # incarnation, a healthy run is the user-visible
+                        # signal that the condition is gone.
+                        #
+                        # Defense 2 iter-8: a healthy run is the ONLY proof
+                        # the system has that the poison-message condition is
+                        # gone, so this is also the only callsite that may
+                        # drop the cap latch. After dropping the latch, the
+                        # cap-related ``_fatal_errors`` entry is removed and
+                        # the aggregate ``_fatal_error`` re-derived (so the
+                        # System Health surface stops showing the stale
+                        # message). The Repairs delete below stays inside
+                        # ``self._hass is not None`` and intentionally also
+                        # runs when no latch was set (cheap idempotent UI
+                        # cleanup).
+                        cap_was_latched = entry_id in self._short_run_cap_latched
+                        if cap_was_latched:
+                            self._short_run_cap_latched.discard(entry_id)
+                            # Iter-16: a healthy run is also the moment to
+                            # retire the cap-fire snapshot so the
+                            # pass-through clear branch cannot re-introduce
+                            # it after the latch is gone.
+                            self._short_run_cap_messages.pop(entry_id, None)
+                            cap_message = self._fatal_errors.get(entry_id)
+                            if cap_message and cap_message.startswith(
+                                CRASH_LOOP_FATAL_PREFIX
+                            ):
+                                self._fatal_errors.pop(entry_id, None)
+                                self._fatal_error = next(
+                                    iter(self._fatal_errors.values()), None
+                                )
+                                _LOGGER.info(
+                                    "[entry=%s] FCM short-run cap latch released "
+                                    "by healthy supervisor run",
+                                    entry_id,
+                                )
+                        if self._hass is not None:
+                            try:
+                                ir.async_delete_issue(
+                                    self._hass,
+                                    DOMAIN,
+                                    f"fcm_short_run_crash_loop_{entry_id}",
+                                )
+                            except Exception:  # noqa: BLE001
+                                pass
 
                     # Cleanup before restart
                     try:
@@ -1331,7 +1749,12 @@ class FcmReceiverHA:
             else:
                 self._entry_caches.pop(entry_id, None)
                 self._purge_entry_tokens(entry_id)
-                self._clear_fatal_error_for_entry(entry_id, reason="Entry unregistered")
+                # Hard-reset on unregister: the entry is going away, so the
+                # short-run cap latch must be released together with the
+                # fatal-error map and the Repairs issue (force=True).
+                self._clear_fatal_error_for_entry(
+                    entry_id, reason="Entry unregistered", force=True
+                )
 
     # -------------------- Incoming notifications --------------------
 

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1267,7 +1267,25 @@ class FcmReceiverHA:
                     # correctly, and (b) a long pre-start hang does not
                     # falsely clear a real cap latch (no healthy proof).
                     run_duration = time.monotonic() - entry_start
-                    if not became_started:
+                    credential_error = getattr(pc, "credential_error", None)
+                    if credential_error is not None:
+                        # Finding 1 (Codex): the listener surfaced corrupt FCM
+                        # key material via ``credential_error``. Restarting
+                        # against the same credentials would loop until the
+                        # short-run crash cap fires; instead invalidate the key
+                        # material so the next registration regenerates it
+                        # (android_id/security_token preserved) and do NOT
+                        # charge this run to the crash cap -- corrective action
+                        # is being taken, this is not a poison-message loop.
+                        _LOGGER.error(
+                            "[entry=%s] FCM credential material corrupt (%s); "
+                            "invalidating FCM tokens to force re-registration",
+                            entry_id,
+                            credential_error,
+                        )
+                        await self._invalidate_fcm_tokens(entry_id)
+                        short_run_counter = 0
+                    elif not became_started:
                         # Pre-start failure (no connected/listening state
                         # observed during this run). Do NOT touch the
                         # short-run counter or the cap latch.

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -271,6 +271,12 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
 
         self.run_state: FcmPushClientRunState = FcmPushClientRunState.CREATED
         self.tasks: list[asyncio.Task[None]] = []
+        # Set by ``_listen`` when stored FCM key material is found to be
+        # corrupt/undecodable. The supervisor reads this after the listener
+        # stops to invalidate the bad credentials and force re-registration,
+        # instead of restarting against the same poison key material until the
+        # short-run crash cap fires.
+        self.credential_error: CredentialDecryptionError | None = None
 
         # Locks
         self.stopping_lock: asyncio.Lock = asyncio.Lock()
@@ -844,10 +850,12 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         Defense 1 (CA-CASCADING-FAILURE-001): per-message decode failures
         (``binascii.Error`` padding faults under Python 3.14 strict mode,
         ``RuntimeError`` from ``_app_data_by_key`` key lookups, generic
-        ``ValueError`` from header parsing) are acknowledged and skipped
-        instead of crashing the worker loop. Credential-material errors
-        (``CredentialDecryptionError``) propagate so the supervisor
-        surfaces them via STOPPED state and prompts re-registration.
+        ``ValueError`` from header parsing, and ``http_ece.ECEException``
+        from a corrupt encrypted body / failed auth tag) are acknowledged
+        and skipped instead of crashing the worker loop. Credential-material
+        errors (``CredentialDecryptionError``) propagate so ``_listen``
+        records them and the supervisor invalidates the bad key material and
+        prompts re-registration.
 
         Returns ``True`` to continue the loop, ``False`` to break (writer
         half-dead during ack).
@@ -857,18 +865,28 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             return True
         except CredentialDecryptionError:
             # Credential corruption is permanent; let the supervisor see it
-            # instead of silently ACKing every message that follows.
+            # (via ``_listen``'s dedicated handler) instead of silently ACKing
+            # every message that follows.
             raise
-        except ValueError as decrypt_err:
-            persistent_id = getattr(msg, "persistent_id", None)
-            self._log_warn_with_limit(
-                "Skipping FCM message that failed to decrypt "
-                "(persistent_id=%s): %s",
-                persistent_id,
-                decrypt_err,
-            )
-            return await self._ack_or_disconnect(persistent_id)
-        except (binascii.Error, RuntimeError) as decrypt_err:
+        except (ValueError, RuntimeError, http_ece.ECEException) as decrypt_err:
+            # Per-message poison: the exception-hierarchy UNION of every decode
+            # surface ``_handle_message`` touches.
+            #   * ValueError    -- header-param parse (``_extract_header_param``)
+            #                      plus ``binascii.Error`` padding faults and
+            #                      ``UnicodeError``; both are ValueError
+            #                      subclasses and need no separate arm.
+            #   * RuntimeError  -- ``_app_data_by_key`` missing-key lookup.
+            #   * ECEException  -- ``http_ece`` body decrypt / auth-tag failure.
+            #                      It is a SIBLING of ValueError under Exception
+            #                      (not a subclass), so it must be listed
+            #                      explicitly or it bypasses this poison defense
+            #                      entirely (Exception-Hierarchie-Audit lesson,
+            #                      CA-CASCADING-FAILURE-001).
+            # ``CredentialDecryptionError`` is a ValueError subclass but is
+            # matched by the more specific arm above and re-raised, so it never
+            # reaches here. ACK + skip so the FCM server stops redelivering and
+            # the supervisor's short-run crash cap is not tripped by a single
+            # bad message.
             persistent_id = getattr(msg, "persistent_id", None)
             self._log_warn_with_limit(
                 "Skipping FCM message that failed to decrypt "
@@ -915,6 +933,20 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         except asyncio.CancelledError:
             self.logger.debug("Listener task cancelled")
             raise
+        except CredentialDecryptionError as cred_err:
+            # Stored FCM key material is corrupt/undecodable. Record it as a
+            # DISTINCT credential fault instead of letting it fall through to
+            # the generic "Unknown error" arm below, so the supervisor can
+            # invalidate the bad key material and re-register rather than
+            # restarting the listener against the same poison credentials
+            # until the short-run crash cap fires.
+            self.logger.error(
+                "FCM credential material is corrupt and requires "
+                "re-registration: %s",
+                cred_err,
+            )
+            self.credential_error = cred_err
+            self.do_listen = False
         except ConnectionResetError:
             # Log a clean warning without noisy traceback; supervisor will reconnect.
             self.logger.warning(

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -29,6 +29,7 @@
 from __future__ import annotations
 
 import asyncio
+import binascii
 import json
 import logging
 import random
@@ -84,6 +85,61 @@ http_decrypt: Callable[..., bytes] = http_ece.decrypt
 _logger = logging.getLogger(__name__)
 
 _LEGACY_MCS_PROTOCOL_VERSION = 38
+
+
+class CredentialDecryptionError(ValueError):
+    """Raised when stored FCM credential material cannot be decoded or parsed.
+
+    Subclass of ``ValueError`` for backward-compatibility with external
+    callers that catch broad ``ValueError``. Internal code (notably the
+    listener loop's poison-message defense) discriminates this type via
+    ``isinstance`` to distinguish per-message decode failures (which are
+    safely ACKed and skipped) from credential-corruption failures (which
+    must surface to the supervisor for re-registration).
+
+    Why a typed exception instead of a string-prefix marker: external
+    libraries such as ``cryptography`` and ``http_ece`` raise plain
+    ``ValueError`` without our markers; a ``str.startswith`` catch loses
+    them and silently treats credential corruption as per-message poison.
+    See CA-CRED-VS-MSG-DECRYPT-001 iter-3 lesson.
+    """
+
+
+def _safe_urlsafe_b64decode(value: str | bytes) -> bytes:
+    """Decode URL-safe base64 leniently (Python 3.14 compatibility shim).
+
+    Strips ASCII whitespace and re-appends ``=`` padding before delegating
+    to :func:`base64.urlsafe_b64decode`. Python 3.14 switched
+    ``binascii.a2b_base64`` to ``strict_mode=True`` by default, which
+    rejects payloads containing newlines, stray whitespace, or missing
+    padding -- exactly the conditions the wild FCM stream produces. This
+    helper restores the pre-3.14 lenient behaviour locally without altering
+    the global decoder state.
+
+    Defense layer 3 of the three-defense hotfix for the
+    ``fcmpushclient`` poison-message cascade (CA-CASCADING-FAILURE-001).
+    Defense 1 wraps credential-decode errors as
+    :class:`CredentialDecryptionError`; defense 2 caps the supervisor
+    restart loop. This helper closes the root cause: dirty base64 input
+    that the Python 3.14 strict decoder rejects unconditionally.
+
+    Raises ``binascii.Error`` only when the payload remains undecodable
+    after whitespace removal and padding normalisation. Raises
+    ``UnicodeError`` when ``str`` input contains non-ASCII characters
+    (``str.encode("ascii")`` fails before normalisation runs); callers in
+    a credential-decode path must catch both.
+    """
+    if isinstance(value, str):
+        raw = value.encode("ascii")
+    else:
+        raw = bytes(value)
+    # str.split() / bytes.split() with no args collapses every flavour of
+    # ASCII whitespace (space, tab, newline, CR, vtab, formfeed) -- this
+    # is exactly the set Python 3.14 strict mode now rejects.
+    stripped = b"".join(raw.split())
+    padded = stripped + b"=" * (-len(stripped) % 4)
+    return urlsafe_b64decode(padded)
+
 
 # MCS Message Types and Tags
 MCS_MESSAGE_TAG = {
@@ -434,21 +490,47 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         salt_str: str,
         raw_data: bytes,
     ) -> bytes:
-        crypto_key = urlsafe_b64decode(crypto_key_str.encode("ascii") + b"=" * (-len(crypto_key_str) % 4))
-        salt = urlsafe_b64decode(salt_str.encode("ascii") + b"=" * (-len(salt_str) % 4))
+        # Header decode (crypto-key / salt) -- per-message surface.
+        # Failures here are per-message poison, not credential corruption:
+        # they fall through to the listener's poison-message defense
+        # (selective-ACK + skip) without going through the credential
+        # try-block below.
+        crypto_key = _safe_urlsafe_b64decode(crypto_key_str)
+        salt = _safe_urlsafe_b64decode(salt_str)
 
         keys_section = credentials.get("keys")
         if not isinstance(keys_section, Mapping):
-            raise ValueError("Credentials missing FCM key material")
+            raise CredentialDecryptionError("Credentials missing FCM key material")
 
         private_value = keys_section.get("private")
         secret_value = keys_section.get("secret")
         if not (isinstance(private_value, str) and isinstance(secret_value, str)):
-            raise ValueError("Invalid key values in credential payload")
+            raise CredentialDecryptionError(
+                "Credentials contain invalid key values"
+            )
 
-        der_data = urlsafe_b64decode(private_value.encode("ascii") + b"=" * (-len(private_value) % 4))
-        secret = urlsafe_b64decode(secret_value.encode("ascii") + b"=" * (-len(secret_value) % 4))
-        privkey = load_der_private_key(der_data, password=None)
+        try:
+            der_data = _safe_urlsafe_b64decode(private_value)
+            secret = _safe_urlsafe_b64decode(secret_value)
+        except (binascii.Error, UnicodeError) as cred_decode_err:
+            # binascii.Error: corrupt base64 payload.
+            # UnicodeError (covers UnicodeEncodeError/UnicodeDecodeError):
+            # non-ASCII bytes in cached keys.private/keys.secret; .encode("ascii")
+            # raises before urlsafe_b64decode is reached. Both are permanent
+            # credential-corruption faults, not per-message poison.
+            raise CredentialDecryptionError(
+                "Credentials key material failed base64 decode; re-registration required"
+            ) from cred_decode_err
+        try:
+            privkey = load_der_private_key(der_data, password=None)
+        except Exception as der_err:
+            # cryptography raises plain ValueError (corrupt DER), TypeError
+            # (wrong type), or UnsupportedAlgorithm — all permanent and all
+            # requiring re-registration. Broad catch is intentional: the
+            # only successful path is a valid DER private key.
+            raise CredentialDecryptionError(
+                "Credentials key material failed DER private-key parse; re-registration required"
+            ) from der_err
         decrypted = http_decrypt(
             raw_data,
             salt=salt,
@@ -742,6 +824,60 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             )
         return connected
 
+    async def _ack_or_disconnect(self, persistent_id: str | None) -> bool:
+        """Best-effort selective-ACK for a poison message.
+
+        Returns ``True`` to continue the worker loop; ``False`` if the writer
+        half is dead and the supervisor should reconnect (caller breaks).
+        """
+        if not persistent_id:
+            return True
+        try:
+            await self._send_selective_ack(persistent_id)
+            return True
+        except (OSError, ssl.SSLError, ConnectionError):
+            return False
+
+    async def _process_one_inbound_message(self, msg: MessageProto) -> bool:
+        """Run ``_handle_message`` with poison-message defense.
+
+        Defense 1 (CA-CASCADING-FAILURE-001): per-message decode failures
+        (``binascii.Error`` padding faults under Python 3.14 strict mode,
+        ``RuntimeError`` from ``_app_data_by_key`` key lookups, generic
+        ``ValueError`` from header parsing) are acknowledged and skipped
+        instead of crashing the worker loop. Credential-material errors
+        (``CredentialDecryptionError``) propagate so the supervisor
+        surfaces them via STOPPED state and prompts re-registration.
+
+        Returns ``True`` to continue the loop, ``False`` to break (writer
+        half-dead during ack).
+        """
+        try:
+            await self._handle_message(msg)
+            return True
+        except CredentialDecryptionError:
+            # Credential corruption is permanent; let the supervisor see it
+            # instead of silently ACKing every message that follows.
+            raise
+        except ValueError as decrypt_err:
+            persistent_id = getattr(msg, "persistent_id", None)
+            self._log_warn_with_limit(
+                "Skipping FCM message that failed to decrypt "
+                "(persistent_id=%s): %s",
+                persistent_id,
+                decrypt_err,
+            )
+            return await self._ack_or_disconnect(persistent_id)
+        except (binascii.Error, RuntimeError) as decrypt_err:
+            persistent_id = getattr(msg, "persistent_id", None)
+            self._log_warn_with_limit(
+                "Skipping FCM message that failed to decrypt "
+                "(persistent_id=%s): %s",
+                persistent_id,
+                decrypt_err,
+            )
+            return await self._ack_or_disconnect(persistent_id)
+
     async def _listen(self) -> None:
         """Listens for push notifications until an error or stop() occurs."""
         try:
@@ -760,7 +896,9 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             while self.do_listen:
                 try:
                     if msg := await self._receive_msg():
-                        await self._handle_message(msg)
+                        if not await self._process_one_inbound_message(msg):
+                            self.do_listen = False
+                            break
 
                 except (ConnectionError, ssl.SSLError) as cex:
                     # Treat stream end/TLS quirks as normal stop; supervisor will restart

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -45,6 +45,7 @@ from homeassistant.core import Event
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from ..Auth.fcm_receiver_ha import CRASH_LOOP_FATAL_PREFIX
 from ..const import (
     DEVICE_LIST_POLL_INTERVAL,
     DOMAIN,
@@ -79,6 +80,43 @@ from .helpers.update import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# Iter-14 (Codex follow-up): re-auth-escalation classification SSOT.
+# The FCM receiver's ``_fatal_errors`` map is a shared channel: it carries
+# both classic auth fatals (401/404 with credentials issues, raise
+# ``ConfigEntryAuthFailed`` immediately or after _FCM_ERROR_RETRY_THRESHOLD
+# cycles) and supervisor-level "short-run crash loop" fatals (poison
+# message defense; user must reload / regenerate credentials per the
+# repair issue, NOT re-authenticate). Without this classification the
+# crash-loop fatal would be reclassified as an auth fatal after 3 cycles
+# and push users into HA's re-auth flow. Keep this as a free function so
+# branch-coverage tests can pin the classification contract without
+# spinning up the full update coroutine.
+_FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED = "crash_loop_excluded"
+_FCM_FATAL_CLASS_AUTH_IMMEDIATE = "auth_immediate"
+_FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD = "auth_after_threshold"
+
+
+def _classify_fcm_fatal(fatal_error: str) -> str:
+    """Classify a non-empty FCM fatal error for the re-auth escalation.
+
+    Returns one of:
+      - ``_FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED``: supervisor-level
+        short-run cap; excluded from re-auth (repair issue carries the
+        user-visible guidance).
+      - ``_FCM_FATAL_CLASS_AUTH_IMMEDIATE``: classic auth fatal that
+        should raise ``ConfigEntryAuthFailed`` immediately.
+      - ``_FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD``: unclassified non-cap
+        fatal; count and escalate after _FCM_ERROR_RETRY_THRESHOLD
+        consecutive update cycles.
+    """
+    if fatal_error.startswith(CRASH_LOOP_FATAL_PREFIX):
+        return _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+    if _is_fatal_fcm_auth_error_impl(fatal_error):
+        return _FCM_FATAL_CLASS_AUTH_IMMEDIATE
+    return _FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD
+
 
 # Cooldown constants for crowdsourced reports
 _COOLDOWN_MIN_IN_ALL_AREAS_S = 10 * 60  # 10 minutes
@@ -118,6 +156,7 @@ class PollingOperations(_MixinBase):
     _fcm_status_changed_at: float | None
     _force_device_list_reason: str | None
     _short_retry_cancel: Callable[[], None] | None
+    _fcm_error_count: int
     _fcm_last_error: str | None
     _last_transient_auth_error: str | None
     _is_polling: bool
@@ -607,43 +646,65 @@ class PollingOperations(_MixinBase):
                     fatal_error = fatal_by_entry.get(entry_id)
 
             if isinstance(fatal_error, str) and fatal_error:
-                # Check if this is a fatal auth error that should fail immediately
-                # (e.g., 404/401 with credentials issues - no point retrying)
-                is_fatal_auth = _is_fatal_fcm_auth_error_impl(fatal_error)
+                # Iter-14 (Codex follow-up, channel-confusion): the FCM
+                # receiver's supervisor-level "short-run crash loop" cap
+                # publishes its terminal state into the SAME ``_fatal_errors``
+                # map this re-auth escalation consumes. That defense is a
+                # poison-message bulkhead (the user has to reload or
+                # regenerate credentials per the repair issue, NOT
+                # re-authenticate). Classify the fatal first so a cap-fired
+                # listener-lifecycle fatal does not get reclassified as an
+                # auth fatal after _FCM_ERROR_RETRY_THRESHOLD cycles and
+                # push users into Home Assistant's re-auth flow.
+                fatal_class = _classify_fcm_fatal(fatal_error)
 
-                if is_fatal_auth:
-                    # Fatal auth errors - fail immediately, no retry
-                    _LOGGER.error(
-                        "Fatal FCM authentication error: %s. Triggering re-authentication.",
-                        fatal_error,
-                    )
-                    self._set_auth_state(failed=True, reason=fatal_error)
-                    raise ConfigEntryAuthFailed(fatal_error)
-
-                # Track consecutive FCM errors for transient issues
-                if fatal_error != self._fcm_last_error:
-                    # New error type, reset counter
-                    self._fcm_error_count = 1
-                    self._fcm_last_error = fatal_error
+                if fatal_class == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED:
+                    # Reset any partial auth-error count so a later,
+                    # unrelated auth fatal starts from zero rather than
+                    # inheriting a stale count from the crash-loop window.
+                    if self._fcm_error_count > 0:
+                        _LOGGER.debug(
+                            "FCM crash-loop fatal observed; resetting auth-"
+                            "error counter (was %d). Repair issue surfaces "
+                            "guidance, no re-auth.",
+                            self._fcm_error_count,
+                        )
+                        self._fcm_error_count = 0
+                        self._fcm_last_error = None
                 else:
-                    self._fcm_error_count += 1
+                    if fatal_class == _FCM_FATAL_CLASS_AUTH_IMMEDIATE:
+                        # Fatal auth errors - fail immediately, no retry
+                        _LOGGER.error(
+                            "Fatal FCM authentication error: %s. Triggering re-authentication.",
+                            fatal_error,
+                        )
+                        self._set_auth_state(failed=True, reason=fatal_error)
+                        raise ConfigEntryAuthFailed(fatal_error)
 
-                # Only trigger re-auth after _FCM_ERROR_RETRY_THRESHOLD consecutive failures
-                if self._fcm_error_count >= _FCM_ERROR_RETRY_THRESHOLD:
-                    _LOGGER.error(
-                        "FCM error persisted after %d attempts: %s. Triggering re-authentication.",
-                        self._fcm_error_count,
-                        fatal_error,
-                    )
-                    self._set_auth_state(failed=True, reason=fatal_error)
-                    raise ConfigEntryAuthFailed(fatal_error)
-                else:
-                    _LOGGER.warning(
-                        "FCM error detected (%d/%d): %s. Will retry before triggering re-auth.",
-                        self._fcm_error_count,
-                        _FCM_ERROR_RETRY_THRESHOLD,
-                        fatal_error,
-                    )
+                    # Track consecutive FCM errors for transient issues
+                    if fatal_error != self._fcm_last_error:
+                        # New error type, reset counter
+                        self._fcm_error_count = 1
+                        self._fcm_last_error = fatal_error
+                    else:
+                        self._fcm_error_count += 1
+
+                    # Only trigger re-auth after _FCM_ERROR_RETRY_THRESHOLD consecutive failures
+                    if self._fcm_error_count >= _FCM_ERROR_RETRY_THRESHOLD:
+                        _LOGGER.error(
+                            "FCM error persisted after %d attempts: %s. Triggering re-authentication.",
+                            self._fcm_error_count,
+                            fatal_error,
+                        )
+                        self._set_auth_state(failed=True, reason=fatal_error)
+                        raise ConfigEntryAuthFailed(fatal_error)
+                    else:
+                        _LOGGER.warning(
+                            "FCM error detected (%d/%d): %s. Will retry before triggering re-auth.",
+                            self._fcm_error_count,
+                            _FCM_ERROR_RETRY_THRESHOLD,
+                            fatal_error,
+                        )
             # No error - reset counter on successful check
             elif self._fcm_error_count > 0:
                 _LOGGER.debug(

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM Push Crash Loop Detected",
+      "description": "The FCM push client repeatedly disconnects within seconds of connecting (short-run crash loop). This is most often caused by a persistent poison notification on the inbound queue that cannot be decoded.\n\n1. Reload the integration to clear the run state.\n2. If the issue returns, regenerate your `secrets.json` (Google may have rotated credentials)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM-Push-Abbruchschleife erkannt",
+      "description": "Der FCM-Push-Client trennt die Verbindung wiederholt innerhalb weniger Sekunden nach dem Verbindungsaufbau (Short-Run-Crash-Schleife). Üblicherweise wird das durch eine persistente, nicht dekodierbare Push-Nachricht in der eingehenden Warteschlange ausgelöst.\n\n1. Laden Sie die Integration neu, um den Laufzustand zurückzusetzen.\n2. Falls das Problem erneut auftritt: Erneuern Sie Ihre `secrets.json` (Google könnte Anmeldedaten rotiert haben)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM Push Crash Loop Detected",
+      "description": "The FCM push client repeatedly disconnects within seconds of connecting (short-run crash loop). This is most often caused by a persistent poison notification on the inbound queue that cannot be decoded.\n\n1. Reload the integration to clear the run state.\n2. If the issue returns, regenerate your `secrets.json` (Google may have rotated credentials)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Bucle de fallos de FCM Push detectado",
+      "description": "El cliente push de FCM se desconecta repetidamente a los pocos segundos de conectarse (bucle de fallos cortos). Esto suele estar causado por una notificación corrupta persistente en la cola entrante que no se puede decodificar.\n\n1. Recarga la integración para limpiar el estado de ejecución.\n2. Si el problema vuelve, regenera tu `secrets.json` (Google podría haber rotado las credenciales)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Boucle de plantage FCM Push détectée",
+      "description": "Le client push FCM se déconnecte à plusieurs reprises quelques secondes après s’être connecté (boucle de plantage court). Cela est généralement causé par une notification persistante corrompue dans la file d’attente entrante qui ne peut pas être décodée.\n\n1. Rechargez l’intégration pour réinitialiser l’état d’exécution.\n2. Si le problème revient, régénérez votre `secrets.json` (Google peut avoir rotaté les identifiants)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "לולאת קריסה של FCM Push זוהתה",
+      "description": "לקוח ה-FCM Push מתנתק שוב ושוב תוך שניות לאחר ההתחברות (לולאת קריסה קצרה). הסיבה השכיחה היא הודעה פגומה מתמשכת בתור הנכנס שלא ניתן לפענח.\n\n1. טען מחדש את האינטגרציה כדי לנקות את מצב הריצה.\n2. אם הבעיה חוזרת, חולל מחדש את `secrets.json` (ייתכן ש-Google סובב את האישורים)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Rilevato ciclo di crash di FCM Push",
+      "description": "Il client push FCM si disconnette ripetutamente entro pochi secondi dalla connessione (ciclo di crash brevi). La causa più comune è una notifica persistente corrotta nella coda in arrivo che non può essere decodificata.\n\n1. Ricarica l’integrazione per ripristinare lo stato di esecuzione.\n2. Se il problema si ripresenta, rigenera il tuo `secrets.json` (Google potrebbe aver ruotato le credenziali)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "FCM Push crash-lus gedetecteerd",
+      "description": "De FCM push-client verbreekt herhaaldelijk binnen enkele seconden na het verbinden de verbinding (short-run crash-lus). Dit wordt meestal veroorzaakt door een aanhoudende beschadigde melding in de inkomende wachtrij die niet kan worden gedecodeerd.\n\n1. Laad de integratie opnieuw om de looptijdstatus te wissen.\n2. Als het probleem terugkeert, regenereer je `secrets.json` (Google kan de inloggegevens hebben gerouleerd)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Wykryto pętlę awarii FCM Push",
+      "description": "Klient push FCM wielokrotnie rozłącza się w ciągu kilku sekund od połączenia (pętla krótkich awarii). Najczęstszą przyczyną jest trwałe uszkodzone powiadomienie w kolejce przychodzącej, którego nie można zdekodować.\n\n1. Załaduj ponownie integrację, aby wyczyścić stan działania.\n2. Jeśli problem powraca, wygeneruj ponownie plik `secrets.json` (Google mógł zmienić dane uwierzytelniające)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Detectado ciclo de falhas no FCM Push",
+      "description": "O cliente push do FCM se desconecta repetidamente segundos após conectar (ciclo de falhas curtas). Geralmente isso é causado por uma notificação persistente corrompida na fila de entrada que não pode ser decodificada.\n\n1. Recarregue a integração para limpar o estado de execução.\n2. Se o problema voltar, regenere seu `secrets.json` (o Google pode ter rotacionado as credenciais)."
     }
   },
   "exceptions": {

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -714,6 +714,10 @@
     "cache_purged": {
       "title": "Authentication cache cleared",
       "description": "The stored authentication cache for **{entry_title}** was unreadable and has been cleared. Select **Reconfigure** on the integration card to sign in again and restore access."
+    },
+    "fcm_short_run_crash_loop": {
+      "title": "Detetado ciclo de falhas do FCM Push",
+      "description": "O cliente push do FCM desliga-se repetidamente segundos após a ligação (ciclo de falhas curtas). Normalmente é causado por uma notificação persistente corrompida na fila de entrada que não pode ser descodificada.\n\n1. Recarregue a integração para limpar o estado de execução.\n2. Se o problema voltar, regenere o seu `secrets.json` (a Google pode ter rodado as credenciais)."
     }
   },
   "exceptions": {

--- a/http_ece.pyi
+++ b/http_ece.pyi
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["decrypt", "encrypt"]
+__all__ = ["ECEException", "decrypt", "encrypt"]
+
+class ECEException(Exception): ...
 
 def decrypt(*args: Any, **kwargs: Any) -> bytes: ...
 def encrypt(*args: Any, **kwargs: Any) -> bytes: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,7 +343,11 @@ skip_covered = true
 # (was 60 in PR #1071 with 64 % headroom). Target remains >= 95 % per
 # quality-scale rule test-coverage; this floor only prevents regressions
 # while incremental test expansion lands (60 -> 63 -> 70 -> 80 -> 90 -> 95).
-fail_under = 63
+# Recalibrated to 67 after forward-porting the stranded Class-A coverage suite:
+# local full run measured 68.33 % scoped (3696 passed); floor = floor(68) - 1 Pp
+# jitter margin, clamped to [63, CI total]. Three local entity tests error on a
+# root-owned .storage path that CI does not hit, so CI total is >= 68.33 %.
+fail_under = 67
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",

--- a/tests/helpers/api_stub.py
+++ b/tests/helpers/api_stub.py
@@ -1,0 +1,171 @@
+# tests/helpers/api_stub.py
+"""Test fixtures for :class:`GoogleFindMyAPI` (Phase 4 AP-I).
+
+Mirror production attribute names from :mod:`custom_components.googlefindmy.api`
+verbatim. Properties and helpers read these by exact name; semantic-equivalent
+renames cause AttributeError.
+
+Why factories instead of a subclass?
+- ``GoogleFindMyAPI`` is self-contained (no mixin chain like the coordinator),
+  so a subclass would only obscure construction. Factories let tests assemble
+  exactly the surface they need (cache shape, session loop binding, FCM
+  receiver readiness) without inheriting unrelated production wiring.
+- Each test can rebind module-level provider hooks
+  (``_FCM_ReceiverGetter``) through ``monkeypatch.setattr`` on the imported
+  ``api`` module without polluting other tests.
+
+Stub parity (KV-10): the attribute names below mirror the production
+``CacheProtocol`` and ``FcmReceiverProtocol`` 1:1. Anything renamed semantically
+(e.g. ``entry`` instead of ``entry_id``) is a bug, not a refactor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+
+class StubCache:
+    """Minimal :class:`CacheProtocol`-shaped cache for API tests.
+
+    Mirrors ``TokenCache`` surface used by ``GoogleFindMyAPI``:
+
+    - ``entry_id`` and ``namespace`` attributes (read via ``getattr``)
+    - ``async_get_cached_value`` / ``async_set_cached_value`` coroutines
+    """
+
+    def __init__(
+        self,
+        *,
+        entry_id: str | None = "entry-test",
+        namespace: str | None = None,
+        values: dict[str, Any] | None = None,
+    ) -> None:
+        self.entry_id = entry_id
+        self.namespace = namespace
+        self._values: dict[str, Any] = dict(values or {})
+
+    async def async_get_cached_value(self, key: str) -> Any:
+        return self._values.get(key)
+
+    async def async_set_cached_value(self, key: str, value: Any) -> None:
+        self._values[key] = value
+
+
+class RaisingCache(StubCache):
+    """Cache whose ``entry_id`` attribute raises on access.
+
+    Used to exercise the defensive ``try/except`` paths in
+    :meth:`GoogleFindMyAPI._namespace` and :meth:`_get_fcm_token_for_action`.
+    """
+
+    @property  # type: ignore[override]
+    def entry_id(self) -> str | None:  # noqa: D401 - mimic attribute name
+        raise RuntimeError("entry_id unavailable")
+
+    @entry_id.setter
+    def entry_id(self, _value: str | None) -> None:
+        return None
+
+
+class FakeReceiver:
+    """Minimal :class:`FcmReceiverProtocol`-shaped receiver.
+
+    The production protocol only requires ``get_fcm_token(entry_id=None)``.
+    Optional attributes (``is_ready``/``ready``, ``pc``) are exposed for the
+    push-readiness heuristic in :meth:`GoogleFindMyAPI.is_push_ready`.
+    """
+
+    def __init__(
+        self,
+        *,
+        token: str | None = "token-1234567890",
+        accepts_entry: bool = True,
+        is_ready: bool | None = None,
+        pc: Any | None = None,
+        raise_on_get: BaseException | None = None,
+        raise_on_get_legacy: BaseException | None = None,
+    ) -> None:
+        self._token = token
+        self._accepts_entry = accepts_entry
+        self.is_ready = is_ready
+        self.pc = pc
+        self._raise_on_get = raise_on_get
+        self._raise_on_get_legacy = raise_on_get_legacy
+        self.calls: list[tuple[Any, ...]] = []
+
+    def get_fcm_token(self, *args: Any) -> str | None:
+        self.calls.append(args)
+        if args and not self._accepts_entry:
+            raise TypeError("legacy receiver: entry_id not supported")
+        if args:
+            if self._raise_on_get is not None:
+                raise self._raise_on_get
+        else:
+            if self._raise_on_get_legacy is not None:
+                raise self._raise_on_get_legacy
+            if self._raise_on_get is not None and self._raise_on_get_legacy is None:
+                raise self._raise_on_get
+        return self._token
+
+
+def make_pc(
+    *, run_state_name: str = "STARTED", do_listen: bool = True
+) -> SimpleNamespace:
+    """Build a push-client double for :meth:`GoogleFindMyAPI.is_push_ready`.
+
+    ``run_state`` exposes a ``.name`` attribute, matching the production
+    heuristic that tolerates enum or string values.
+    """
+
+    return SimpleNamespace(
+        run_state=SimpleNamespace(name=run_state_name),
+        do_listen=do_listen,
+    )
+
+
+def install_receiver_provider(
+    monkeypatch: Any,
+    receiver: FakeReceiver | None,
+    *,
+    accepts_entry: bool = True,
+    raise_on_call: BaseException | None = None,
+    raise_on_legacy_call: BaseException | None = None,
+) -> list[tuple[Any, ...]]:
+    """Install a fake ``_FCM_ReceiverGetter`` and return a call-log list.
+
+    The call log captures positional args passed to the provider, so tests can
+    assert entry-scoped vs. legacy invocation.
+    """
+
+    calls: list[tuple[Any, ...]] = []
+
+    def _provider(*args: Any) -> FakeReceiver | None:
+        calls.append(args)
+        if args and not accepts_entry:
+            raise TypeError("legacy provider: entry_id not supported")
+        if args:
+            if raise_on_call is not None:
+                raise raise_on_call
+        else:
+            if raise_on_legacy_call is not None:
+                raise raise_on_legacy_call
+            if raise_on_call is not None and raise_on_legacy_call is None:
+                raise raise_on_call
+        return receiver
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.api._FCM_ReceiverGetter", _provider
+    )
+    return calls
+
+
+def run_coro(coro: Any) -> Any:
+    """Drive a coroutine to completion on a fresh loop (no outer loop active)."""
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()

--- a/tests/helpers/fcm_poison_stub.py
+++ b/tests/helpers/fcm_poison_stub.py
@@ -1,0 +1,108 @@
+# tests/helpers/fcm_poison_stub.py
+# Mirror production attribute names from FcmPushClient.__init__ and DataMessageStanza verbatim
+"""Slim composition stub for FcmPushClient Defense 1 tests (CA-CASCADING-FAILURE-001).
+
+Binds the production ``FcmPushClient._listen`` method to a lightweight container
+that mirrors only the attributes the worker loop touches. This avoids the heavy
+production constructor (``FcmRegisterConfig`` / Firebase wiring) while exercising
+the real Inner-Loop code path, so Defense 1 is verified end-to-end and not
+re-implemented in the stub.
+
+The stub is *not* a subclass of ``FcmPushClient`` (composition only). Production
+attribute names (``logger``, ``do_listen``, ``run_state``, ``config``,
+``log_warn_counters``) are mirrored verbatim from ``FcmPushClient.__init__``;
+test instrumentation fields (``_loop_iteration_count``, ``_last_handled_id``,
+``_after_iter_hook``) are exposed for the Aggregate-Anti-Cascading test.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClient,
+    FcmPushClientConfig,
+    FcmPushClientRunState,
+)
+
+
+def make_poison_data_message(
+    persistent_id: str, kind: str = "padding"
+) -> SimpleNamespace:
+    """Build a DataMessageStanza-shaped namespace for Inner-Loop tests.
+
+    ``kind`` selects the failure class the test will raise on decrypt:
+      - ``padding`` -> ``binascii.Error("Incorrect padding")``
+      - ``value``   -> ``RuntimeError("couldn't find in app_data crypto-key")``
+      - ``valid``   -> message that should pass through without raising
+    """
+    if kind not in {"padding", "value", "valid"}:
+        raise ValueError(f"unknown kind: {kind!r}")
+    return SimpleNamespace(
+        app_data=[],
+        persistent_id=persistent_id,
+        stream_id=1,
+        last_stream_id_received=0,
+        status="ok",
+        _kind=kind,
+    )
+
+
+def make_valid_data_message(persistent_id: str) -> SimpleNamespace:
+    """Convenience wrapper for a pass-through (non-poison) message."""
+    return make_poison_data_message(persistent_id, kind="valid")
+
+
+class FcmPushClientSlim:
+    """Composition stub for Defense 1 tests.
+
+    Binds ``FcmPushClient._listen`` to ``self`` so the production worker loop
+    runs against a controlled set of mocked dependencies. Only the attributes
+    the loop reads or writes are mirrored; everything else is left out.
+    """
+
+    def __init__(self) -> None:
+        # Mirror production attribute names from FcmPushClient.__init__ verbatim
+        self.logger = logging.getLogger(__name__ + ".FcmPushClientSlim")
+        self.logger.propagate = True
+        self.do_listen = True
+        self.run_state: FcmPushClientRunState = FcmPushClientRunState.STARTED
+        self.config = FcmPushClientConfig()  # log_warn_limit default = 5
+        self.log_warn_counters: dict[str, int] = {}
+        self.persistent_ids: list[str] = []
+        self.writer = None  # _do_writer_close short-circuits on None
+
+        # Async-stubbed production methods (overridable per test).
+        self._receive_msg = AsyncMock(return_value=None)
+        self._handle_message = AsyncMock(return_value=None)
+        self._send_selective_ack = AsyncMock(return_value=None)
+        self._connect_with_retry = AsyncMock(return_value=True)
+        self._login = AsyncMock(return_value=None)
+        self._do_writer_close = AsyncMock(return_value=None)
+
+        # Test instrumentation (NOT production attributes).
+        self._loop_iteration_count = 0
+        self._last_handled_id: str | None = None
+        self._after_iter_hook: Callable[[], Any] = lambda: None
+
+    def _log_warn_with_limit(self, msg: str, *args: object) -> None:
+        """Production-verbatim rate-limited WARN helper (KV-H7)."""
+        if msg not in self.log_warn_counters:
+            self.log_warn_counters[msg] = 0
+        if (
+            self.config.log_warn_limit
+            and self.config.log_warn_limit > self.log_warn_counters[msg]
+        ):
+            self.log_warn_counters[msg] += 1
+            self.logger.warning(msg, *args)
+
+    # Bind the real production _listen unbound function to this slim instance.
+    # When invoked via ``self._listen()`` it resolves ``self`` to the stub.
+    # Defense 1 was extracted into two helpers (_process_one_inbound_message,
+    # _ack_or_disconnect); bind both so the unbound _listen can reach them.
+    _listen = FcmPushClient._listen  # type: ignore[assignment]
+    _process_one_inbound_message = FcmPushClient._process_one_inbound_message  # type: ignore[assignment]
+    _ack_or_disconnect = FcmPushClient._ack_or_disconnect  # type: ignore[assignment]

--- a/tests/helpers/fcm_poison_stub.py
+++ b/tests/helpers/fcm_poison_stub.py
@@ -70,6 +70,9 @@ class FcmPushClientSlim:
         self.logger.propagate = True
         self.do_listen = True
         self.run_state: FcmPushClientRunState = FcmPushClientRunState.STARTED
+        # Mirror the production credential-error signal (_listen sets it when
+        # CredentialDecryptionError surfaces; the supervisor reads it).
+        self.credential_error = None
         self.config = FcmPushClientConfig()  # log_warn_limit default = 5
         self.log_warn_counters: dict[str, int] = {}
         self.persistent_ids: list[str] = []

--- a/tests/helpers/identity_mixin_stub.py
+++ b/tests/helpers/identity_mixin_stub.py
@@ -1,0 +1,70 @@
+# tests/helpers/identity_mixin_stub.py
+"""Test stub for :class:`IdentityOperations` mixin standalone unit tests.
+
+PR 1.A.2 (Phase 2, AP-A): exercise the simple identity mixin methods
+(``_get_account_email``, ``_create_auth_issue``, ``_dismiss_auth_issue``,
+``_schedule_eid_resolver_refresh``, ``_register_identity_key``,
+``_reset_resolver_offset``) without the full coordinator. ``_MixinBase`` is
+runtime-empty, so a minimal subclass seeds every attribute the mixin reads
+and pre-mocks cross-mixin methods (``_entry_id``) to dodge the
+``NotImplementedError`` traps that come from ``_MixinBase``.
+
+The complex ``get_active_device_identities`` (732 LOC, dozens of
+collaborators) is intentionally out of scope here; it lands in a later AP.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.googlefindmy.coordinator.identity import IdentityOperations
+
+
+def make_hass_stub() -> MagicMock:
+    """Return a Home Assistant stub with ``hass.data`` and ``async_create_task``.
+
+    ``hass.data`` is a plain dict so tests can populate it with the
+    ``DOMAIN`` -> ``{DATA_EID_RESOLVER: ...}`` shape that
+    :meth:`IdentityOperations._schedule_eid_resolver_refresh` reads.
+    """
+
+    hass = MagicMock(spec_set=["data", "async_create_task"])
+    hass.data = {}
+    hass.async_create_task = MagicMock(return_value=None)
+    return hass
+
+
+class IdentityStub(IdentityOperations):
+    """Minimal :class:`IdentityOperations` subclass for isolated mixin tests.
+
+    Cross-mixin ``_MixinBase`` stubs (``_entry_id``) are seeded as
+    ``MagicMock`` so methods under test can call them transparently; tests
+    rebind per-case via :func:`setattr`. No ``super().__init__`` chain runs
+    because ``DataUpdateCoordinator.__init__`` would require a full HA
+    runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+    ) -> None:
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+
+        # Shared-tracker bookkeeping (read+written by ``_register_identity_key``).
+        self._identity_key_to_devices: dict[bytes, set[str]] = {}
+
+        # Cross-mixin methods owned by RegistryOperations: return the entry's
+        # ``entry_id`` (or None) by default so ``_reset_resolver_offset`` works
+        # without extra wiring. Tests override per-case via setattr().
+        entry_id = getattr(config_entry, "entry_id", None) if config_entry else None
+        self._entry_id = MagicMock(return_value=entry_id)
+
+        # Diagnostics buffer (``get_active_device_identities`` reads it; kept
+        # here as None so its absence is well-defined for future tests).
+        self._diag = None
+
+
+__all__ = ["IdentityStub", "make_hass_stub"]

--- a/tests/helpers/locate_mixin_stub.py
+++ b/tests/helpers/locate_mixin_stub.py
@@ -1,0 +1,104 @@
+# tests/helpers/locate_mixin_stub.py
+"""Test stub for :class:`LocateOperations` mixin standalone unit tests.
+
+Phase 3 AP-C: exercise the locate mixin methods (``_normalize_coords``,
+``can_play_sound``, ``_get_device_lock``, ``can_request_location``) and
+gating branches of the async helpers (``async_locate_device``,
+``async_play_sound``, ``async_stop_sound``) without the full coordinator.
+``_MixinBase`` is runtime-empty, so a minimal subclass seeds every
+attribute the mixin reads and pre-mocks cross-mixin methods to dodge the
+``NotImplementedError`` traps that come from ``_MixinBase``.
+
+The deep success-path branches of ``async_locate_device`` (Nova roundtrip,
+Google Home filter, weighted fusion, cache commit) are intentionally out
+of scope here; they land in Phase 4.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.googlefindmy.coordinator.locate import LocateOperations
+
+
+def make_hass_stub(*, loop: Any | None = None) -> MagicMock:
+    """Return a Home Assistant stub with ``data``, ``loop`` and task helpers."""
+
+    hass = MagicMock(spec_set=["data", "loop", "async_create_task"])
+    hass.data = {}
+    hass.loop = loop if loop is not None else MagicMock()
+    hass.async_create_task = MagicMock(return_value=None)
+    return hass
+
+
+class LocateStub(LocateOperations):
+    """Minimal :class:`LocateOperations` subclass for isolated mixin tests.
+
+    Cross-mixin ``_MixinBase`` stubs are seeded as ``MagicMock`` so methods
+    under test can call them transparently; tests rebind per-case via
+    :func:`setattr`. No ``super().__init__`` chain runs because
+    ``DataUpdateCoordinator.__init__`` would require a full HA runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        api: Any | None = None,
+        location_poll_interval: int = 120,
+        min_poll_interval: int = 60,
+    ) -> None:
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+        self.data: list[dict[str, Any]] = []
+
+        # Locate-state attributes the mixin reads or mutates.
+        self._device_caps: dict[str, dict[str, Any]] = {}
+        self._device_action_locks: dict[str, Any] = {}
+        self._locate_inflight: set[str] = set()
+        self._locate_cooldown_until: dict[str, float] = {}
+        self._device_poll_cooldown_until: dict[str, float] = {}
+        self._push_cooldown_until: float = 0.0
+        self._device_location_data: dict[str, dict[str, Any]] = {}
+        self._sound_request_uuids: dict[str, str] = {}
+        self._sound_request_timestamps: dict[str, float] = {}
+        self._last_poll_mono: float = 0.0
+        self._present_last_seen: dict[str, float] = {}
+        self._is_polling: bool = False
+
+        # Cross-mixin scalars used by helpers.
+        self.location_poll_interval = location_poll_interval
+        self.min_poll_interval = min_poll_interval
+        self.api = api if api is not None else MagicMock()
+        self.api.async_get_device_location = AsyncMock(return_value={})
+        self.api.async_play_sound = AsyncMock(return_value=(True, "uuid-stub"))
+        self.api.async_stop_sound = AsyncMock(return_value=True)
+
+        # Cross-mixin methods owned by other mixins or DataUpdateCoordinator:
+        # mock them so default behavior is a no-op. Tests override per-case.
+        entry_id = getattr(config_entry, "entry_id", None) if config_entry else None
+        self._entry_id = MagicMock(return_value=entry_id)
+        self.increment_stat = MagicMock(return_value=None)
+        self.is_ignored = MagicMock(return_value=False)
+        self.get_device_display_name = MagicMock(return_value=None)
+        self._api_push_ready = MagicMock(return_value=True)
+        self._ensure_device_name_cache = MagicMock(return_value={})
+        self._set_auth_state = MagicMock(return_value=None)
+        self._record_semantic_label = MagicMock(return_value=None)
+        self._apply_semantic_mapping = MagicMock(return_value=False)
+        self._get_google_home_filter = MagicMock(return_value=None)
+        self._should_preserve_precise_home_coordinates = MagicMock(return_value=False)
+        self.update_device_cache = MagicMock(return_value=None)
+        self._apply_weighted_location_fusion = MagicMock(return_value=True)
+        self.note_error = MagicMock(return_value=None)
+        self.push_updated = MagicMock(return_value=None)
+        self._short_error_message = MagicMock(return_value="short-err")
+        self._async_save_sound_uuids = AsyncMock(return_value=None)
+        self.async_set_updated_data = MagicMock(return_value=None)
+        self.async_request_refresh = AsyncMock(return_value=None)
+        self._note_push_transport_problem = MagicMock(return_value=None)
+
+
+__all__ = ["LocateStub", "make_hass_stub"]

--- a/tests/helpers/main_coordinator_stub.py
+++ b/tests/helpers/main_coordinator_stub.py
@@ -1,0 +1,111 @@
+# tests/helpers/main_coordinator_stub.py
+"""Test stub for :class:`GoogleFindMyCoordinator` standalone unit tests.
+
+Phase 3 AP-F: exercise the coordinator's pure helpers, static methods and
+attribute-driven branches (``_get_ignored_set``, ``is_ignored``,
+``safe_update_metric``, ``mark_recent_reconfigure``, ``recent_reconfigure_at``,
+``cache`` property, ``_apply_semantic_mapping``, ``_find_semantic_match``,
+``_record_semantic_label``, ``get_observed_semantic_labels``,
+``_should_preserve_precise_home_coordinates``, ``auth_error_active``) without
+the full HA runtime. ``MainCoordinatorStub`` bypasses
+``GoogleFindMyCoordinator.__init__`` (which would pull in
+``aiohttp_get_clientsession``, ``DataUpdateCoordinator.__init__`` and
+``_get_api_class``) and seeds the minimum attribute set the targeted methods
+read or mutate.
+
+Deep async branches (``async_setup``, ``async_shutdown``, ``async_update_data``
+and the Nova-roundtrip locate paths) are intentionally out of scope here; they
+land in Phase 4 alongside ``__init__.py`` and ``config_flow.py``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.googlefindmy.coordinator.main import GoogleFindMyCoordinator
+
+
+def make_hass_stub(*, loop: Any | None = None) -> MagicMock:
+    """Return a Home Assistant stub with ``data``, ``loop`` and task helpers."""
+
+    hass = MagicMock(spec_set=["data", "loop", "async_create_task", "bus"])
+    hass.data = {}
+    hass.loop = loop if loop is not None else MagicMock()
+    hass.async_create_task = MagicMock(return_value=None)
+    hass.bus = MagicMock()
+    return hass
+
+
+class MainCoordinatorStub(GoogleFindMyCoordinator):
+    """Minimal :class:`GoogleFindMyCoordinator` subclass for isolated unit tests.
+
+    Cross-mixin ``_MixinBase`` stubs (``_entry_id``, ``_is_on_hass_loop``,
+    ``_run_on_hass_loop``, ``_dispatch_async_request_refresh`` and friends)
+    are seeded as ``MagicMock`` so methods under test can call them
+    transparently; tests rebind per-case via :func:`setattr`. No
+    ``super().__init__`` chain runs because
+    ``DataUpdateCoordinator.__init__`` would require a full HA runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        cache: Any | None = None,
+    ) -> None:
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+        self.data: list[dict[str, Any]] = []
+
+        # Cache (private + property-backed)
+        self._cache = cache if cache is not None else MagicMock()
+        self._cache.async_get_cached_value = AsyncMock(return_value=None)
+        self._cache.async_set_cached_value = AsyncMock(return_value=None)
+
+        # Reconfigure marker
+        self._recent_reconfigure_at: float | None = None
+
+        # Performance metrics / errors
+        self.performance_metrics: dict[str, float] = {}
+        self.recent_errors: deque[tuple[float, str, str]] = deque(maxlen=20)
+        self._setup_started_at: float | None = None
+        self._setup_completed_at: float | None = None
+
+        # Auth state (mirror production attribute names from
+        # ``GoogleFindMyCoordinator.__init__`` so the ``auth_error_active``
+        # property and any helper that reads ``_auth_error_message`` work).
+        self._auth_error_active: bool = False
+        self._auth_error_message: str | None = None
+
+        # Force-refresh state
+        self._force_device_list_refresh: bool = False
+        self._force_device_list_reason: str | None = None
+
+        # Semantic-label cache (lazy in production, pre-seeded here for clarity)
+        self._semantic_label_cache: dict[str, Any] = {}
+
+        # Ignored devices fallback attribute (used when entry.options is empty)
+        self.ignored_devices: list[str] | None = None
+
+        # Stats / device caches consumed by the public reporting helpers
+        self._device_location_data: dict[str, dict[str, Any]] = {}
+        self._device_names: dict[str, str] = {}
+        self._device_names_by_user: dict[str, str] = {}
+        self._present_device_ids: set[str] = set()
+
+        # Cross-mixin methods that the coordinator helpers may invoke transparently.
+        entry_id = getattr(config_entry, "entry_id", None) if config_entry else None
+        self._entry_id = MagicMock(return_value=entry_id)
+        self._is_on_hass_loop = MagicMock(return_value=True)
+        self._run_on_hass_loop = MagicMock(return_value=None)
+        self._dispatch_async_request_refresh = MagicMock(return_value=None)
+        self._haversine_distance = MagicMock(return_value=0.0)
+        self._ensure_service_device_exists = MagicMock(return_value=None)
+        self._reindex_poll_targets_from_device_registry = MagicMock(return_value=None)
+        self._cancel_pending_subentry_repair = MagicMock(return_value=None)
+
+
+__all__ = ["MainCoordinatorStub", "make_hass_stub"]

--- a/tests/helpers/polling_branches_stub.py
+++ b/tests/helpers/polling_branches_stub.py
@@ -1,0 +1,64 @@
+# tests/helpers/polling_branches_stub.py
+"""Branch-coverage test stub for :class:`PollingOperations`.
+
+Mirror production attribute names from PollingOperations / _MixinBase verbatim.
+Properties read these by exact name; semantic-equivalent renames cause AttributeError.
+
+Extends :class:`tests.helpers.polling_mixin_stub.PollingStub` (Phase 2) with the
+extra cross-mixin hook ``async_request_refresh`` that the branch APIs under test
+in Phase 4 AP-J exercise:
+
+- ``_dispatch_async_request_refresh`` (loop detection + awaitable scheduling
+  + exception swallowing)
+- ``_schedule_short_retry`` (coalesce, delay clamping, callback dispatch)
+- ``_handle_dr_event`` (reindex + dispatch fan-out)
+- ``_is_fcm_ready_soft`` (3-tier priority: API / receiver / push-client)
+- ``_note_fcm_deferral`` (escalation timeline at 0/120/300s)
+
+The Phase 2 ``PollingStub`` deliberately omitted ``async_request_refresh``
+because the simple mixin methods do not touch it. CA-F6 (no in-place edit of a
+gemerged stub) requires the addition to live in a new helper module.
+
+Why subclass instead of monkeypatching?
+- Tests can rebind ``async_request_refresh`` per-case (sync ``MagicMock``, async
+  coroutine, raising ``MagicMock``) without leaking state across test methods.
+- A subclass keeps the production isinstance/mro structure of ``PollingStub``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from tests.helpers.polling_mixin_stub import PollingStub
+
+
+class PollingBranchesStub(PollingStub):
+    """Phase 4 AP-J branch-coverage stub for :class:`PollingOperations`."""
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        api: Any | None = None,
+        location_poll_interval: int = 120,
+        min_poll_interval: int = 60,
+    ) -> None:
+        super().__init__(
+            hass,
+            config_entry,
+            api=api,
+            location_poll_interval=location_poll_interval,
+            min_poll_interval=min_poll_interval,
+        )
+
+        # Cross-mixin hook exercised by ``_dispatch_async_request_refresh``
+        # and indirectly by ``_schedule_short_retry`` and ``_handle_dr_event``.
+        # Default is a no-op ``MagicMock`` so tests that only need the
+        # callable-check branch can ignore it. Tests override per-case to a
+        # coroutine factory or a raising MagicMock.
+        self.async_request_refresh = MagicMock(return_value=None)
+
+
+__all__ = ["PollingBranchesStub"]

--- a/tests/helpers/polling_mixin_stub.py
+++ b/tests/helpers/polling_mixin_stub.py
@@ -1,0 +1,118 @@
+# tests/helpers/polling_mixin_stub.py
+"""Test stub for :class:`PollingOperations` mixin standalone unit tests.
+
+PR 1.A.3 (Phase 2, AP-B): exercise the simple polling mixin methods
+(``_set_api_status``, ``_set_fcm_status``, ``api_status``, ``fcm_status``,
+``is_fcm_connected``, ``consecutive_timeouts``, ``last_poll_result``,
+``_is_on_hass_loop``, ``_run_on_hass_loop``, ``_compute_type_cooldown_seconds``,
+``_apply_report_type_cooldown``, ``is_polling``,
+``get_fcm_acquire_duration_seconds``, ``get_last_poll_duration_seconds``,
+``_clear_fcm_deferral``, ``_nudge_fcm_supervisor``,
+``_get_predicted_poll_time``, ``_note_push_transport_problem``,
+``force_poll_due``) without the full coordinator. ``_MixinBase`` is
+runtime-empty, so a minimal subclass seeds every attribute the mixin reads
+and pre-mocks cross-mixin methods (``_entry_id``, ``get_metric``,
+``_get_duration``, ``async_set_updated_data``,
+``_reindex_poll_targets_from_device_registry``) to dodge the
+``NotImplementedError`` traps that come from ``_MixinBase``.
+
+The complex async methods (``_async_update_data``,
+``_async_start_poll_cycle``, ``_handle_dr_event``,
+``_dispatch_async_request_refresh``, ``_schedule_short_retry``,
+``_is_fcm_ready_soft``, ``_note_fcm_deferral``) are intentionally out of
+scope here; they land in a later AP.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.googlefindmy.coordinator.helpers.stats import (
+    ApiStatus,
+    FcmStatus,
+)
+from custom_components.googlefindmy.coordinator.polling import PollingOperations
+
+
+def make_hass_stub(*, loop: Any | None = None) -> MagicMock:
+    """Return a Home Assistant stub with ``data``, ``loop`` and task helpers.
+
+    ``loop`` defaults to a fresh :class:`MagicMock` so equality checks against
+    the running loop default to ``False``. Tests that want the "on-loop"
+    branch can pass ``asyncio.get_event_loop()`` (or the running loop).
+    """
+
+    hass = MagicMock(spec_set=["data", "loop", "async_create_task"])
+    hass.data = {}
+    hass.loop = loop if loop is not None else MagicMock()
+    hass.async_create_task = MagicMock(return_value=None)
+    return hass
+
+
+class PollingStub(PollingOperations):
+    """Minimal :class:`PollingOperations` subclass for isolated mixin tests.
+
+    Cross-mixin ``_MixinBase`` stubs (``_entry_id``, ``get_metric``,
+    ``_get_duration``, ``async_set_updated_data``,
+    ``_reindex_poll_targets_from_device_registry``) are seeded as
+    ``MagicMock`` so methods under test can call them transparently; tests
+    rebind per-case via :func:`setattr`. No ``super().__init__`` chain runs
+    because ``DataUpdateCoordinator.__init__`` would require a full HA
+    runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        api: Any | None = None,
+        location_poll_interval: int = 120,
+        min_poll_interval: int = 60,
+    ) -> None:
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+        self.data: list[dict[str, Any]] = []
+
+        # Polling-state attributes (declared on _MixinBase, populated here).
+        self._api_status_state: str = ApiStatus.UNKNOWN
+        self._api_status_reason: str | None = None
+        self._api_status_changed_at: float | None = None
+        self._fcm_status_state: str = FcmStatus.UNKNOWN
+        self._fcm_status_reason: str | None = None
+        self._fcm_status_changed_at: float | None = None
+
+        self._consecutive_timeouts: int = 0
+        self._last_poll_result: str | None = None
+        self._is_polling: bool = False
+
+        self._fcm_defer_started_mono: float = 0.0
+        self._fcm_last_stage: int = 0
+        self._degraded_mode_warned: bool = False
+
+        self._device_poll_cooldown_until: dict[str, float] = {}
+        self._short_retry_cancel = None
+        self._push_cooldown_until: float = 0.0
+        self._push_ready_memo: bool | None = None
+
+        self._last_poll_mono: float = 0.0
+        self._device_update_history: dict[str, deque[float]] = {}
+
+        # Cross-mixin scalars used by helpers.
+        self.location_poll_interval = location_poll_interval
+        self.min_poll_interval = min_poll_interval
+        self.api = api if api is not None else MagicMock()
+
+        # Cross-mixin methods owned by other mixins or DataUpdateCoordinator:
+        # mock them so default behavior is a no-op. Tests override per-case.
+        entry_id = getattr(config_entry, "entry_id", None) if config_entry else None
+        self._entry_id = MagicMock(return_value=entry_id)
+        self.get_metric = MagicMock(return_value=None)
+        self._get_duration = MagicMock(return_value=None)
+        self.async_set_updated_data = MagicMock(return_value=None)
+        self._reindex_poll_targets_from_device_registry = MagicMock(return_value=None)
+
+
+__all__ = ["PollingStub", "make_hass_stub"]

--- a/tests/helpers/registry_mixin_stub.py
+++ b/tests/helpers/registry_mixin_stub.py
@@ -1,0 +1,174 @@
+# tests/helpers/registry_mixin_stub.py
+"""Test stub for :class:`RegistryOperations` mixin standalone unit tests.
+
+PR 1.A.1b (AP-1.1a-β): exercise mixin methods M1-M14 + M17 without the
+full coordinator. ``_MixinBase`` is runtime-empty, so a minimal subclass
+seeds every attribute the mixin reads, and cross-mixin methods owned by
+``SubentryOperations``/``IdentityOperations`` are pre-mocked to dodge the
+``NotImplementedError`` traps (risk R-NEU-3 in the notes sidecar).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.googlefindmy.const import DOMAIN, TRACKER_SUBENTRY_KEY
+from custom_components.googlefindmy.coordinator.registry import RegistryOperations
+
+
+class _DevRegStub:
+    """In-memory device registry; replaces ``dr.async_get(hass)`` results.
+
+    Holds devices as ``SimpleNamespace`` so tests can mutate ``.identifiers``,
+    ``.disabled_by`` etc. without touching real Home Assistant classes.
+    """
+
+    def __init__(self) -> None:
+        self.devices: list[SimpleNamespace] = []
+        self.update_calls: list[dict[str, Any]] = []
+        self._next_id = 0
+
+    def add_device(
+        self,
+        *,
+        identifiers: set[tuple[str, str]] | None = None,
+        name: str | None = None,
+        name_by_user: str | None = None,
+        disabled_by: Any | None = None,
+        config_entries: set[str] | None = None,
+    ) -> SimpleNamespace:
+        """Insert a synthetic device entry and return it."""
+
+        self._next_id += 1
+        device = SimpleNamespace(
+            id=f"dev-{self._next_id}",
+            identifiers=set(identifiers or set()),
+            name=name,
+            name_by_user=name_by_user,
+            disabled_by=disabled_by,
+            config_entries=set(config_entries or set()),
+        )
+        self.devices.append(device)
+        return device
+
+    def async_update_device(self, device_id: str, **kwargs: Any) -> SimpleNamespace | None:
+        """Stub used by ``_device_registry_allows_translation_update`` (signature only)."""
+
+        self.update_calls.append({"device_id": device_id, **kwargs})
+        for device in self.devices:
+            if device.id == device_id:
+                for key, value in kwargs.items():
+                    setattr(device, key, value)
+                return device
+        return None
+
+
+class _EntRegStub:
+    """In-memory entity registry; replaces ``er.async_get(hass)`` results."""
+
+    def __init__(self) -> None:
+        self.entries: list[SimpleNamespace] = []
+        self._next_id = 0
+
+    def add_entry(
+        self,
+        *,
+        platform: str = DOMAIN,
+        domain: str = "device_tracker",
+        device_id: str | None = None,
+        disabled_by: Any | None = None,
+    ) -> SimpleNamespace:
+        """Insert a synthetic entity registry entry."""
+
+        self._next_id += 1
+        entry = SimpleNamespace(
+            entity_id=f"{domain}.entity_{self._next_id}",
+            platform=platform,
+            domain=domain,
+            device_id=device_id,
+            disabled_by=disabled_by,
+        )
+        self.entries.append(entry)
+        return entry
+
+
+def make_hass_stub(*, with_setdefault_error: bool = False) -> MagicMock:
+    """Return a Home Assistant stub with ``hass.data`` and ``hass.config_entries``.
+
+    ``with_setdefault_error`` triggers the defensive branch in
+    :meth:`RegistryOperations._sync_owner_index` (B3) where
+    ``hass.data.setdefault`` raises.
+    """
+
+    # spec_set whitelists the two attributes the mixin actually reads on hass.
+    # An empty list would have blocked every assignment below (AttributeError).
+    hass = MagicMock(spec_set=["data", "config_entries"])
+    hass.data = {} if not with_setdefault_error else _RaisingDict()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_get_entry = MagicMock(return_value=None)
+    return hass
+
+
+class _RaisingDict(dict[str, Any]):
+    """``hass.data`` variant whose ``setdefault`` raises (defensive-guard test)."""
+
+    def setdefault(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[override]
+        raise RuntimeError("simulated hass.data corruption")
+
+
+class RegistryStub(RegistryOperations):
+    """Minimal :class:`RegistryOperations` subclass for isolated mixin tests.
+
+    Cross-mixin ``_MixinBase`` stubs are seeded as ``MagicMock`` so methods
+    under test can call them transparently; tests rebind per-case via
+    :func:`setattr`. No ``super().__init__`` chain runs because
+    ``DataUpdateCoordinator.__init__`` would require a full HA runtime.
+    """
+
+    def __init__(
+        self,
+        hass: Any | None = None,
+        config_entry: Any | None = None,
+        *,
+        data: list[dict[str, Any]] | None = None,
+    ) -> None:
+        # _MixinBase declares these as plain annotations; assign at runtime.
+        self.hass = hass if hass is not None else make_hass_stub()
+        self.config_entry = config_entry
+        self.data = data if data is not None else []
+
+        # Caches populated lazily by the mixin.
+        self._device_registry_config_subentry_kwarg_cache = None
+        self._device_registry_supports_translation_update = None
+        self._device_names: dict[str, str] | None = None
+
+        # Owner-index / poll-target sets the mixin reads and writes.
+        self._devices_with_entry: set[str] = set()
+        self._enabled_poll_device_ids: set[str] = set()
+        self._identity_key_to_devices: dict[bytes, set[str]] = {}
+
+        # Service-device bookkeeping (read by M15 in PR 1.A.2).
+        self._service_device_ready = False
+        self._service_device_id = None
+
+        # Subentry metadata mapping (typed on _MixinBase; runtime-empty here).
+        self._subentry_metadata = {}
+
+        # Cross-mixin methods (R-NEU-3): mock them so default behavior is a no-op.
+        # Tests can override per-case via setattr().
+        self._refresh_subentry_index = MagicMock(return_value=None)
+        self._schedule_eid_resolver_refresh = MagicMock(return_value=None)
+        self.get_subentry_metadata = MagicMock(return_value=None)
+        self.stable_subentry_identifier = MagicMock(return_value=TRACKER_SUBENTRY_KEY)
+        self.get_device_display_name = MagicMock(return_value=None)
+        self.increment_stat = MagicMock(return_value=None)
+
+
+__all__ = [
+    "RegistryStub",
+    "_DevRegStub",
+    "_EntRegStub",
+    "make_hass_stub",
+]

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -1,0 +1,1229 @@
+# tests/test_api_basics.py
+"""Basics coverage for :mod:`custom_components.googlefindmy.api` (Phase 4 AP-I).
+
+Risk-priority follows Aniche RV-G3: methods whose failure mode silently corrupts
+user-facing data (token retrieval, error mapping, sync-wrappers) are covered
+first. End-to-end Auth round-trips and HTTP transport remain Phase-5 scope.
+
+Class naming uses the ``Basics`` suffix (CA-F6: disjoint from existing
+``_StubCache`` / ``_SyncHarness`` classes in :mod:`tests.test_api_location_selection`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import ClientError
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.googlefindmy import api as api_module
+from custom_components.googlefindmy.api import (
+    GoogleFindMyAPI,
+    _build_can_ring_index,
+    _EphemeralCache,
+    _infer_can_ring_slot,
+    _is_multi_entry_guard_message,
+    _maybe_log_guard_once,
+    _short_err,
+    register_fcm_receiver_provider,
+    unregister_fcm_receiver_provider,
+)
+from custom_components.googlefindmy.const import (
+    CONTRIBUTOR_MODE_HIGH_TRAFFIC,
+    CONTRIBUTOR_MODE_IN_ALL_AREAS,
+    DEFAULT_CONTRIBUTOR_MODE,
+)
+from custom_components.googlefindmy.NovaApi.nova_request import (
+    NovaAuthError,
+    NovaHTTPError,
+    NovaLogicError,
+    NovaProtobufDecodeError,
+    NovaRateLimitError,
+)
+from tests.helpers.api_stub import (
+    FakeReceiver,
+    RaisingCache,
+    StubCache,
+    install_receiver_provider,
+    make_pc,
+    run_coro,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_fcm_provider() -> Any:
+    """Snapshot/restore the module-level FCM receiver getter."""
+
+    saved = api_module._FCM_ReceiverGetter
+    yield
+    api_module._FCM_ReceiverGetter = saved
+
+
+@pytest.fixture(autouse=True)
+def _reset_guard_log_flag() -> Any:
+    """Reset the module-level multi-entry guard log flag between tests."""
+
+    api_module._GUARD_LOGGED_ONCE = False
+    yield
+    api_module._GUARD_LOGGED_ONCE = False
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+class TestShortErrBasics:
+    """:func:`_short_err` truncation and pass-through."""
+
+    def test_short_message_is_returned_verbatim(self) -> None:
+        assert _short_err("kurz") == "kurz"
+
+    def test_long_message_is_truncated_with_ellipsis(self) -> None:
+        long = "x" * (api_module._MAX_ERR_CHARS + 50)
+        result = _short_err(long)
+        assert len(result) == api_module._MAX_ERR_CHARS
+        assert result.endswith("...")
+
+    def test_exception_input_is_stringified(self) -> None:
+        assert _short_err(RuntimeError("boom")) == "boom"
+
+
+class TestMultiEntryGuardDetection:
+    """Both markers of the multi-entry guard message."""
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "Multiple config entries active for googlefindmy",
+            "entry.runtime_data missing for this entry",
+        ],
+    )
+    def test_detects_known_markers(self, msg: str) -> None:
+        assert _is_multi_entry_guard_message(msg) is True
+
+    @pytest.mark.parametrize("msg", ["", "unrelated error"])
+    def test_rejects_unrelated_messages(self, msg: str) -> None:
+        assert _is_multi_entry_guard_message(msg) is False
+
+
+class TestMaybeLogGuardOnce:
+    """Initial INFO log, subsequent DEBUG suppression, optional context."""
+
+    def test_first_call_logs_info_then_suppressed(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger=api_module._LOGGER.name)
+        _maybe_log_guard_once("device_list")
+        _maybe_log_guard_once("device_list")
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert len(info_records) == 1
+        assert len(debug_records) == 1
+        assert "device_list" in debug_records[0].getMessage()
+
+    def test_extras_are_appended(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO, logger=api_module._LOGGER.name)
+        _maybe_log_guard_once(
+            "device_list", email="user@example.com", entry_id="entry-1"
+        )
+        info = [r for r in caplog.records if r.levelno == logging.INFO]
+        message = info[0].getMessage()
+        assert "email=user@example.com" in message
+        assert "entry_id=entry-1" in message
+
+
+class TestFcmProviderRegistration:
+    """Register/unregister keeps the module-global provider in sync."""
+
+    def test_register_and_unregister_round_trip(self) -> None:
+        def _getter(_entry_id: str | None = None) -> FakeReceiver:
+            return FakeReceiver()
+
+        register_fcm_receiver_provider(_getter)
+        assert api_module._FCM_ReceiverGetter is _getter
+        unregister_fcm_receiver_provider()
+        assert api_module._FCM_ReceiverGetter is None
+
+
+# ---------------------------------------------------------------------------
+# Capability helpers
+# ---------------------------------------------------------------------------
+
+
+class TestInferCanRingSlotBasics:
+    """Slot inference across the documented input shapes."""
+
+    @pytest.mark.parametrize(
+        "device, expected",
+        [
+            ({"can_ring": True}, True),
+            ({"can_ring": False}, False),
+            ({"canRing": True}, True),
+            ({"capabilities": ["ring", "vibrate"]}, True),
+            ({"capabilities": {"PLAY_SOUND": True}}, True),
+            ({"capabilities": {"ring": False, "play_sound": False}}, False),
+            ({"capabilities": "scalar-not-iterable"}, None),
+            ({}, None),
+        ],
+    )
+    def test_returns_expected_verdict(
+        self, device: dict[str, Any], expected: bool | None
+    ) -> None:
+        assert _infer_can_ring_slot(device) is expected
+
+    def test_returns_none_on_internal_error(self) -> None:
+        class _Boom(dict):  # type: ignore[type-arg]
+            def __contains__(self, key: object) -> bool:
+                raise RuntimeError("boom")
+
+        assert _infer_can_ring_slot(_Boom()) is None
+
+
+class TestBuildCanRingIndexBasics:
+    """Index respects identifier fallbacks and ignores undecidable rows."""
+
+    def test_uses_canonical_id_and_skips_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Empirie: api.py:Z290-Z315 (_infer_can_ring_slot) — returns None ONLY when
+        # neither `can_ring`/`canRing` nor a `capabilities` key is present. An empty
+        # list/dict for `capabilities` still triggers the membership check, yielding
+        # False (a valid bool), so such a row IS recorded in the index. To test the
+        # skip-unknown path we must omit the `capabilities` key entirely.
+        rows = [
+            {"canonicalId": "A", "can_ring": True},
+            {"id": "B", "can_ring": False},
+            {"device_id": "C"},  # no can_ring / canRing / capabilities → verdict None
+            {"id": "", "can_ring": True},
+        ]
+        monkeypatch.setattr(
+            api_module, "get_devices_with_location", lambda *_a, **_k: rows
+        )
+        index = _build_can_ring_index(object(), cache=None)
+        assert index == {"A": True, "B": False}
+
+    def test_decoder_error_yields_empty_index(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(*_a: Any, **_k: Any) -> list[dict[str, Any]]:
+            raise RuntimeError("decoder boom")
+
+        monkeypatch.setattr(api_module, "get_devices_with_location", _raise)
+        assert _build_can_ring_index(object(), cache=None) == {}
+
+
+# ---------------------------------------------------------------------------
+# Constructor / EphemeralCache / contributor mode / namespace
+# ---------------------------------------------------------------------------
+
+
+class TestApiInitBasics:
+    """``__init__`` paths: cache, ephemeral, missing credentials, epoch."""
+
+    def test_requires_cache_or_credentials(self) -> None:
+        with pytest.raises(TypeError, match="GoogleFindMyAPI requires"):
+            GoogleFindMyAPI()
+
+    def test_ephemeral_cache_built_from_token_or_email(self) -> None:
+        api = GoogleFindMyAPI(oauth_token="tok", google_email="x@example.com")
+        assert isinstance(api._cache, _EphemeralCache)
+
+    def test_invalid_switch_epoch_falls_back_to_now(self) -> None:
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            contributor_mode_switch_epoch=0,
+        )
+        assert api._contributor_mode_switch_epoch > 0
+
+    def test_contributor_mode_normalized_at_init(self) -> None:
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            contributor_mode="  HIGH_TRAFFIC  ",
+        )
+        assert api._contributor_mode == CONTRIBUTOR_MODE_HIGH_TRAFFIC
+
+    def test_unknown_contributor_mode_uses_default(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(), contributor_mode="bogus")
+        assert api._contributor_mode == DEFAULT_CONTRIBUTOR_MODE
+
+
+class TestEphemeralCacheBasics:
+    """Public TokenCache-protocol surface of :class:`_EphemeralCache`."""
+
+    def test_get_set_delete_round_trip(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        run_coro(cache.set("k", "v"))
+        assert run_coro(cache.get("k")) == "v"
+        run_coro(cache.set("k", None))
+        assert run_coro(cache.get("k")) is None
+
+    def test_all_returns_snapshot_copy(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        snap = run_coro(cache.all())
+        snap["mutated"] = True
+        assert "mutated" not in run_coro(cache.all())
+
+    def test_get_or_set_with_sync_generator(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        value = run_coro(cache.get_or_set("new", lambda: "computed"))
+        assert value == "computed"
+        assert run_coro(cache.get("new")) == "computed"
+
+    def test_get_or_set_with_async_generator(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+
+        async def _gen() -> str:
+            return "async-value"
+
+        assert run_coro(cache.get_or_set("k", _gen)) == "async-value"
+
+    def test_get_or_set_returns_existing(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        run_coro(cache.set("k", "pre"))
+        assert run_coro(cache.get_or_set("k", lambda: "new")) == "pre"
+
+    def test_protocol_aliases_forward_to_base(self) -> None:
+        cache = _EphemeralCache(oauth_token="tok", email="x@example.com")
+        run_coro(cache.async_set_cached_value("k", "v"))
+        assert run_coro(cache.async_get_cached_value("k")) == "v"
+
+    def test_secrets_bundle_injects_fcm_credentials(self) -> None:
+        cache = _EphemeralCache(
+            oauth_token=None,
+            email=None,
+            secrets_bundle={"fcm_credentials": {"android_id": "42"}},
+        )
+        assert run_coro(cache.get("fcm_credentials")) == {"android_id": "42"}
+
+    def test_secrets_bundle_without_fcm_creds_is_logged(self) -> None:
+        cache = _EphemeralCache(
+            oauth_token=None,
+            email=None,
+            secrets_bundle={"other": "value"},
+        )
+        assert run_coro(cache.get("fcm_credentials")) is None
+
+
+class TestApiCloseAndContributorMode:
+    """``close`` unrefs the shared session; ``set_contributor_mode`` validates."""
+
+    def test_close_clears_session_reference(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(), session=MagicMock())
+        run_coro(api.close())
+        assert api._session is None
+
+    def test_normalize_contributor_mode_known_value(self) -> None:
+        assert (
+            GoogleFindMyAPI._normalize_contributor_mode("  in_all_areas  ")
+            == CONTRIBUTOR_MODE_IN_ALL_AREAS
+        )
+
+    def test_normalize_contributor_mode_non_string(self) -> None:
+        assert (
+            GoogleFindMyAPI._normalize_contributor_mode(None)
+            == DEFAULT_CONTRIBUTOR_MODE
+        )
+        assert (
+            GoogleFindMyAPI._normalize_contributor_mode(123)  # type: ignore[arg-type]
+            == DEFAULT_CONTRIBUTOR_MODE
+        )
+
+    def test_set_contributor_mode_invalid_epoch_uses_now(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        api._contributor_mode_switch_epoch = 0
+        api.set_contributor_mode("high_traffic", switch_epoch=-5)
+        assert api._contributor_mode == CONTRIBUTOR_MODE_HIGH_TRAFFIC
+        assert api._contributor_mode_switch_epoch > 0
+
+
+class TestNamespaceBasics:
+    """``_namespace`` reads ``entry_id`` then ``namespace`` then returns None."""
+
+    def test_prefers_entry_id(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="  entry-x  "))
+        assert api._namespace() == "entry-x"
+
+    def test_falls_back_to_namespace(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(entry_id=None, namespace="ns-1"))
+        assert api._namespace() == "ns-1"
+
+    def test_returns_none_when_absent(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache(entry_id=None, namespace=None))
+        assert api._namespace() is None
+
+    def test_returns_none_on_exception(self) -> None:
+        api = GoogleFindMyAPI(cache=RaisingCache())
+        assert api._namespace() is None
+
+    def test_decoder_token_cache_returns_none_for_stub(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._decoder_token_cache() is None
+
+
+# ---------------------------------------------------------------------------
+# Sync-call guard / loop resolution / helper
+# ---------------------------------------------------------------------------
+
+
+class TestSyncCallGuardBasics:
+    """Detect a running loop and log the guard message."""
+
+    def test_returns_false_without_running_loop(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._sync_call_guard("should not log") is False
+
+    def test_returns_true_when_loop_running(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _probe() -> bool:
+            return api._sync_call_guard("guard:active loop")
+
+        loop = asyncio.new_event_loop()
+        try:
+            assert loop.run_until_complete(_probe()) is True
+        finally:
+            loop.close()
+        assert any("guard:active loop" in r.getMessage() for r in caplog.records)
+
+
+class TestResolveSyncLoopBasics:
+    """Session-bound vs. fresh-loop resolution paths."""
+
+    def test_session_without_loop_raises(self) -> None:
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            session=SimpleNamespace(loop=None),
+        )
+        with pytest.raises(RuntimeError, match="determine the event loop"):
+            api._resolve_sync_loop()
+
+    def test_session_with_closed_loop_raises(self) -> None:
+        closed = asyncio.new_event_loop()
+        closed.close()
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            session=SimpleNamespace(loop=closed),
+        )
+        with pytest.raises(RuntimeError, match="closed"):
+            api._resolve_sync_loop()
+
+    def test_session_with_open_loop_returns_it(self) -> None:
+        open_loop = asyncio.new_event_loop()
+        try:
+            api = GoogleFindMyAPI(
+                cache=StubCache(),
+                session=SimpleNamespace(loop=open_loop),
+            )
+            assert api._resolve_sync_loop() is open_loop
+        finally:
+            open_loop.close()
+
+    def test_no_session_creates_and_caches_loop(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        try:
+            loop_a = api._resolve_sync_loop()
+            loop_b = api._resolve_sync_loop()
+            assert loop_a is loop_b
+        finally:
+            if api._sync_loop is not None:
+                api._sync_loop.close()
+
+    def test_closed_cached_loop_is_replaced(self) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        old = asyncio.new_event_loop()
+        old.close()
+        api._sync_loop = old
+        try:
+            new_loop = api._resolve_sync_loop()
+            assert new_loop is not old
+            assert not new_loop.is_closed()
+        finally:
+            if api._sync_loop is not None:
+                api._sync_loop.close()
+
+
+class TestRunSyncHelperBasics:
+    """Guard short-circuit / resolve failure / running loop / coroutine errors."""
+
+    def test_returns_default_when_guard_active(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _probe() -> Any:
+            async def _factory() -> str:
+                return "ok"
+
+            return api._run_sync_helper(
+                _factory,
+                guard_message="guard:short",
+                context="ctx",
+                default="default",
+            )
+
+        loop = asyncio.new_event_loop()
+        try:
+            assert loop.run_until_complete(_probe()) == "default"
+        finally:
+            loop.close()
+
+    def test_returns_default_when_resolve_fails(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        api = GoogleFindMyAPI(
+            cache=StubCache(),
+            session=SimpleNamespace(loop=None),
+        )
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _factory() -> str:
+            return "unused"
+
+        assert (
+            api._run_sync_helper(
+                _factory,
+                guard_message="g",
+                context="ctx",
+                default="def",
+            )
+            == "def"
+        )
+        assert any("sync setup" in r.getMessage() for r in caplog.records)
+
+    def test_returns_default_when_target_loop_already_running(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        running = MagicMock(spec=asyncio.AbstractEventLoop)
+        running.is_running.return_value = True
+        running.is_closed.return_value = False
+        api = GoogleFindMyAPI(cache=StubCache())
+        monkeypatch.setattr(api, "_resolve_sync_loop", lambda: running)
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _factory() -> str:
+            return "unused"
+
+        assert (
+            api._run_sync_helper(
+                _factory, guard_message="g", context="ctx", default="def"
+            )
+            == "def"
+        )
+
+    def test_coroutine_exception_returns_default(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        api = GoogleFindMyAPI(cache=StubCache())
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+
+        async def _factory() -> str:
+            raise RuntimeError("inner boom")
+
+        try:
+            result = api._run_sync_helper(
+                _factory, guard_message="g", context="ctx", default="def"
+            )
+        finally:
+            if api._sync_loop is not None:
+                api._sync_loop.close()
+        assert result == "def"
+        assert any("inner boom" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# FCM token retrieval (action / quiet)
+# ---------------------------------------------------------------------------
+
+
+class TestFcmTokenForActionBasics:
+    """All branches of :meth:`_get_fcm_token_for_action`."""
+
+    def test_no_provider_returns_none(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._get_fcm_token_for_action() is None
+
+    def test_entry_scoped_token_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(token="entry-token-1234")
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="entry-x"))
+        assert api._get_fcm_token_for_action() == "entry-token-1234"
+
+    def test_provider_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(token="legacy-token-12345")
+        install_receiver_provider(monkeypatch, receiver, accepts_entry=False)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._get_fcm_token_for_action() == "legacy-token-12345"
+
+    def test_provider_legacy_failure_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            accepts_entry=False,
+            raise_on_legacy_call=RuntimeError("legacy boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        caplog.set_level(logging.ERROR, logger=api_module._LOGGER.name)
+        assert api._get_fcm_token_for_action() is None
+        assert any("legacy path" in r.getMessage() for r in caplog.records)
+
+    def test_provider_general_exception_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            raise_on_call=RuntimeError("provider boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._get_fcm_token_for_action() is None
+
+    def test_receiver_none_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        install_receiver_provider(monkeypatch, None)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._get_fcm_token_for_action() is None
+
+    def test_receiver_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(
+            token="receiver-legacy-1234",
+            accepts_entry=False,
+        )
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._get_fcm_token_for_action() == "receiver-legacy-1234"
+
+    def test_receiver_legacy_failure_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(
+            accepts_entry=False,
+            raise_on_get_legacy=RuntimeError("legacy receiver boom"),
+        )
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._get_fcm_token_for_action() is None
+
+    def test_receiver_general_exception_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(raise_on_get=RuntimeError("receiver boom"))
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._get_fcm_token_for_action() is None
+
+    def test_short_token_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(token="abc")
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._get_fcm_token_for_action() is None
+
+    def test_cache_entry_id_exception_falls_back_to_legacy_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Empirie: api.py:Z624-Z638 (_namespace) wraps BOTH getattr calls in a single
+        # try/except Exception. When entry_id raises, the whole function returns None
+        # — the namespace attribute is NEVER reached. _get_fcm_token_for_action then
+        # passes None to the provider, which falls through to the legacy receiver
+        # call (no args). Author's mental model (entry_id raises → namespace used) is
+        # wrong; the defensive wrapper short-circuits BOTH attribute reads.
+        receiver = FakeReceiver(token="legacy-token-1234567")
+        calls = install_receiver_provider(monkeypatch, receiver)
+        cache = RaisingCache()
+        cache.namespace = "never-reached-because-entry_id-raises"  # type: ignore[attr-defined]
+        api = GoogleFindMyAPI(cache=cache)
+        assert api._get_fcm_token_for_action() == "legacy-token-1234567"
+        assert calls and calls[0] == (None,)
+
+    def test_namespace_fallback_used_when_entry_id_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Empirie: api.py:Z624-Z638 (_namespace) — when getattr(cache, "entry_id")
+        # returns None WITHOUT raising, the `or getattr(cache, "namespace", None)`
+        # branch is reached and resolves to "ns-via-fallback". The provider is then
+        # called entry-scoped with that resolved namespace.
+        receiver = FakeReceiver(token="ns-token-1234567")
+        calls = install_receiver_provider(monkeypatch, receiver)
+        cache = StubCache(entry_id=None, namespace="ns-via-fallback")
+        api = GoogleFindMyAPI(cache=cache)
+        assert api._get_fcm_token_for_action() == "ns-token-1234567"
+        assert calls and calls[0] == ("ns-via-fallback",)
+
+
+class TestPeekFcmTokenQuietlyBasics:
+    """Quiet probe mirrors action-token paths but logs at DEBUG only."""
+
+    def test_no_provider_returns_none(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(token="peek-token-12345")
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() == "peek-token-12345"
+
+    def test_provider_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(token="peek-legacy-12345")
+        install_receiver_provider(monkeypatch, receiver, accepts_entry=False)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() == "peek-legacy-12345"
+
+    def test_provider_legacy_failure_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            accepts_entry=False,
+            raise_on_legacy_call=RuntimeError("peek legacy boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_provider_general_exception_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            raise_on_call=RuntimeError("peek provider boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_receiver_none_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        install_receiver_provider(monkeypatch, None)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_receiver_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(
+            token="receiver-peek-12345",
+            accepts_entry=False,
+        )
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() == "receiver-peek-12345"
+
+    def test_receiver_legacy_failure_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(
+            accepts_entry=False,
+            raise_on_get_legacy=RuntimeError("peek receiver legacy"),
+        )
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_receiver_general_exception_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(raise_on_get=RuntimeError("peek receiver boom"))
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() is None
+
+    def test_short_token_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(token="ab")
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api._peek_fcm_token_quietly() is None
+
+
+# ---------------------------------------------------------------------------
+# Push readiness / can_play_sound
+# ---------------------------------------------------------------------------
+
+
+class TestIsPushReadyBasics:
+    """All decision branches of :meth:`is_push_ready`."""
+
+    def test_returns_false_without_provider(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api.is_push_ready() is False
+
+    def test_returns_false_when_receiver_is_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(monkeypatch, None)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is False
+
+    def test_returns_value_of_is_ready_boolean(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is True
+
+    def test_returns_true_when_push_client_started(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=None, pc=make_pc(do_listen=True))
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is True
+
+    def test_returns_false_when_push_client_not_listening(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=None, pc=make_pc(do_listen=False))
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is False
+
+    def test_returns_false_when_no_signals_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=None, pc=None)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.is_push_ready() is False
+
+    def test_provider_typeerror_falls_back_to_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver, accepts_entry=False)
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api.is_push_ready() is True
+
+    def test_provider_general_exception_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch, None, raise_on_call=RuntimeError("push provider boom")
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api.is_push_ready() is False
+
+    def test_provider_legacy_failure_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(
+            monkeypatch,
+            None,
+            accepts_entry=False,
+            raise_on_legacy_call=RuntimeError("push legacy boom"),
+        )
+        api = GoogleFindMyAPI(cache=StubCache())
+        assert api.is_push_ready() is False
+
+    def test_push_ready_property_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.push_ready is True
+
+
+class TestCanPlaySoundBasics:
+    """Capability cache + push-ready gate decide the verdict."""
+
+    def test_returns_false_when_push_not_ready(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        install_receiver_provider(monkeypatch, None)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        api._device_capabilities["dev"] = True
+        assert api.can_play_sound("dev") is False
+
+    def test_returns_cached_value_when_known(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        api._device_capabilities["dev"] = False
+        assert api.can_play_sound("dev") is False
+
+    def test_returns_none_when_capability_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        receiver = FakeReceiver(is_ready=True)
+        install_receiver_provider(monkeypatch, receiver)
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert api.can_play_sound("unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# Async error mapping: device list / location / play / stop
+# ---------------------------------------------------------------------------
+
+
+def _make_api_with_session() -> GoogleFindMyAPI:
+    return GoogleFindMyAPI(cache=StubCache(entry_id="entry-1"), session=None)
+
+
+class TestAsyncBasicDeviceListErrorMapping:
+    """Each documented exception class is mapped to UpdateFailed/AuthFailed."""
+
+    def _patch_request(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        exc: BaseException,
+    ) -> None:
+        async def _raise(*_a: Any, **_k: Any) -> str:
+            raise exc
+
+        monkeypatch.setattr(api_module, "async_request_device_list", _raise)
+
+    def test_rate_limit_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaRateLimitError("rate"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_http_401_403_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch, status: int
+    ) -> None:
+        self._patch_request(monkeypatch, NovaHTTPError(status, "http"))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_http_500_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaHTTPError(500, "server"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_nova_auth_error_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaAuthError(401, "auth"))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_protobuf_decode_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaProtobufDecodeError("decode"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_logic_error_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaLogicError(message="logic", code=1))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    @pytest.mark.parametrize(
+        "marker",
+        ["BadAuthentication", "Missing 'Token' in gpsoauth", "Bad Authentication"],
+    )
+    def test_bad_auth_runtime_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch, marker: str
+    ) -> None:
+        self._patch_request(monkeypatch, RuntimeError(marker))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_token_cache_closed_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, RuntimeError("TokenCache is closed"))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_multi_entry_guard_message_maps_to_update_failed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        self._patch_request(
+            monkeypatch, RuntimeError("Multiple config entries active here")
+        )
+        api = _make_api_with_session()
+        caplog.set_level(logging.INFO, logger=api_module._LOGGER.name)
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+        assert any(
+            "multiple config entries" in r.getMessage().lower() for r in caplog.records
+        )
+
+    def test_generic_runtime_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, RuntimeError("other transient"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_client_error_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, ClientError("net"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+    def test_unexpected_exception_maps_to_update_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, Exception("boom"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+
+
+class TestAsyncDeviceLocationErrorMapping:
+    """Each documented exception class for the location request branch."""
+
+    def _patch_request(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        exc: BaseException,
+    ) -> None:
+        async def _raise(*_a: Any, **_k: Any) -> list[Any]:
+            raise exc
+
+        monkeypatch.setattr(api_module, "get_location_data_for_device", _raise)
+
+    def test_nova_auth_permanent_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(
+            monkeypatch, api_module.NovaAuthPermanentError(401, "perm-auth")
+        )
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_device_location("d", "name"))
+
+    def test_nova_auth_transient_reraised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaAuthError(401, "transient"))
+        api = _make_api_with_session()
+        with pytest.raises(NovaAuthError):
+            run_coro(api.async_get_device_location("d", "name"))
+
+    def test_nova_auth_permanent_via_flag_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(
+            monkeypatch,
+            NovaAuthError(401, "perm-flag", is_permanent=True),
+        )
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_device_location("d", "name"))
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_http_401_403_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch, status: int
+    ) -> None:
+        self._patch_request(monkeypatch, NovaHTTPError(status, "http"))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed):
+            run_coro(api.async_get_device_location("d", "name"))
+
+    def test_http_500_returns_empty_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_request(monkeypatch, NovaHTTPError(500, "server"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_rate_limit_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaRateLimitError("rate"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_protobuf_decode_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaProtobufDecodeError("decode"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_logic_error_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, NovaLogicError(message="logic", code=2))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_client_error_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, ClientError("net"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_fcm_startup_runtime_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(
+            monkeypatch,
+            RuntimeError("FCM receiver provider has not been registered yet"),
+        )
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_generic_runtime_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, RuntimeError("other"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_unexpected_exception_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_request(monkeypatch, ValueError("boom"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+
+class TestAsyncPlaySoundErrorMapping:
+    """Each documented exception class for the play-sound branch."""
+
+    def _api_with_token(self, monkeypatch: pytest.MonkeyPatch) -> GoogleFindMyAPI:
+        receiver = FakeReceiver(token="play-token-1234567")
+        install_receiver_provider(monkeypatch, receiver)
+        return GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+
+    def _patch_submit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        result: Any,
+        *,
+        raises: BaseException | None = None,
+    ) -> None:
+        async def _submit(*_a: Any, **_k: Any) -> Any:
+            if raises is not None:
+                raise raises
+            return result
+
+        monkeypatch.setattr(api_module, "async_submit_start_sound_request", _submit)
+
+    def test_missing_token_short_circuits(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert run_coro(api.async_play_sound("d")) == (False, None)
+
+    def test_empty_submission_response(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, None)
+        assert run_coro(api.async_play_sound("d")) == (False, None)
+
+    def test_success_returns_uuid_tuple(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, ("AB", "uuid-1234"))
+        assert run_coro(api.async_play_sound("d")) == (True, "uuid-1234")
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            NovaAuthError(401, "auth"),
+            NovaHTTPError(401, "http"),
+            NovaHTTPError(503, "http"),
+            NovaRateLimitError("rate"),
+            ClientError("net"),
+            Exception("boom"),
+        ],
+    )
+    def test_documented_exceptions_return_false_none(
+        self, monkeypatch: pytest.MonkeyPatch, exc: BaseException
+    ) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, None, raises=exc)
+        assert run_coro(api.async_play_sound("d")) == (False, None)
+
+
+class TestAsyncStopSoundErrorMapping:
+    """Each documented exception class for the stop-sound branch."""
+
+    def _api_with_token(self, monkeypatch: pytest.MonkeyPatch) -> GoogleFindMyAPI:
+        receiver = FakeReceiver(token="stop-token-1234567")
+        install_receiver_provider(monkeypatch, receiver)
+        return GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+
+    def _patch_submit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        result: Any,
+        *,
+        raises: BaseException | None = None,
+    ) -> None:
+        async def _submit(*_a: Any, **_k: Any) -> Any:
+            if raises is not None:
+                raise raises
+            return result
+
+        monkeypatch.setattr(api_module, "async_submit_stop_sound_request", _submit)
+
+    def test_missing_token_short_circuits(self) -> None:
+        api_module._FCM_ReceiverGetter = None
+        api = GoogleFindMyAPI(cache=StubCache(entry_id="e"))
+        assert run_coro(api.async_stop_sound("d")) is False
+
+    def test_none_response_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, None)
+        assert run_coro(api.async_stop_sound("d", "uuid-1234")) is False
+
+    def test_success_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, "CDEF")
+        assert run_coro(api.async_stop_sound("d", "uuid-5678")) is True
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            NovaAuthError(401, "auth"),
+            NovaHTTPError(403, "http"),
+            NovaHTTPError(500, "http"),
+            NovaRateLimitError("rate"),
+            ClientError("net"),
+            Exception("boom"),
+        ],
+    )
+    def test_documented_exceptions_return_false(
+        self, monkeypatch: pytest.MonkeyPatch, exc: BaseException
+    ) -> None:
+        api = self._api_with_token(monkeypatch)
+        self._patch_submit(monkeypatch, None, raises=exc)
+        assert run_coro(api.async_stop_sound("d")) is False

--- a/tests/test_config_flow_basics.py
+++ b/tests/test_config_flow_basics.py
@@ -1,0 +1,1241 @@
+# tests/test_config_flow_basics.py
+"""Basics coverage for :mod:`custom_components.googlefindmy.config_flow` (Phase 4 AP-L).
+
+Targets pure-function helpers that are reachable without instantiating a
+full Home Assistant flow manager: validators, normalizers, payload builders,
+error mapping, credential interpreters, discovery helpers and the lightweight
+dataclass surface. The 25 helpers tested here are all reachable from the flow
+steps, so every test exercises a code path that real onboarding traverses
+(Aniche RV-G3: user-setup path, every branch is onboarding critical).
+
+Empiricism trace (CA-MOCK-001 / CA-ASSERTION-EMPIRIE-001):
+- All assertions are grounded against the production implementation in
+  ``custom_components/googlefindmy/config_flow.py`` (read at commit
+  a2edc23d). Line anchors are noted on the test classes.
+- No mocks of pure-function behaviour; only thin shims for the
+  ``HomeAssistant``/``ConfigEntry`` boundary where the helpers touch HA APIs
+  (``_find_entry_by_email``, ``_resolve_entry_email_for_lookup``,
+  ``_ensure_optional_entry_attributes``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy import config_flow as cf
+
+# ---------------------------------------------------------------------------
+# Block A: validators (cf.py lines 944-956)
+# ---------------------------------------------------------------------------
+
+
+class TestEmailValid:
+    """Empiricism: ``_email_valid`` returns ``bool(_EMAIL_RE.match(value or ""))``."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "user@example.com",
+            "first.last@sub.example.co.uk",
+            "user+tag@example.com",
+            "U_S_E_R@example.io",
+        ],
+    )
+    def test_accepts_well_formed_addresses(self, value: str) -> None:
+        assert cf._email_valid(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",  # empty
+            "not-an-email",  # no @
+            "@example.com",  # missing local part
+            "user@",  # missing domain
+            "user@nope",  # missing TLD
+            "user@.com",  # empty subdomain label
+            "a@b.c",  # TLD too short
+            " user@example.com",  # leading whitespace blocks regex
+        ],
+    )
+    def test_rejects_malformed_addresses(self, value: str) -> None:
+        assert cf._email_valid(value) is False
+
+    def test_handles_none_via_value_or_empty(self) -> None:
+        # The implementation defends against ``None`` via ``value or ""``.
+        assert cf._email_valid(None) is False  # type: ignore[arg-type]
+
+
+class TestTokenPlausible:
+    """Empiricism: ``_TOKEN_RE`` requires ``\\S{16,}`` (no whitespace, len>=16)."""
+
+    def test_accepts_long_token_without_whitespace(self) -> None:
+        assert cf._token_plausible("a" * 16) is True
+        assert cf._token_plausible("aas_et/" + "x" * 64) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "short",  # too short
+            "a" * 15,  # one shy of minimum length
+            "with whitespace1234567890",  # contains space
+            "with\ttab12345678",  # contains tab
+        ],
+    )
+    def test_rejects_short_or_whitespace_tokens(self, value: str) -> None:
+        assert cf._token_plausible(value) is False
+
+    def test_handles_none(self) -> None:
+        assert cf._token_plausible(None) is False  # type: ignore[arg-type]
+
+
+class TestLooksLikeJwt:
+    """Empiricism: ``count(".") >= 2 and value[:3] == 'eyJ'``."""
+
+    def test_classic_jwt_shape_accepted(self) -> None:
+        assert cf._looks_like_jwt("eyJabc.eyJdef.signature") is True
+
+    def test_two_dots_but_wrong_prefix_rejected(self) -> None:
+        assert cf._looks_like_jwt("aaa.bbb.ccc") is False
+
+    def test_correct_prefix_but_no_dots_rejected(self) -> None:
+        assert cf._looks_like_jwt("eyJabcdefghijklmnop") is False
+
+    def test_empty_string_rejected(self) -> None:
+        # Slicing ``""[:3]`` yields ``""`` which is not ``"eyJ"`` — no IndexError.
+        assert cf._looks_like_jwt("") is False
+
+
+# ---------------------------------------------------------------------------
+# Block B: normalizers (cf.py lines 964-988)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeFeatureList:
+    """Empiricism: dedupes, strips, lowercases, sorts; skips non-str."""
+
+    def test_strips_lowercases_dedupes_and_sorts(self) -> None:
+        result = cf._normalize_feature_list(
+            ["  Maps ", "device_tracker", "MAPS", "Sensor"]
+        )
+        assert result == ["device_tracker", "maps", "sensor"]
+
+    def test_skips_non_string_entries(self) -> None:
+        # Non-str entries are silently dropped (no exception, no insertion).
+        result = cf._normalize_feature_list(["sensor", 42, None, "button"])  # type: ignore[list-item]
+        assert result == ["button", "sensor"]
+
+    def test_drops_empty_after_strip(self) -> None:
+        result = cf._normalize_feature_list(["", "  ", "sensor"])
+        assert result == ["sensor"]
+
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert cf._normalize_feature_list([]) == []
+
+
+class TestNormalizeVisibleIds:
+    """Empiricism: strips and dedupes (no case-folding!), sorts."""
+
+    def test_strips_and_dedupes(self) -> None:
+        result = cf._normalize_visible_ids(["  abc ", "abc", "def"])
+        assert result == ["abc", "def"]
+
+    def test_preserves_case(self) -> None:
+        # Visible IDs are case-sensitive device identifiers.
+        result = cf._normalize_visible_ids(["ABC", "abc"])
+        assert result == ["ABC", "abc"]
+
+    def test_skips_non_strings_and_blanks(self) -> None:
+        result = cf._normalize_visible_ids(["abc", 0, None, "", " "])  # type: ignore[list-item]
+        assert result == ["abc"]
+
+    def test_empty_input(self) -> None:
+        assert cf._normalize_visible_ids([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Block C: feature settings and payload builder (cf.py lines 991-1063)
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveFeatureSettings:
+    """Empiricism: per-key precedence options_payload > defaults > module DEFAULT."""
+
+    def test_explicit_options_override_defaults(self) -> None:
+        opt_key = cf.OPT_GOOGLE_HOME_FILTER_ENABLED
+        if opt_key is None:
+            pytest.skip("OPT_GOOGLE_HOME_FILTER_ENABLED not available in this build")
+
+        opt_stats = cf.OPT_ENABLE_STATS_ENTITIES
+        opt_map = cf.OPT_MAP_VIEW_TOKEN_EXPIRATION
+
+        has_filter, flags = cf._derive_feature_settings(
+            options_payload={
+                opt_key: True,
+                opt_stats: False,
+                opt_map: True,
+            },
+            defaults={opt_stats: True},
+        )
+        assert has_filter is True
+        assert flags[opt_stats] is False  # options wins over defaults
+        assert flags[opt_map] is True
+        assert flags[opt_key] is True
+
+    def test_defaults_apply_when_options_silent(self) -> None:
+        opt_key = cf.OPT_GOOGLE_HOME_FILTER_ENABLED
+        if opt_key is None:
+            pytest.skip("OPT_GOOGLE_HOME_FILTER_ENABLED not available in this build")
+        opt_stats = cf.OPT_ENABLE_STATS_ENTITIES
+
+        has_filter, flags = cf._derive_feature_settings(
+            options_payload={},
+            defaults={opt_key: True, opt_stats: True},
+        )
+        assert has_filter is True
+        assert flags[opt_stats] is True
+
+    def test_module_default_used_when_options_and_defaults_silent(self) -> None:
+        opt_key = cf.OPT_GOOGLE_HOME_FILTER_ENABLED
+        if opt_key is None or cf.DEFAULT_GOOGLE_HOME_FILTER_ENABLED is None:
+            pytest.skip("Module default not configured in this build")
+
+        has_filter, _flags = cf._derive_feature_settings(
+            options_payload={}, defaults={}
+        )
+        assert has_filter is bool(cf.DEFAULT_GOOGLE_HOME_FILTER_ENABLED)
+
+    def test_contributor_mode_passthrough(self) -> None:
+        has_filter, flags = cf._derive_feature_settings(
+            options_payload={cf.OPT_CONTRIBUTOR_MODE: "high_traffic"},
+            defaults={},
+        )
+        assert flags[cf.OPT_CONTRIBUTOR_MODE] == "high_traffic"
+        # contributor_mode does not affect the filter flag itself.
+        assert isinstance(has_filter, bool)
+
+
+class TestBuildSubentryPayload:
+    """Empiricism: lines 1040-1063 — composes group_key/features/flags dict."""
+
+    def test_basic_payload_without_visible_ids(self) -> None:
+        payload = cf._build_subentry_payload(
+            group_key="trackers",
+            features=["device_tracker", "Sensor"],
+            entry_title="Acme",
+            has_google_home_filter=True,
+            feature_flags={"enable_stats": True},
+        )
+        assert payload["group_key"] == "trackers"
+        assert payload["features"] == ["device_tracker", "sensor"]
+        assert payload["fcm_push_enabled"] is False
+        assert payload["has_google_home_filter"] is True
+        assert payload["feature_flags"] == {"enable_stats": True}
+        assert payload["entry_title"] == "Acme"
+        # Without visible_device_ids, key must NOT be present.
+        assert "visible_device_ids" not in payload
+
+    def test_visible_device_ids_included_when_provided(self) -> None:
+        payload = cf._build_subentry_payload(
+            group_key="trackers",
+            features=[],
+            entry_title="T",
+            has_google_home_filter=False,
+            feature_flags={},
+            visible_device_ids=["dev_b", "dev_a", "dev_a"],
+        )
+        assert payload["visible_device_ids"] == ["dev_a", "dev_b"]
+
+    def test_empty_visible_ids_after_normalization_drops_key(self) -> None:
+        # All-empty visible_device_ids list becomes [] after normalization → dropped.
+        payload = cf._build_subentry_payload(
+            group_key="g",
+            features=[],
+            entry_title="t",
+            has_google_home_filter=False,
+            feature_flags={},
+            visible_device_ids=["", "   "],
+        )
+        assert "visible_device_ids" not in payload
+
+    def test_feature_flags_is_copied_not_referenced(self) -> None:
+        flags = {"a": True}
+        payload = cf._build_subentry_payload(
+            group_key="g",
+            features=[],
+            entry_title="t",
+            has_google_home_filter=False,
+            feature_flags=flags,
+        )
+        flags["b"] = False  # mutate source after build
+        assert payload["feature_flags"] == {"a": True}
+
+
+# ---------------------------------------------------------------------------
+# Block D: token persistence guard + multi-entry guard (cf.py lines 1072-1088)
+# ---------------------------------------------------------------------------
+
+
+class TestDisqualifiesForPersistence:
+    """Empiricism: rejects JWT-shaped tokens, accepts everything else."""
+
+    def test_jwt_rejected(self) -> None:
+        reason = cf._disqualifies_for_persistence("eyJabc.eyJdef.signature")
+        assert isinstance(reason, str)
+        assert "JWT" in reason or "installation" in reason
+
+    def test_aas_token_accepted(self) -> None:
+        assert cf._disqualifies_for_persistence("aas_et/" + "x" * 64) is None
+
+    def test_generic_token_accepted(self) -> None:
+        assert cf._disqualifies_for_persistence("a" * 32) is None
+
+
+class TestIsMultiEntryGuardError:
+    """Empiricism: returns True only for substring match of two guard phrases."""
+
+    def test_recognizes_multi_entry_phrase(self) -> None:
+        assert cf._is_multi_entry_guard_error(
+            Exception("Multiple config entries active here")
+        )
+
+    def test_recognizes_runtime_data_phrase(self) -> None:
+        assert cf._is_multi_entry_guard_error(Exception("pass entry.runtime_data"))
+
+    def test_unrelated_error_not_recognized(self) -> None:
+        assert cf._is_multi_entry_guard_error(Exception("not found")) is False
+
+    def test_works_with_non_exception_repr(self) -> None:
+        # _is_multi_entry_guard_error stringifies with f"{err}".
+        class _Custom(Exception):
+            def __str__(self) -> str:
+                return "Multiple config entries active"
+
+        assert cf._is_multi_entry_guard_error(_Custom()) is True
+
+
+# ---------------------------------------------------------------------------
+# Block E: API exception mapping (cf.py lines 1094-1127)
+# ---------------------------------------------------------------------------
+
+
+class TestMapApiExcToErrorKey:
+    """Empiricism: 5-branch dispatcher — DependencyNotReady > name > status > aiohttp > guard > unknown."""
+
+    def test_dependency_not_ready_wins(self) -> None:
+        err = cf.DependencyNotReady("deps missing")
+        assert cf._map_api_exc_to_error_key(err) == "dependency_not_ready"
+
+    @pytest.mark.parametrize(
+        "exc_cls_name",
+        ["AuthError", "UnauthorizedAccess", "ForbiddenRequest", "CredentialFailure"],
+    )
+    def test_auth_keywords_in_name(self, exc_cls_name: str) -> None:
+        cls = type(exc_cls_name, (Exception,), {})
+        assert cf._map_api_exc_to_error_key(cls("x")) == "invalid_auth"
+
+    def test_status_401_maps_to_invalid_auth(self) -> None:
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status = 401  # type: ignore[attr-defined]
+        assert cf._map_api_exc_to_error_key(err) == "invalid_auth"
+
+    def test_status_code_attribute_403(self) -> None:
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status_code = 403  # type: ignore[attr-defined]
+        assert cf._map_api_exc_to_error_key(err) == "invalid_auth"
+
+    def test_status_as_string_digit(self) -> None:
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status = "401"  # type: ignore[attr-defined]
+        assert cf._map_api_exc_to_error_key(err) == "invalid_auth"
+
+    def test_status_as_bool_true_is_one(self) -> None:
+        # Empiricism (lines 1108-1109): bool is checked BEFORE int — True -> 1, not 401.
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status = True  # type: ignore[attr-defined]
+        result = cf._map_api_exc_to_error_key(err)
+        # 1 is not in (401, 403) → falls through to network heuristic → name has no
+        # timeout/connect → ends in "unknown".
+        assert result == "unknown"
+
+    def test_non_digit_status_string_falls_through(self) -> None:
+        err = type("HttpError", (Exception,), {})("nope")
+        err.status = "Service Unavailable"  # type: ignore[attr-defined]
+        # Not digit → status_int stays None → falls through.
+        assert cf._map_api_exc_to_error_key(err) == "unknown"
+
+    def test_timeout_in_class_name_maps_to_cannot_connect(self) -> None:
+        cls = type("ReadTimeoutError", (Exception,), {})
+        assert cf._map_api_exc_to_error_key(cls("x")) == "cannot_connect"
+
+    def test_connection_in_class_name(self) -> None:
+        cls = type("ConnectionRefusedError", (Exception,), {})
+        assert cf._map_api_exc_to_error_key(cls("x")) == "cannot_connect"
+
+    def test_multi_entry_guard_returns_unknown(self) -> None:
+        # Even though the guard is recognized, the mapping is still "unknown".
+        assert (
+            cf._map_api_exc_to_error_key(Exception("Multiple config entries active"))
+            == "unknown"
+        )
+
+    def test_plain_runtime_error_unknown(self) -> None:
+        assert cf._map_api_exc_to_error_key(RuntimeError("boom")) == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Block F: secrets extractors (cf.py lines 1167-1251)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEmailFromSecrets:
+    """Empiricism: flat key priority list, then nested ``account.email`` fallback."""
+
+    def test_prefers_google_home_username(self) -> None:
+        data: dict[str, Any] = {
+            "googleHomeUsername": "primary@example.com",
+            cf.CONF_GOOGLE_EMAIL: "other@example.com",
+            "email": "third@example.com",
+        }
+        assert cf._extract_email_from_secrets(data) == "primary@example.com"
+
+    def test_falls_through_to_conf_google_email(self) -> None:
+        data = {cf.CONF_GOOGLE_EMAIL: "via_conf@example.com"}
+        assert cf._extract_email_from_secrets(data) == "via_conf@example.com"
+
+    def test_nested_account_email_fallback(self) -> None:
+        data: dict[str, Any] = {"account": {"email": "nested@example.com"}}
+        assert cf._extract_email_from_secrets(data) == "nested@example.com"
+
+    def test_nested_lookup_swallows_exceptions(self) -> None:
+        # account is a string → indexing raises → swallowed → None.
+        assert cf._extract_email_from_secrets({"account": "not-a-dict"}) is None
+
+    def test_non_email_values_are_rejected(self) -> None:
+        data = {"email": "no_at_sign"}
+        assert cf._extract_email_from_secrets(data) is None
+
+    def test_returns_none_when_no_candidates(self) -> None:
+        assert cf._extract_email_from_secrets({}) is None
+
+
+class TestExtractOauthCandidatesFromSecrets:
+    """Empiricism: aas_token first, then flat keys, then fcm fallbacks; de-dup."""
+
+    def test_aas_token_listed_first(self) -> None:
+        data: dict[str, Any] = {
+            cf.CONF_OAUTH_TOKEN: "oauth_token_value_with_padding_xxxx",
+            "aas_token": "aas_token_value_with_padding_xxxx",
+        }
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        labels = [label for label, _token in cands]
+        assert labels[0] == "aas_token"
+        assert cf.CONF_OAUTH_TOKEN in labels
+
+    def test_deduplicates_repeated_token_value(self) -> None:
+        token = "shared_token_value_padding_xxxx"
+        data = {
+            "aas_token": token,
+            "oauth_token": token,
+            "access_token": token,
+        }
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        # All three keys point to the same token → only first survives dedup.
+        assert len(cands) == 1
+        assert cands[0][0] == "aas_token"
+
+    def test_skips_implausible_tokens(self) -> None:
+        data: dict[str, Any] = {
+            "aas_token": "short",  # < 16 chars
+            "oauth_token": None,  # not a string
+            "token": "valid_token_padding_xxxxxxxxxxxx",
+        }
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        assert [label for label, _token in cands] == ["token"]
+
+    def test_fcm_credentials_used_as_fallback(self) -> None:
+        data = {
+            "fcm_credentials": {
+                "installation": {"token": "fcm_install_token_padding_xxxx"},
+                "fcm": {
+                    "registration": {"token": "fcm_register_token_padding_xx"}
+                },
+            }
+        }
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        labels = {label for label, _token in cands}
+        assert {"fcm_installation", "fcm_registration"} <= labels
+
+    def test_partial_fcm_paths_swallowed(self) -> None:
+        # Missing nested key raises KeyError, caught by except.
+        data = {"fcm_credentials": {"installation": "not-a-dict"}}
+        # Should not raise; just return whatever else is plausible (here: nothing).
+        cands = cf._extract_oauth_candidates_from_secrets(data)
+        assert cands == []
+
+    def test_empty_payload(self) -> None:
+        assert cf._extract_oauth_candidates_from_secrets({}) == []
+
+
+class TestExtractFcmCredentialsFromSecrets:
+    """Empiricism: returns dict if present, otherwise None; swallows exceptions."""
+
+    def test_returns_dict_when_present(self) -> None:
+        creds = {"installation": {"token": "x"}}
+        assert cf._extract_fcm_credentials_from_secrets({"fcm_credentials": creds}) is creds
+
+    def test_returns_none_when_absent(self) -> None:
+        assert cf._extract_fcm_credentials_from_secrets({}) is None
+
+    def test_returns_none_when_not_a_dict(self) -> None:
+        assert (
+            cf._extract_fcm_credentials_from_secrets({"fcm_credentials": "string"})
+            is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Block G: candidate labels + credential interpreters (cf.py lines 1360-1478)
+# ---------------------------------------------------------------------------
+
+
+class TestCandLabels:
+    """Empiricism: lines 1360-1365 — sorted unique source labels or 'none'."""
+
+    def test_returns_none_for_empty_list(self) -> None:
+        assert cf._cand_labels([]) == "none"
+
+    def test_returns_none_when_all_labels_blank(self) -> None:
+        # Sources falsy → filtered out → empty set → "none".
+        assert cf._cand_labels([("", "tok1"), ("", "tok2")]) == "none"
+
+    def test_sorted_unique(self) -> None:
+        cands = [
+            ("oauth_token", "a" * 16),
+            ("aas_token", "b" * 16),
+            ("oauth_token", "c" * 16),  # duplicate label
+        ]
+        assert cf._cand_labels(cands) == "aas_token, oauth_token"
+
+
+class TestLogTokenValidationFailure:
+    """Empiricism: emits a single warning with masked email + candidate sources."""
+
+    def test_emits_warning_with_masked_email(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger=cf._LOGGER.name)
+        cf._log_token_validation_failure(
+            email="user@example.com",
+            candidates=[("aas_token", "x" * 16)],
+        )
+        assert any(
+            "Token validation failed" in record.getMessage()
+            for record in caplog.records
+        )
+
+
+class TestInterpretCredentialsChoice:
+    """Empiricism: lines 1385-1435 — secrets XOR (token AND email)."""
+
+    def test_mixing_secrets_and_token_returns_choose_one(self) -> None:
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {"secrets_json": "{}", "oauth_token": "tok", "email": ""},
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, email, cands, err) == (None, None, None, "choose_one")
+
+    def test_completely_empty_input_returns_choose_one(self) -> None:
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {"secrets_json": "", "oauth_token": "", "email": ""},
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert err == "choose_one"
+        assert method is None and email is None and cands is None
+
+    def test_invalid_json_returns_invalid_json(self) -> None:
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {"secrets_json": "not json", "oauth_token": "", "email": ""},
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, email, cands, err) == ("secrets", None, None, "invalid_json")
+
+    def test_secrets_not_a_dict_returns_invalid_json(self) -> None:
+        # JSON arrays parse successfully but fail the dict check.
+        method, _email, _cands, err = cf._interpret_credentials_choice(
+            {"secrets_json": "[1, 2]", "oauth_token": "", "email": ""},
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, err) == ("secrets", "invalid_json")
+
+    def test_secrets_path_happy(self) -> None:
+        secrets = {
+            "googleHomeUsername": "user@example.com",
+            "aas_token": "aas_token_value_padding_xxxxxxx",
+        }
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": json.dumps(secrets),
+                "oauth_token": "",
+                "email": "",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert method == "secrets"
+        assert email == "user@example.com"
+        assert cands and cands[0][0] == "aas_token"
+        assert err is None
+
+    def test_secrets_path_invalid_token(self) -> None:
+        # Email valid but no plausible tokens → invalid_token.
+        secrets = {"googleHomeUsername": "user@example.com", "aas_token": "short"}
+        method, _email, _cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": json.dumps(secrets),
+                "oauth_token": "",
+                "email": "",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, err) == ("secrets", "invalid_token")
+
+    def test_manual_path_happy(self) -> None:
+        method, email, cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": "",
+                "oauth_token": "a" * 32,
+                "email": "user@example.com",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert method == "manual"
+        assert email == "user@example.com"
+        assert cands == [("manual", "a" * 32)]
+        assert err is None
+
+    def test_manual_path_rejects_jwt(self) -> None:
+        method, _email, _cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": "",
+                "oauth_token": "eyJabc.eyJdef.signature_padding_xxxx",
+                "email": "user@example.com",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        # JWT-shaped tokens cannot be persisted.
+        assert (method, err) == ("manual", "invalid_token")
+
+    def test_manual_path_invalid_email(self) -> None:
+        method, _email, _cands, err = cf._interpret_credentials_choice(
+            {
+                "secrets_json": "",
+                "oauth_token": "a" * 32,
+                "email": "not-an-email",
+            },
+            secrets_field="secrets_json",
+            token_field="oauth_token",
+            email_field="email",
+        )
+        assert (method, err) == ("manual", "invalid_token")
+
+
+class TestInterpretReauthChoice:
+    """Empiricism: lines 1445-1478 — secrets XOR (currently disabled) token."""
+
+    def test_both_paths_active_returns_choose_one(self) -> None:
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "{}", "new_oauth_token": "tok"}
+        )
+        assert (method, data, err) == (None, None, "choose_one")
+
+    def test_neither_path_returns_choose_one(self) -> None:
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "", "new_oauth_token": ""}
+        )
+        assert (method, data, err) == (None, None, "choose_one")
+
+    def test_secrets_path_happy(self) -> None:
+        payload = {
+            "googleHomeUsername": "user@example.com",
+            "aas_token": "aas_token_value_padding_xxxxxxx",
+        }
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": json.dumps(payload), "new_oauth_token": ""}
+        )
+        assert method == "secrets"
+        assert isinstance(data, dict) and data["googleHomeUsername"] == "user@example.com"
+        assert err is None
+
+    def test_secrets_path_invalid_json(self) -> None:
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "garbage", "new_oauth_token": ""}
+        )
+        assert (method, data, err) == (None, None, "invalid_json")
+
+    def test_secrets_path_array_not_dict(self) -> None:
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "[]", "new_oauth_token": ""}
+        )
+        assert (method, data, err) == (None, None, "invalid_json")
+
+    def test_secrets_invalid_token_returns_invalid_token(self) -> None:
+        # Email present but no plausible candidate token.
+        payload = {"googleHomeUsername": "user@example.com"}
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": json.dumps(payload), "new_oauth_token": ""}
+        )
+        assert (method, data, err) == (None, None, "invalid_token")
+
+    def test_token_only_path_falls_through_to_choose_one(self) -> None:
+        # The manual reauth token path is intentionally disabled — falls through
+        # to "choose_one" until re-enabled.
+        method, data, err = cf._interpret_reauth_choice(
+            {"secrets_json": "", "new_oauth_token": "a" * 32}
+        )
+        assert (method, data, err) == (None, None, "choose_one")
+
+
+# ---------------------------------------------------------------------------
+# Block H: entry resolver, masking, callbacks (cf.py lines 1481-1606, 745-774)
+# ---------------------------------------------------------------------------
+
+
+class TestMaskEmailForLogs:
+    """Empiricism: privacy-preserving mask for logs."""
+
+    def test_typical_email_masked(self) -> None:
+        assert cf._mask_email_for_logs("user@example.com") == "u***@example.com"
+
+    def test_single_char_local_part(self) -> None:
+        assert cf._mask_email_for_logs("a@example.com") == "*@example.com"
+
+    def test_missing_local_returns_star_at_domain(self) -> None:
+        # "@example.com" → local="" → returns "*@example.com" (line 771).
+        assert cf._mask_email_for_logs("@example.com") == "*@example.com"
+
+    def test_none_returns_unknown(self) -> None:
+        assert cf._mask_email_for_logs(None) == "<unknown>"
+
+    def test_empty_returns_unknown(self) -> None:
+        assert cf._mask_email_for_logs("") == "<unknown>"
+
+    def test_no_at_returns_unknown(self) -> None:
+        assert cf._mask_email_for_logs("no-at-sign") == "<unknown>"
+
+
+class TestTypedCallback:
+    """Empiricism: lines 745-748 — preserves the wrapped callable via HA callback."""
+
+    def test_returns_decorated_callable(self) -> None:
+        def fn(x: int) -> int:
+            return x * 2
+
+        wrapped = cf._typed_callback(fn)
+        assert callable(wrapped)
+        # The decorator from HA returns the same function instance (it just tags it),
+        # so behaviour must be preserved.
+        assert wrapped(3) == 6
+
+
+class TestIsDiscoveryUpdateInfo:
+    """Empiricism: lines 751-760 — recognizes two source identifiers."""
+
+    def test_recognizes_primary_source(self) -> None:
+        assert cf._is_discovery_update_info({"source": cf.DISCOVERY_UPDATE_SOURCE})
+
+    def test_recognizes_legacy_source(self) -> None:
+        assert cf._is_discovery_update_info(
+            {"source": cf.LEGACY_DISCOVERY_UPDATE_SOURCE}
+        )
+
+    def test_rejects_unrelated_source(self) -> None:
+        assert cf._is_discovery_update_info({"source": "user"}) is False
+
+    def test_rejects_none(self) -> None:
+        assert cf._is_discovery_update_info(None) is False
+
+    def test_rejects_non_mapping(self) -> None:
+        assert cf._is_discovery_update_info("not-a-mapping") is False  # type: ignore[arg-type]
+
+
+class TestRegisterDependencyError:
+    """Empiricism: lines 653-663 — single-shot record for "base" field."""
+
+    def test_records_import_failed_once(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.ERROR, logger=cf._LOGGER.name)
+        errors: dict[str, str] = {}
+        cf._register_dependency_error(errors, ImportError("boom"))
+        assert errors == {"base": "import_failed"}
+        # Second call with same field is a no-op.
+        cf._register_dependency_error(errors, ImportError("again"))
+        assert errors == {"base": "import_failed"}
+
+    def test_uses_custom_field(self) -> None:
+        errors: dict[str, str] = {}
+        cf._register_dependency_error(errors, ImportError("x"), field="oauth")
+        assert errors == {"oauth": "import_failed"}
+
+
+class TestEnsureOptionalEntryAttributes:
+    """Empiricism: lines 1586-1605 — fills missing attrs, defends against slot stubs."""
+
+    def test_none_entry_is_noop(self) -> None:
+        # No raise, no side effects.
+        cf._ensure_optional_entry_attributes(None)  # type: ignore[arg-type]
+
+    def test_missing_source_is_populated(self) -> None:
+        entry = SimpleNamespace()
+        cf._ensure_optional_entry_attributes(entry)  # type: ignore[arg-type]
+        assert hasattr(entry, "source")
+        assert entry.source is None  # type: ignore[attr-defined]
+
+    def test_existing_source_is_preserved(self) -> None:
+        entry = SimpleNamespace(source="user")
+        cf._ensure_optional_entry_attributes(entry)  # type: ignore[arg-type]
+        assert entry.source == "user"
+
+    def test_slots_object_does_not_raise(self) -> None:
+        # A class with __slots__ that does NOT include "source" must not crash
+        # the helper; the defensive try/except swallows the AttributeError.
+        class Slotted:
+            __slots__ = ("entry_id",)
+
+            def __init__(self) -> None:
+                self.entry_id = "e1"
+
+        cf._ensure_optional_entry_attributes(Slotted())  # type: ignore[arg-type]
+
+
+class TestResolveEntryEmailForLookup:
+    """Empiricism: lines 1481-1528 — caches resolver, defensively guards exceptions."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_resolver_cache(self) -> Any:
+        """Reset the module-level lazy cache between tests."""
+        original_resolve = cf._RESOLVE_ENTRY_EMAIL
+        original_coalesce = cf._COALESCE_ENTRIES
+        cf._RESOLVE_ENTRY_EMAIL = None
+        cf._COALESCE_ENTRIES = None
+        yield
+        cf._RESOLVE_ENTRY_EMAIL = original_resolve
+        cf._COALESCE_ENTRIES = original_coalesce
+
+    def test_uses_data_then_options_for_email(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force the fallback resolver by making the integration import return a
+        # module without _resolve_entry_email.
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+
+        entry = SimpleNamespace(
+            data={cf.CONF_GOOGLE_EMAIL: "  Found@Example.com  "},
+            options={},
+            entry_id="entry-1",
+        )
+        raw, normalized = cf._resolve_entry_email_for_lookup(entry)  # type: ignore[arg-type]
+        assert raw == "Found@Example.com"
+        assert normalized == "found@example.com"
+
+    def test_options_used_when_data_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+
+        entry = SimpleNamespace(
+            data={},
+            options={cf.CONF_GOOGLE_EMAIL: "opts@example.com"},
+            entry_id="entry-2",
+        )
+        raw, normalized = cf._resolve_entry_email_for_lookup(entry)  # type: ignore[arg-type]
+        assert raw == "opts@example.com"
+        assert normalized == "opts@example.com"
+
+    def test_no_email_returns_none_pair(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+        entry = SimpleNamespace(data={}, options={}, entry_id="entry-3")
+        raw, normalized = cf._resolve_entry_email_for_lookup(entry)  # type: ignore[arg-type]
+        assert raw is None and normalized is None
+
+    def test_custom_resolver_from_integration_is_used(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called: list[Any] = []
+
+        def custom_resolver(entry: Any) -> tuple[str | None, str | None]:
+            called.append(entry)
+            return ("Raw@X.com", "raw@x.com")
+
+        fake_pkg = SimpleNamespace(_resolve_entry_email=custom_resolver)
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+        entry = SimpleNamespace(entry_id="e")
+        raw, normalized = cf._resolve_entry_email_for_lookup(entry)  # type: ignore[arg-type]
+        assert (raw, normalized) == ("Raw@X.com", "raw@x.com")
+        assert called and called[0] is entry
+
+
+class TestFindEntryByEmail:
+    """Empiricism: lines 1531-1542 — match against normalized email."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_resolver_cache(self) -> Any:
+        original = cf._RESOLVE_ENTRY_EMAIL
+        cf._RESOLVE_ENTRY_EMAIL = None
+        yield
+        cf._RESOLVE_ENTRY_EMAIL = original
+
+    def _make_hass_with_entries(self, entries: list[Any]) -> Any:
+        async_entries = lambda _domain: entries  # noqa: E731
+        return SimpleNamespace(
+            config_entries=SimpleNamespace(async_entries=async_entries)
+        )
+
+    def test_empty_target_returns_none(self) -> None:
+        hass = self._make_hass_with_entries([])
+        assert cf._find_entry_by_email(hass, "") is None
+
+    def test_matches_normalized_email(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+        e1 = SimpleNamespace(
+            data={cf.CONF_GOOGLE_EMAIL: "Match@Example.com"},
+            options={},
+            entry_id="e1",
+        )
+        e2 = SimpleNamespace(
+            data={cf.CONF_GOOGLE_EMAIL: "other@example.com"},
+            options={},
+            entry_id="e2",
+        )
+        hass = self._make_hass_with_entries([e2, e1])
+        result = cf._find_entry_by_email(hass, "MATCH@example.com")
+        assert result is e1
+
+    def test_no_match_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_pkg = SimpleNamespace()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.config_flow.import_integration_package",
+            lambda: fake_pkg,
+            raising=True,
+        )
+        e1 = SimpleNamespace(
+            data={cf.CONF_GOOGLE_EMAIL: "x@example.com"},
+            options={},
+            entry_id="e1",
+        )
+        hass = self._make_hass_with_entries([e1])
+        assert cf._find_entry_by_email(hass, "y@example.com") is None
+
+
+# ---------------------------------------------------------------------------
+# Block I: discovery helpers (cf.py lines 1622-1740)
+# ---------------------------------------------------------------------------
+
+
+class TestSubentryOptionProperty:
+    """Empiricism: lines 901-916 — subentry_id falls through to None when missing."""
+
+    def test_subentry_id_returns_attribute_when_present(self) -> None:
+        sub = SimpleNamespace(subentry_id="abc")
+        opt = cf._SubentryOption(
+            key="k", label="L", subentry=sub, visible_device_ids=()  # type: ignore[arg-type]
+        )
+        assert opt.subentry_id == "abc"
+
+    def test_subentry_id_none_when_subentry_missing(self) -> None:
+        opt = cf._SubentryOption(
+            key="k", label="L", subentry=None, visible_device_ids=()
+        )
+        assert opt.subentry_id is None
+
+    def test_subentry_id_none_when_attribute_absent(self) -> None:
+        # A subentry object without subentry_id attribute → getattr returns None.
+        opt = cf._SubentryOption(
+            key="k", label="L", subentry=SimpleNamespace(), visible_device_ids=()  # type: ignore[arg-type]
+        )
+        assert opt.subentry_id is None
+
+
+class TestDiscoveryFlowError:
+    """Empiricism: lines 1613-1618 — exposes ``reason`` attribute."""
+
+    def test_reason_is_captured(self) -> None:
+        err = cf.DiscoveryFlowError("invalid_discovery_info")
+        assert err.reason == "invalid_discovery_info"
+        assert "invalid_discovery_info" in str(err)
+
+
+class TestDiscoveryPayloadEquivalent:
+    """Empiricism: lines 1632-1646 — three layered equality checks."""
+
+    def _make(
+        self,
+        *,
+        email: str = "user@example.com",
+        uid: str = "acct:user@example.com",
+        cands: tuple[tuple[str, str], ...] = (("aas_token", "x" * 16),),
+        bundle: Any | None = None,
+        title: str | None = None,
+    ) -> cf.CloudDiscoveryData:
+        return cf.CloudDiscoveryData(
+            email=email,
+            unique_id=uid,
+            candidates=cands,
+            secrets_bundle=bundle,
+            title=title,
+        )
+
+    def test_equal_when_all_fields_match(self) -> None:
+        a = self._make()
+        b = self._make()
+        assert cf._discovery_payload_equivalent(a, b) is True
+
+    def test_differing_unique_id(self) -> None:
+        a = self._make(uid="acct:a")
+        b = self._make(uid="acct:b")
+        assert cf._discovery_payload_equivalent(a, b) is False
+
+    def test_differing_email(self) -> None:
+        a = self._make(email="a@x.com")
+        b = self._make(email="b@x.com")
+        assert cf._discovery_payload_equivalent(a, b) is False
+
+    def test_differing_candidates(self) -> None:
+        a = self._make(cands=(("x", "y" * 16),))
+        b = self._make(cands=(("x", "z" * 16),))
+        assert cf._discovery_payload_equivalent(a, b) is False
+
+    def test_both_bundles_none_remains_equal(self) -> None:
+        a = self._make(bundle=None)
+        b = self._make(bundle=None)
+        assert cf._discovery_payload_equivalent(a, b) is True
+
+    def test_one_bundle_none_is_not_equivalent(self) -> None:
+        a = self._make(bundle=None)
+        b = self._make(bundle={"k": "v"})
+        assert cf._discovery_payload_equivalent(a, b) is False
+
+    def test_equal_bundles_match(self) -> None:
+        a = self._make(bundle={"k": "v"})
+        b = self._make(bundle={"k": "v"})
+        assert cf._discovery_payload_equivalent(a, b) is True
+
+
+class TestNormalizeAndValidateDiscoveryPayload:
+    """Empiricism: lines 1649-1740 — multi-branch normalizer for discovery info."""
+
+    def test_non_mapping_raises_invalid_discovery_info(self) -> None:
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload(None)
+        assert exc_info.value.reason == "invalid_discovery_info"
+
+    def test_missing_email_raises(self) -> None:
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload({"candidate_tokens": "tok"})
+        assert exc_info.value.reason == "invalid_discovery_info"
+
+    def test_invalid_secrets_json_raises(self) -> None:
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload(
+                {cf.CONF_GOOGLE_EMAIL: "user@example.com", "secrets_json": "{bad"}
+            )
+        assert exc_info.value.reason == "invalid_discovery_info"
+
+    def test_email_only_without_candidates_raises_cannot_connect(self) -> None:
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload(
+                {cf.CONF_GOOGLE_EMAIL: "user@example.com"}
+            )
+        # Valid email but no token candidates → cannot_connect.
+        assert exc_info.value.reason == "cannot_connect"
+
+    def test_secrets_provide_email_and_candidates(self) -> None:
+        secrets = {
+            "googleHomeUsername": "user@example.com",
+            "aas_token": "aas_token_value_padding_xxxxxxx",
+        }
+        payload = {cf.DATA_SECRET_BUNDLE: secrets}
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert result.email == "user@example.com"
+        assert result.unique_id.startswith("acct:")
+        labels = {label for label, _token in result.candidates}
+        assert "aas_token" in labels
+        assert result.secrets_bundle is not None
+
+    def test_secrets_json_string_is_parsed(self) -> None:
+        secrets = {
+            "googleHomeUsername": "user@example.com",
+            "aas_token": "aas_token_value_padding_xxxxxxx",
+        }
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "secrets_json": json.dumps(secrets),
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert result.email == "user@example.com"
+
+    def test_candidate_tokens_string_form(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "candidate_tokens": "a" * 32,
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        labels = {label for label, _token in result.candidates}
+        assert "candidate_tokens" in labels
+
+    def test_candidate_tokens_mapping_form(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "candidates": {"primary": "a" * 32, "secondary": "b" * 32},
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        labels = {label for label, _token in result.candidates}
+        assert {"primary", "secondary"} <= labels
+
+    def test_candidate_tokens_iterable_of_mappings(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "tokens": [
+                {"label": "first", "token": "a" * 32},
+                {"source": "second", "token": "b" * 32},
+                {"token": "c" * 32},  # neither label nor source → falls back to key
+            ],
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        labels = {label for label, _token in result.candidates}
+        assert {"first", "second", "tokens"} <= labels
+
+    def test_candidate_tokens_iterable_of_strings(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            "tokens": ["a" * 32, "b" * 32],
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        labels = {label for label, _token in result.candidates}
+        # Strings in an iterable produce labels of the form "{key}_{idx}".
+        assert any(label.startswith("tokens_") for label in labels)
+
+    def test_direct_oauth_token_keys(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            cf.CONF_OAUTH_TOKEN: "a" * 32,
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert any(
+            label == cf.CONF_OAUTH_TOKEN for label, _token in result.candidates
+        )
+
+    def test_title_propagated_when_string(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            cf.CONF_OAUTH_TOKEN: "a" * 32,
+            "title": "My Account",
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert result.title == "My Account"
+
+    def test_non_string_title_becomes_none(self) -> None:
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "user@example.com",
+            cf.CONF_OAUTH_TOKEN: "a" * 32,
+            "title": 123,
+        }
+        result = cf._normalize_and_validate_discovery_payload(payload)
+        assert result.title is None
+
+    def test_invalid_email_raises_invalid_discovery_info(self) -> None:
+        # candidate_tokens valid, email malformed.
+        payload = {
+            cf.CONF_GOOGLE_EMAIL: "not-an-email",
+            cf.CONF_OAUTH_TOKEN: "a" * 32,
+        }
+        with pytest.raises(cf.DiscoveryFlowError) as exc_info:
+            cf._normalize_and_validate_discovery_payload(payload)
+        assert exc_info.value.reason == "invalid_discovery_info"
+
+
+# ---------------------------------------------------------------------------
+# Block J: module-level constants (cheap, smoke-tests imports)
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    """Sanity-check module-level constants to lock the surface."""
+
+    def test_email_regex_is_compiled(self) -> None:
+        assert isinstance(cf._EMAIL_RE, re.Pattern)
+
+    def test_token_regex_is_compiled(self) -> None:
+        assert isinstance(cf._TOKEN_RE, re.Pattern)
+
+    def test_auth_method_constants_present(self) -> None:
+        assert cf._AUTH_METHOD_SECRETS == "secrets_json"
+        assert cf._AUTH_METHOD_INDIVIDUAL == "individual_tokens"
+
+    def test_discovery_update_sources_distinct(self) -> None:
+        assert cf.DISCOVERY_UPDATE_SOURCE != cf.LEGACY_DISCOVERY_UPDATE_SOURCE
+
+    def test_default_subentry_titles_cover_known_keys(self) -> None:
+        assert cf.TRACKER_SUBENTRY_KEY in cf._DEFAULT_SUBENTRY_TITLES
+        assert cf.SERVICE_SUBENTRY_KEY in cf._DEFAULT_SUBENTRY_TITLES
+
+    def test_step_user_schema_validates_secrets_method(self) -> None:
+        # Smoke-test the schema accepts the secrets_json auth method.
+        validated = cf.STEP_USER_DATA_SCHEMA({"auth_method": "secrets_json"})
+        assert validated == {"auth_method": "secrets_json"}
+
+    def test_step_secrets_schema_passes_through_string(self) -> None:
+        validated = cf.STEP_SECRETS_DATA_SCHEMA({"secrets_json": "{}"})
+        assert validated == {"secrets_json": "{}"}

--- a/tests/test_coordinator_identity_basics.py
+++ b/tests/test_coordinator_identity_basics.py
@@ -1,0 +1,485 @@
+# tests/test_coordinator_identity_basics.py
+"""Branch-coverage tests for the simple ``IdentityOperations`` mixin methods.
+
+PR 1.A.2 (Phase 2, AP-A). Scope: ``coordinator/identity.py`` lines 72-233
+(``_get_account_email``, ``_create_auth_issue``, ``_dismiss_auth_issue``,
+``_schedule_eid_resolver_refresh``, ``_register_identity_key``,
+``_reset_resolver_offset``). The complex ``get_active_device_identities``
+(lines 235-967) lands in a later AP.
+
+Aniche-style adequacy progression: Specification → Boundary → Structural.
+:class:`IdentityStub` (``tests.helpers.identity_mixin_stub``) seeds every
+attribute ``_MixinBase`` declares and pre-mocks ``_entry_id``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.googlefindmy.const import (
+    CONF_GOOGLE_EMAIL,
+    DATA_EID_RESOLVER,
+    DOMAIN,
+    ISSUE_AUTH_EXPIRED_KEY,
+    issue_id_for,
+)
+from custom_components.googlefindmy.coordinator import identity as identity_mod
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.identity_mixin_stub import IdentityStub, make_hass_stub
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def coord() -> IdentityStub:
+    """Return a default :class:`IdentityStub` bound to a synthetic config entry."""
+
+    entry = make_config_entry(
+        entry_id="entry-xyz",
+        title="My GFM Account",
+        data={CONF_GOOGLE_EMAIL: "user@example.com"},
+    )
+    return IdentityStub(hass=make_hass_stub(), config_entry=entry)
+
+
+@pytest.fixture
+def coord_no_entry() -> IdentityStub:
+    """Return a stub without a bound ``ConfigEntry`` (early-startup state)."""
+
+    return IdentityStub(hass=make_hass_stub(), config_entry=None)
+
+
+# ---------------------------------------------------------------------------
+# M1 ``_get_account_email`` (3 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestGetAccountEmail:
+    """B1: no entry → ''; B2: email is str → return; B3: missing/non-str → ''."""
+
+    def test_no_entry_returns_empty(self, coord_no_entry: IdentityStub) -> None:
+        assert coord_no_entry._get_account_email() == ""
+
+    def test_str_email_is_returned(self, coord: IdentityStub) -> None:
+        assert coord._get_account_email() == "user@example.com"
+
+    def test_missing_email_key_returns_empty(self) -> None:
+        # ``data`` is an empty dict — ``.get`` returns ``None`` (non-str branch).
+        entry = make_config_entry(entry_id="entry-abc", data={})
+        stub = IdentityStub(config_entry=entry)
+        assert stub._get_account_email() == ""
+
+    def test_non_str_email_returns_empty(self) -> None:
+        # ``data`` carries a non-str value (e.g. int from corrupted storage).
+        entry = make_config_entry(entry_id="entry-abc", data={CONF_GOOGLE_EMAIL: 42})
+        stub = IdentityStub(config_entry=entry)
+        assert stub._get_account_email() == ""
+
+
+# ---------------------------------------------------------------------------
+# M2 ``_create_auth_issue`` (3 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAuthIssue:
+    """B1: no entry → no-op; B2: success path; B3: exception swallowed."""
+
+    def test_no_entry_is_noop(
+        self, coord_no_entry: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called = MagicMock()
+        monkeypatch.setattr(ir, "async_create_issue", called)
+        coord_no_entry._create_auth_issue()
+        called.assert_not_called()
+
+    def test_success_path_passes_email_and_translation_key(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def _fake(
+            hass: Any,
+            domain: str,
+            issue_id: str,
+            *,
+            is_fixable: bool,
+            severity: Any,
+            translation_key: str,
+            translation_placeholders: dict[str, str],
+        ) -> None:
+            captured.update(
+                hass=hass,
+                domain=domain,
+                issue_id=issue_id,
+                is_fixable=is_fixable,
+                severity=severity,
+                translation_key=translation_key,
+                translation_placeholders=translation_placeholders,
+            )
+
+        monkeypatch.setattr(ir, "async_create_issue", _fake)
+        coord._create_auth_issue()
+
+        assert captured["domain"] == DOMAIN
+        assert captured["issue_id"] == issue_id_for("entry-xyz")
+        assert captured["is_fixable"] is False
+        assert captured["severity"] is ir.IssueSeverity.ERROR
+        assert captured["translation_key"] == ISSUE_AUTH_EXPIRED_KEY
+        assert captured["translation_placeholders"] == {
+            "email": "user@example.com",
+            "entry_title": "My GFM Account",
+        }
+
+    def test_unknown_email_falls_back_to_placeholder(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        entry = make_config_entry(entry_id="entry-abc", data={})
+        stub = IdentityStub(hass=make_hass_stub(), config_entry=entry)
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            ir,
+            "async_create_issue",
+            lambda *a, **kw: captured.update(kw),
+        )
+        stub._create_auth_issue()
+        assert captured["translation_placeholders"]["email"] == "unknown"
+
+    def test_empty_title_falls_back_to_entry_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Build the entry with the factory's strict-typed default title, then
+        # override ``entry.title`` to ``None`` after construction so the
+        # ``entry.title or entry.entry_id`` fallback branch is exercised
+        # without breaking ``make_config_entry``'s ``title: str`` signature.
+        entry = make_config_entry(
+            entry_id="entry-abc",
+            data={CONF_GOOGLE_EMAIL: "x@y"},
+        )
+        entry.title = None  # Override: exercises fallback branch for empty title
+        stub = IdentityStub(hass=make_hass_stub(), config_entry=entry)
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(
+            ir,
+            "async_create_issue",
+            lambda *a, **kw: captured.update(kw),
+        )
+        stub._create_auth_issue()
+        assert captured["translation_placeholders"]["entry_title"] == "entry-abc"
+
+    def test_exception_is_swallowed(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("registry corrupted")
+
+        monkeypatch.setattr(ir, "async_create_issue", _boom)
+        # Must not propagate; debug-logged only.
+        coord._create_auth_issue()
+
+
+# ---------------------------------------------------------------------------
+# M3 ``_dismiss_auth_issue`` (5 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestDismissAuthIssue:
+    """B1: no entry → False; B2: registry-get raises → False if delete works;
+    B3: issue present → True; B4: issue absent → False; B5: delete raises → False.
+    """
+
+    def test_no_entry_returns_false(self, coord_no_entry: IdentityStub) -> None:
+        assert coord_no_entry._dismiss_auth_issue() is False
+
+    def test_issue_present_returns_true(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = SimpleNamespace(async_get_issue=MagicMock(return_value=object()))
+        deleted: list[tuple[Any, str, str]] = []
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+        monkeypatch.setattr(
+            ir,
+            "async_delete_issue",
+            lambda hass, domain, issue_id: deleted.append((hass, domain, issue_id)),
+        )
+
+        assert coord._dismiss_auth_issue() is True
+        assert deleted == [(coord.hass, DOMAIN, issue_id_for("entry-xyz"))]
+        registry.async_get_issue.assert_called_once_with(
+            DOMAIN, issue_id_for("entry-xyz")
+        )
+
+    def test_issue_absent_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = SimpleNamespace(async_get_issue=MagicMock(return_value=None))
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+        monkeypatch.setattr(ir, "async_delete_issue", lambda *a, **kw: None)
+
+        assert coord._dismiss_auth_issue() is False
+
+    def test_registry_async_get_raises_then_delete_succeeds_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise(_hass: Any) -> Any:
+            raise RuntimeError("registry init failed")
+
+        monkeypatch.setattr(ir, "async_get", _raise)
+        monkeypatch.setattr(ir, "async_delete_issue", lambda *a, **kw: None)
+        # ``issue_present`` defaults to ``False`` after the registry lookup
+        # failed; delete succeeds, so return value is ``False``.
+        assert coord._dismiss_auth_issue() is False
+
+    def test_registry_without_get_method_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Registry object exists but lacks ``async_get_issue`` (defensive branch).
+        registry = SimpleNamespace()
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+        monkeypatch.setattr(ir, "async_delete_issue", lambda *a, **kw: None)
+        assert coord._dismiss_auth_issue() is False
+
+    def test_get_issue_raises_then_delete_succeeds_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = SimpleNamespace(
+            async_get_issue=MagicMock(side_effect=RuntimeError("boom"))
+        )
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+        monkeypatch.setattr(ir, "async_delete_issue", lambda *a, **kw: None)
+        assert coord._dismiss_auth_issue() is False
+
+    def test_delete_raises_returns_false(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        registry = SimpleNamespace(async_get_issue=MagicMock(return_value=object()))
+        monkeypatch.setattr(ir, "async_get", lambda hass: registry)
+
+        def _boom(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("delete failed")
+
+        monkeypatch.setattr(ir, "async_delete_issue", _boom)
+        # When delete raises, the function returns ``False`` early — it does
+        # not surface the registry-present flag.
+        assert coord._dismiss_auth_issue() is False
+
+
+# ---------------------------------------------------------------------------
+# M4 ``_schedule_eid_resolver_refresh`` (5 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleEidResolverRefresh:
+    """B1: ``hass.data`` not a dict; B2: ``DOMAIN`` bucket missing/non-dict;
+    B3: resolver missing; B4: ``async_refresh`` not callable; B5: success.
+    """
+
+    def test_hass_data_not_dict_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass = SimpleNamespace(data=None)
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_no_hass_attribute_is_noop(self, coord: IdentityStub) -> None:
+        # ``hass`` itself is ``None`` (rare but defensive).
+        coord.hass = None  # type: ignore[assignment]
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_missing_domain_bucket_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass.data = {}
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_non_dict_domain_bucket_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass.data = {DOMAIN: "not-a-dict"}
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_missing_resolver_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass.data = {DOMAIN: {}}
+        coord._schedule_eid_resolver_refresh()  # must not raise
+
+    def test_resolver_without_async_refresh_is_noop(self, coord: IdentityStub) -> None:
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: SimpleNamespace()}}
+        coord._schedule_eid_resolver_refresh()
+        coord.hass.async_create_task.assert_not_called()
+
+    def test_success_schedules_refresh(self, coord: IdentityStub) -> None:
+        refreshed: list[bool] = []
+
+        async def _refresh() -> None:
+            refreshed.append(True)
+
+        resolver = SimpleNamespace(async_refresh=_refresh)
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: resolver}}
+        coord._schedule_eid_resolver_refresh()
+        # ``async_create_task`` is called with the coroutine returned by
+        # ``async_refresh``; we don't await it here.
+        coord.hass.async_create_task.assert_called_once()
+        # Close the coroutine to avoid the ``RuntimeWarning: coroutine was
+        # never awaited`` since pytest-asyncio is not driving this test.
+        (coro,) = coord.hass.async_create_task.call_args.args
+        coro.close()
+
+    def test_hass_without_async_create_task_is_noop(self, coord: IdentityStub) -> None:
+        async def _refresh() -> None:  # pragma: no cover - never awaited
+            return None
+
+        resolver = SimpleNamespace(async_refresh=_refresh)
+        # Replace ``hass`` with a stub lacking ``async_create_task``.
+        coord.hass = SimpleNamespace(data={DOMAIN: {DATA_EID_RESOLVER: resolver}})
+        # The implementation tolerates this defensively (``callable(None)`` is
+        # ``False``); no exception should escape.
+        coord._schedule_eid_resolver_refresh()
+
+
+# ---------------------------------------------------------------------------
+# M5 ``_register_identity_key`` (3 branches + shared-tracker log)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterIdentityKey:
+    """B1: non-bytes is rejected; B2: wrong length is rejected;
+    B3: new device added; B4: duplicate is a no-op; B5: shared tracker logs.
+    """
+
+    def test_non_bytes_key_is_rejected(self, coord: IdentityStub) -> None:
+        coord._register_identity_key("dev-1", "not-bytes")  # type: ignore[arg-type]
+        assert coord._identity_key_to_devices == {}
+
+    def test_wrong_length_key_is_rejected(self, coord: IdentityStub) -> None:
+        coord._register_identity_key("dev-1", b"\x00" * 31)  # too short
+        coord._register_identity_key("dev-2", b"\x00" * 33)  # too long
+        assert coord._identity_key_to_devices == {}
+
+    def test_new_device_is_added(self, coord: IdentityStub) -> None:
+        key = b"\xaa" * 32
+        coord._register_identity_key("dev-1", key)
+        assert coord._identity_key_to_devices == {key: {"dev-1"}}
+
+    def test_duplicate_device_is_idempotent(self, coord: IdentityStub) -> None:
+        key = b"\xaa" * 32
+        coord._register_identity_key("dev-1", key)
+        coord._register_identity_key("dev-1", key)
+        assert coord._identity_key_to_devices == {key: {"dev-1"}}
+
+    def test_shared_tracker_logs_info(
+        self, coord: IdentityStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        key = b"\xbb" * 32
+        coord._register_identity_key("dev-1", key)
+        with caplog.at_level("INFO", logger=identity_mod.__name__):
+            coord._register_identity_key("dev-2", key)
+        assert coord._identity_key_to_devices == {key: {"dev-1", "dev-2"}}
+        assert any(
+            "Shared tracker detected" in record.message for record in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# M6 ``_reset_resolver_offset`` (multiple defensive branches)
+# ---------------------------------------------------------------------------
+
+
+class _FakeDeviceReg:
+    """Minimal ``dr.async_get(hass)`` substitute for tests."""
+
+    def __init__(self, device: SimpleNamespace | None) -> None:
+        self._device = device
+        self.calls: list[set[tuple[str, str]]] = []
+
+    def async_get_device(
+        self, *, identifiers: set[tuple[str, str]] | None = None
+    ) -> SimpleNamespace | None:
+        self.calls.append(set(identifiers or set()))
+        return self._device
+
+
+class TestResetResolverOffset:
+    """B1: no hass → return; B2: no entry_id → debug log + return;
+    B3: device missing → return; B4: hass.data not dict → return;
+    B5: bucket missing → return; B6: resolver None → return;
+    B7: ``reset_device_offset`` not callable → return; B8: success.
+    """
+
+    def test_no_hass_returns_early(self, coord: IdentityStub) -> None:
+        coord.hass = None  # type: ignore[assignment]
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_no_entry_id_returns_without_call(
+        self, coord_no_entry: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        called = MagicMock()
+        monkeypatch.setattr(dr, "async_get", called)
+        # ``IdentityStub._entry_id`` returns ``None`` when entry is missing.
+        coord_no_entry._reset_resolver_offset("dev-1")
+        # ``dr.async_get(hass)`` is invoked anyway (guarded by ``entry_id``
+        # only for the identifier lookup, not for the registry fetch);
+        # ensure no side effects beyond that.
+        assert called.called
+
+    def test_device_not_found_logs_and_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_reg = _FakeDeviceReg(device=None)
+        monkeypatch.setattr(dr, "async_get", lambda hass: fake_reg)
+        coord._reset_resolver_offset("dev-1")
+        # The lookup was attempted with both identifier shapes.
+        assert fake_reg.calls == [{(DOMAIN, "entry-xyz:dev-1"), (DOMAIN, "dev-1")}]
+
+    def test_hass_data_not_dict_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        coord.hass.data = None
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_missing_domain_bucket_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        coord.hass.data = {}
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_non_dict_domain_bucket_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        coord.hass.data = {DOMAIN: "not-a-dict"}
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_resolver_none_returns(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: None}}
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_resolver_without_reset_is_noop(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        resolver = SimpleNamespace()  # no reset_device_offset
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: resolver}}
+        coord._reset_resolver_offset("dev-1")  # must not raise
+
+    def test_success_calls_reset_with_registry_id(
+        self, coord: IdentityStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        device = SimpleNamespace(id="reg-123")
+        monkeypatch.setattr(dr, "async_get", lambda hass: _FakeDeviceReg(device))
+        reset_calls: list[str] = []
+        # Pass ``list.append`` directly (no wrapping lambda) to satisfy
+        # Ruff PLW0108 (unnecessary-lambda) under the repo's PL selector.
+        resolver = SimpleNamespace(reset_device_offset=reset_calls.append)
+        coord.hass.data = {DOMAIN: {DATA_EID_RESOLVER: resolver}}
+        coord._reset_resolver_offset("dev-1")
+        assert reset_calls == ["reg-123"]

--- a/tests/test_coordinator_locate_basics.py
+++ b/tests/test_coordinator_locate_basics.py
@@ -1,0 +1,326 @@
+# tests/test_coordinator_locate_basics.py
+"""Branch-Coverage tests for ``coordinator.locate``.
+
+Phase 3 AP-C: target ``coordinator/locate.py`` branch-coverage by
+exercising the pure helpers (``_normalize_coords``, ``_get_device_lock``,
+``can_request_location``, ``can_play_sound``) and the gating branches of
+the async helpers (``async_locate_device``, ``async_play_sound``,
+``async_stop_sound``). Deep success-path branches (Nova roundtrip,
+Google Home filter, weighted fusion, cache commit) remain out of scope
+and stay for Phase 4.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+
+import pytest
+
+from custom_components.googlefindmy.const import DEFAULT_MIN_POLL_INTERVAL
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.locate_mixin_stub import LocateStub
+
+
+@pytest.fixture
+def coord() -> LocateStub:
+    """Return a default :class:`LocateStub` bound to a synthetic config entry."""
+
+    entry = make_config_entry(entry_id="locate-test-entry")
+    return LocateStub(config_entry=entry)
+
+
+class TestNormalizeCoords:
+    """Exercise ``_normalize_coords`` branches."""
+
+    def test_missing_lat_returns_false(self, coord: LocateStub) -> None:
+        payload: dict = {"longitude": 12.0}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_not_called()
+
+    def test_missing_lon_returns_false(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_not_called()
+
+    def test_non_numeric_increments_invalid_and_returns_false(
+        self, coord: LocateStub
+    ) -> None:
+        payload: dict = {"latitude": "abc", "longitude": "def"}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_called_once_with("invalid_coords")
+
+    def test_non_numeric_warn_off_skips_warning(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": "abc", "longitude": "def"}
+        assert coord._normalize_coords(payload, warn_on_invalid=False) is False
+        coord.increment_stat.assert_called_once_with("invalid_coords")
+
+    @pytest.mark.parametrize(
+        ("lat", "lon"),
+        [
+            (math.nan, 0.0),
+            (math.inf, 0.0),
+            (0.0, math.inf),
+            (95.0, 0.0),
+            (0.0, -181.0),
+        ],
+    )
+    def test_out_of_range_increments_invalid(
+        self, coord: LocateStub, lat: float, lon: float
+    ) -> None:
+        payload: dict = {"latitude": lat, "longitude": lon}
+        assert coord._normalize_coords(payload) is False
+        coord.increment_stat.assert_called_once_with("invalid_coords")
+
+    def test_valid_coords_returns_true_and_normalizes(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": "50.0", "longitude": "12.0"}
+        assert coord._normalize_coords(payload) is True
+        assert payload["latitude"] == 50.0
+        assert payload["longitude"] == 12.0
+
+    def test_accuracy_valid_kept(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0, "longitude": 12.0, "accuracy": "5.0"}
+        assert coord._normalize_coords(payload) is True
+        assert payload["accuracy"] == 5.0
+
+    def test_accuracy_invalid_dropped(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0, "longitude": 12.0, "accuracy": 0.0}
+        assert coord._normalize_coords(payload) is True
+        assert "accuracy" not in payload
+
+    def test_accuracy_unparsable_dropped(self, coord: LocateStub) -> None:
+        payload: dict = {"latitude": 50.0, "longitude": 12.0, "accuracy": "junk"}
+        assert coord._normalize_coords(payload) is True
+        assert "accuracy" not in payload
+
+
+class TestGetDeviceLock:
+    """Exercise ``_get_device_lock`` branches."""
+
+    def test_create_new_lock(self, coord: LocateStub) -> None:
+        lock = coord._get_device_lock("dev-1")
+        assert isinstance(lock, asyncio.Lock)
+        assert coord._device_action_locks["dev-1"] is lock
+
+    def test_return_existing_lock(self, coord: LocateStub) -> None:
+        first = coord._get_device_lock("dev-1")
+        second = coord._get_device_lock("dev-1")
+        assert first is second
+
+
+class TestCanRequestLocation:
+    """Exercise ``can_request_location`` branches."""
+
+    def test_ignored_device_blocked(self, coord: LocateStub) -> None:
+        coord.is_ignored.return_value = True
+        assert coord.can_request_location("dev-1") is False
+
+    def test_polling_in_progress_blocked(self, coord: LocateStub) -> None:
+        coord._is_polling = True
+        assert coord.can_request_location("dev-1") is False
+
+    def test_inflight_blocked(self, coord: LocateStub) -> None:
+        coord._locate_inflight.add("dev-1")
+        assert coord.can_request_location("dev-1") is False
+
+    def test_manual_cooldown_active_blocked(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._locate_cooldown_until["dev-1"] = 200.0
+        assert coord.can_request_location("dev-1") is False
+
+    def test_poll_cooldown_active_blocked(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._device_poll_cooldown_until["dev-1"] = 200.0
+        assert coord.can_request_location("dev-1") is False
+
+    def test_all_clear_allows(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        assert coord.can_request_location("dev-1") is True
+
+    def test_expired_cooldown_allows(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 300.0,
+        )
+        coord._locate_cooldown_until["dev-1"] = 200.0
+        coord._device_poll_cooldown_until["dev-1"] = 250.0
+        assert coord.can_request_location("dev-1") is True
+
+
+class TestCanPlaySound:
+    """Exercise ``can_play_sound`` branches."""
+
+    def test_capability_known_true(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        assert coord.can_play_sound("dev-1") is True
+
+    def test_capability_known_false(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": False}
+        assert coord.can_play_sound("dev-1") is False
+
+    def test_push_not_ready_with_cooldown_blocks(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coord._api_push_ready.return_value = False
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._push_cooldown_until = 200.0
+        assert coord.can_play_sound("dev-1") is False
+
+    def test_push_not_ready_no_cooldown_falls_back_optimistic(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coord._api_push_ready.return_value = False
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        coord._ensure_device_name_cache.return_value = {"dev-1": "Phone"}
+        assert coord.can_play_sound("dev-1") is True
+
+    def test_known_device_optimistic_true(self, coord: LocateStub) -> None:
+        coord._ensure_device_name_cache.return_value = {"dev-1": "Phone"}
+        assert coord.can_play_sound("dev-1") is True
+
+    def test_unknown_device_falls_back_optimistic(self, coord: LocateStub) -> None:
+        coord._ensure_device_name_cache.return_value = {}
+        assert coord.can_play_sound("dev-1") is True
+
+
+class TestAsyncLocateDeviceGating:
+    """Exercise gating branches of ``async_locate_device`` (no Nova roundtrip)."""
+
+    async def test_blocks_when_cannot_request_location(self, coord: LocateStub) -> None:
+        coord.is_ignored.return_value = True
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+        coord.api.async_get_device_location.assert_not_called()
+
+    async def test_blocks_when_push_cooldown_active(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 100.0,
+        )
+        coord._api_push_ready.return_value = False
+        coord._push_cooldown_until = 200.0
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+        coord.api.async_get_device_location.assert_not_called()
+
+    async def test_empty_payload_returns_empty(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        coord.api.async_get_device_location.return_value = None
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+        assert "dev-1" not in coord._locate_inflight  # finally branch cleared it
+
+    async def test_payload_without_coords_returns_empty(
+        self, coord: LocateStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+        coord.api.async_get_device_location.return_value = {
+            "last_seen": 1234567890,
+        }
+        result = await coord.async_locate_device("dev-1")
+        assert result == {}
+
+
+class TestAsyncPlaySoundGating:
+    """Exercise gating branches of ``async_play_sound``."""
+
+    async def test_blocks_when_cannot_play_sound(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": False}
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is False
+        coord.api.async_play_sound.assert_not_called()
+
+    async def test_success_stores_uuid(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is True
+        assert coord._sound_request_uuids.get("dev-1") == "uuid-stub"
+        coord._async_save_sound_uuids.assert_awaited_once()
+
+    async def test_failure_notes_problem(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        coord.api.async_play_sound.return_value = (False, None)
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is False
+        coord._note_push_transport_problem.assert_called_once()
+
+    async def test_unexpected_exception_returns_false(self, coord: LocateStub) -> None:
+        coord._device_caps["dev-1"] = {"can_ring": True}
+        coord.api.async_play_sound.side_effect = RuntimeError("boom")
+        ok = await coord.async_play_sound("dev-1")
+        assert ok is False
+        coord.note_error.assert_called_once()
+        coord._note_push_transport_problem.assert_called_once()
+
+
+class TestAsyncStopSoundGating:
+    """Exercise gating branches of ``async_stop_sound``."""
+
+    async def test_blocks_when_push_not_ready(self, coord: LocateStub) -> None:
+        coord._api_push_ready.return_value = False
+        ok = await coord.async_stop_sound("dev-1")
+        assert ok is False
+        coord.api.async_stop_sound.assert_not_called()
+
+    async def test_uses_cached_uuid_when_none_passed(self, coord: LocateStub) -> None:
+        coord._sound_request_uuids["dev-1"] = "cached-uuid"
+        ok = await coord.async_stop_sound("dev-1")
+        assert ok is True
+        coord.api.async_stop_sound.assert_awaited_once_with("dev-1", "cached-uuid")
+        # successful stop removes the uuid
+        assert "dev-1" not in coord._sound_request_uuids
+
+    async def test_explicit_uuid_overrides_cache(self, coord: LocateStub) -> None:
+        coord._sound_request_uuids["dev-1"] = "cached-uuid"
+        ok = await coord.async_stop_sound("dev-1", request_uuid="explicit")
+        assert ok is True
+        coord.api.async_stop_sound.assert_awaited_once_with("dev-1", "explicit")
+
+    async def test_missing_uuid_warns_but_attempts_stop(
+        self, coord: LocateStub
+    ) -> None:
+        ok = await coord.async_stop_sound("dev-1")
+        assert ok is True
+        coord.api.async_stop_sound.assert_awaited_once_with("dev-1", None)
+
+    async def test_failure_notes_problem(self, coord: LocateStub) -> None:
+        coord.api.async_stop_sound.return_value = False
+        ok = await coord.async_stop_sound("dev-1", request_uuid="x")
+        assert ok is False
+        coord._note_push_transport_problem.assert_called_once()
+
+
+_ = DEFAULT_MIN_POLL_INTERVAL  # silence unused-import lint when production no-ops

--- a/tests/test_coordinator_main_basics.py
+++ b/tests/test_coordinator_main_basics.py
@@ -1,0 +1,864 @@
+# tests/test_coordinator_main_basics.py
+"""Branch-coverage tests for ``coordinator.main`` pure helpers and static methods.
+
+Phase 3 AP-F: target the pure helpers and ``GoogleFindMyCoordinator`` static
+methods exposed by ``coordinator/main.py``. Async lifecycle methods
+(``async_setup``, ``async_shutdown``, ``async_update_data``) stay out of
+scope; they land in Phase 4 with HA-loop test methodology.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from types import ModuleType, SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import main as main_module
+from custom_components.googlefindmy.coordinator.main import (
+    DeviceIdentity,
+    GoogleFindMyCoordinator,
+    SemanticLabelRecord,
+    _as_ha_attributes,
+    _get_api_class,
+    _normalize_epoch_seconds,
+    _parse_last_seen_timestamp,
+    _RecorderHistoryProxy,
+    _resolve_last_seen_from_attributes,
+    _sync_get_last_gps_from_history,
+    _update_preserve_metadata,
+    format_epoch_utc,
+    get_recorder,
+    normalize_epoch_seconds,
+)
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.main_coordinator_stub import MainCoordinatorStub
+
+# ---------------------------------------------------------------------------
+# Module-level pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePreserveMetadata:
+    """``_update_preserve_metadata`` keeps persisted metadata sticky."""
+
+    def test_non_metadata_keys_use_dict_update_semantics(self) -> None:
+        target = {"battery_level": 70, "name": "Old"}
+        source = {"name": "New", "status": "Online"}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {"battery_level": 70, "name": "New", "status": "Online"}
+
+    def test_metadata_key_with_none_value_does_not_clobber_existing(self) -> None:
+        target = {"battery_level": 80}
+        source = {"battery_level": None}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {"battery_level": 80}
+
+    def test_metadata_key_with_real_value_overwrites(self) -> None:
+        target = {"battery_level": 80}
+        source = {"battery_level": 90}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {"battery_level": 90}
+
+    def test_metadata_key_added_when_target_missing(self) -> None:
+        target: dict[str, Any] = {}
+        source = {"identity_key": b"\xaa\xbb"}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {"identity_key": b"\xaa\xbb"}
+
+    def test_metadata_none_does_not_add_key(self) -> None:
+        target: dict[str, Any] = {}
+        source = {"identity_key": None, "battery_level": None}
+
+        _update_preserve_metadata(target, source)
+
+        assert target == {}
+
+
+class TestEpochHelpers:
+    """``normalize_epoch_seconds`` and ``format_epoch_utc`` are tolerant aliases."""
+
+    def test_normalize_epoch_seconds_public_and_alias_agree(self) -> None:
+        public_result = normalize_epoch_seconds(1_700_000_000)
+        alias_result = _normalize_epoch_seconds(1_700_000_000)
+
+        assert public_result == 1_700_000_000
+        assert alias_result == 1_700_000_000
+
+    def test_normalize_epoch_seconds_accepts_milliseconds(self) -> None:
+        # 1.7e12 looks like ms-since-epoch; the helper normalises to seconds.
+        result = normalize_epoch_seconds(1_700_000_000_000)
+
+        assert result == 1_700_000_000
+
+    def test_normalize_epoch_seconds_returns_none_for_invalid(self) -> None:
+        assert normalize_epoch_seconds("not a number") is None
+        assert normalize_epoch_seconds(None) is None
+
+    def test_format_epoch_utc_returns_iso8601(self) -> None:
+        # 2023-11-14T22:13:20Z = 1700000000
+        result = format_epoch_utc(1_700_000_000)
+
+        assert isinstance(result, str)
+        assert result.startswith("2023-11-14T22:13:20")
+
+    def test_format_epoch_utc_none_in_none_out(self) -> None:
+        assert format_epoch_utc(None) is None
+
+
+class TestLastSeenHelpers:
+    """``_parse_last_seen_timestamp`` and ``_resolve_last_seen_from_attributes``."""
+
+    def test_parse_last_seen_accepts_epoch_int(self) -> None:
+        assert _parse_last_seen_timestamp(1_700_000_000) == 1_700_000_000.0
+
+    def test_parse_last_seen_returns_none_for_unparseable(self) -> None:
+        assert _parse_last_seen_timestamp("not a timestamp") is None
+
+    def test_resolve_returns_fallback_when_attributes_empty(self) -> None:
+        result = _resolve_last_seen_from_attributes(None, 42.0)
+
+        assert result == 42.0
+
+    def test_resolve_returns_fallback_when_attributes_lack_last_seen(self) -> None:
+        result = _resolve_last_seen_from_attributes({"other": "key"}, 99.0)
+
+        assert result == 99.0
+
+    def test_resolve_prefers_last_seen_attribute(self) -> None:
+        attrs = {"last_seen": 1_700_000_000}
+
+        result = _resolve_last_seen_from_attributes(attrs, 0.0)
+
+        assert result == 1_700_000_000.0
+
+    def test_resolve_falls_back_to_last_seen_utc(self) -> None:
+        attrs = {"last_seen": None, "last_seen_utc": 1_700_000_000}
+
+        result = _resolve_last_seen_from_attributes(attrs, 0.0)
+
+        assert result == 1_700_000_000.0
+
+
+class TestAsHaAttributes:
+    """``_as_ha_attributes`` curates HA-recorder-friendly attribute dicts."""
+
+    def test_empty_row_returns_none(self) -> None:
+        assert _as_ha_attributes(None) is None
+        assert _as_ha_attributes({}) is None
+
+    def test_full_row_includes_lat_lon_and_optional_fields(self) -> None:
+        row = {
+            "name": "Phone",
+            "device_id": "abc",
+            "status": "Online",
+            "semantic_name": "Home",
+            "battery_level": 90,
+            "latitude": 1.0,
+            "longitude": 2.0,
+            "accuracy": 5.0,
+            "altitude": 100.0,
+            "last_seen": 1_700_000_000,
+        }
+
+        result = _as_ha_attributes(row)
+
+        assert result is not None
+        assert result["device_name"] == "Phone"
+        assert result["device_id"] == "abc"
+        assert result["latitude"] == 1.0
+        assert result["longitude"] == 2.0
+        assert result["accuracy_m"] == 5.0
+        assert result["altitude_m"] == 100.0
+        assert result["last_seen"].startswith("2023-11-14T22:13:20")
+
+    def test_partial_row_drops_lat_lon_when_one_missing(self) -> None:
+        row = {"name": "Phone", "latitude": 1.0, "longitude": None}
+
+        result = _as_ha_attributes(row)
+
+        assert result is not None
+        assert "latitude" not in result
+        assert "longitude" not in result
+
+    def test_non_finite_lat_lon_are_dropped(self) -> None:
+        row = {"latitude": math.nan, "longitude": math.inf}
+
+        result = _as_ha_attributes(row)
+
+        assert result is not None
+        assert "latitude" not in result
+        assert "longitude" not in result
+
+    def test_id_falls_back_to_device_id_field(self) -> None:
+        row = {"id": "fallback-id"}
+
+        result = _as_ha_attributes(row)
+
+        assert result is not None
+        assert result["device_id"] == "fallback-id"
+
+
+# ---------------------------------------------------------------------------
+# _RecorderHistoryProxy & get_recorder
+# ---------------------------------------------------------------------------
+
+
+class TestRecorderHistoryProxy:
+    """``_RecorderHistoryProxy`` is a lazy passthrough to the HA history module."""
+
+    def test_load_caches_module_after_first_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``_RecorderHistoryProxy._load`` executes
+        # ``from homeassistant.components.recorder import history as history_module``.
+        # That statement resolves through ``sys.modules``, so the test must
+        # replace the module entries there rather than ``setattr`` on the
+        # parent package (which only retargets the attribute lookup, not the
+        # cached import path used by ``from ... import history``).
+        fake_history = ModuleType("homeassistant.components.recorder.history")
+        fake_recorder = ModuleType("homeassistant.components.recorder")
+        fake_recorder.history = fake_history  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "homeassistant.components.recorder", fake_recorder
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "homeassistant.components.recorder.history",
+            fake_history,
+        )
+
+        proxy = _RecorderHistoryProxy()
+        first = proxy._load()
+        second = proxy._load()
+
+        assert first is fake_history
+        assert first is second
+
+    def test_get_recorder_imports_lazily(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # ``get_recorder`` runs
+        # ``from homeassistant.components.recorder import get_instance as ...``;
+        # the lookup goes through ``sys.modules["homeassistant.components.recorder"]``.
+        # ``monkeypatch.setattr("homeassistant.components.recorder", ...)`` only
+        # rebinds the ``recorder`` attribute on the parent package and leaves
+        # the conftest stub in ``sys.modules`` in place, so we replace the
+        # cached module instead.
+        sentinel = object()
+        fake_recorder = ModuleType("homeassistant.components.recorder")
+        fake_recorder.get_instance = lambda hass: sentinel  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "homeassistant.components.recorder", fake_recorder
+        )
+
+        result = get_recorder(MagicMock())
+
+        assert result is sentinel
+
+
+class TestSyncGetLastGpsFromHistory:
+    """``_sync_get_last_gps_from_history`` reads the most recent GPS state."""
+
+    def test_no_samples_returns_none(self) -> None:
+        history = MagicMock()
+        history.get_last_state_changes = MagicMock(return_value={"entity": []})
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(main_module, "recorder_history", history)
+            result = _sync_get_last_gps_from_history(MagicMock(), "entity")
+
+        assert result is None
+
+    def test_missing_lat_lon_returns_none(self) -> None:
+        sample = SimpleNamespace(
+            attributes={"gps_accuracy": 10},
+            last_updated=SimpleNamespace(timestamp=lambda: 1_700_000_000.0),
+        )
+        history = MagicMock()
+        history.get_last_state_changes = MagicMock(return_value={"entity": [sample]})
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(main_module, "recorder_history", history)
+            result = _sync_get_last_gps_from_history(MagicMock(), "entity")
+
+        assert result is None
+
+    def test_happy_path_returns_dict(self) -> None:
+        sample = SimpleNamespace(
+            attributes={
+                "latitude": 1.0,
+                "longitude": 2.0,
+                "gps_accuracy": 5,
+                "last_seen": 1_700_000_000,
+            },
+            last_updated=SimpleNamespace(timestamp=lambda: 1_700_000_000.0),
+        )
+        history = MagicMock()
+        history.get_last_state_changes = MagicMock(return_value={"entity": [sample]})
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(main_module, "recorder_history", history)
+            result = _sync_get_last_gps_from_history(MagicMock(), "entity")
+
+        assert result is not None
+        assert result["latitude"] == 1.0
+        assert result["longitude"] == 2.0
+        assert result["accuracy"] == 5
+        assert result["last_seen"] == 1_700_000_000.0
+        assert result["status"] == "Using historical data"
+
+    def test_history_exception_returns_none(self) -> None:
+        history = MagicMock()
+        history.get_last_state_changes = MagicMock(side_effect=RuntimeError("boom"))
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(main_module, "recorder_history", history)
+            result = _sync_get_last_gps_from_history(MagicMock(), "entity")
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticLabelRecordCopy:
+    """``SemanticLabelRecord.copy`` returns an independent device set."""
+
+    def test_copy_clones_device_set(self) -> None:
+        record = SemanticLabelRecord(
+            label="Home", first_seen=1.0, last_seen=2.0, devices={"a", "b"}
+        )
+
+        snapshot = record.copy()
+        snapshot.devices.add("c")
+
+        assert record.devices == {"a", "b"}
+        assert snapshot.devices == {"a", "b", "c"}
+
+    def test_copy_preserves_scalar_fields(self) -> None:
+        record = SemanticLabelRecord(label="Work", first_seen=10.0, last_seen=11.0)
+
+        snapshot = record.copy()
+
+        assert snapshot.label == "Work"
+        assert snapshot.first_seen == 10.0
+        assert snapshot.last_seen == 11.0
+
+
+class TestDeviceIdentityDataclass:
+    """``DeviceIdentity`` is a slotted dataclass with sensible defaults."""
+
+    def test_required_fields_only(self) -> None:
+        identity = DeviceIdentity(
+            registry_id="reg-1",
+            canonical_id="canon-1",
+            identity_key=None,
+        )
+
+        assert identity.registry_id == "reg-1"
+        assert identity.canonical_id == "canon-1"
+        assert identity.identity_key is None
+        assert identity.encrypted_identity_key is None
+        assert identity.owner_key_version is None
+        assert identity.device_type is None
+
+    def test_optional_fields_round_trip(self) -> None:
+        identity = DeviceIdentity(
+            registry_id="reg-2",
+            canonical_id="canon-2",
+            identity_key=b"\x01",
+            owner_key_version=7,
+            device_type=3,
+            manufacturer="Acme",
+            model="ABC-123",
+        )
+
+        assert identity.identity_key == b"\x01"
+        assert identity.owner_key_version == 7
+        assert identity.manufacturer == "Acme"
+        assert identity.model == "ABC-123"
+
+
+# ---------------------------------------------------------------------------
+# _get_api_class
+# ---------------------------------------------------------------------------
+
+
+class TestGetApiClass:
+    """``_get_api_class`` honours module- and package-level monkeypatches."""
+
+    def test_no_patch_returns_original(self) -> None:
+        original = main_module._OriginalGoogleFindMyAPI
+
+        assert _get_api_class() is original
+
+    def test_module_level_patch_takes_priority(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sentinel = type("PatchedAPI", (), {})
+
+        monkeypatch.setattr(main_module, "GoogleFindMyAPI", sentinel, raising=True)
+
+        assert _get_api_class() is sentinel
+
+    def test_package_level_patch_used_when_module_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coordinator_pkg = __import__(
+            "custom_components.googlefindmy.coordinator", fromlist=["GoogleFindMyAPI"]
+        )
+        sentinel = type("PackagePatchedAPI", (), {})
+
+        monkeypatch.setattr(coordinator_pkg, "GoogleFindMyAPI", sentinel, raising=False)
+
+        assert _get_api_class() is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Coordinator static methods (no stub needed)
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeContributorMode:
+    """``_sanitize_contributor_mode`` normalises optional strings."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("high_traffic", "high_traffic"),
+            ("HIGH_TRAFFIC", "high_traffic"),
+            ("  in_all_areas  ", "in_all_areas"),
+            ("unsupported", "in_all_areas"),
+            (None, "in_all_areas"),
+            (123, "in_all_areas"),
+        ],
+    )
+    def test_normalisation(self, raw: Any, expected: str) -> None:
+        # DEFAULT_CONTRIBUTOR_MODE is "in_all_areas"; unsupported / non-string
+        # inputs fall back to the default.
+        assert GoogleFindMyCoordinator._sanitize_contributor_mode(raw) == expected
+
+
+class TestCoerceFloat:
+    """``_coerce_float`` rejects non-numeric and non-finite values."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (1, 1.0),
+            (1.5, 1.5),
+            ("2.5", 2.5),
+            (None, None),
+            ("not a number", None),
+        ],
+    )
+    def test_round_trip(self, raw: Any, expected: float | None) -> None:
+        assert GoogleFindMyCoordinator._coerce_float(raw) == expected
+
+
+class TestNormalizeIdentityKey:
+    """``_normalize_identity_key`` accepts bytes, bytearray and hex strings."""
+
+    def test_bytes_pass_through(self) -> None:
+        assert (
+            GoogleFindMyCoordinator._normalize_identity_key(b"\xaa\xbb") == b"\xaa\xbb"
+        )
+
+    def test_bytearray_converts_to_bytes(self) -> None:
+        result = GoogleFindMyCoordinator._normalize_identity_key(bytearray(b"\xcc"))
+
+        assert isinstance(result, bytes)
+        assert result == b"\xcc"
+
+    def test_hex_string_decodes(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key("aabb") == b"\xaa\xbb"
+
+    def test_invalid_hex_returns_none(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key("not hex") is None
+
+    def test_non_string_non_bytes_returns_none(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key(123) is None
+        assert GoogleFindMyCoordinator._normalize_identity_key(None) is None
+
+
+class TestNormalizeIdentityKeyCandidates:
+    """``_normalize_identity_key_candidates`` flattens scalar or iterable input."""
+
+    def test_none_returns_empty(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key_candidates(None) == []
+
+    def test_single_bytes_wrapped(self) -> None:
+        result = GoogleFindMyCoordinator._normalize_identity_key_candidates(b"\x01")
+
+        assert result == [b"\x01"]
+
+    def test_iterable_deduplicates(self) -> None:
+        result = GoogleFindMyCoordinator._normalize_identity_key_candidates(
+            [b"\x01", b"\x01", b"\x02"]
+        )
+
+        assert result == [b"\x01", b"\x02"]
+
+    def test_iterable_with_invalid_entries_skipped(self) -> None:
+        result = GoogleFindMyCoordinator._normalize_identity_key_candidates(
+            [b"\x01", "not hex", 123, b"\x02"]
+        )
+
+        assert result == [b"\x01", b"\x02"]
+
+    def test_unsupported_input_returns_empty(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_identity_key_candidates(42) == []
+
+
+class TestNormalizeOptionalString:
+    """``_normalize_optional_string`` strips and returns None for empty input."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (" hello ", "hello"),
+            ("", None),
+            ("   ", None),
+            (None, None),
+            (123, None),
+        ],
+    )
+    def test_round_trip(self, raw: Any, expected: str | None) -> None:
+        assert GoogleFindMyCoordinator._normalize_optional_string(raw) == expected
+
+
+class TestNormalizeEncryptedBlob:
+    """``_normalize_encrypted_blob`` mirrors ``_normalize_identity_key`` semantics."""
+
+    def test_bytes_pass_through(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_encrypted_blob(b"\xaa") == b"\xaa"
+
+    def test_hex_string_decodes(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_encrypted_blob("aa") == b"\xaa"
+
+    def test_invalid_hex_returns_none(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_encrypted_blob("not hex") is None
+
+    def test_non_string_non_bytes_returns_none(self) -> None:
+        assert GoogleFindMyCoordinator._normalize_encrypted_blob(123) is None
+
+
+# ---------------------------------------------------------------------------
+# Stub-based tests (instance methods reading attribute state)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def coord() -> MainCoordinatorStub:
+    """Return a default :class:`MainCoordinatorStub` bound to a config entry."""
+
+    entry = make_config_entry(entry_id="entry-abc")
+    return MainCoordinatorStub(config_entry=entry)
+
+
+class TestCacheProperty:
+    """``cache`` is a read-only property returning the bound cache."""
+
+    def test_returns_seeded_cache(self, coord: MainCoordinatorStub) -> None:
+        assert coord.cache is coord._cache
+
+
+class TestRecentReconfigure:
+    """``mark_recent_reconfigure`` and ``recent_reconfigure_at`` are paired."""
+
+    def test_initially_none(self, coord: MainCoordinatorStub) -> None:
+        assert coord.recent_reconfigure_at is None
+
+    def test_mark_uses_supplied_timestamp(self, coord: MainCoordinatorStub) -> None:
+        coord.mark_recent_reconfigure(when=42.0)
+
+        assert coord.recent_reconfigure_at == 42.0
+
+    def test_mark_uses_time_time_when_omitted(
+        self, coord: MainCoordinatorStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(main_module.time, "time", lambda: 99.0)
+
+        coord.mark_recent_reconfigure()
+
+        assert coord.recent_reconfigure_at == 99.0
+
+
+class TestSafeUpdateMetric:
+    """``safe_update_metric`` coerces floats and swallows errors."""
+
+    def test_writes_metric(self, coord: MainCoordinatorStub) -> None:
+        coord.safe_update_metric("latency_ms", 12.5)
+
+        assert coord.performance_metrics["latency_ms"] == 12.5
+
+    def test_string_numeric_coerced(self, coord: MainCoordinatorStub) -> None:
+        coord.safe_update_metric("count", "3")  # type: ignore[arg-type]
+
+        assert coord.performance_metrics["count"] == 3.0
+
+    def test_invalid_value_swallowed(self, coord: MainCoordinatorStub) -> None:
+        coord.safe_update_metric("bad", "not a number")  # type: ignore[arg-type]
+
+        assert "bad" not in coord.performance_metrics
+
+
+class TestGetIgnoredSet:
+    """``_get_ignored_set`` reads from entry options (preferred) or attribute."""
+
+    def test_empty_when_entry_options_missing(self, coord: MainCoordinatorStub) -> None:
+        coord.config_entry = make_config_entry(entry_id="e", options={})
+
+        assert coord._get_ignored_set() == set()
+
+    def test_reads_mapping_from_options(self) -> None:
+        entry = make_config_entry(
+            entry_id="e",
+            options={"ignored_devices": {"dev-1": {}, "dev-2": {}}},
+        )
+        coord = MainCoordinatorStub(config_entry=entry)
+
+        assert coord._get_ignored_set() == {"dev-1", "dev-2"}
+
+    def test_falls_back_to_attribute(self, coord: MainCoordinatorStub) -> None:
+        coord.config_entry = None
+        coord.ignored_devices = ["a", "b", 3]  # type: ignore[list-item]
+
+        assert coord._get_ignored_set() == {"a", "b"}
+
+    def test_attribute_not_list_returns_empty(self, coord: MainCoordinatorStub) -> None:
+        coord.config_entry = None
+        coord.ignored_devices = "not a list"  # type: ignore[assignment]
+
+        assert coord._get_ignored_set() == set()
+
+
+class TestIsIgnored:
+    """``is_ignored`` delegates to ``_get_ignored_set``."""
+
+    def test_true_when_in_set(self, coord: MainCoordinatorStub) -> None:
+        coord._get_ignored_set = MagicMock(return_value={"dev-1"})  # type: ignore[method-assign]
+
+        assert coord.is_ignored("dev-1") is True
+
+    def test_false_when_not_in_set(self, coord: MainCoordinatorStub) -> None:
+        coord._get_ignored_set = MagicMock(return_value={"dev-1"})  # type: ignore[method-assign]
+
+        assert coord.is_ignored("dev-2") is False
+
+
+class TestFindSemanticMatch:
+    """``_find_semantic_match`` is case- and 'Near '-prefix-insensitive."""
+
+    def test_exact_match(self, coord: MainCoordinatorStub) -> None:
+        mapping = {"Home": {"latitude": 1.0}}
+
+        result = coord._find_semantic_match("home", mapping)
+
+        assert result == {"latitude": 1.0}
+
+    def test_strips_near_prefix(self, coord: MainCoordinatorStub) -> None:
+        mapping = {"Home": {"latitude": 1.0}}
+
+        result = coord._find_semantic_match("Near Home", mapping)
+
+        assert result == {"latitude": 1.0}
+
+    def test_returns_none_when_missing(self, coord: MainCoordinatorStub) -> None:
+        result = coord._find_semantic_match("Unknown", {"Home": {"latitude": 1.0}})
+
+        assert result is None
+
+
+class TestApplySemanticMapping:
+    """``_apply_semantic_mapping`` rewrites payload coordinates when matched."""
+
+    def test_returns_false_when_no_semantic_name(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        assert coord._apply_semantic_mapping({}) is False
+
+    def test_returns_false_for_blank_string(self, coord: MainCoordinatorStub) -> None:
+        assert coord._apply_semantic_mapping({"semantic_name": "   "}) is False
+
+    def test_returns_false_for_replayed_payload(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        payload = {"semantic_name": "Home", "is_replayed": True}
+
+        assert coord._apply_semantic_mapping(payload) is False
+
+    def test_returns_false_without_entry(self) -> None:
+        coord = MainCoordinatorStub(config_entry=None)
+
+        assert coord._apply_semantic_mapping({"semantic_name": "Home"}) is False
+
+    def test_returns_false_when_no_mappings_configured(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        # Default entry has empty options + empty data → no mappings
+        assert coord._apply_semantic_mapping({"semantic_name": "Home"}) is False
+
+    def test_rewrites_payload_on_match(self) -> None:
+        entry = make_config_entry(
+            entry_id="e",
+            options={
+                "semantic_locations": {
+                    "Home": {"latitude": 50.0, "longitude": 10.0, "accuracy": 25.0}
+                }
+            },
+        )
+        coord = MainCoordinatorStub(config_entry=entry)
+        payload: dict[str, Any] = {"semantic_name": "Home"}
+
+        result = coord._apply_semantic_mapping(payload)
+
+        assert result is True
+        assert payload["latitude"] == 50.0
+        assert payload["longitude"] == 10.0
+        assert payload["accuracy"] == 25.0
+        assert payload["location_type"] == "trusted"
+
+    def test_skips_mapping_with_invalid_coords(self) -> None:
+        entry = make_config_entry(
+            entry_id="e",
+            options={
+                "semantic_locations": {"Home": {"latitude": "bad", "longitude": 1.0}}
+            },
+        )
+        coord = MainCoordinatorStub(config_entry=entry)
+
+        assert coord._apply_semantic_mapping({"semantic_name": "Home"}) is False
+
+
+class TestSemanticLabelTracking:
+    """``_record_semantic_label`` + ``get_observed_semantic_labels``."""
+
+    def test_record_ignores_non_string(self, coord: MainCoordinatorStub) -> None:
+        coord._record_semantic_label({"semantic_name": 123})
+
+        assert coord.get_observed_semantic_labels() == []
+
+    def test_record_ignores_empty_string(self, coord: MainCoordinatorStub) -> None:
+        coord._record_semantic_label({"semantic_name": "   "})
+
+        assert coord.get_observed_semantic_labels() == []
+
+    def test_record_creates_entry(
+        self, coord: MainCoordinatorStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(main_module.time, "time", lambda: 100.0)
+
+        coord._record_semantic_label({"semantic_name": "Home"}, device_id="dev-1")
+
+        snapshot = coord.get_observed_semantic_labels()
+        assert len(snapshot) == 1
+        assert snapshot[0].label == "Home"
+        assert snapshot[0].first_seen == 100.0
+        assert snapshot[0].devices == {"dev-1"}
+
+    def test_record_updates_existing(
+        self, coord: MainCoordinatorStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ticks = iter([100.0, 200.0])
+        monkeypatch.setattr(main_module.time, "time", lambda: next(ticks))
+
+        coord._record_semantic_label({"semantic_name": "Home"}, device_id="dev-1")
+        coord._record_semantic_label({"semantic_name": "Home"}, device_id="dev-2")
+
+        snapshot = coord.get_observed_semantic_labels()
+        assert len(snapshot) == 1
+        assert snapshot[0].first_seen == 100.0
+        assert snapshot[0].last_seen == 200.0
+        assert snapshot[0].devices == {"dev-1", "dev-2"}
+
+    def test_snapshot_is_independent_of_cache(
+        self, coord: MainCoordinatorStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(main_module.time, "time", lambda: 1.0)
+
+        coord._record_semantic_label({"semantic_name": "Home"}, device_id="dev-1")
+        snapshot = coord.get_observed_semantic_labels()
+        snapshot[0].devices.add("dev-X")
+
+        # Cache untouched
+        live = coord.get_observed_semantic_labels()
+        assert live[0].devices == {"dev-1"}
+
+    def test_empty_cache_returns_empty_list(self, coord: MainCoordinatorStub) -> None:
+        assert coord.get_observed_semantic_labels() == []
+
+
+class TestShouldPreservePreciseHomeCoordinates:
+    """``_should_preserve_precise_home_coordinates`` guards against semantic drift."""
+
+    def test_no_prev_location_returns_false(self, coord: MainCoordinatorStub) -> None:
+        result = coord._should_preserve_precise_home_coordinates(None, {})
+
+        assert result is False
+
+    def test_invalid_prev_location_returns_false(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        prev = {"latitude": "bad", "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+    def test_non_finite_values_return_false(self, coord: MainCoordinatorStub) -> None:
+        prev = {"latitude": math.nan, "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+    def test_prev_accuracy_worse_than_radius_returns_false(
+        self, coord: MainCoordinatorStub
+    ) -> None:
+        prev = {"latitude": 0.0, "longitude": 0.0, "accuracy": 200.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+    def test_zero_radius_returns_false(self, coord: MainCoordinatorStub) -> None:
+        prev = {"latitude": 0.0, "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 0.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+    def test_within_radius_returns_true(self, coord: MainCoordinatorStub) -> None:
+        coord._haversine_distance = MagicMock(return_value=50.0)  # type: ignore[method-assign]
+        prev = {"latitude": 0.0, "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is True
+
+    def test_outside_radius_returns_false(self, coord: MainCoordinatorStub) -> None:
+        coord._haversine_distance = MagicMock(return_value=500.0)  # type: ignore[method-assign]
+        prev = {"latitude": 0.0, "longitude": 0.0, "accuracy": 1.0}
+        proposed = {"latitude": 0.0, "longitude": 0.0, "radius": 100.0}
+
+        assert coord._should_preserve_precise_home_coordinates(prev, proposed) is False
+
+
+class TestAuthErrorActive:
+    """``auth_error_active`` reads the private auth-failure flag."""
+
+    def test_initially_false(self, coord: MainCoordinatorStub) -> None:
+        assert coord.auth_error_active is False
+
+    def test_reflects_private_flag(self, coord: MainCoordinatorStub) -> None:
+        coord._auth_error_active = True
+
+        assert coord.auth_error_active is True

--- a/tests/test_coordinator_polling_basics.py
+++ b/tests/test_coordinator_polling_basics.py
@@ -1,0 +1,503 @@
+# tests/test_coordinator_polling_basics.py
+"""Branch-coverage tests for the simple ``PollingOperations`` mixin methods.
+
+PR 1.A.3 (Phase 2, AP-B). Scope: ``coordinator/polling.py`` simple helpers
+(``_set_api_status``, ``_set_fcm_status``, ``api_status``, ``fcm_status``,
+``is_fcm_connected``, ``consecutive_timeouts``, ``last_poll_result``,
+``_is_on_hass_loop``, ``_run_on_hass_loop``,
+``_compute_type_cooldown_seconds``, ``_apply_report_type_cooldown``,
+``is_polling``, ``get_fcm_acquire_duration_seconds``,
+``get_last_poll_duration_seconds``, ``_clear_fcm_deferral``,
+``_nudge_fcm_supervisor``, ``_get_predicted_poll_time``,
+``_note_push_transport_problem``, ``force_poll_due``). The complex async
+methods (``_async_update_data``, ``_async_start_poll_cycle``,
+``_handle_dr_event``, ``_dispatch_async_request_refresh``,
+``_schedule_short_retry``, ``_is_fcm_ready_soft``, ``_note_fcm_deferral``)
+remain out of scope here; they land in a later AP.
+
+Aniche-style adequacy progression: Specification → Boundary → Structural.
+:class:`PollingStub` (``tests.helpers.polling_mixin_stub``) seeds every
+attribute ``_MixinBase`` declares and pre-mocks cross-mixin methods
+(``_entry_id``, ``get_metric``, ``_get_duration``,
+``async_set_updated_data``, ``_reindex_poll_targets_from_device_registry``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.const import DOMAIN
+from custom_components.googlefindmy.coordinator.helpers.stats import (
+    ApiStatus,
+    FcmStatus,
+    StatusSnapshot,
+)
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.polling_mixin_stub import PollingStub, make_hass_stub
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def coord() -> PollingStub:
+    """Return a default :class:`PollingStub` bound to a synthetic config entry."""
+
+    entry = make_config_entry(entry_id="entry-xyz")
+    return PollingStub(hass=make_hass_stub(), config_entry=entry)
+
+
+# ---------------------------------------------------------------------------
+# T1 ``_set_api_status``
+# ---------------------------------------------------------------------------
+
+
+class TestSetApiStatus:
+    """B1: no change → early return; B2: change → update + notify;
+    B3: ``async_set_updated_data`` raises → swallow."""
+
+    def test_no_change_is_noop(self, coord: PollingStub) -> None:
+        coord._api_status_state = ApiStatus.OK
+        coord._api_status_reason = "stable"
+        coord._api_status_changed_at = 12345.0
+        coord._set_api_status(ApiStatus.OK, reason="stable")
+        # No state mutation, no listener notification.
+        assert coord._api_status_changed_at == 12345.0
+        coord.async_set_updated_data.assert_not_called()
+
+    def test_state_change_updates_and_notifies(self, coord: PollingStub) -> None:
+        before = time.time()
+        coord._set_api_status(ApiStatus.ERROR, reason="boom")
+        assert coord._api_status_state == ApiStatus.ERROR
+        assert coord._api_status_reason == "boom"
+        assert coord._api_status_changed_at is not None
+        assert coord._api_status_changed_at >= before
+        coord.async_set_updated_data.assert_called_once_with(coord.data)
+
+    def test_reason_change_only_still_notifies(self, coord: PollingStub) -> None:
+        coord._api_status_state = ApiStatus.OK
+        coord._api_status_reason = None
+        coord._set_api_status(ApiStatus.OK, reason="hint")
+        assert coord._api_status_reason == "hint"
+        coord.async_set_updated_data.assert_called_once_with(coord.data)
+
+    def test_set_updated_data_exception_is_swallowed(self, coord: PollingStub) -> None:
+        coord.async_set_updated_data = MagicMock(side_effect=RuntimeError("early"))
+        coord._set_api_status(ApiStatus.OK, reason="startup")
+        # State persists despite the listener failure.
+        assert coord._api_status_state == ApiStatus.OK
+        assert coord._api_status_reason == "startup"
+
+
+# ---------------------------------------------------------------------------
+# T2 ``_set_fcm_status``
+# ---------------------------------------------------------------------------
+
+
+class TestSetFcmStatus:
+    """B1: no change → early return; B2: change → update + notify;
+    B3: ``async_set_updated_data`` raises → swallow."""
+
+    def test_no_change_is_noop(self, coord: PollingStub) -> None:
+        coord._fcm_status_state = FcmStatus.CONNECTED
+        coord._fcm_status_reason = None
+        coord._fcm_status_changed_at = 999.0
+        coord._set_fcm_status(FcmStatus.CONNECTED, reason=None)
+        assert coord._fcm_status_changed_at == 999.0
+        coord.async_set_updated_data.assert_not_called()
+
+    def test_state_change_updates_and_notifies(self, coord: PollingStub) -> None:
+        coord._set_fcm_status(FcmStatus.DEGRADED, reason="slow")
+        assert coord._fcm_status_state == FcmStatus.DEGRADED
+        assert coord._fcm_status_reason == "slow"
+        coord.async_set_updated_data.assert_called_once_with(coord.data)
+
+    def test_set_updated_data_exception_is_swallowed(self, coord: PollingStub) -> None:
+        coord.async_set_updated_data = MagicMock(side_effect=RuntimeError("early"))
+        coord._set_fcm_status(FcmStatus.DISCONNECTED, reason="gone")
+        assert coord._fcm_status_state == FcmStatus.DISCONNECTED
+
+
+# ---------------------------------------------------------------------------
+# T3 / T4 / T5 / T6 Property getters
+# ---------------------------------------------------------------------------
+
+
+class TestStatusProperties:
+    """Snapshot dataclasses + scalar getters mirror the underlying attrs."""
+
+    def test_api_status_snapshot(self, coord: PollingStub) -> None:
+        coord._api_status_state = ApiStatus.OK
+        coord._api_status_reason = "happy"
+        coord._api_status_changed_at = 42.0
+        snapshot = coord.api_status
+        assert isinstance(snapshot, StatusSnapshot)
+        assert snapshot.state == ApiStatus.OK
+        assert snapshot.reason == "happy"
+        assert snapshot.changed_at == 42.0
+
+    def test_fcm_status_snapshot(self, coord: PollingStub) -> None:
+        coord._fcm_status_state = FcmStatus.DEGRADED
+        coord._fcm_status_reason = "slow"
+        coord._fcm_status_changed_at = 1.5
+        snapshot = coord.fcm_status
+        assert isinstance(snapshot, StatusSnapshot)
+        assert snapshot.state == FcmStatus.DEGRADED
+        assert snapshot.reason == "slow"
+        assert snapshot.changed_at == 1.5
+
+    def test_is_fcm_connected_true(self, coord: PollingStub) -> None:
+        coord._fcm_status_state = FcmStatus.CONNECTED
+        assert coord.is_fcm_connected is True
+
+    @pytest.mark.parametrize(
+        "state",
+        [FcmStatus.UNKNOWN, FcmStatus.DEGRADED, FcmStatus.DISCONNECTED, "other"],
+    )
+    def test_is_fcm_connected_false(self, coord: PollingStub, state: str) -> None:
+        coord._fcm_status_state = state
+        assert coord.is_fcm_connected is False
+
+    def test_scalar_getters_read_through(self, coord: PollingStub) -> None:
+        coord._consecutive_timeouts = 5
+        coord._last_poll_result = "success"
+        coord._is_polling = True
+        assert coord.consecutive_timeouts == 5
+        assert coord.last_poll_result == "success"
+        assert coord.is_polling is True
+
+
+# ---------------------------------------------------------------------------
+# T7 ``_is_on_hass_loop``
+# ---------------------------------------------------------------------------
+
+
+class TestIsOnHassLoop:
+    """B1: running loop equals hass.loop → True; B2: differs → False;
+    B3: RuntimeError (no running loop) → False."""
+
+    def test_returns_false_when_no_running_loop(self, coord: PollingStub) -> None:
+        # No event loop is running in this sync test → RuntimeError → False.
+        assert coord._is_on_hass_loop() is False
+
+    async def test_returns_true_when_running_loop_matches(self) -> None:
+        # ``asyncio_mode = "auto"`` (pyproject.toml) supplies the running loop;
+        # avoid ``asyncio.run()`` here so the architecture guard
+        # (tests/test_guard_asyncio_run_antipattern.py) stays satisfied.
+        loop = asyncio.get_running_loop()
+        stub = PollingStub(hass=make_hass_stub(loop=loop))
+        assert stub._is_on_hass_loop() is True
+
+    async def test_returns_false_when_running_loop_differs(self) -> None:
+        # hass.loop is a MagicMock (different identity from the running loop),
+        # so the equality check returns ``False`` even on the HA loop thread.
+        stub = PollingStub(hass=make_hass_stub())
+        assert stub._is_on_hass_loop() is False
+
+
+# ---------------------------------------------------------------------------
+# T8 ``_run_on_hass_loop``
+# ---------------------------------------------------------------------------
+
+
+class TestRunOnHassLoop:
+    """B1: no kwargs → loop.call_soon_threadsafe(func, *args);
+    B2: kwargs → loop.call_soon_threadsafe(functools.partial(...))."""
+
+    def test_without_kwargs_passes_func_and_args(self, coord: PollingStub) -> None:
+        captured: list[tuple[object, ...]] = []
+        coord.hass.loop.call_soon_threadsafe = MagicMock(
+            side_effect=lambda *args: captured.append(args)
+        )
+
+        def _noop(*_args: object) -> None:
+            pass
+
+        coord._run_on_hass_loop(_noop, "a", "b")
+        assert len(captured) == 1
+        assert captured[0][0] is _noop
+        assert captured[0][1:] == ("a", "b")
+
+    def test_with_kwargs_wraps_in_partial(self, coord: PollingStub) -> None:
+        captured: list[tuple[object, ...]] = []
+        coord.hass.loop.call_soon_threadsafe = MagicMock(
+            side_effect=lambda *args: captured.append(args)
+        )
+
+        def _noop(*_args: object, **_kwargs: object) -> None:
+            pass
+
+        coord._run_on_hass_loop(_noop, 1, key="value")
+        assert len(captured) == 1
+        # functools.partial wraps the function; first positional must be callable.
+        wrapped = captured[0][0]
+        assert callable(wrapped)
+        # Confirm the partial captured the right args/kwargs without invoking.
+        assert getattr(wrapped, "args", ()) == (1,)
+        assert getattr(wrapped, "keywords", {}) == {"key": "value"}
+
+
+# ---------------------------------------------------------------------------
+# T9 ``_compute_type_cooldown_seconds``
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTypeCooldownSeconds:
+    """B1: no hint → 0; B2: ``in_all_areas`` base; B3: ``high_traffic`` base;
+    B4: unknown hint → 0; B5: ``max(base, effective_poll)``."""
+
+    def test_none_hint_returns_zero(self, coord: PollingStub) -> None:
+        assert coord._compute_type_cooldown_seconds(None) == 0
+
+    def test_empty_hint_returns_zero(self, coord: PollingStub) -> None:
+        assert coord._compute_type_cooldown_seconds("") == 0
+
+    def test_in_all_areas_uses_10_minute_floor(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 60
+        assert coord._compute_type_cooldown_seconds("in_all_areas") == 10 * 60
+
+    def test_high_traffic_uses_5_minute_floor(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 60
+        assert coord._compute_type_cooldown_seconds("high_traffic") == 5 * 60
+
+    def test_unknown_hint_returns_zero(self, coord: PollingStub) -> None:
+        assert coord._compute_type_cooldown_seconds("unknown") == 0
+
+    def test_long_poll_interval_dominates_base(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 30 * 60  # 30 min
+        assert coord._compute_type_cooldown_seconds("in_all_areas") == 30 * 60
+
+    def test_zero_poll_interval_clamped_to_one_minimum(
+        self, coord: PollingStub
+    ) -> None:
+        coord.location_poll_interval = 0
+        # base 10*60 still wins over effective_poll=max(1,0)=1
+        assert coord._compute_type_cooldown_seconds("in_all_areas") == 10 * 60
+
+
+# ---------------------------------------------------------------------------
+# T10 ``_apply_report_type_cooldown``
+# ---------------------------------------------------------------------------
+
+
+class TestApplyReportTypeCooldown:
+    """B1: zero seconds → skip; B2: new > prev → set;
+    B3: new <= prev → no-op; B4: ``_compute_type_cooldown_seconds`` raises → swallow."""
+
+    def test_zero_seconds_skips(self, coord: PollingStub) -> None:
+        coord._apply_report_type_cooldown("dev-1", None)
+        assert "dev-1" not in coord._device_poll_cooldown_until
+
+    def test_new_deadline_writes_entry(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 60
+        before = time.monotonic()
+        coord._apply_report_type_cooldown("dev-1", "in_all_areas")
+        deadline = coord._device_poll_cooldown_until["dev-1"]
+        assert deadline >= before + 10 * 60 - 1  # tolerate clock skew
+
+    def test_existing_longer_deadline_kept(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 60
+        future = time.monotonic() + 9999
+        coord._device_poll_cooldown_until["dev-1"] = future
+        coord._apply_report_type_cooldown("dev-1", "high_traffic")
+        assert coord._device_poll_cooldown_until["dev-1"] == future
+
+    def test_compute_exception_is_swallowed(self, coord: PollingStub) -> None:
+        original = coord._compute_type_cooldown_seconds
+        try:
+            coord._compute_type_cooldown_seconds = MagicMock(  # type: ignore[method-assign]
+                side_effect=RuntimeError("boom")
+            )
+            coord._apply_report_type_cooldown("dev-1", "in_all_areas")
+            assert "dev-1" not in coord._device_poll_cooldown_until
+        finally:
+            coord._compute_type_cooldown_seconds = original  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# T11 ``get_fcm_acquire_duration_seconds`` + ``get_last_poll_duration_seconds``
+# ---------------------------------------------------------------------------
+
+
+class TestDurationGetters:
+    """B1: ``get_fcm_acquire_duration_seconds`` delegates to ``helpers.stats``;
+    B2: ``get_last_poll_duration_seconds`` delegates to ``_get_duration``."""
+
+    def test_get_fcm_acquire_duration_uses_recorded_metrics(
+        self, coord: PollingStub
+    ) -> None:
+        coord.get_metric = MagicMock(side_effect=[10.0, 25.5])
+        assert coord.get_fcm_acquire_duration_seconds() == pytest.approx(15.5)
+
+    def test_get_fcm_acquire_duration_returns_none_when_missing(
+        self, coord: PollingStub
+    ) -> None:
+        coord.get_metric = MagicMock(return_value=None)
+        assert coord.get_fcm_acquire_duration_seconds() is None
+
+    def test_get_last_poll_duration_delegates(self, coord: PollingStub) -> None:
+        coord._get_duration = MagicMock(return_value=7.25)  # type: ignore[method-assign]
+        assert coord.get_last_poll_duration_seconds() == 7.25
+        coord._get_duration.assert_called_once_with(
+            "last_poll_start_mono", "last_poll_end_mono"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T12 ``_clear_fcm_deferral``
+# ---------------------------------------------------------------------------
+
+
+class TestClearFcmDeferral:
+    """B1: was deferred → log info + clear; B2: not deferred → silent clear."""
+
+    def test_clears_state_when_previously_deferred(self, coord: PollingStub) -> None:
+        coord._fcm_defer_started_mono = 100.0
+        coord._fcm_last_stage = 2
+        coord._degraded_mode_warned = True
+        coord._clear_fcm_deferral()
+        assert coord._fcm_defer_started_mono == 0.0
+        assert coord._fcm_last_stage == 0
+        assert coord._degraded_mode_warned is False
+        assert coord._fcm_status_state == FcmStatus.CONNECTED
+
+    def test_clear_when_not_deferred_still_sets_connected(
+        self, coord: PollingStub
+    ) -> None:
+        coord._fcm_defer_started_mono = 0.0
+        coord._fcm_status_state = FcmStatus.UNKNOWN
+        coord._clear_fcm_deferral()
+        assert coord._fcm_status_state == FcmStatus.CONNECTED
+
+
+# ---------------------------------------------------------------------------
+# T13 ``_nudge_fcm_supervisor``
+# ---------------------------------------------------------------------------
+
+
+class TestNudgeFcmSupervisor:
+    """B1: no fcm receiver → silent; B2: receiver lacks ``nudge_retry`` → silent;
+    B3: callable nudge → invoked with entry_id; B4: nudge raises → swallow."""
+
+    def test_no_fcm_is_silent(self, coord: PollingStub) -> None:
+        coord.hass.data = {DOMAIN: {}}
+        # Should not raise.
+        coord._nudge_fcm_supervisor()
+
+    def test_missing_nudge_retry_is_silent(self, coord: PollingStub) -> None:
+        receiver = MagicMock(spec_set=["other_attr"])
+        receiver.other_attr = "x"
+        coord.hass.data = {DOMAIN: {"fcm_receiver": receiver}}
+        coord._nudge_fcm_supervisor()
+
+    def test_callable_nudge_invoked_with_entry_id(self, coord: PollingStub) -> None:
+        receiver = MagicMock()
+        coord.hass.data = {DOMAIN: {"fcm_receiver": receiver}}
+        coord._entry_id = MagicMock(return_value="entry-xyz")
+        coord._nudge_fcm_supervisor()
+        receiver.nudge_retry.assert_called_once_with("entry-xyz")
+
+    def test_nudge_exception_is_swallowed(self, coord: PollingStub) -> None:
+        receiver = MagicMock()
+        receiver.nudge_retry = MagicMock(side_effect=RuntimeError("boom"))
+        coord.hass.data = {DOMAIN: {"fcm_receiver": receiver}}
+        coord._nudge_fcm_supervisor()
+
+
+# ---------------------------------------------------------------------------
+# T14 ``_get_predicted_poll_time``
+# ---------------------------------------------------------------------------
+
+
+class TestGetPredictedPollTime:
+    """B1: no history store → None; B2: empty store → None;
+    B3: histories with <2 entries skipped; B4: high stdev skipped;
+    B5: returns ``min(predictions)``."""
+
+    def test_no_history_attribute_returns_none(self, coord: PollingStub) -> None:
+        # Remove the attribute so getattr returns None.
+        del coord._device_update_history
+        assert coord._get_predicted_poll_time() is None
+
+    def test_empty_history_returns_none(self, coord: PollingStub) -> None:
+        coord._device_update_history = {}
+        assert coord._get_predicted_poll_time() is None
+
+    def test_only_short_histories_returns_none(self, coord: PollingStub) -> None:
+        # len(history) < 2 → no intervals computable.
+        coord._device_update_history = {"dev-1": deque([100.0])}
+        assert coord._get_predicted_poll_time() is None
+
+    def test_steady_history_predicts_next_update(self, coord: PollingStub) -> None:
+        # Three samples spaced 60s apart → avg interval 60s → next at 220.0.
+        coord._device_update_history = {"dev-1": deque([100.0, 160.0, 220.0])}
+        assert coord._get_predicted_poll_time() == pytest.approx(280.0)
+
+    def test_chooses_earliest_prediction(self, coord: PollingStub) -> None:
+        coord._device_update_history = {
+            "early": deque([0.0, 30.0, 60.0]),  # next at 90.0
+            "late": deque([100.0, 160.0, 220.0]),  # next at 280.0
+        }
+        assert coord._get_predicted_poll_time() == pytest.approx(90.0)
+
+    def test_high_stdev_history_is_skipped(self, coord: PollingStub) -> None:
+        # Intervals [10, 1000] → stdev far above 300 → device excluded.
+        coord._device_update_history = {
+            "noisy": deque([0.0, 10.0, 1010.0]),
+            "calm": deque([100.0, 160.0, 220.0]),
+        }
+        assert coord._get_predicted_poll_time() == pytest.approx(280.0)
+
+    def test_all_high_stdev_returns_none(self, coord: PollingStub) -> None:
+        coord._device_update_history = {
+            "noisy": deque([0.0, 10.0, 1010.0]),
+        }
+        assert coord._get_predicted_poll_time() is None
+
+
+# ---------------------------------------------------------------------------
+# T15 ``_note_push_transport_problem`` + ``force_poll_due``
+# ---------------------------------------------------------------------------
+
+
+class TestNotePushTransportProblem:
+    """B1: default 90s cooldown applied; B2: explicit cooldown honored;
+    B3: ``_push_ready_memo`` invalidated; B4: FCM status set to DEGRADED."""
+
+    def test_default_cooldown_sets_state(self, coord: PollingStub) -> None:
+        before = time.monotonic()
+        coord._note_push_transport_problem()
+        assert coord._push_cooldown_until >= before + 89  # tolerate skew
+        assert coord._push_ready_memo is False
+        assert coord._fcm_status_state == FcmStatus.DEGRADED
+
+    def test_custom_cooldown_used(self, coord: PollingStub) -> None:
+        before = time.monotonic()
+        coord._note_push_transport_problem(cooldown_s=30)
+        assert coord._push_cooldown_until >= before + 29
+        assert coord._push_cooldown_until < before + 120
+
+
+class TestForcePollDue:
+    """B1: backshift baseline by effective interval."""
+
+    def test_backshifts_last_poll_mono(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 90
+        coord.min_poll_interval = 60
+        coord.force_poll_due()
+        # _last_poll_mono = now - max(90, 60) = now - 90.
+        elapsed_since_baseline = time.monotonic() - coord._last_poll_mono
+        assert elapsed_since_baseline >= 90 - 0.5  # tolerate skew
+
+    def test_uses_min_when_location_smaller(self, coord: PollingStub) -> None:
+        coord.location_poll_interval = 10
+        coord.min_poll_interval = 60
+        coord.force_poll_due()
+        elapsed_since_baseline = time.monotonic() - coord._last_poll_mono
+        assert elapsed_since_baseline >= 60 - 0.5

--- a/tests/test_coordinator_polling_branches.py
+++ b/tests/test_coordinator_polling_branches.py
@@ -1,0 +1,461 @@
+# tests/test_coordinator_polling_branches.py
+"""Branch-coverage tests for :mod:`coordinator.polling` (Phase 4 AP-J).
+
+Phase 2 AP-B covered the simple read-through mixin methods. This module
+exercises the harder branch logic: loop-detection dispatch, coalesced retry
+scheduling, device-registry event handling, 3-tier FCM-ready probing and the
+escalation timeline. Class names use the ``Branches`` suffix to keep
+disjoint from ``test_coordinator_polling_basics.py`` (CA-F6).
+
+Scope (Phase 4 AP-J):
+- ``_dispatch_async_request_refresh`` (5 branches)
+- ``_schedule_short_retry`` (6 branches)
+- ``_handle_dr_event`` (1 branch)
+- ``_is_fcm_ready_soft`` (3-tier priority, ~12 branches)
+- ``_note_fcm_deferral`` (4 stages)
+
+Out of scope (Phase 5):
+- ``_async_update_data``, ``_async_start_poll_cycle`` (full poll-cycle roundtrip)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.coordinator.helpers.stats import FcmStatus
+from tests.helpers.polling_branches_stub import PollingBranchesStub
+
+
+@pytest.fixture
+def coord() -> PollingBranchesStub:
+    """Return a fresh :class:`PollingBranchesStub` with default scalars."""
+
+    return PollingBranchesStub()
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_async_request_refresh
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchAsyncRequestRefreshBranches:
+    """Loop detection, awaitable scheduling, exception swallowing."""
+
+    def test_no_async_request_refresh_callable_returns(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.async_request_refresh = None  # type: ignore[assignment]
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._dispatch_async_request_refresh(task_name="t", log_context="ctx")
+
+        coord.hass.async_create_task.assert_not_called()
+
+    def test_on_loop_with_non_awaitable_result_skips_task_create(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.async_request_refresh = MagicMock(return_value=None)
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._dispatch_async_request_refresh(task_name="t", log_context="ctx")
+
+        coord.async_request_refresh.assert_called_once_with()
+        coord.hass.async_create_task.assert_not_called()
+
+    def test_on_loop_with_awaitable_schedules_task(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        async def _awaitable() -> None:
+            return None
+
+        coro = _awaitable()
+        coord.async_request_refresh = MagicMock(return_value=coro)
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._dispatch_async_request_refresh(task_name="task-x", log_context="on-loop")
+
+        coord.hass.async_create_task.assert_called_once_with(coro, name="task-x")
+        coro.close()
+
+    def test_on_loop_exception_swallowed_and_logged(
+        self, coord: PollingBranchesStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord.async_request_refresh = MagicMock(side_effect=RuntimeError("boom"))
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
+            coord._dispatch_async_request_refresh(task_name="t", log_context="explode")
+
+        assert "explode" in caplog.text
+        coord.hass.async_create_task.assert_not_called()
+
+    def test_off_loop_uses_run_on_hass_loop(self, coord: PollingBranchesStub) -> None:
+        coord.async_request_refresh = MagicMock(return_value=None)
+        coord._is_on_hass_loop = MagicMock(return_value=False)
+
+        captured: list[Any] = []
+        coord._run_on_hass_loop = lambda fn, *a, **kw: captured.append(fn)  # type: ignore[assignment]
+
+        coord._dispatch_async_request_refresh(task_name="t", log_context="off")
+
+        assert len(captured) == 1
+        # The deferred callable still works: invoke it and verify no task scheduled.
+        captured[0]()
+        coord.async_request_refresh.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# _schedule_short_retry
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleShortRetryBranches:
+    """Coalesce, delay clamp, callback dispatch."""
+
+    def test_on_loop_uses_async_call_later(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sentinel = object()
+        fake_call_later = MagicMock(return_value=sentinel)
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            fake_call_later,
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._schedule_short_retry(delay_s=3.0)
+
+        fake_call_later.assert_called_once()
+        args, _kwargs = fake_call_later.call_args
+        assert args[0] is coord.hass
+        assert args[1] == 3.0
+        assert callable(args[2])
+        assert coord._short_retry_cancel is sentinel
+
+    def test_off_loop_routes_through_run_on_hass_loop(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_call_later = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            fake_call_later,
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=False)
+
+        captured: list[Any] = []
+        coord._run_on_hass_loop = lambda fn, *a, **kw: captured.append(fn)  # type: ignore[assignment]
+
+        coord._schedule_short_retry(delay_s=1.5)
+
+        fake_call_later.assert_not_called()
+        assert len(captured) == 1
+        captured[0]()  # invoke the deferred scheduler
+        fake_call_later.assert_called_once()
+
+    def test_pending_cancel_called_before_new_schedule(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        prev_cancel = MagicMock()
+        coord._short_retry_cancel = prev_cancel
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            MagicMock(return_value=MagicMock()),
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._schedule_short_retry(delay_s=2.0)
+
+        prev_cancel.assert_called_once_with()
+
+    def test_pending_cancel_exception_swallowed(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        prev_cancel = MagicMock(side_effect=RuntimeError("nope"))
+        coord._short_retry_cancel = prev_cancel
+        new_handle = MagicMock()
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            MagicMock(return_value=new_handle),
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._schedule_short_retry(delay_s=1.0)
+
+        # Cancel raised, schedule must still proceed and overwrite the handle.
+        assert coord._short_retry_cancel is new_handle
+
+    def test_negative_delay_clamped_to_zero(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_call_later = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            fake_call_later,
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+
+        coord._schedule_short_retry(delay_s=-5.0)
+
+        args, _ = fake_call_later.call_args
+        assert args[1] == 0.0
+
+    def test_callback_clears_handle_and_dispatches(
+        self, coord: PollingBranchesStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured_cb: dict[str, Any] = {}
+
+        def _capture(_hass: Any, _delay: float, cb: Any) -> Any:
+            captured_cb["cb"] = cb
+            return MagicMock()  # the cancel handle
+
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.polling.async_call_later",
+            _capture,
+        )
+        coord._is_on_hass_loop = MagicMock(return_value=True)
+        dispatch_mock = MagicMock()
+        coord._dispatch_async_request_refresh = dispatch_mock  # type: ignore[assignment]
+
+        coord._schedule_short_retry(delay_s=1.0)
+        assert coord._short_retry_cancel is not None
+        captured_cb["cb"](object())  # fake datetime arg
+
+        assert coord._short_retry_cancel is None
+        dispatch_mock.assert_called_once()
+        _, kwargs = dispatch_mock.call_args
+        assert kwargs["log_context"] == "short retry"
+
+
+# ---------------------------------------------------------------------------
+# _handle_dr_event
+# ---------------------------------------------------------------------------
+
+
+class TestHandleDrEventBranches:
+    """Device-registry event triggers reindex + refresh dispatch."""
+
+    async def test_reindex_and_dispatch_invoked(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        dispatch_mock = MagicMock()
+        coord._dispatch_async_request_refresh = dispatch_mock  # type: ignore[assignment]
+        event = MagicMock()
+
+        await coord._handle_dr_event(event)
+
+        coord._reindex_poll_targets_from_device_registry.assert_called_once_with()
+        dispatch_mock.assert_called_once()
+        _, kwargs = dispatch_mock.call_args
+        assert kwargs["log_context"] == "device registry event"
+
+
+# ---------------------------------------------------------------------------
+# _is_fcm_ready_soft (3-tier priority)
+# ---------------------------------------------------------------------------
+
+
+class TestIsFcmReadySoftBranches:
+    """API > receiver-flags > push-client heuristic; defensive returns."""
+
+    def test_api_is_push_ready_true_short_circuits(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(is_push_ready=MagicMock(return_value=True))
+        # Even with no receiver, the API short-circuit wins.
+        coord.hass.data = {}
+
+        assert coord._is_fcm_ready_soft() is True
+
+    def test_api_is_push_ready_false_short_circuits(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(is_push_ready=MagicMock(return_value=False))
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_api_raises_falls_through_to_receiver(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(
+            is_push_ready=MagicMock(side_effect=RuntimeError("api fail"))
+        )
+        fcm = MagicMock(spec_set=["is_ready", "_fatal_error", "_fatal_errors", "pc"])
+        fcm.is_ready = True
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        fcm.pc = None
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is True
+
+    def test_no_fcm_receiver_returns_false(self, coord: PollingBranchesStub) -> None:
+        coord.api = MagicMock(spec_set=[])  # no is_push_ready attribute
+        coord.hass.data = {}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_fatal_error_string_returns_false(self, coord: PollingBranchesStub) -> None:
+        coord.api = MagicMock(spec_set=[])
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = "boom"
+        fcm._fatal_errors = None
+        fcm.is_ready = True
+        fcm.pc = None
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_fatal_error_by_entry_returns_false(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(spec_set=[])
+        coord._entry_id = MagicMock(return_value="entry-xyz")
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = None
+        fcm._fatal_errors = {"entry-xyz": "auth-broken"}
+        fcm.is_ready = True
+        fcm.pc = None
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_receiver_ready_attribute_wins_over_pc(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(spec_set=[])
+        fcm = MagicMock(spec_set=["ready", "_fatal_error", "_fatal_errors", "pc"])
+        fcm.ready = False
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        # ``pc`` would say True, but the explicit ready=False wins.
+        fcm.pc = MagicMock(run_state=MagicMock(name="STARTED"), do_listen=True)
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_pc_started_with_do_listen_true(self, coord: PollingBranchesStub) -> None:
+        coord.api = MagicMock(spec_set=[])
+        pc = MagicMock(spec_set=["run_state", "do_listen"])
+        pc.run_state = MagicMock(name="STARTED")
+        pc.run_state.name = "STARTED"
+        pc.do_listen = True
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        fcm.is_ready = None  # not a bool -> skip receiver-flag branch
+        fcm.pc = pc
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is True
+
+    def test_pc_started_without_do_listen_returns_false(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord.api = MagicMock(spec_set=[])
+        pc = MagicMock(spec_set=["run_state", "do_listen"])
+        pc.run_state = MagicMock()
+        pc.run_state.name = "STARTED"
+        pc.do_listen = False
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        fcm.is_ready = None
+        fcm.pc = pc
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_pc_other_state_returns_false(self, coord: PollingBranchesStub) -> None:
+        coord.api = MagicMock(spec_set=[])
+        pc = MagicMock(spec_set=["run_state", "do_listen"])
+        pc.run_state = MagicMock()
+        pc.run_state.name = "STOPPED"
+        pc.do_listen = True
+        fcm = MagicMock(spec_set=["_fatal_error", "_fatal_errors", "is_ready", "pc"])
+        fcm._fatal_error = None
+        fcm._fatal_errors = None
+        fcm.is_ready = None
+        fcm.pc = pc
+        coord.hass.data = {"googlefindmy": {"fcm_receiver": fcm}}
+
+        assert coord._is_fcm_ready_soft() is False
+
+    def test_outer_exception_returns_false(self, coord: PollingBranchesStub) -> None:
+        # An attribute that raises on access on coord.hass.data forces the
+        # outer ``except Exception`` branch.
+        broken_data = MagicMock()
+        broken_data.get = MagicMock(side_effect=RuntimeError("data broken"))
+        coord.hass.data = broken_data
+        coord.api = MagicMock(spec_set=[])
+
+        assert coord._is_fcm_ready_soft() is False
+
+
+# ---------------------------------------------------------------------------
+# _note_fcm_deferral (escalation timeline)
+# ---------------------------------------------------------------------------
+
+
+class TestNoteFcmDeferralBranches:
+    """Stage 0 (start) -> Stage 1 (120s INFO) -> Stage 2 (300s WARNING)."""
+
+    def test_first_call_sets_started_and_degraded(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord._fcm_defer_started_mono = 0.0
+        coord._fcm_last_stage = 0
+
+        coord._note_fcm_deferral(now_mono=1000.0)
+
+        assert coord._fcm_defer_started_mono == 1000.0
+        assert coord._fcm_last_stage == 0
+        assert coord._fcm_status_state == FcmStatus.DEGRADED
+
+    def test_subsequent_call_under_2min_does_not_escalate(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord._fcm_defer_started_mono = 1000.0
+        coord._fcm_last_stage = 0
+
+        coord._note_fcm_deferral(now_mono=1050.0)  # 50s elapsed
+
+        assert coord._fcm_last_stage == 0
+
+    def test_at_2min_emits_stage_1_info(
+        self, coord: PollingBranchesStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord._fcm_defer_started_mono = 1000.0
+        coord._fcm_last_stage = 0
+
+        with caplog.at_level(logging.INFO, logger="custom_components.googlefindmy"):
+            coord._note_fcm_deferral(now_mono=1120.0)
+
+        assert coord._fcm_last_stage == 1
+        assert coord._fcm_status_state == FcmStatus.DEGRADED
+        assert any("2 min" in r.message for r in caplog.records)
+
+    def test_at_5min_emits_stage_2_warning_and_disconnects(
+        self, coord: PollingBranchesStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord._fcm_defer_started_mono = 1000.0
+        coord._fcm_last_stage = 1  # already emitted stage 1
+
+        with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+            coord._note_fcm_deferral(now_mono=1300.0)
+
+        assert coord._fcm_last_stage == 2
+        assert coord._fcm_status_state == FcmStatus.DISCONNECTED
+
+    def test_after_stage2_no_further_escalation(
+        self, coord: PollingBranchesStub
+    ) -> None:
+        coord._fcm_defer_started_mono = 1000.0
+        coord._fcm_last_stage = 2
+
+        coord._note_fcm_deferral(now_mono=2000.0)
+
+        assert coord._fcm_last_stage == 2

--- a/tests/test_coordinator_polling_fatal_channel.py
+++ b/tests/test_coordinator_polling_fatal_channel.py
@@ -1,0 +1,102 @@
+# tests/test_coordinator_polling_fatal_channel.py
+"""Channel-confusion regression tests for ``coordinator.polling``.
+
+Iter-14 (Codex follow-up): the FCM receiver's supervisor-level "short-run
+crash loop" cap publishes its terminal state into the SAME ``_fatal_errors``
+map that the coordinator's re-auth escalation consumes. Without explicit
+classification the crash-loop fatal would be reclassified as an auth fatal
+after ``_FCM_ERROR_RETRY_THRESHOLD`` consecutive update cycles and push users
+into Home Assistant's re-auth flow for what is structurally a listener-
+lifecycle fatal (the repair issue carries the actual user-visible guidance).
+
+This module pins three contracts:
+
+1. ``_classify_fcm_fatal`` (free function, branch-coverage friendly):
+   - crash-loop prefix => ``_FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED``
+   - classic auth fatal (401/404/credentials text) =>
+     ``_FCM_FATAL_CLASS_AUTH_IMMEDIATE``
+   - any other non-empty fatal => ``_FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD``
+2. The polling-side fatal-classification call is the SSOT consumer for the
+   crash-loop prefix exported by ``Auth.fcm_receiver_ha``.
+3. The crash-loop prefix matches the message produced by the cap-fire
+   branch in ``Auth.fcm_receiver_ha`` (cross-module wire contract).
+"""
+
+from __future__ import annotations
+
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
+    _MAX_CONSECUTIVE_SHORT_RUNS,
+    _SHORT_RUN_THRESHOLD_S,
+    CRASH_LOOP_FATAL_PREFIX,
+)
+from custom_components.googlefindmy.coordinator.polling import (
+    _FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD,
+    _FCM_FATAL_CLASS_AUTH_IMMEDIATE,
+    _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED,
+    _classify_fcm_fatal,
+)
+
+
+class TestClassifyFcmFatal:
+    """Branch coverage for the channel-confusion fix."""
+
+    def test_crash_loop_prefix_is_excluded(self) -> None:
+        """A cap-fired crash-loop fatal must never escalate to re-auth."""
+        cap_message = (
+            f"{CRASH_LOOP_FATAL_PREFIX} 10 consecutive runs ended within 30s "
+            f"(persistent poison message suspected)"
+        )
+
+        assert (
+            _classify_fcm_fatal(cap_message) == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+        )
+
+    def test_bare_prefix_is_also_excluded(self) -> None:
+        """Defense is on the prefix alone, not the full message body."""
+        assert (
+            _classify_fcm_fatal(CRASH_LOOP_FATAL_PREFIX)
+            == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+        )
+
+    def test_classic_auth_fatal_is_immediate(self) -> None:
+        """A 401 credentials fatal must classify as auth_immediate.
+
+        ``is_fatal_fcm_auth_error`` matches plain ``"401"`` substrings, so a
+        message that contains ``"HTTP 401"`` classifies as the immediate
+        auth-fatal path.
+        """
+        msg = "FCM auth failed: invalid credentials (HTTP 401)"
+
+        assert _classify_fcm_fatal(msg) == _FCM_FATAL_CLASS_AUTH_IMMEDIATE
+
+    def test_unrelated_transient_fatal_uses_threshold_path(self) -> None:
+        """An unrecognised non-crash-loop fatal goes through the counter."""
+        # A network error that does not match auth patterns AND does not
+        # start with the crash-loop prefix.
+        msg = "Transient FCM error: connection reset"
+
+        assert (
+            _classify_fcm_fatal(msg) == _FCM_FATAL_CLASS_AUTH_AFTER_THRESHOLD
+        )
+
+    def test_wire_contract_cap_message_matches_prefix(self) -> None:
+        """The cap-fire branch must produce a message the classifier excludes.
+
+        This pins the cross-module wire contract: if the cap-fire branch in
+        ``Auth.fcm_receiver_ha`` ever changes its message template, this test
+        fails fast and forces the change to be propagated through
+        ``CRASH_LOOP_FATAL_PREFIX`` rather than diverging silently.
+        """
+        # Reproduce the cap-fire branch's f-string template literally.
+        cap_message = (
+            f"{CRASH_LOOP_FATAL_PREFIX} "
+            f"{_MAX_CONSECUTIVE_SHORT_RUNS} consecutive "
+            f"runs ended within "
+            f"{_SHORT_RUN_THRESHOLD_S:.0f}s "
+            f"(persistent poison message suspected)"
+        )
+
+        assert cap_message.startswith(CRASH_LOOP_FATAL_PREFIX)
+        assert (
+            _classify_fcm_fatal(cap_message) == _FCM_FATAL_CLASS_CRASH_LOOP_EXCLUDED
+        )

--- a/tests/test_coordinator_registry_basics.py
+++ b/tests/test_coordinator_registry_basics.py
@@ -1,0 +1,863 @@
+# tests/test_coordinator_registry_basics.py
+"""Branch-coverage tests for ``RegistryOperations`` mixin methods M1-M14 + M17.
+
+PR 1.A.1b (AP-1.1a-β). Scope: ``coordinator/registry.py`` lines 121-499
+(M1-M14) and lines 1289-1293 (M17). M15/M16/M18 land in PR 1.A.2.
+
+Aniche-style adequacy progression: Specification → Boundary → Structural.
+:class:`RegistryStub` (``tests.helpers.registry_mixin_stub``) seeds every
+attribute ``_MixinBase`` declares and pre-mocks the cross-mixin
+``NotImplementedError`` traps (notes sidecar risk R-NEU-3).
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.const import (
+    DOMAIN,
+    LEGACY_SERVICE_IDENTIFIER,
+    SERVICE_DEVICE_IDENTIFIER_PREFIX,
+)
+from custom_components.googlefindmy.coordinator import registry as registry_mod
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.registry_mixin_stub import (
+    RegistryStub,
+    _DevRegStub,
+    _EntRegStub,
+    make_hass_stub,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def coord() -> RegistryStub:
+    """Return a default :class:`RegistryStub` bound to a synthetic config entry."""
+
+    entry = make_config_entry(entry_id="entry-xyz")
+    return RegistryStub(hass=make_hass_stub(), config_entry=entry)
+
+
+@pytest.fixture
+def coord_no_entry() -> RegistryStub:
+    """Return a stub without a bound ``ConfigEntry`` (early-startup state)."""
+
+    return RegistryStub(hass=make_hass_stub(), config_entry=None)
+
+
+# ---------------------------------------------------------------------------
+# M14 ``_redact_text`` (3 documented branches) — start with the trivial Pure
+# function so a smoke failure surfaces as a stub problem, not a Mixin issue.
+# ---------------------------------------------------------------------------
+
+
+class TestRedactText:
+    """B1: ``None``/empty → ``''``; B2: short → identity; B3: long → truncated."""
+
+    def test_none_returns_empty(self, coord: RegistryStub) -> None:
+        assert coord._redact_text(None) == ""
+
+    def test_empty_string_returns_empty(self, coord: RegistryStub) -> None:
+        # `not value` short-circuits on the empty string (falsy);
+        # whitespace-only strings are truthy and pass through unchanged.
+        assert coord._redact_text("") == ""
+
+    @pytest.mark.parametrize("value", ["   ", "\t"])
+    def test_whitespace_is_truthy_and_passes_through(
+        self, coord: RegistryStub, value: str
+    ) -> None:
+        # Documents the current contract: only Python-falsy values short-circuit.
+        # Whitespace strings are returned verbatim (no .strip() in production).
+        assert coord._redact_text(value) == value
+
+    def test_short_returns_identity(self, coord: RegistryStub) -> None:
+        assert coord._redact_text("hello") == "hello"
+
+    def test_long_is_truncated_with_ellipsis(self, coord: RegistryStub) -> None:
+        long = "x" * 200
+        out = coord._redact_text(long, max_len=120)
+        assert out == "x" * 120 + "…"
+        assert len(out) == 121  # 120 chars + ellipsis
+
+    def test_default_max_len_is_120(self, coord: RegistryStub) -> None:
+        assert coord._redact_text("x" * 121).endswith("…")
+        assert coord._redact_text("x" * 120) == "x" * 120
+
+
+# ---------------------------------------------------------------------------
+# M12 ``_entry_id`` (3 branches) + M13 ``_config_entry_exists`` (5 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestEntryId:
+    """B1: no entry → None; B2: entry without entry_id → None; B3: present → str."""
+
+    def test_no_entry_returns_none(self, coord_no_entry: RegistryStub) -> None:
+        assert coord_no_entry._entry_id() is None
+
+    def test_entry_without_attr_returns_none(self) -> None:
+        coord = RegistryStub(config_entry=SimpleNamespace())  # no entry_id attr
+        assert coord._entry_id() is None
+
+    def test_entry_with_id_returns_str(self, coord: RegistryStub) -> None:
+        assert coord._entry_id() == "entry-xyz"
+
+
+class TestConfigEntryExists:
+    """5 branches: missing id, no hass, getter ok/None/raises."""
+
+    def test_no_entry_id_returns_false(self, coord_no_entry: RegistryStub) -> None:
+        coord_no_entry.hass = None
+        assert coord_no_entry._config_entry_exists() is False
+
+    def test_no_hass_returns_true_defensively(self, coord: RegistryStub) -> None:
+        coord.hass = None
+        assert coord._config_entry_exists() is True
+
+    def test_getter_returns_entry(self, coord: RegistryStub) -> None:
+        coord.hass.config_entries.async_get_entry = MagicMock(
+            return_value=SimpleNamespace(entry_id="entry-xyz")
+        )
+        assert coord._config_entry_exists() is True
+
+    def test_getter_returns_none(self, coord: RegistryStub) -> None:
+        coord.hass.config_entries.async_get_entry = MagicMock(return_value=None)
+        assert coord._config_entry_exists() is False
+
+    def test_getter_raises_returns_true_defensively(
+        self, coord: RegistryStub
+    ) -> None:
+        def _boom(_eid: str) -> Any:
+            raise RuntimeError("registry corrupted")
+
+        coord.hass.config_entries.async_get_entry = _boom
+        assert coord._config_entry_exists() is True
+
+    def test_no_callable_getter_returns_true(self, coord: RegistryStub) -> None:
+        coord.hass.config_entries.async_get_entry = "not-callable"
+        assert coord._config_entry_exists() is True
+
+    def test_explicit_entry_id_argument(self, coord: RegistryStub) -> None:
+        coord.hass.config_entries.async_get_entry = MagicMock(return_value=object())
+        assert coord._config_entry_exists("custom-id") is True
+        coord.hass.config_entries.async_get_entry.assert_called_once_with("custom-id")
+
+
+# ---------------------------------------------------------------------------
+# M9 ``_ensure_device_name_cache`` (2 branches) + M10 ``_apply_pending_via_updates``
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureDeviceNameCache:
+    """B1: not initialized → fresh dict; B2: initialized → identity."""
+
+    def test_first_call_initializes_empty_dict(self, coord: RegistryStub) -> None:
+        cache = coord._ensure_device_name_cache()
+        assert cache == {}
+        assert coord._device_names is cache
+
+    def test_second_call_returns_same_object(self, coord: RegistryStub) -> None:
+        first = coord._ensure_device_name_cache()
+        first["abc"] = "Alice"
+        second = coord._ensure_device_name_cache()
+        assert second is first
+        assert second["abc"] == "Alice"
+
+
+class TestApplyPendingViaUpdates:
+    """M10 is a documented no-op for backward compatibility."""
+
+    def test_returns_none_without_side_effects(self, coord: RegistryStub) -> None:
+        snapshot = vars(coord).copy()
+        assert coord._apply_pending_via_updates() is None
+        assert vars(coord) == snapshot
+
+
+# ---------------------------------------------------------------------------
+# M11 ``_device_display_name`` (passthrough)
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceDisplayName:
+    """Passes through to ``extract_device_display_name`` helper."""
+
+    def test_prefers_name_by_user(self, coord: RegistryStub) -> None:
+        dev = SimpleNamespace(name_by_user="Custom", name="Default")
+        assert coord._device_display_name(dev, "fallback") == "Custom"
+
+    def test_falls_back_to_name(self, coord: RegistryStub) -> None:
+        dev = SimpleNamespace(name_by_user=None, name="Default")
+        assert coord._device_display_name(dev, "fallback") == "Default"
+
+    def test_uses_fallback_when_both_empty(self, coord: RegistryStub) -> None:
+        dev = SimpleNamespace(name_by_user=None, name=None)
+        assert coord._device_display_name(dev, "fallback") == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# M3 ``_device_registry_build_legacy_kwargs`` (delegation) + M2 retry detection
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLegacyKwargs:
+    """Static-passthrough to ``build_legacy_device_registry_kwargs``."""
+
+    def test_translates_modern_keys(self) -> None:
+        out = RegistryStub._device_registry_build_legacy_kwargs(
+            {"add_config_entry_id": "e1", "add_config_subentry_id": "s1"}
+        )
+        assert out == {"config_entry_id": "e1", "config_subentry_id": "s1"}
+
+    def test_drops_remove_config_subentry_id(self) -> None:
+        out = RegistryStub._device_registry_build_legacy_kwargs(
+            {"remove_config_subentry_id": "s1", "name": "Phone"}
+        )
+        assert out == {"name": "Phone"}
+
+    def test_does_not_mutate_input(self) -> None:
+        original = {"add_config_entry_id": "e1"}
+        RegistryStub._device_registry_build_legacy_kwargs(original)
+        assert original == {"add_config_entry_id": "e1"}
+
+
+class TestKwargsNeedLegacyRetry:
+    """Delegates to ``needs_legacy_kwarg_retry`` helper after kwarg-name lookup."""
+
+    def test_modern_registry_does_not_retry(self, coord: RegistryStub) -> None:
+        def modern_api(*, add_config_subentry_id: str | None = None) -> None: ...
+
+        err = TypeError("add_config_subentry_id rejected")
+        assert (
+            coord._device_registry_kwargs_need_legacy_retry(
+                modern_api, err, {"add_config_subentry_id": "s1"}
+            )
+            is False
+        )
+
+    def test_legacy_registry_triggers_retry(self, coord: RegistryStub) -> None:
+        def legacy_api(*, config_subentry_id: str | None = None) -> None: ...
+
+        err = TypeError("got unexpected keyword argument 'add_config_entry_id'")
+        assert (
+            coord._device_registry_kwargs_need_legacy_retry(
+                legacy_api, err, {"add_config_entry_id": "e1"}
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# M4 ``_device_registry_config_subentry_kwarg_name`` (7+ branches)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSubentryKwargName:
+    """Cover signature-based detection, caching, and defensive fallbacks."""
+
+    def test_returns_config_subentry_id_when_present(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(*, config_subentry_id: str | None = None) -> None: ...
+
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(api)
+            == "config_subentry_id"
+        )
+
+    def test_returns_add_config_subentry_id_when_present(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(*, add_config_subentry_id: str | None = None) -> None: ...
+
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(api)
+            == "add_config_subentry_id"
+        )
+
+    def test_var_keyword_returns_config_subentry_id(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(**kwargs: Any) -> None: ...
+
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(api)
+            == "config_subentry_id"
+        )
+
+    def test_unrelated_signature_returns_none(self, coord: RegistryStub) -> None:
+        def api(a: int, b: int) -> None: ...
+
+        assert coord._device_registry_config_subentry_kwarg_name(api) is None
+
+    def test_signature_typeerror_returns_none(
+        self, coord: RegistryStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def api() -> None: ...
+
+        def _raise(_call: Any) -> Any:
+            raise TypeError("C extension")
+
+        monkeypatch.setattr(inspect, "signature", _raise)
+        assert coord._device_registry_config_subentry_kwarg_name(api) is None
+
+    def test_signature_valueerror_returns_none(
+        self, coord: RegistryStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def api() -> None: ...
+
+        def _raise(_call: Any) -> Any:
+            raise ValueError("no signature")
+
+        monkeypatch.setattr(inspect, "signature", _raise)
+        assert coord._device_registry_config_subentry_kwarg_name(api) is None
+
+    def test_cache_hit_avoids_second_signature_call(
+        self, coord: RegistryStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def api(*, config_subentry_id: str | None = None) -> None: ...
+
+        original_signature = inspect.signature
+        call_count = {"n": 0}
+
+        def _counting(call: Any) -> Any:
+            call_count["n"] += 1
+            return original_signature(call)
+
+        monkeypatch.setattr(inspect, "signature", _counting)
+
+        assert coord._device_registry_config_subentry_kwarg_name(api) == (
+            "config_subentry_id"
+        )
+        assert coord._device_registry_config_subentry_kwarg_name(api) == (
+            "config_subentry_id"
+        )
+        assert call_count["n"] == 1
+
+    def test_cache_resets_when_attribute_is_not_a_dict(
+        self, coord: RegistryStub
+    ) -> None:
+        coord._device_registry_config_subentry_kwarg_cache = "not-a-dict"  # type: ignore[assignment]
+
+        def api(*, config_subentry_id: str | None = None) -> None: ...
+
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(api)
+            == "config_subentry_id"
+        )
+        assert isinstance(coord._device_registry_config_subentry_kwarg_cache, dict)
+
+    def test_bound_method_uses_underlying_func_for_cache_key(
+        self, coord: RegistryStub
+    ) -> None:
+        class _Api:
+            def call(self, *, config_subentry_id: str | None = None) -> None: ...
+
+        a = _Api()
+        b = _Api()
+        # First call seeds the cache via the unbound function.
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(a.call)
+            == "config_subentry_id"
+        )
+        cache = coord._device_registry_config_subentry_kwarg_cache
+        assert isinstance(cache, dict)
+        assert len(cache) == 1
+        # Different bound instance, same underlying ``__func__`` → reuses entry.
+        assert (
+            coord._device_registry_config_subentry_kwarg_name(b.call)
+            == "config_subentry_id"
+        )
+        assert len(cache) == 1
+
+
+# ---------------------------------------------------------------------------
+# M5 ``_device_registry_allows_translation_update`` (5 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowsTranslationUpdate:
+    """Detect translation kwarg support in ``async_update_device``."""
+
+    def test_cached_true_returned_directly(self, coord: RegistryStub) -> None:
+        coord._device_registry_supports_translation_update = True
+        assert coord._device_registry_allows_translation_update(MagicMock()) is True
+
+    def test_cached_false_returned_directly(self, coord: RegistryStub) -> None:
+        coord._device_registry_supports_translation_update = False
+        assert coord._device_registry_allows_translation_update(MagicMock()) is False
+
+    def test_missing_update_helper_returns_false(
+        self, coord: RegistryStub
+    ) -> None:
+        dev_reg = SimpleNamespace()  # no async_update_device attribute
+        assert (
+            coord._device_registry_allows_translation_update(dev_reg) is False
+        )
+        assert coord._device_registry_supports_translation_update is False
+
+    def test_both_translation_params_returns_true(
+        self, coord: RegistryStub
+    ) -> None:
+        def async_update_device(
+            device_id: str,
+            *,
+            translation_key: str | None = None,
+            translation_placeholders: dict[str, str] | None = None,
+        ) -> None: ...
+
+        dev_reg = SimpleNamespace(async_update_device=async_update_device)
+        assert coord._device_registry_allows_translation_update(dev_reg) is True
+
+    def test_partial_translation_params_returns_false(
+        self, coord: RegistryStub
+    ) -> None:
+        def async_update_device(
+            device_id: str, *, translation_key: str | None = None
+        ) -> None: ...
+
+        dev_reg = SimpleNamespace(async_update_device=async_update_device)
+        assert (
+            coord._device_registry_allows_translation_update(dev_reg) is False
+        )
+
+    def test_signature_failure_returns_false(
+        self, coord: RegistryStub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        dev_reg = SimpleNamespace(async_update_device=lambda *a, **k: None)
+
+        def _raise(_call: Any) -> Any:
+            raise TypeError("C extension")
+
+        monkeypatch.setattr(inspect, "signature", _raise)
+        assert (
+            coord._device_registry_allows_translation_update(dev_reg) is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# M1 ``_call_device_registry_api`` (10 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestCallDeviceRegistryApi:
+    """B1..B10: kwargs handling, retry, fallback paths."""
+
+    def test_no_base_kwargs_calls_with_empty_kwargs(
+        self, coord: RegistryStub
+    ) -> None:
+        call = MagicMock(return_value="ok")
+        assert coord._call_device_registry_api(call) == "ok"
+        call.assert_called_once_with()
+
+    def test_config_subentry_dropped_when_replacement_is_none(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(*, name: str) -> str:
+            return f"name={name}"
+
+        result = coord._call_device_registry_api(
+            api,
+            base_kwargs={"name": "Phone", "config_subentry_id": "s1"},
+        )
+        assert result == "name=Phone"
+
+    def test_replacement_equal_to_config_subentry_id_no_rename(
+        self, coord: RegistryStub
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        def api(*, config_subentry_id: str) -> None:
+            captured["seen"] = config_subentry_id
+
+        coord._call_device_registry_api(api, base_kwargs={"config_subentry_id": "s1"})
+        assert captured == {"seen": "s1"}
+
+    def test_replacement_renames_kwarg(self, coord: RegistryStub) -> None:
+        captured: dict[str, Any] = {}
+
+        def api(*, add_config_subentry_id: str) -> None:
+            captured["seen"] = add_config_subentry_id
+
+        coord._call_device_registry_api(api, base_kwargs={"config_subentry_id": "s1"})
+        assert captured == {"seen": "s1"}
+
+    def test_typeerror_without_legacy_match_reraises(
+        self, coord: RegistryStub
+    ) -> None:
+        def api(*, name: str) -> None:
+            raise TypeError("unrelated error about 'name'")
+
+        with pytest.raises(TypeError, match="unrelated error"):
+            coord._call_device_registry_api(api, base_kwargs={"name": "Phone"})
+
+    def test_typeerror_with_legacy_match_triggers_retry(
+        self, coord: RegistryStub
+    ) -> None:
+        attempts: list[dict[str, Any]] = []
+
+        def api(**kwargs: Any) -> str:
+            attempts.append(kwargs.copy())
+            if "add_config_entry_id" in kwargs:
+                raise TypeError("got unexpected keyword 'add_config_entry_id'")
+            return "ok"
+
+        result = coord._call_device_registry_api(
+            api, base_kwargs={"add_config_entry_id": "e1"}
+        )
+        assert result == "ok"
+        assert len(attempts) == 2
+        assert attempts[0] == {"add_config_entry_id": "e1"}
+        assert attempts[1] == {"config_entry_id": "e1"}
+
+    def test_unknown_subentry_with_add_config_kwarg_reraises(
+        self, coord: RegistryStub
+    ) -> None:
+        from homeassistant.config_entries import UnknownSubEntry
+
+        def api(*, add_config_subentry_id: str | None = None) -> None:
+            raise UnknownSubEntry()
+
+        with pytest.raises(UnknownSubEntry):
+            coord._call_device_registry_api(
+                api, base_kwargs={"config_subentry_id": "missing"}
+            )
+
+    def test_unknown_subentry_without_config_subentry_id_reraises(
+        self, coord: RegistryStub
+    ) -> None:
+        from homeassistant.config_entries import UnknownEntry
+
+        def api(*, name: str) -> None:
+            raise UnknownEntry()
+
+        with pytest.raises(UnknownEntry):
+            coord._call_device_registry_api(api, base_kwargs={"name": "Phone"})
+
+    def test_unknown_subentry_with_legacy_kwarg_falls_back(
+        self, coord: RegistryStub
+    ) -> None:
+        from homeassistant.config_entries import UnknownSubEntry
+
+        attempts: list[dict[str, Any]] = []
+
+        def api(*, config_subentry_id: str | None = None, name: str = "") -> str:
+            attempts.append(
+                {"config_subentry_id": config_subentry_id, "name": name}
+            )
+            if config_subentry_id == "missing":
+                raise UnknownSubEntry()
+            return "ok"
+
+        result = coord._call_device_registry_api(
+            api,
+            base_kwargs={"name": "Phone", "config_subentry_id": "missing"},
+        )
+        assert result == "ok"
+        # First attempt with subentry, fallback without it.
+        assert attempts[0]["config_subentry_id"] == "missing"
+        assert attempts[1]["config_subentry_id"] is None
+        assert attempts[1]["name"] == "Phone"
+
+
+# ---------------------------------------------------------------------------
+# M7 ``_extract_our_identifier`` (3 branches)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractOurIdentifier:
+    """Walks ``device.identifiers``; first valid wins, else ``None``."""
+
+    def test_empty_identifiers_returns_none(self, coord: RegistryStub) -> None:
+        device = SimpleNamespace(identifiers=set())
+        assert coord._extract_our_identifier(device) is None
+
+    def test_only_foreign_identifiers_returns_none(
+        self, coord: RegistryStub
+    ) -> None:
+        device = SimpleNamespace(identifiers={("other-domain", "xyz")})
+        assert coord._extract_our_identifier(device) is None
+
+    def test_entry_scoped_identifier_returns_raw_device_id(
+        self, coord: RegistryStub
+    ) -> None:
+        device = SimpleNamespace(
+            identifiers={(DOMAIN, "entry-xyz:dev-1")}
+        )
+        assert coord._extract_our_identifier(device) == "dev-1"
+
+    def test_legacy_identifier_returns_device_id(
+        self, coord: RegistryStub
+    ) -> None:
+        device = SimpleNamespace(identifiers={(DOMAIN, "dev-legacy")})
+        assert coord._extract_our_identifier(device) == "dev-legacy"
+
+    def test_service_device_identifier_returns_none(
+        self, coord: RegistryStub
+    ) -> None:
+        # SERVICE_DEVICE_IDENTIFIER_PREFIX-based identifiers are not tracker IDs;
+        # the helper filters them out at parse time.
+        device = SimpleNamespace(
+            identifiers={
+                (DOMAIN, f"{SERVICE_DEVICE_IDENTIFIER_PREFIX}entry-xyz")
+            }
+        )
+        assert coord._extract_our_identifier(device) is None
+
+    def test_legacy_service_identifier_returns_none(
+        self, coord: RegistryStub
+    ) -> None:
+        device = SimpleNamespace(
+            identifiers={(DOMAIN, LEGACY_SERVICE_IDENTIFIER)}
+        )
+        assert coord._extract_our_identifier(device) is None
+
+
+# ---------------------------------------------------------------------------
+# M8 ``_sync_owner_index`` (8+ branches)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncOwnerIndex:
+    """Cover early-exit, defensive, prune, and overwrite-guard branches."""
+
+    def test_no_hass_returns_early(self, coord: RegistryStub) -> None:
+        coord.hass = None
+        # Should not raise.
+        coord._sync_owner_index([{"canonicalId": "abc"}])
+
+    def test_no_entry_id_returns_early(
+        self, coord_no_entry: RegistryStub
+    ) -> None:
+        coord_no_entry._sync_owner_index([{"canonicalId": "abc"}])
+        assert "device_owner_index" not in coord_no_entry.hass.data.get(DOMAIN, {})
+
+    def test_setdefault_error_does_not_raise(self) -> None:
+        coord = RegistryStub(
+            hass=make_hass_stub(with_setdefault_error=True),
+            config_entry=SimpleNamespace(entry_id="e1"),
+        )
+        # Defensive guard: error logged at DEBUG, no exception propagated.
+        coord._sync_owner_index([{"canonicalId": "abc"}])
+
+    def test_none_devices_is_no_op(self, coord: RegistryStub) -> None:
+        coord._sync_owner_index(None)
+        bucket = coord.hass.data.get(DOMAIN, {})
+        assert bucket.get("device_owner_index", {}) == {}
+
+    def test_canonical_id_field_wins(self, coord: RegistryStub) -> None:
+        coord._sync_owner_index(
+            [
+                {"canonicalId": "cid-1"},
+                {"canonical_id": "cid-2"},
+                {"id": "id-3"},
+                {"device_id": "id-4"},
+            ]
+        )
+        index = coord.hass.data[DOMAIN]["device_owner_index"]
+        assert index == {
+            "cid-1": "entry-xyz",
+            "cid-2": "entry-xyz",
+            "id-3": "entry-xyz",
+            "id-4": "entry-xyz",
+        }
+
+    def test_missing_id_skipped(self, coord: RegistryStub) -> None:
+        coord._sync_owner_index([{"unrelated": "value"}])
+        assert coord.hass.data.get(DOMAIN, {}).get("device_owner_index", {}) == {}
+
+    def test_non_string_canonical_is_coerced(self, coord: RegistryStub) -> None:
+        coord._sync_owner_index([{"id": 12345}])
+        assert (
+            coord.hass.data[DOMAIN]["device_owner_index"]["12345"] == "entry-xyz"
+        )
+
+    def test_empty_canonical_after_strip_skipped(
+        self, coord: RegistryStub
+    ) -> None:
+        coord._sync_owner_index([{"id": "   "}])
+        assert coord.hass.data.get(DOMAIN, {}).get("device_owner_index", {}) == {}
+
+    def test_existing_owner_from_other_entry_not_overwritten(
+        self, coord: RegistryStub
+    ) -> None:
+        coord.hass.data[DOMAIN] = {
+            "device_owner_index": {"shared": "entry-other"}
+        }
+        coord._sync_owner_index([{"id": "shared"}])
+        assert (
+            coord.hass.data[DOMAIN]["device_owner_index"]["shared"]
+            == "entry-other"
+        )
+
+    def test_stale_entries_for_this_entry_are_pruned(
+        self, coord: RegistryStub
+    ) -> None:
+        coord.hass.data[DOMAIN] = {
+            "device_owner_index": {
+                "stale": "entry-xyz",
+                "fresh": "entry-xyz",
+                "other": "entry-other",
+            }
+        }
+        coord._sync_owner_index([{"id": "fresh"}])
+        index = coord.hass.data[DOMAIN]["device_owner_index"]
+        assert "stale" not in index  # pruned: belonged to this entry, not seen
+        assert index["fresh"] == "entry-xyz"
+        assert index["other"] == "entry-other"  # other entry never pruned
+
+
+# ---------------------------------------------------------------------------
+# M6 ``_reindex_poll_targets_from_device_registry`` (7 branches + cross-call)
+# ---------------------------------------------------------------------------
+
+
+class TestReindexPollTargets:
+    """Drive every documented branch via monkeypatched dr/er modules."""
+
+    @pytest.fixture
+    def reindex_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[_DevRegStub, _EntRegStub]:
+        dev_reg = _DevRegStub()
+        ent_reg = _EntRegStub()
+        monkeypatch.setattr(registry_mod.dr, "async_get", lambda _hass: dev_reg)
+        monkeypatch.setattr(registry_mod.er, "async_get", lambda _hass: ent_reg)
+        monkeypatch.setattr(
+            registry_mod.dr,
+            "async_entries_for_config_entry",
+            lambda _reg, _eid: list(dev_reg.devices),
+        )
+        monkeypatch.setattr(
+            registry_mod.er,
+            "async_entries_for_config_entry",
+            lambda _reg, _eid: list(ent_reg.entries),
+        )
+        return dev_reg, ent_reg
+
+    def test_no_entry_id_resets_sets_and_returns(
+        self,
+        coord_no_entry: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        coord_no_entry._devices_with_entry = {"stale"}
+        coord_no_entry._enabled_poll_device_ids = {"stale"}
+        coord_no_entry._reindex_poll_targets_from_device_registry()
+        assert coord_no_entry._devices_with_entry == set()
+        assert coord_no_entry._enabled_poll_device_ids == set()
+        coord_no_entry._refresh_subentry_index.assert_not_called()
+
+    def test_happy_path_two_devices_one_enabled(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:tracker-1")})
+        d2 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:tracker-2")})
+        ent_reg.add_entry(device_id=d1.id)
+        # d2 has no entity → present but not enabled.
+        # d1 has tracker entity → enabled.
+
+        coord._reindex_poll_targets_from_device_registry()
+
+        assert coord._devices_with_entry == {"tracker-1", "tracker-2"}
+        assert coord._enabled_poll_device_ids == {"tracker-1"}
+        coord._refresh_subentry_index.assert_called_once()
+        coord._schedule_eid_resolver_refresh.assert_called_once()
+        # Silence unused-fixture warning.
+        assert d2.id in {dev.id for dev in dev_reg.devices}
+
+    def test_disabled_entity_does_not_enable_device(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:t1")})
+        ent_reg.add_entry(device_id=d1.id, disabled_by="user")
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._devices_with_entry == {"t1"}
+        assert coord._enabled_poll_device_ids == set()
+
+    def test_wrong_platform_entity_skipped(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:t1")})
+        ent_reg.add_entry(platform="other", device_id=d1.id)
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._enabled_poll_device_ids == set()
+
+    def test_wrong_domain_entity_skipped(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(identifiers={(DOMAIN, "entry-xyz:t1")})
+        ent_reg.add_entry(domain="sensor", device_id=d1.id)
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._enabled_poll_device_ids == set()
+
+    def test_disabled_device_present_but_not_enabled(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, ent_reg = reindex_env
+        d1 = dev_reg.add_device(
+            identifiers={(DOMAIN, "entry-xyz:t1")}, disabled_by="user"
+        )
+        ent_reg.add_entry(device_id=d1.id)
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._devices_with_entry == {"t1"}
+        assert coord._enabled_poll_device_ids == set()
+
+    def test_device_without_known_identifier_skipped(
+        self,
+        coord: RegistryStub,
+        reindex_env: tuple[_DevRegStub, _EntRegStub],
+    ) -> None:
+        dev_reg, _ent_reg = reindex_env
+        dev_reg.add_device(identifiers={("other-domain", "stranger")})
+
+        coord._reindex_poll_targets_from_device_registry()
+        assert coord._devices_with_entry == set()
+
+
+# ---------------------------------------------------------------------------
+# M17 ``find_tracker_entity_entry`` (public wrapper)
+# ---------------------------------------------------------------------------
+
+
+class TestFindTrackerEntityEntry:
+    """Wraps :meth:`_find_tracker_entity_entry`; pure delegation."""
+
+    def test_passes_device_id_and_returns_result(
+        self, coord: RegistryStub
+    ) -> None:
+        sentinel = SimpleNamespace(entity_id="device_tracker.x")
+        coord._find_tracker_entity_entry = MagicMock(return_value=sentinel)  # type: ignore[method-assign]
+
+        assert coord.find_tracker_entity_entry("dev-1") is sentinel
+        coord._find_tracker_entity_entry.assert_called_once_with("dev-1")
+
+    def test_returns_none_when_inner_returns_none(
+        self, coord: RegistryStub
+    ) -> None:
+        coord._find_tracker_entity_entry = MagicMock(return_value=None)  # type: ignore[method-assign]
+        assert coord.find_tracker_entity_entry("missing") is None

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -13,6 +13,9 @@ import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
+    CRASH_LOOP_FATAL_PREFIX,
+)
 from custom_components.googlefindmy.binary_sensor import GoogleFindMyPollingSensor
 from custom_components.googlefindmy.const import (
     CONF_GOOGLE_EMAIL,
@@ -245,6 +248,91 @@ def test_global_fatal_error_ignored_for_clean_entry(
     assert result == []
     assert coordinator.auth_error_active is False
     assert coordinator.hass.bus.fired == []
+
+
+# --------------------------------------------------------------------------
+# AP7 / CA-6: re-auth-escalation dispatch wiring for the crash-loop fatal.
+#
+# cov-integ's ``test_coordinator_polling_fatal_channel.py`` only pins the
+# pure ``_classify_fcm_fatal`` function (RV-G3q scenarios a+b). It never
+# drives ``_async_update_data``, so a regression that re-wires the
+# CRASH_LOOP_EXCLUDED branch back into the re-auth path (the #1086
+# channel-confusion bug, RV-G3q) would not turn any cov-integ test red.
+# These two tests pin the consumer-branch wiring (RV-G3q scenarios c+d):
+#   (c) no ConfigEntryAuthFailed / no auth-error flip for a cap fatal;
+#   (d) a crash-loop fatal resets a stale transient auth-error count.
+# --------------------------------------------------------------------------
+
+
+def test_crash_loop_fatal_excluded_from_reauth_escalation(
+    coordinator: GoogleFindMyCoordinator, dummy_api: _DummyAPI
+) -> None:
+    """AP7/CA-6 (c): a supervisor short-run-cap fatal must NOT escalate to re-auth.
+
+    The FCM receiver's poison-message cap publishes its terminal state into
+    the same ``_fatal_errors`` map the re-auth escalation consumes. Polling
+    ``_async_update_data`` well past ``_FCM_ERROR_RETRY_THRESHOLD`` with a
+    ``CRASH_LOOP_FATAL_PREFIX`` fatal must never raise ConfigEntryAuthFailed
+    nor flip the auth-error state.
+    """
+    fatal_error = f"{CRASH_LOOP_FATAL_PREFIX} entry abc stopped after 10 short runs"
+
+    class _DummyFcm:
+        def __init__(self, message: str) -> None:
+            self._fatal_error = message
+            self._fatal_errors = {coordinator.config_entry.entry_id: message}
+
+    dummy_api.fcm = _DummyFcm(fatal_error)
+    dummy_api.device_list = [{"id": "dev-1", "name": "Device"}]
+    coordinator.config_entry.runtime_data = SimpleNamespace(
+        coordinator=coordinator, fcm_receiver=dummy_api.fcm
+    )
+    coordinator._is_fcm_ready_soft = lambda: False
+
+    loop = coordinator.hass.loop
+    # Five cycles is comfortably past the threshold (3); no escalation allowed.
+    for _ in range(5):
+        result = loop.run_until_complete(coordinator._async_update_data())
+        assert result == []
+
+    assert coordinator.auth_error_active is False
+    assert coordinator.hass.bus.fired == []
+    assert coordinator._fcm_error_count == 0
+
+
+def test_crash_loop_fatal_resets_stale_auth_error_count(
+    coordinator: GoogleFindMyCoordinator, dummy_api: _DummyAPI
+) -> None:
+    """AP7/CA-6 (d): a crash-loop fatal resets a stale transient auth-error count.
+
+    A partial count left over from earlier transient (non-cap) auth fatals
+    must not let a later real auth fatal inherit the crash-loop window's
+    count and escalate prematurely.
+    """
+    fatal_error = f"{CRASH_LOOP_FATAL_PREFIX} entry abc stopped after 10 short runs"
+
+    class _DummyFcm:
+        def __init__(self, message: str) -> None:
+            self._fatal_error = message
+            self._fatal_errors = {coordinator.config_entry.entry_id: message}
+
+    dummy_api.fcm = _DummyFcm(fatal_error)
+    dummy_api.device_list = [{"id": "dev-1", "name": "Device"}]
+    coordinator.config_entry.runtime_data = SimpleNamespace(
+        coordinator=coordinator, fcm_receiver=dummy_api.fcm
+    )
+    coordinator._is_fcm_ready_soft = lambda: False
+    # Simulate two prior transient (non-cap) auth-error cycles.
+    coordinator._fcm_error_count = 2
+    coordinator._fcm_last_error = "GCM Registration failed (401): transient"
+
+    loop = coordinator.hass.loop
+    result = loop.run_until_complete(coordinator._async_update_data())
+
+    assert result == []
+    assert coordinator._fcm_error_count == 0
+    assert coordinator._fcm_last_error is None
+    assert coordinator.auth_error_active is False
 
 
 def test_api_status_recovers_after_success(

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -1,0 +1,1589 @@
+# tests/test_fcm_receiver_ha_short_run_cap.py
+"""Defense-2 regression tests for the FCM supervisor short-run crash cap.
+
+Covers PLAN_HOTFIX_FCM_CASCADING_FAILURE AP-2 (`fcm_receiver_ha.py`):
+- 7 building-block tests (threshold trigger, break, reset, re-registration,
+  per-entry independence, orthogonality to `_fatal_retry_counts`, unload-cleanup)
+- 1 boundary test that pins `<` vs. `<=` drift on `_SHORT_RUN_THRESHOLD_S`
+- 1 cross-locale symmetry test for the `fcm_short_run_crash_loop` translation key
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth import fcm_receiver_ha
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
+    _MAX_CONSECUTIVE_SHORT_RUNS,
+    _SHORT_RUN_THRESHOLD_S,
+    DOMAIN,
+    FcmReceiverHA,
+)
+
+
+class _MonoClock:
+    """Stateful auto-increment monotonic clock for deterministic run-duration math.
+
+    Each call returns ``value`` then advances by ``step``. ``jump(seconds)``
+    skips ahead without consuming a call slot (used to simulate a long run
+    between ``entry_start`` and the run-duration check).
+    """
+
+    def __init__(self, step: float = 0.01) -> None:
+        self.value = 0.0
+        self.step = step
+
+    def __call__(self) -> float:
+        v = self.value
+        self.value += self.step
+        return v
+
+    def jump(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class _SupervisorPushClientStub:
+    """Lightweight ``FcmPushClient`` substitute for supervisor-loop tests.
+
+    Mirrors only the surface the supervisor reads/writes (``start``, ``stop``,
+    ``run_state``, ``do_listen``, ``_observe_counter``).
+
+    Two clock-injection hooks model the supervisor's snapshot boundary
+    correctly:
+
+    * ``jump_on_start`` advances the clock inside ``start()`` BEFORE the
+      supervisor takes the ``entry_start`` snapshot (Z. 960). It models
+      pre-monitor elapsed time and does NOT influence ``run_duration``.
+    * ``jump_on_run_state_read`` advances the clock on the first
+      ``pc.run_state`` access INSIDE the monitor loop (Z. 964), which is
+      AFTER the ``entry_start`` snapshot. It is the only correct way to
+      inject elapsed-run time that ``run_duration = time.monotonic() -
+      entry_start`` actually observes. Use this for boundary math.
+
+    Iter-11 ``become_started``: defaults to ``True`` so the first
+    ``run_state`` read returns ``FcmPushClientRunState.STARTED`` (setting
+    the supervisor's per-run ``became_started`` latch) and the second
+    read returns ``None`` (forcing the ``state is None`` break path on
+    the next iteration with ``last_activity is None``). This mirrors the
+    poison-message scenario the cap is designed to catch: client
+    connects, decodes, dies, repeat. Set ``become_started=False`` to
+    model a pre-start failure (MCS unreachable / login failed) where the
+    client NEVER reaches ``STARTED`` and the cap MUST NOT advance the
+    counter.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: _MonoClock | None = None,
+        jump_on_start: float = 0.0,
+        jump_on_run_state_read: float = 0.0,
+        become_started: bool = True,
+        has_been_started: bool | None = None,
+    ) -> None:
+        self.clock = clock
+        self.jump_on_start = jump_on_start
+        self.jump_on_run_state_read = jump_on_run_state_read
+        self.become_started = become_started
+        # Iter-12 ``has_been_started``: mirrors the production subclass'
+        # ``_has_been_started`` latch which is set by the vendored
+        # library the moment ``run_state = STARTED`` is assigned,
+        # independent of polling cadence. Default mirrors
+        # ``become_started`` so existing tests behave as before; pass
+        # explicitly to model the micro-window crash scenario
+        # (``become_started=False, has_been_started=True``: client
+        # reached STARTED and crashed before the first monitor poll)
+        # or a true pre-start failure
+        # (``become_started=False, has_been_started=False``: client
+        # never reached STARTED at all).
+        if has_been_started is None:
+            has_been_started = become_started
+        self._has_been_started = has_been_started
+        self.do_listen = True
+        self.start_calls = 0
+        self.stop_calls = 0
+        self._observed_short_run_counter: int | None = None
+        self._run_state_reads = 0
+
+    @property
+    def run_state(self):  # noqa: D401 - mirror attribute access
+        self._run_state_reads += 1
+        if (
+            self._run_state_reads == 1
+            and self.clock is not None
+            and self.jump_on_run_state_read
+        ):
+            self.clock.jump(self.jump_on_run_state_read)
+        if self.become_started and self._run_state_reads == 1:
+            from custom_components.googlefindmy.Auth.firebase_messaging import (
+                FcmPushClientRunState,
+            )
+
+            return FcmPushClientRunState.STARTED
+        # Implicit ``None`` return forces the ``state is None`` break path
+        # in the supervisor monitor loop on the next iteration. With
+        # ``become_started=True`` this also gives ``last_activity is
+        # None`` break exactly one iteration AFTER ``STARTED`` was
+        # observed, which is the poison-message run shape (client
+        # connects, no message processed, restart).
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        if self.clock is not None and self.jump_on_start:
+            self.clock.jump(self.jump_on_start)
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+
+    def _observe_counter(self, counter: int) -> None:
+        # Last writer wins so tests observe the most recent supervisor pass.
+        self._observed_short_run_counter = counter
+
+
+def _install_supervisor_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    receiver: FcmReceiverHA,
+    *,
+    clock: _MonoClock,
+    ensure_clients: list,
+) -> AsyncMock:
+    """Wire the common supervisor-loop mock surface and return the register mock."""
+
+    monkeypatch.setattr(fcm_receiver_ha.time, "monotonic", clock)
+
+    ensure_iter = iter(ensure_clients)
+
+    async def _ensure(entry_id: str, cache):  # noqa: ARG001
+        # Codex Iter-7 (PR #1086): modelling exhaustion as ``None`` mirrors
+        # production's ``if not pc`` path, which is designed to back off and
+        # retry **forever**. The non-cap tests (long-run reset,
+        # re-registration, entry-B independence, 30s boundary) all rely on
+        # natural supervisor completion after the configured client list is
+        # exhausted, so we MUST stop the supervisor explicitly here instead
+        # of falling into the retry-forever branch (CA-TEST-TERMINATION-001).
+        try:
+            return next(ensure_iter)
+        except StopIteration:
+            stop_evt = receiver._stop_evts.get(entry_id)
+            if stop_evt is not None:
+                stop_evt.set()
+            return None
+
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
+
+    register_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        fcm_receiver_ha.random, "uniform", lambda *_a, **_kw: 0.0
+    )
+
+    real_wait_for = asyncio.wait_for
+
+    async def _instant_wait_for(fut, *, timeout=None):
+        if timeout is not None and timeout > 0:
+            coro_name = getattr(fut, "__name__", "") or getattr(
+                getattr(fut, "cr_code", None), "co_name", ""
+            )
+            if coro_name == "wait":
+                if asyncio.iscoroutine(fut):
+                    fut.close()
+                raise TimeoutError
+        return await real_wait_for(fut, timeout=timeout)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "wait_for", _instant_wait_for)
+    return register_mock
+
+
+def _install_ir_capture(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, MagicMock]:
+    """Capture ``ir.async_create_issue`` and ``ir.async_delete_issue`` calls."""
+
+    create_issue = MagicMock()
+    delete_issue = MagicMock()
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_delete_issue", delete_issue)
+    monkeypatch.setattr(
+        fcm_receiver_ha.ir,
+        "IssueSeverity",
+        SimpleNamespace(WARNING="warning", ERROR="error"),
+    )
+    return create_issue, delete_issue
+
+
+# --------------------------------------------------------------------------
+# Building blocks
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_short_run_triggers_repair_issue_after_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """10 short runs in one supervisor pass produce exactly one ERROR repair issue."""
+    entry_id = "entry-trigger"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)  # 1ms per call -> every run is short
+    clients = [_SupervisorPushClientStub(clock=clock) for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert register_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS
+    assert create_issue.call_count == 1
+    call = create_issue.call_args
+    assert call.args[1] == DOMAIN
+    assert call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    assert call.kwargs["is_fixable"] is False
+    assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.ERROR
+    assert call.kwargs["translation_key"] == "fcm_short_run_crash_loop"
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_short_run_break_after_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The supervisor task completes after the 10th short run (no further iters)."""
+    entry_id = "entry-break"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # Provide more clients than the threshold to detect "loop kept going".
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS + 5)
+    ]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert receiver.supervisors[entry_id].done()
+    assert register_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS
+
+
+@pytest.mark.asyncio
+async def test_long_run_resets_closure_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """9 short + 1 long + 9 short runs must not trigger the threshold."""
+    entry_id = "entry-reset"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # Build 19 clients: short, short, ..., LONG at index 9, short, short, ...
+    # The LONG run must use ``jump_on_run_state_read`` (not ``jump_on_start``)
+    # so the 60s elapse AFTER the supervisor captures ``entry_start`` at
+    # Z. 960; otherwise the jump is consumed by the snapshot itself and
+    # ``run_duration`` collapses to ~0, making this run count as short.
+    clients = []
+    for idx in range(19):
+        if idx == 9:
+            clients.append(
+                _SupervisorPushClientStub(
+                    clock=clock, jump_on_run_state_read=60.0
+                )
+            )
+        else:
+            clients.append(_SupervisorPushClientStub(clock=clock))
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # No repair issue: the long run at index 9 resets the counter, so the
+    # remaining 9 short runs never reach the threshold of 10.
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+    assert register_mock.await_count == 19
+
+
+@pytest.mark.asyncio
+async def test_re_registration_does_not_inherit_old_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled supervisor's counter must not bleed into a fresh supervisor."""
+    entry_id = "entry-rereg"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # First supervisor: 9 short runs then we cancel.
+    clients_first = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(9)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients_first
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    # Run the first supervisor to natural completion (runs out of clients).
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+    # Pre-condition: 9 short runs did NOT trigger the cap.
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+    # Remove the spent stop_evt so a fresh supervisor can start.
+    receiver._stop_evts.pop(entry_id, None)
+    receiver.supervisors.pop(entry_id, None)
+
+    # Second supervisor: 9 more short runs. If the counter were shared, the
+    # combined 18 runs would have crossed the threshold and re-fired.
+    clients_second = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(9)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients_second
+    )
+    create_issue_b, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue_b.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+
+@pytest.mark.asyncio
+async def test_per_entry_supervisors_independent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entry A crash-loops, entry B stays healthy: only A produces a repair issue."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock_a = _MonoClock(step=0.001)
+    clock_b = _MonoClock(step=0.001)
+    # Entry A: 10 short runs (will trip the cap).
+    clients_a = [_SupervisorPushClientStub(clock=clock_a) for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)]
+    # Entry B: 5 healthy long runs (well above threshold).
+    # ``jump_on_run_state_read`` (not ``jump_on_start``) is required so the
+    # 60s elapse AFTER ``entry_start`` snapshot at Z. 960 and actually mark
+    # each run as a long run; otherwise the test passes only by accident
+    # because 5 short runs also stay below the cap of 10.
+    clients_b = [
+        _SupervisorPushClientStub(clock=clock_b, jump_on_run_state_read=60.0)
+        for _ in range(5)
+    ]
+
+    # Single shared monkeypatch fixture but per-receiver wiring.
+    # We can't run both supervisors against the same monkeypatched function,
+    # so we sequence A then B.
+    register_a = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock_a, ensure_clients=clients_a
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry("entry-a", None)
+    await asyncio.wait_for(receiver.supervisors["entry-a"], timeout=5.0)
+
+    register_b = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock_b, ensure_clients=clients_b
+    )
+    await receiver._start_supervisor_for_entry("entry-b", None)
+    await asyncio.wait_for(receiver.supervisors["entry-b"], timeout=5.0)
+
+    # Exactly one issue was raised, and it targets entry A.
+    assert create_issue.call_count == 1
+    assert create_issue.call_args.args[2] == "fcm_short_run_crash_loop_entry-a"
+    assert receiver._fatal_errors.get("entry-a", "").startswith(
+        "FCM short-run crash loop"
+    )
+    assert "entry-b" not in receiver._fatal_errors
+    assert register_a.await_count == _MAX_CONSECUTIVE_SHORT_RUNS
+    assert register_b.await_count == 5
+
+
+@pytest.mark.asyncio
+async def test_fatal_retry_counts_orthogonal_to_short_run_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`_fatal_retry_counts` and the closure-counter advance independently.
+
+    A short run pumps the closure counter; a `FatalRegistrationError` from
+    the registration path pumps `_fatal_retry_counts`. They share no state
+    and must not double-fire the short-run repair issue.
+    """
+    from custom_components.googlefindmy.exceptions import FatalRegistrationError
+
+    entry_id = "entry-orthogonal"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [_SupervisorPushClientStub(clock=clock) for _ in range(6)]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    # Override register: first 5 successes (short runs), 6th raises fatal endpoint.
+    side_effects: list = [True, True, True, True, True]
+    err = FatalRegistrationError("registration failed")
+    err.is_auth_error = False  # endpoint path, not auth
+    side_effects.append(err)
+    register_mock = AsyncMock(side_effect=side_effects)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    # 6th iteration's FatalRegistrationError triggers endpoint path
+    # which retries up to _MAX_FATAL_ENDPOINT_RETRIES (7) before giving up.
+    # Refill register with the same error so the endpoint counter exhausts.
+    side_effects.extend([err] * 6)
+
+    # Bounded run via wait_for to avoid hanging on register-retry backoff.
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    try:
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+    except TimeoutError:  # noqa: PERF203 - test bounded fallback
+        receiver._stop_evts[entry_id].set()
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # The short-run counter reached 5 (< 10), so no short-run issue.
+    short_run_calls = [
+        c for c in create_issue.call_args_list
+        if c.args[2].startswith("fcm_short_run_crash_loop_")
+    ]
+    assert len(short_run_calls) == 0
+    # _fatal_retry_counts was incremented at least once by the endpoint path.
+    counter_key = f"{entry_id}:endpoint"
+    assert receiver._fatal_retry_counts.get(counter_key, 0) >= 1
+
+
+def test_unload_clears_fatal_errors_via_force() -> None:
+    """`_clear_fatal_error_for_entry(force=True)` (unload path) releases the latch.
+
+    Defense 2 iter-8: the unregister path must clear the cap latch alongside
+    the fatal-error map because the entry itself goes away. Without ``force``
+    the clear-path is a no-op while the latch is set (Codex second finding).
+    """
+    receiver = FcmReceiverHA()
+    receiver._fatal_errors["entry-unload"] = "FCM short-run crash loop: ..."
+    receiver._fatal_error = "FCM short-run crash loop: ..."
+    receiver._short_run_cap_latched.add("entry-unload")
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-unload", reason="Entry unregistered", force=True
+    )
+
+    assert "entry-unload" not in receiver._fatal_errors
+    assert "entry-unload" not in receiver._short_run_cap_latched
+    assert receiver._fatal_error is None
+
+
+# --------------------------------------------------------------------------
+# Defense 2 iter-8: cap-latch lifecycle (Codex second finding)
+# --------------------------------------------------------------------------
+#
+# Codex objected that the cap state lives in the same ``_fatal_errors`` map
+# that ``_register_for_fcm_entry`` unconditionally clears after a successful
+# registration. Registration is NOT a recovery proof for a poison-message
+# crash loop: only a real healthy supervisor run (>= 30s) shows that the
+# poisoned notification is gone. The tests below pin the new lifecycle
+# contract (CA-STATE-LIFECYCLE-ASYMMETRY-001):
+#
+#   * ``_short_run_cap_latched`` is set at cap-fire time alongside the
+#     ``_fatal_errors`` entry and the Repairs issue.
+#   * ``_clear_fatal_error_for_entry`` is a no-op while the latch is set
+#     (unless ``force=True`` is passed, which only the unregister path does).
+#   * Only the healthy-run branch of the supervisor loop releases the latch,
+#     pops the cap-related ``_fatal_errors`` entry, and re-derives the
+#     aggregate ``_fatal_error``.
+
+
+def test_clear_fatal_error_is_noop_while_cap_latched() -> None:
+    """Registration-success paths cannot drop the latch (Codex iter-8 finding 2)."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._fatal_errors["entry-latched"] = "FCM short-run crash loop: ..."
+    receiver._fatal_error = "FCM short-run crash loop: ..."
+    receiver._short_run_cap_latched.add("entry-latched")
+
+    # ``force`` defaults to ``False``: this is the path that
+    # ``_register_for_fcm_entry`` and the credential-update handler take.
+    receiver._clear_fatal_error_for_entry(
+        "entry-latched", reason="Registration succeeded"
+    )
+
+    # Nothing changed: the latch, the fatal-error map, and the aggregate
+    # all survive because the registration did not prove a healthy run.
+    assert "entry-latched" in receiver._short_run_cap_latched
+    assert receiver._fatal_errors["entry-latched"].startswith(
+        "FCM short-run crash loop"
+    )
+    assert receiver._fatal_error == "FCM short-run crash loop: ..."
+
+
+def test_clear_without_latch_still_clears_fatal_errors() -> None:
+    """Without an active cap latch, the clear-path behaves idempotently."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._fatal_errors["entry-clean"] = "FCM auth failed ..."
+    receiver._fatal_error = "FCM auth failed ..."
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-clean", reason="Registration succeeded"
+    )
+
+    assert "entry-clean" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+
+
+@pytest.mark.asyncio
+async def test_cap_fire_sets_short_run_cap_latched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cap-fire installs the latch alongside the fatal-error map and the issue."""
+    entry_id = "entry-cap-latch"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue.call_count == 1
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_cap_latch_survives_registration_success_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A simulated registration-success path cannot drop the latch.
+
+    Defense 2 iter-8 (Codex second finding): without the latch, a reload or
+    credential update after cap-fire would clear the fatal-error map and the
+    Repairs issue before the supervisor proved the poison message is gone,
+    leaving the user blind during the next 10-run burst.
+    """
+    entry_id = "entry-survive"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert entry_id in receiver._short_run_cap_latched
+    pre_message = receiver._fatal_errors[entry_id]
+
+    # Simulate ``_register_for_fcm_entry`` success path (Z. 1260) and the
+    # credential-update path (Z. 2069). Neither must release the latch.
+    receiver._clear_fatal_error_for_entry(
+        entry_id, reason="Registration succeeded"
+    )
+    receiver._clear_fatal_error_for_entry(
+        entry_id, reason="Credentials updated for entry"
+    )
+
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id] == pre_message
+
+
+# --------------------------------------------------------------------------
+# Defense 2 iter-10: cap-latch guard granularity (Codex follow-up finding)
+# --------------------------------------------------------------------------
+#
+# Codex objected that the iter-8 latch guard was unconditional and blocked
+# every later ``_clear_fatal_error_for_entry`` call while the latch was set.
+# Scenario: the cap fires, then the user reloads or re-registers; the new
+# registration hits a terminal 401/404 and overwrites ``_fatal_errors[entry_id]``
+# with a non-cap message; a credentials recovery later tries to clear that
+# fatal but is blocked by the latch guard, so the coordinator keeps seeing
+# the stale auth-fatal even after the underlying problem is fixed.
+#
+# CA-GUARD-GRANULARITY-001: the latch guard is now SELECTIVE:
+#
+#   * Latch active AND stored fatal IS the cap message
+#     -> full no-op (cap state + Repairs UI artefact preserved).
+#   * Latch active AND stored fatal is a NON-cap message
+#     -> clear the non-cap fatal, but keep the latch and the Repairs UI
+#        artefact (cap warning stays visible until a healthy run releases it).
+#   * Latch active AND no fatal stored
+#     -> full no-op (treat as cap-only state).
+#   * Latch not active OR force=True
+#     -> normal clear-all path (unchanged).
+
+
+def test_clear_clears_non_cap_fatal_while_cap_latched() -> None:
+    """Non-cap fatals must clear normally even while the cap latch is active.
+
+    Defense 2 iter-10 (Codex follow-up): the iter-8 guard was too broad and
+    blocked every clear-call, so a terminal 401/404 written into
+    ``_fatal_errors`` by a re-registration attempt after cap-fire could never
+    be dropped by a subsequent credentials recovery. The guard now blocks
+    only when the stored fatal IS the cap message; non-cap fatals are
+    dropped while latch and Repairs UI artefact stay in place.
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    # Cap is latched (set by an earlier cap-fire); a subsequent
+    # re-registration then overwrote the fatal map with a non-cap auth error.
+    receiver._short_run_cap_latched.add("entry-mixed")
+    receiver._fatal_errors["entry-mixed"] = (
+        "FCM registration failed: HTTP 401 Unauthorized"
+    )
+    receiver._fatal_error = "FCM registration failed: HTTP 401 Unauthorized"
+
+    # Credentials recovery path: ``_register_for_fcm_entry`` calls this after
+    # a new successful registration. The non-cap fatal MUST clear so the
+    # coordinator does not see a stale auth-fatal.
+    receiver._clear_fatal_error_for_entry(
+        "entry-mixed", reason="Credentials updated for entry"
+    )
+
+    # Non-cap fatal cleared.
+    assert "entry-mixed" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    # Cap latch SURVIVES: only a real healthy supervisor run may drop it.
+    assert "entry-mixed" in receiver._short_run_cap_latched
+
+
+def test_clear_preserves_repair_issue_when_clearing_non_cap_fatal() -> None:
+    """Clearing a non-cap fatal while latched must not delete the Repairs issue.
+
+    The Repairs UI artefact (``fcm_short_run_crash_loop_<entry_id>``) is the
+    user-visible cap warning. Dropping it during an unrelated credentials
+    recovery would invalidate the cap warning before the listener proves the
+    poison message is gone (the very failure mode iter-8 pinned).
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    deleted_issues: list[tuple[str, str]] = []
+
+    def fake_async_delete_issue(hass, domain: str, issue_id: str) -> None:
+        deleted_issues.append((domain, issue_id))
+
+    monkey = pytest.MonkeyPatch()
+    try:
+        monkey.setattr(
+            fcm_receiver_ha.ir, "async_delete_issue", fake_async_delete_issue
+        )
+
+        receiver._short_run_cap_latched.add("entry-keep-issue")
+        receiver._fatal_errors["entry-keep-issue"] = (
+            "FCM registration failed: HTTP 404 Not Found"
+        )
+        receiver._fatal_error = "FCM registration failed: HTTP 404 Not Found"
+
+        receiver._clear_fatal_error_for_entry(
+            "entry-keep-issue", reason="Credentials updated for entry"
+        )
+    finally:
+        monkey.undo()
+
+    # Non-cap fatal cleared but the Repairs UI artefact must remain (no
+    # ``async_delete_issue`` call for the cap issue id).
+    assert "entry-keep-issue" not in receiver._fatal_errors
+    assert deleted_issues == []
+    assert "entry-keep-issue" in receiver._short_run_cap_latched
+
+
+def test_clear_no_stored_fatal_while_latched_is_full_noop() -> None:
+    """Latch active and no fatal stored: full no-op, latch survives."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    receiver._short_run_cap_latched.add("entry-no-fatal")
+    # No entry in ``_fatal_errors``.
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-no-fatal", reason="Registration succeeded"
+    )
+
+    assert "entry-no-fatal" in receiver._short_run_cap_latched
+    assert "entry-no-fatal" not in receiver._fatal_errors
+
+
+# --------------------------------------------------------------------------
+# Iter-16 regression: latch-restoration on pass-through clear
+# (Codex 8cfd5b25 follow-up)
+# --------------------------------------------------------------------------
+#
+# Pinning contract for ``_short_run_cap_messages``:
+#   * Populated by the real cap-fire branch in ``_supervisor`` (snapshot of
+#     the user-visible cap message).
+#   * Restored into ``_fatal_errors[entry_id]`` by the pass-through clear
+#     branch in ``_clear_fatal_error_for_entry`` so the per-entry fatal
+#     stays visible to the coordinator/diag binary sensor across non-cap
+#     overwrites.
+#   * Dropped in lockstep with the latch in the two release paths:
+#       (a) ``force=True`` teardown
+#       (b) healthy-run cleanup branch in ``_supervisor``
+#
+# These are unit-tests of the helper contract (no supervisor loop).
+
+
+def test_iter16_pass_through_restores_cap_message_from_snapshot() -> None:
+    """Pass-through clear must restore the cap-fire snapshot.
+
+    Iter-16 (Codex follow-up on commit 8cfd5b25): without restoration the
+    coordinator and the diagnostic binary sensor lose visibility of the
+    cap-fatal state during the recovery/retry window even though
+    ``_short_run_cap_latched`` is still set.
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    cap_message = (
+        "FCM short-run crash loop: 10 consecutive runs ended within 30s "
+        "(persistent poison message suspected)"
+    )
+
+    # Simulate the state right after a cap fire + a later non-cap fatal
+    # overwriting the per-entry fatal map slot.
+    receiver._short_run_cap_latched.add("entry-restore")
+    receiver._short_run_cap_messages["entry-restore"] = cap_message
+    receiver._fatal_errors["entry-restore"] = (
+        "FCM registration failed: HTTP 401 Unauthorized"
+    )
+    receiver._fatal_error = "FCM registration failed: HTTP 401 Unauthorized"
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-restore", reason="Credentials updated for entry"
+    )
+
+    # The non-cap fatal is gone, the cap snapshot is restored, the latch
+    # and the snapshot cache survive (only a healthy run or force=True may
+    # drop them).
+    assert receiver._fatal_errors["entry-restore"] == cap_message
+    assert receiver._fatal_error == cap_message
+    assert "entry-restore" in receiver._short_run_cap_latched
+    assert receiver._short_run_cap_messages["entry-restore"] == cap_message
+
+
+def test_iter16_force_true_clear_drops_cap_message_snapshot() -> None:
+    """A force=True teardown must also drop the cap-fire snapshot."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    receiver._short_run_cap_latched.add("entry-force")
+    receiver._short_run_cap_messages["entry-force"] = (
+        "FCM short-run crash loop: ..."
+    )
+    receiver._fatal_errors["entry-force"] = (
+        "FCM short-run crash loop: ..."
+    )
+    receiver._fatal_error = "FCM short-run crash loop: ..."
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-force", reason="Unload", force=True
+    )
+
+    assert "entry-force" not in receiver._short_run_cap_latched
+    assert "entry-force" not in receiver._short_run_cap_messages
+    assert "entry-force" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+
+
+def test_iter16_pass_through_with_empty_snapshot_falls_back_to_iter10() -> None:
+    """When no snapshot was captured the iter-10 behaviour must survive.
+
+    Edge case: a stale latch is set manually (test harness) or the snapshot
+    was already dropped while the latch remained. The pass-through clear
+    must NOT fabricate a cap message - it simply clears the non-cap fatal
+    and lets the latch keep blocking future cap-fatal clears.
+    """
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    receiver._short_run_cap_latched.add("entry-empty-snapshot")
+    # NO entry in ``_short_run_cap_messages`` for this entry_id.
+    receiver._fatal_errors["entry-empty-snapshot"] = (
+        "FCM registration failed: HTTP 401 Unauthorized"
+    )
+    receiver._fatal_error = "FCM registration failed: HTTP 401 Unauthorized"
+
+    receiver._clear_fatal_error_for_entry(
+        "entry-empty-snapshot", reason="Credentials updated for entry"
+    )
+
+    # Iter-10 contract: non-cap fatal cleared, latch survives, no
+    # restoration because nothing was snapshotted.
+    assert "entry-empty-snapshot" not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    assert "entry-empty-snapshot" in receiver._short_run_cap_latched
+    assert "entry-empty-snapshot" not in receiver._short_run_cap_messages
+
+
+@pytest.mark.asyncio
+async def test_healthy_run_releases_cap_latch_and_fatal_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A healthy run (>= 30s) clears the latch, the fatal map entry, and the issue."""
+    entry_id = "entry-recover"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # 10 short runs trip the cap; one healthy run afterwards must release it.
+    # The healthy run is modelled as a long supervisor pass (jump after the
+    # ``entry_start`` snapshot via ``jump_on_run_state_read``).
+    short_clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    healthy_client = _SupervisorPushClientStub(
+        clock=clock, jump_on_run_state_read=60.0
+    )
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock,
+        ensure_clients=[*short_clients, healthy_client],
+    )
+    create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    # Phase 1: 10 short runs trip the cap and stop the supervisor.
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue.call_count == 1
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+    # Phase 2: simulate a reload (fresh stop_evt + fresh supervisor task).
+    receiver._stop_evts.pop(entry_id, None)
+    receiver.supervisors.pop(entry_id, None)
+
+    # The healthy run drops the latch from inside the supervisor loop's
+    # else branch (counter reset path).
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert entry_id not in receiver._short_run_cap_latched
+    assert entry_id not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    # Iter-16: the healthy-run cleanup branch must also retire the
+    # cap-fire snapshot so a later non-cap fatal cannot accidentally
+    # restore a stale cap message.
+    assert entry_id not in receiver._short_run_cap_messages
+    # The Repairs issue is deleted at least once on the healthy path.
+    delete_calls_for_entry = [
+        call
+        for call in delete_issue.call_args_list
+        if call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    ]
+    assert delete_calls_for_entry, (
+        "expected a delete_issue call for the short-run crash loop key"
+    )
+
+
+# --------------------------------------------------------------------------
+# Boundary test (Iteration-2-L3)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_long_run_boundary_exactly_30s_does_not_count_as_short(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`<` vs. `<=` drift sentry: run_duration == 30.0 must NOT count as short."""
+    assert _SHORT_RUN_THRESHOLD_S == 30.0  # pin the constant against silent drift
+
+    entry_id = "entry-boundary"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    # Frozen clock (``step=0.0``): every ``time.monotonic()`` call returns
+    # the same value unless ``.jump(seconds)`` is invoked. This is the only
+    # way to drive ``run_duration`` to *exactly* 30.0 — any auto-increment
+    # would push the read at Z. 1008 past the boundary by a few ``step``s
+    # and let an off-by-one bug (`<=` instead of `<`) hide inside the noise.
+    clock = _MonoClock(step=0.0)
+
+    # Critical ordering (Codex Iter-5 finding):
+    # ``jump_on_start`` would fire BEFORE the supervisor records
+    # ``entry_start = time.monotonic()`` (Z. 960), so the jump is baked
+    # into the snapshot and ``run_duration`` ends up ~0s. Instead, hook
+    # the jump on the first ``pc.run_state`` read (Z. 964), which is the
+    # first clock-observable event INSIDE the monitor loop, AFTER the
+    # snapshot. Then ``time.monotonic() - entry_start == 30.0`` exactly.
+    stub = _SupervisorPushClientStub(clock=clock, jump_on_run_state_read=30.0)
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=[stub]
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # The else-branch was hit (counter reset to 0), not the short-run branch.
+    # If `<` ever drifts to `<=`, ``run_duration == 30.0`` falls into the
+    # short-run path and ``_observed_short_run_counter`` becomes 1.
+    assert stub._observed_short_run_counter == 0, (
+        f"Boundary 30.0s was counted as short — `<` drifted to `<=`? "
+        f"Counter={stub._observed_short_run_counter}"
+    )
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
+
+
+# --------------------------------------------------------------------------
+# Cross-locale symmetry (Iteration-2-L2)
+# --------------------------------------------------------------------------
+
+
+def test_translation_key_present_in_all_locales(integration_root: Path) -> None:
+    """`fcm_short_run_crash_loop` exists in every locale file under `issues`."""
+    key = "fcm_short_run_crash_loop"
+    files = {
+        "strings.json": integration_root / "strings.json",
+        "de.json": integration_root / "translations" / "de.json",
+        "en.json": integration_root / "translations" / "en.json",
+        "es.json": integration_root / "translations" / "es.json",
+        "fr.json": integration_root / "translations" / "fr.json",
+        "he.json": integration_root / "translations" / "he.json",
+        "it.json": integration_root / "translations" / "it.json",
+        "nl.json": integration_root / "translations" / "nl.json",
+        "pl.json": integration_root / "translations" / "pl.json",
+        "pt-BR.json": integration_root / "translations" / "pt-BR.json",
+        "pt.json": integration_root / "translations" / "pt.json",
+    }
+
+    titles: dict[str, str] = {}
+    descriptions: dict[str, str] = {}
+    for label, path in files.items():
+        assert path.exists(), f"locale file missing: {path}"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "issues" in data, f"{label}: no issues section"
+        assert key in data["issues"], f"{label}: missing key {key!r}"
+        entry = data["issues"][key]
+        assert isinstance(entry, dict), f"{label}: {key!r} must be a dict"
+        assert entry.get("title", "").strip(), f"{label}: empty title for {key!r}"
+        assert (
+            entry.get("description", "").strip()
+        ), f"{label}: empty description for {key!r}"
+        assert len(entry["description"]) >= 50, (
+            f"{label}: description too short ({len(entry['description'])} chars) "
+            f"for a repair-issue body"
+        )
+        titles[label] = entry["title"]
+        descriptions[label] = entry["description"]
+
+    # No copy-paste drift between German and English description.
+    assert descriptions["de.json"] != descriptions["en.json"], (
+        "Copy-paste drift: de.json description matches en.json — translation missing"
+    )
+    # Strings.json (master) matches en.json (English locale)
+    assert descriptions["strings.json"] == descriptions["en.json"], (
+        "strings.json description must mirror en.json"
+    )
+
+
+# --------------------------------------------------------------------------
+# Defense 2 iter-9 (Codex PR #1086 follow-up):
+# Cap-fire must TERMINATE the supervisor; the inner-loop ``break`` alone
+# falls through to the per-iteration restart block and keeps spawning fresh
+# FCM clients (retry pressure + log spam continue indefinitely despite the
+# cap latch). See CA-DEFENSE-TERMINATION-001.
+#
+# These tests deliberately do NOT rely on the helper's
+# StopIteration->stop_evt.set() emergency brake (CA-TEST-TERMINATION-001):
+# they install their own ``_ensure_client_for_entry`` mock that fails the
+# test the moment the supervisor calls it AFTER the cap should have fired.
+# That isolates the production-side termination contract from the test-helper
+# safety net.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cap_fire_terminates_outer_loop_without_helper_safety_net(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cap-fire must stop the supervisor in production, not via the test helper.
+
+    Codex iter-9 (PR #1086): ``break`` after the cap fires only exits the
+    inner monitor loop; the outer ``while not stop_evt.is_set()`` keeps
+    spinning and ``_ensure_client_for_entry`` is called for an 11th client.
+    The production fix sets ``stop_evt`` and pops ``_stop_evts[entry_id]``
+    inside the cap-fire branch, so the outer loop exits before any further
+    ensure call.
+    """
+    entry_id = "entry-cap-terminates"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS + 5)
+    ]
+    ensure_iter = iter(clients)
+    ensure_call_count = 0
+
+    async def _ensure(entry_id_inner: str, cache):  # noqa: ARG001
+        # NOTE: no StopIteration->stop_evt.set() escape hatch here. If the
+        # production cap fails to terminate the supervisor, this returns the
+        # 11th client and we explicitly fail the test below.
+        nonlocal ensure_call_count
+        ensure_call_count += 1
+        return next(ensure_iter)
+
+    monkeypatch.setattr(fcm_receiver_ha.time, "monotonic", clock)
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
+    register_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        fcm_receiver_ha.random, "uniform", lambda *_a, **_kw: 0.0
+    )
+
+    real_wait_for = asyncio.wait_for
+
+    async def _instant_wait_for(fut, *, timeout=None):
+        if timeout is not None and timeout > 0:
+            coro_name = getattr(fut, "__name__", "") or getattr(
+                getattr(fut, "cr_code", None), "co_name", ""
+            )
+            if coro_name == "wait":
+                if asyncio.iscoroutine(fut):
+                    fut.close()
+                raise TimeoutError
+        return await real_wait_for(fut, timeout=timeout)
+
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "wait_for", _instant_wait_for)
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Production-side termination contract: exactly _MAX ensure calls.
+    # An 11th call would mean the outer loop kept running after cap-fire.
+    assert ensure_call_count == _MAX_CONSECUTIVE_SHORT_RUNS, (
+        f"Supervisor kept spinning after cap-fire: ensure was called "
+        f"{ensure_call_count} times (expected {_MAX_CONSECUTIVE_SHORT_RUNS}). "
+        f"Defense 2 cap is a paper tiger."
+    )
+    assert receiver.supervisors[entry_id].done()
+    assert entry_id in receiver._short_run_cap_latched
+
+
+@pytest.mark.asyncio
+async def test_cap_fire_pops_stop_evt_for_legitimate_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After cap-fire, ``_stop_evts[entry_id]`` is gone so a reload restarts cleanly.
+
+    The cap-fire branch calls ``stop_evt.set()`` AND
+    ``self._stop_evts.pop(entry_id, None)``. Without the pop, the next
+    legitimate restart via ``_start_supervisor_for_entry`` would reuse the
+    already-set event through ``setdefault`` and the new supervisor would
+    terminate immediately.
+    """
+    entry_id = "entry-cap-pop"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # After cap-fire the stop event has been consumed AND removed so that a
+    # legitimate ``_register_for_fcm_entry`` or reload constructs a fresh one.
+    assert entry_id not in receiver._stop_evts, (
+        "Stale stop event lingers in _stop_evts after cap-fire; a "
+        "legitimate restart would short-circuit because setdefault would "
+        "reuse the already-set event."
+    )
+
+
+# --------------------------------------------------------------------------
+# Iter-11: Defense-Specificity (pre-start failures excluded from cap)
+# --------------------------------------------------------------------------
+# Pins the ``became_started`` per-run latch contract:
+# - Pre-start failures (MCS unreachable / login failed, client never
+#   reaches STARTED) MUST NOT advance the short-run counter and MUST
+#   NOT clear an existing cap latch.
+# - Real poison-message short-runs (became_started=True + run<30s) MUST
+#   still advance the counter as before. The cap stays specific to the
+#   scenario it was designed for.
+# - A mixed cascade (poison-message runs interleaved with transient
+#   outages) still accumulates correctly: the outages are no-ops, the
+#   poison-message runs add up to the cap at iteration N+M_short.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_start_failure_does_not_advance_cap_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """15 pre-start failures (no STARTED reached) must NOT fire the cap.
+
+    Models the Codex iter-11 scenario: an ordinary network/Google outage
+    where ``_listen()`` exhausts its 5 connection retries (~15-20s) and
+    the client never reaches ``STARTED``. Before the gate, 10 such
+    bursts would have permanently capped the supervisor and disabled
+    FCM push until reload.
+    """
+    entry_id = "entry-pre-start"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # 15 stubs that NEVER set become_started -> run_state stays None on
+    # every read -> ``became_started`` stays False in the supervisor.
+    clients = [
+        _SupervisorPushClientStub(clock=clock, become_started=False)
+        for _ in range(15)
+    ]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # The supervisor only terminates when the helper exhausts the client
+    # list (StopIteration -> stop_evt.set()). We MUST see all 15 registration
+    # attempts -- none was prematurely cut off by a cap fire.
+    assert register_mock.await_count == 15, (
+        f"Pre-start failures advanced the cap counter and terminated "
+        f"early -- expected 15 attempts, got {register_mock.await_count}"
+    )
+    assert create_issue.call_count == 0, (
+        "Cap repair issue was created from pre-start failures; the "
+        "``became_started`` gate is broken."
+    )
+    assert entry_id not in receiver._fatal_errors
+    assert entry_id not in receiver._short_run_cap_latched
+
+
+@pytest.mark.asyncio
+async def test_mixed_burst_only_counts_real_short_runs_toward_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """5 real short-runs + 3 pre-start failures + 5 real short-runs -> cap fires at 10 real.
+
+    Pins the "counter unchanged across pre-start failures" semantics: a
+    poison-message cascade interleaved with outages must still
+    accumulate correctly. The outages are no-ops, the real short-runs
+    accumulate 5+5=10 and the cap fires on the 10th REAL short-run.
+    """
+    entry_id = "entry-mixed"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    clients: list[_SupervisorPushClientStub] = []
+    # 5 real poison-message-style short-runs (became_started=True, run<30s)
+    for _ in range(5):
+        clients.append(_SupervisorPushClientStub(clock=clock))
+    # 3 transient outages (become_started=False) -- must be ignored by the cap
+    for _ in range(3):
+        clients.append(
+            _SupervisorPushClientStub(clock=clock, become_started=False)
+        )
+    # 5 more real short-runs -- together with the first 5 these are the 10
+    # consecutive REAL short-runs that fire the cap.
+    for _ in range(5):
+        clients.append(_SupervisorPushClientStub(clock=clock))
+    # Extra clients beyond the cap-fire would expose "loop kept going".
+    for _ in range(3):
+        clients.append(_SupervisorPushClientStub(clock=clock))
+
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Cap fires after the 13th client (5 real + 3 outage + 5th real = 13).
+    # Anything beyond 13 indicates the cap miscounted or did not terminate.
+    assert register_mock.await_count == 13, (
+        f"Mixed burst miscounted -- expected 13 client attempts "
+        f"(5 real + 3 outage + 5 real, cap on the 13th), got "
+        f"{register_mock.await_count}"
+    )
+    assert create_issue.call_count == 1
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_long_pre_start_does_not_release_cap_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Long-running pre-start failure (run>=30s) does NOT clear the cap latch.
+
+    Models a slow-to-fail connection attempt that hangs in pre-start for
+    more than 30s. Before the gate, the supervisor would have hit the
+    ``else`` branch (long run) and released the cap latch + Repairs UI
+    issue without ever proving the listener can stay up. The
+    ``became_started`` gate makes this a no-op so the latch remains.
+    """
+    entry_id = "entry-long-prestart"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    # Pre-seed the latch as if a prior cap-fire was still active. This
+    # mirrors the production state right after iter-9 termination but
+    # before any healthy run has cleared it.
+    receiver._short_run_cap_latched.add(entry_id)
+    receiver._fatal_errors[entry_id] = (
+        "FCM short-run crash loop: 10 consecutive runs ended within 30s "
+        "(persistent poison message suspected)"
+    )
+
+    clock = _MonoClock(step=0.0)
+    # become_started=False AND a 60s jump after the snapshot. Without the
+    # gate, the supervisor would see run_duration >= 30s and hit the
+    # ``else`` branch, releasing the latch.
+    stub = _SupervisorPushClientStub(
+        clock=clock, jump_on_run_state_read=60.0, become_started=False
+    )
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=[stub]
+    )
+    _create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Latch survives the long pre-start (no healthy proof was observed).
+    assert entry_id in receiver._short_run_cap_latched, (
+        "Long pre-start failure cleared the cap latch without ever "
+        "proving a healthy run -- gate is broken."
+    )
+    assert entry_id in receiver._fatal_errors
+    assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+    # Repairs UI issue for the short-run cap was NOT deleted by the long
+    # pre-start. (The supervisor may issue unrelated ``fcm_stuck`` delete
+    # calls after a successful registration; we filter on the specific
+    # ``fcm_short_run_crash_loop_*`` key.)
+    cap_issue_key = f"fcm_short_run_crash_loop_{entry_id}"
+    cap_deletes = [
+        call for call in delete_issue.call_args_list
+        if len(call.args) >= 3 and call.args[2] == cap_issue_key
+    ]
+    assert cap_deletes == [], (
+        f"Long pre-start deleted the cap Repairs issue without a healthy "
+        f"run; cap_deletes={cap_deletes}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Iter-12 (Codex follow-up): sampling-gap defense
+#
+# When the full lifecycle CREATED -> STARTED -> CRASH happens between two
+# monitor polls (>=0.5s), the supervisor's monitor loop NEVER reads
+# ``state == STARTED`` and ``became_started`` would remain false. The
+# vendored ``_ObservableFcmPushClient`` subclass latches
+# ``_has_been_started`` via a ``__setattr__`` hook the moment the library
+# assigns ``run_state = STARTED`` -- independent of polling cadence.
+# The supervisor's cap branch consults this latch before deciding whether
+# a short run advances the counter. (CA-DEFENSE-OBSERVABILITY-001)
+# --------------------------------------------------------------------------
+
+
+def test_observable_subclass_latches_started_transition() -> None:
+    """The ``__setattr__`` hook latches ``_has_been_started`` on STARTED.
+
+    Unit-tests the observer mechanic in isolation: bypass the library
+    ``__init__`` and only exercise the attribute hook. The latch is
+    monotonic (set on STARTED, never cleared) and ignores non-STARTED
+    state assignments.
+    """
+    pc_cls = fcm_receiver_ha._ObservableFcmPushClientCls
+    if pc_cls is None:
+        pytest.skip("Vendored library not available; subclass not active")
+
+    from custom_components.googlefindmy.Auth.firebase_messaging import (
+        FcmPushClientRunState,
+    )
+
+    # Bypass library ``__init__`` -- we only exercise the ``__setattr__``
+    # hook. Seed the latch the same way the subclass' ``__init__`` does.
+    pc = pc_cls.__new__(pc_cls)
+    object.__setattr__(pc, "_has_been_started", False)
+
+    # Non-STARTED transitions do NOT set the latch.
+    pc.run_state = FcmPushClientRunState.CREATED
+    assert pc._has_been_started is False
+    pc.run_state = FcmPushClientRunState.STARTING_LOGIN
+    assert pc._has_been_started is False
+
+    # STARTED sets the latch.
+    pc.run_state = FcmPushClientRunState.STARTED
+    assert pc._has_been_started is True
+
+    # Latch is monotonic -- subsequent non-STARTED transitions do NOT
+    # clear it (the cap needs evidence the client was EVER started, not
+    # whether it is started right now).
+    pc.run_state = FcmPushClientRunState.STOPPING
+    assert pc._has_been_started is True
+    pc.run_state = FcmPushClientRunState.STOPPED
+    assert pc._has_been_started is True
+
+
+@pytest.mark.asyncio
+async def test_micro_window_crash_advances_cap_via_observable_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Micro-window CREATED -> STARTED -> CRASH between polls still counts.
+
+    Models the exact scenario the cap is meant to detect: the client
+    connects, decodes a poison message, and crashes before the supervisor's
+    first ``await asyncio.sleep(FCM_MONITOR_INTERVAL_S)`` sample. The
+    monitor loop reads STOPPED/!do_listen and ``became_started`` would
+    remain false WITHOUT the subclass latch. The latch
+    (``_has_been_started=True``, set by the vendored ``__setattr__`` hook
+    during ``pc.start()``) lets the cap correctly classify the run as a
+    short crash and advance the counter. 10 such micro-window crashes
+    fire the cap.
+    """
+    entry_id = "entry-micro-window"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    # become_started=False: the monitor loop never reads ``run_state ==
+    # STARTED`` (state read returns None on the first call, forcing the
+    # ``state is None`` break path immediately).
+    # has_been_started=True: the subclass latch was set during the
+    # library's CREATED -> STARTED transition that completed BEFORE the
+    # first monitor poll.
+    clients = [
+        _SupervisorPushClientStub(
+            clock=clock, become_started=False, has_been_started=True
+        )
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Cap fired despite the supervisor monitor loop never reading STARTED.
+    assert register_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS, (
+        f"Expected exactly {_MAX_CONSECUTIVE_SHORT_RUNS} register calls "
+        f"(one per micro-window crash); got {register_mock.await_count}. "
+        f"Without the subclass latch, became_started=False would keep the "
+        f"cap from firing and the supervisor would retry indefinitely."
+    )
+    assert create_issue.call_count == 1
+    cap_issue_call = create_issue.call_args
+    assert cap_issue_call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    assert entry_id in receiver._short_run_cap_latched
+    assert receiver._fatal_errors[entry_id].startswith(
+        "FCM short-run crash loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_burst_micro_window_and_pre_start_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-start failures interleaved with micro-window crashes count only the latter.
+
+    Cascade: 5 micro-window crashes (has_been_started=True) + 3 true
+    pre-start failures (has_been_started=False) + 5 micro-window crashes.
+    The cap MUST fire at exactly 10 cumulative micro-window crashes
+    (counter reaches threshold on the 13th supervisor pass). Pre-start
+    failures leave the counter AND the latch UNTOUCHED. This pins the
+    orthogonality of the sampling-gap defense to the pre-start-failure
+    gate from iter-11 (CA-DEFENSE-SPECIFICITY-001).
+    """
+    entry_id = "entry-mixed-burst"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)
+    cascade = (
+        [
+            _SupervisorPushClientStub(
+                clock=clock, become_started=False, has_been_started=True
+            )
+            for _ in range(5)
+        ]
+        + [
+            _SupervisorPushClientStub(
+                clock=clock, become_started=False, has_been_started=False
+            )
+            for _ in range(3)
+        ]
+        + [
+            _SupervisorPushClientStub(
+                clock=clock, become_started=False, has_been_started=True
+            )
+            for _ in range(5)
+        ]
+    )
+    register_mock = _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=cascade
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Cap fired on the 13th iteration (5 + 3 + 5 = 13 stubs total, cap
+    # advances on micro-window crashes only).
+    assert register_mock.await_count == 13, (
+        f"Expected 13 register calls (5 + 3 + 5 cascade); got "
+        f"{register_mock.await_count}. Pre-start failures must NOT count "
+        f"toward the cap (iter-11), but real micro-window crashes MUST "
+        f"(iter-12)."
+    )
+    assert create_issue.call_count == 1
+    cap_issue_call = create_issue.call_args
+    assert cap_issue_call.args[2] == f"fcm_short_run_crash_loop_{entry_id}"
+    assert entry_id in receiver._short_run_cap_latched
+
+
+# --------------------------------------------------------------------------
+# CI follow-up (PR #1086 iter-13): Class-Identity substitution defense
+#
+# Iter-12 added _ObservableFcmPushClient as a subclass of FcmPushClient. The
+# production factory must construct that subclass. Tests, however, may
+# substitute the module-level FcmPushClient symbol via monkeypatch (the
+# documented seam) to inject test doubles -- e.g. test_receiver_reuses_
+# hass_managed_session in tests/test_fcm_receiver_guard.py asserts
+# ``isinstance(created, DummyPushClient)``. A factory that always returns
+# the production subclass would break isinstance identity against the
+# patched symbol because the subclass inherits from the ORIGINAL class,
+# not from the patched one. The factory therefore checks at CALL TIME
+# whether the module symbol still points at the snapshot of the original
+# class, and instantiates the patched class directly when not.
+# (CA-SUBCLASS-IDENTITY-001)
+# --------------------------------------------------------------------------
+
+
+def test_factory_uses_observable_subclass_in_production() -> None:
+    """When the FcmPushClient symbol is untouched the factory returns the subclass.
+
+    Pins the production path: the runtime check
+    ``current is _OriginalFcmPushClient`` is true, so the factory MUST
+    instantiate ``_ObservableFcmPushClient`` (not the plain library class).
+    """
+    if fcm_receiver_ha._ObservableFcmPushClientCls is None:
+        pytest.skip("Vendored library not available; subclass not active")
+
+    from custom_components.googlefindmy.Auth.firebase_messaging import (
+        FcmPushClientConfig,
+        FcmRegisterConfig,
+    )
+
+    config = FcmPushClientConfig()
+    register_cfg = FcmRegisterConfig(
+        project_id="p",
+        app_id="a",
+        api_key="k",
+        messaging_sender_id="s",
+    )
+
+    async def _noop_cb(*_args: object, **_kw: object) -> None:
+        return None
+
+    pc = fcm_receiver_ha._FcmPushClientFactory(
+        _noop_cb,
+        register_cfg,
+        {},
+        _noop_cb,
+        config=config,
+    )
+
+    assert isinstance(pc, fcm_receiver_ha._ObservableFcmPushClientCls)
+    # Latch was seeded before super().__init__ so it is observable here.
+    assert pc._has_been_started is False
+
+
+def test_factory_honours_monkeypatched_fcm_push_client_symbol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Substituting FcmPushClient via monkeypatch is the documented seam.
+
+    Regression pin for CA-SUBCLASS-IDENTITY-001: when tests patch the
+    module-level ``FcmPushClient`` symbol to inject a test double, the
+    factory MUST instantiate the patched class DIRECTLY -- not a subclass
+    of the original library class. Otherwise ``isinstance`` assertions on
+    the patched symbol (as used by tests in tests/test_fcm_receiver_guard
+    .py) fail because the production subclass diverges from the patched
+    class hierarchy.
+    """
+
+    captured: dict[str, object] = {}
+
+    class _PatchedClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "FcmPushClient",
+        _PatchedClient,
+    )
+
+    pc = fcm_receiver_ha._FcmPushClientFactory(
+        "callback",
+        "config",
+        {"creds": True},
+        "creds_cb",
+        http_client_session="session",
+    )
+
+    # The factory honoured the patch: identity matches the patched class,
+    # not the production subclass and not the original library class.
+    assert isinstance(pc, _PatchedClient)
+    if fcm_receiver_ha._ObservableFcmPushClientCls is not None:
+        assert not isinstance(pc, fcm_receiver_ha._ObservableFcmPushClientCls)
+    assert captured["args"][0] == "callback"
+    assert captured["kwargs"]["http_client_session"] == "session"

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -85,11 +85,16 @@ class _SupervisorPushClientStub:
         jump_on_run_state_read: float = 0.0,
         become_started: bool = True,
         has_been_started: bool | None = None,
+        credential_error: object | None = None,
     ) -> None:
         self.clock = clock
         self.jump_on_start = jump_on_start
         self.jump_on_run_state_read = jump_on_run_state_read
         self.become_started = become_started
+        # Finding 1: mirror the production ``credential_error`` signal the
+        # supervisor reads after the monitor loop ends to escalate corrupt
+        # FCM key material to ``_invalidate_fcm_tokens`` + re-registration.
+        self.credential_error = credential_error
         # Iter-12 ``has_been_started``: mirrors the production subclass'
         # ``_has_been_started`` latch which is set by the vendored
         # library the moment ``run_state = STARTED`` is assigned,
@@ -249,6 +254,49 @@ async def test_short_run_triggers_repair_issue_after_threshold(
     assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.ERROR
     assert call.kwargs["translation_key"] == "fcm_short_run_crash_loop"
     assert receiver._fatal_errors[entry_id].startswith("FCM short-run crash loop")
+
+
+@pytest.mark.asyncio
+async def test_credential_error_invalidates_tokens_and_bypasses_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A listener ``credential_error`` escalates to re-registration, not the cap.
+
+    Codex Finding 1: when the listener reports corrupt FCM key material via
+    ``pc.credential_error``, the supervisor must invalidate the bad tokens
+    (forcing re-registration with the device identity preserved) instead of
+    charging the short run to the crash cap. Even
+    ``_MAX_CONSECUTIVE_SHORT_RUNS + 2`` such runs must NOT fire the cap
+    repair issue -- corrective action is being taken, this is not a
+    poison-message loop.
+    """
+    entry_id = "entry-cred"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+
+    clock = _MonoClock(step=0.001)  # every run is short
+    cred_err = ValueError("Credentials key material failed base64 decode")
+    clients = [
+        _SupervisorPushClientStub(clock=clock, credential_error=cred_err)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS + 2)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _delete_issue = _install_ir_capture(monkeypatch)
+
+    invalidate_mock = AsyncMock()
+    monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", invalidate_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    # Every credential-error run escalated to re-registration ...
+    assert invalidate_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS + 2
+    invalidate_mock.assert_awaited_with(entry_id)
+    # ... and NONE of them tripped the short-run crash cap.
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._fatal_errors
 
 
 @pytest.mark.asyncio

--- a/tests/test_fcmpushclient_b64_hardening.py
+++ b/tests/test_fcmpushclient_b64_hardening.py
@@ -1,0 +1,161 @@
+# tests/test_fcmpushclient_b64_hardening.py
+"""Regression suite for ``_safe_urlsafe_b64decode`` (defense 3).
+
+Defense layer 3 of the three-defense hotfix for the FCM listener
+poison-message cascade (CA-CASCADING-FAILURE-001). Python 3.14 switched
+``binascii.a2b_base64`` to ``strict_mode=True`` by default, which rejects
+payloads that contain newlines, leading/trailing whitespace, or missing
+padding -- conditions the wild FCM crypto-key and salt headers reliably
+produce. Before this helper, ``urlsafe_b64decode`` raised
+``binascii.Error: Incorrect padding`` on every notification, the listener
+loop's poison-message handler selective-ACKed the message and looped, and
+the memory leak observed on Home Assistant Core 2026.6.x followed.
+
+The helper restores the pre-3.14 lenient behaviour locally (whitespace
+strip + padding append) without touching the global decoder state. These
+tests pin that lenient contract against a future regression that would
+re-introduce strict decoding on dirty input.
+"""
+from __future__ import annotations
+
+import binascii
+from base64 import urlsafe_b64encode
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    CredentialDecryptionError,
+    FcmPushClient,
+    _safe_urlsafe_b64decode,
+)
+
+
+def _b64_no_pad(data: bytes) -> str:
+    """URL-safe base64 string without padding (matches FCM stream format)."""
+    return urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def test_missing_padding_decodes_cleanly() -> None:
+    """Unpadded base64 string decodes successfully.
+
+    FCM crypto-key and salt headers routinely omit ``=`` padding. Python
+    3.14 strict mode rejects this with ``binascii.Error: Incorrect padding``;
+    the helper must re-append padding and decode without raising.
+    """
+    payload = b"\xde\xad\xbe\xef" * 4  # 16 bytes -> 22 base64 chars (no pad)
+    unpadded = _b64_no_pad(payload)
+    assert not unpadded.endswith("=")
+
+    assert _safe_urlsafe_b64decode(unpadded) == payload
+
+
+def test_embedded_newlines_are_stripped() -> None:
+    """Base64 strings split by newlines decode after newline stripping.
+
+    Some FCM payload sources (MIME-style splits, debug-log round-tripping)
+    inject ``\\n`` mid-payload. Python 3.14 strict mode treats this as an
+    invalid character; the helper must strip it before decoding.
+    """
+    payload = b"hello-world-padding-test"
+    encoded = urlsafe_b64encode(payload).decode("ascii")
+    # Inject newlines every 8 chars (MIME-style 76-char split, scaled down).
+    dirty = "\n".join(encoded[i : i + 8] for i in range(0, len(encoded), 8))
+    assert "\n" in dirty
+
+    assert _safe_urlsafe_b64decode(dirty) == payload
+
+
+def test_leading_and_trailing_whitespace_are_stripped() -> None:
+    """Surrounding whitespace (space, tab, CR, vtab, formfeed) is removed.
+
+    HTTP header parsers sometimes leave trailing CRLF or leading SP on the
+    decoded parameter value. The helper collapses every ASCII whitespace
+    flavour (space, tab, newline, CR, vtab, formfeed) via ``bytes.split``.
+    """
+    payload = b"trailing-whitespace-defense"
+    clean = _b64_no_pad(payload)
+    dirty = f" \t{clean}\r\n\x0b\x0c"
+
+    assert _safe_urlsafe_b64decode(dirty) == payload
+
+
+def test_bytes_input_is_accepted() -> None:
+    """``bytes`` input decodes equivalently to ``str`` input.
+
+    Callers in the credential path pass ``str`` from cached JSON; future
+    callers in the wire-decode path may pass raw ``bytes`` straight out of
+    the socket. The helper accepts both without an extra encode step.
+    """
+    payload = b"bytes-input-contract"
+    encoded_str = _b64_no_pad(payload)
+    encoded_bytes = encoded_str.encode("ascii")
+
+    assert _safe_urlsafe_b64decode(encoded_bytes) == payload
+    assert _safe_urlsafe_b64decode(encoded_bytes) == _safe_urlsafe_b64decode(
+        encoded_str
+    )
+
+
+def test_python314_strict_mode_simulation_does_not_leak() -> None:
+    """Strict-mode ``binascii.a2b_base64`` does not see dirty input.
+
+    Simulates Python 3.14's strict default by patching the underlying
+    ``binascii.a2b_base64`` to refuse newlines and missing padding (the
+    exact failure mode reported on HA Core 2026.6.x). The helper must
+    pre-clean the input so that the strict decoder receives a payload it
+    accepts -- otherwise the cascade returns.
+    """
+    real_a2b = binascii.a2b_base64
+
+    def strict_a2b(data: bytes | str, *, strict_mode: bool = False) -> bytes:
+        # Mimic Python 3.14 strict_mode=True default: reject whitespace and
+        # missing padding regardless of the strict_mode kwarg the caller
+        # passes (the strict-mode default flip is the regression source).
+        if isinstance(data, str):
+            data = data.encode("ascii")
+        if any(ws in data for ws in (b" ", b"\t", b"\n", b"\r")):
+            raise binascii.Error("Invalid base64-encoded string")
+        if len(data) % 4 != 0:
+            raise binascii.Error("Incorrect padding")
+        return real_a2b(data, strict_mode=True)
+
+    payload = b"strict-mode-survives"
+    dirty = f"\n {_b64_no_pad(payload)}\r\n"
+
+    with patch.object(binascii, "a2b_base64", side_effect=strict_a2b):
+        # The helper must pre-clean before delegating; otherwise the
+        # patched strict decoder would raise.
+        assert _safe_urlsafe_b64decode(dirty) == payload
+
+
+def test_end_to_end_dirty_headers_decrypt_path_does_not_cascade() -> None:
+    """Dirty crypto-key / salt headers reach ``_decrypt_raw_data`` cleanly.
+
+    End-to-end check: ``_decrypt_raw_data`` is called with whitespace-laden
+    header strings (the field the FCM listener actually receives from the
+    wire). The helper must absorb the noise so the function reaches the
+    credential surface; a credential-stage failure here proves the header
+    decode succeeded (without the helper, ``binascii.Error`` would fire
+    before the credentials are ever consulted).
+
+    Empty credentials are passed deliberately: the test asserts the failure
+    surface, not a full decrypt. The point is that the decrypt is reached.
+    """
+    payload_key = b"\xde\xad\xbe\xef" * 4
+    payload_salt = b"\xfe\xed\xfa\xce" * 4
+    crypto_key_dirty = f"\n {_b64_no_pad(payload_key)}\r\n"
+    salt_dirty = f"  {_b64_no_pad(payload_salt)}\t"
+
+    # No keys section -> credential surface raises CredentialDecryptionError.
+    # The crucial assertion is that we get the CREDENTIAL error, not a
+    # header-stage binascii.Error. If defense 3 regresses, the header
+    # decode would raise first and this test would fail with a different
+    # exception type.
+    credentials: dict[str, object] = {"gcm": {"app_id": "x"}}
+    with pytest.raises(
+        CredentialDecryptionError, match="missing FCM key material"
+    ):
+        FcmPushClient._decrypt_raw_data(
+            credentials, crypto_key_dirty, salt_dirty, b"raw"
+        )

--- a/tests/test_fcmpushclient_credential_decryption.py
+++ b/tests/test_fcmpushclient_credential_decryption.py
@@ -1,0 +1,174 @@
+# tests/test_fcmpushclient_credential_decryption.py
+"""Direct unit tests for FcmPushClient._decrypt_raw_data credential failures.
+
+Regression suite for CA-CRED-VS-MSG-DECRYPT-001 iter-3 (Codex review on
+commit 14b5a45451): when the cached FCM credential material is structurally
+broken, ``_decrypt_raw_data`` must raise ``CredentialDecryptionError`` (a
+typed subclass of ``ValueError``) so the listener loop's poison-message
+defense can discriminate credential corruption (escalate to supervisor) from
+per-message decode failures (selective-ACK + skip).
+
+The iter-2 implementation used a string-prefix marker ("Credentials ...")
+which silently leaked plain ``ValueError`` from upstream libraries -- most
+notably ``cryptography.hazmat.primitives.serialization.load_der_private_key``
+raising ``ValueError("Could not deserialize key data ...")`` for valid base64
+but invalid DER content. That leak caused the listener to ACK every incoming
+message while silently dropping it. The iter-3 fix wraps every credential
+decode surface and raises ``CredentialDecryptionError`` instead, so the
+discriminator is the exception TYPE rather than the message text.
+"""
+from __future__ import annotations
+
+from base64 import urlsafe_b64encode
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    CredentialDecryptionError,
+    FcmPushClient,
+)
+
+
+def _b64(data: bytes) -> str:
+    """URL-safe base64 string without padding (matches FCM credential format)."""
+    return urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def test_missing_keys_section_raises_typed_error() -> None:
+    """``credentials["keys"]`` absent -> CredentialDecryptionError."""
+    credentials: dict[str, object] = {"gcm": {"app_id": "x"}}
+    with pytest.raises(CredentialDecryptionError, match="missing FCM key material"):
+        FcmPushClient._decrypt_raw_data(
+            credentials, "crypto", "salt", b"raw"
+        )
+
+
+def test_invalid_key_value_types_raise_typed_error() -> None:
+    """``keys.private``/``keys.secret`` non-string -> CredentialDecryptionError."""
+    credentials: dict[str, object] = {
+        "keys": {"private": 42, "secret": None},
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="contain invalid key values"
+    ):
+        FcmPushClient._decrypt_raw_data(
+            credentials, "crypto", "salt", b"raw"
+        )
+
+
+def test_non_base64_key_material_raises_typed_error() -> None:
+    """``keys.private`` not valid base64 -> CredentialDecryptionError, not bare binascii.Error.
+
+    Covers the b64decode failure surface (iter-2 fix). The error chain
+    preserves the original binascii.Error via ``__cause__``.
+    """
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": "###not-base64###",
+            "secret": _b64(b"valid-secret-bytes"),
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed base64 decode"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    # __cause__ chain preserves the underlying binascii.Error for diagnostics.
+    assert exc_info.value.__cause__ is not None
+
+
+def test_non_ascii_in_private_key_raises_typed_error() -> None:
+    """``keys.private`` with non-ASCII bytes -> CredentialDecryptionError.
+
+    THIS IS THE ITER-4 CODEX REGRESSION (commit ae70dccc90). ``.encode("ascii")``
+    on a corrupted cached key value raises ``UnicodeEncodeError`` BEFORE
+    ``urlsafe_b64decode`` is reached. ``UnicodeEncodeError`` is a subclass of
+    ``ValueError`` but NOT of ``binascii.Error``, so the iter-3 catch
+    ``except binascii.Error`` let it through, the listener loop's per-message
+    ValueError handler swallowed it, and every push was selective-ACKed and
+    silently dropped instead of surfacing a credential fault. The iter-4 fix
+    widens the catch to ``(binascii.Error, UnicodeError)``.
+    """
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": "☃snowman",  # non-ASCII -> UnicodeEncodeError on .encode("ascii")
+            "secret": _b64(b"valid-secret-bytes-16b"),
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed base64 decode"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    # __cause__ preserves the underlying UnicodeEncodeError for diagnostics.
+    assert exc_info.value.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__, UnicodeError)
+
+
+def test_non_ascii_in_secret_raises_typed_error() -> None:
+    """``keys.secret`` with non-ASCII bytes -> CredentialDecryptionError.
+
+    Mirror of the iter-4 regression for the secret field: both cred encodes
+    run inside the same try-block, so the same widened catch must apply.
+    """
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": _b64(b"\xde\xad\xbe\xef" * 16),
+            "secret": "café",  # non-ASCII -> UnicodeEncodeError
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed base64 decode"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    assert isinstance(exc_info.value.__cause__, UnicodeError)
+
+
+def test_corrupted_der_private_key_raises_typed_error() -> None:
+    """Valid base64 but invalid DER content -> CredentialDecryptionError.
+
+    THIS IS THE ITER-3 CODEX REGRESSION. Under the iter-2 string-marker
+    discipline this path leaked a plain ValueError("Could not deserialize key
+    data ...") from cryptography, which the listener loop misinterpreted as
+    per-message poison and silently ACKed every incoming message while
+    dropping all notifications. The iter-3 fix wraps load_der_private_key and
+    re-raises as CredentialDecryptionError so the supervisor can escalate.
+    """
+    # Valid base64 of plausible-length garbage that load_der_private_key will
+    # reject. "deadbeef" * 8 = 64 bytes, looks key-sized but is not DER.
+    fake_der_payload = b"\xde\xad\xbe\xef" * 16
+    credentials: dict[str, object] = {
+        "keys": {
+            "private": _b64(fake_der_payload),
+            "secret": _b64(b"valid-secret-bytes-16b"),
+        },
+    }
+    with pytest.raises(
+        CredentialDecryptionError, match="failed DER private-key parse"
+    ) as exc_info:
+        FcmPushClient._decrypt_raw_data(
+            credentials, _b64(b"k"), _b64(b"s"), b"raw"
+        )
+    # __cause__ preserves the underlying cryptography error for diagnostics.
+    assert exc_info.value.__cause__ is not None
+
+
+def test_credential_decryption_error_is_value_error_subclass() -> None:
+    """Subclass-of-ValueError contract: backward compat for legacy ``except ValueError``.
+
+    Any external caller that catches broad ValueError still catches
+    CredentialDecryptionError. The listener loop's poison-message defense
+    uses ``isinstance`` discrimination (CredentialDecryptionError first, then
+    ValueError) to enforce the iter-3 propagation contract.
+    """
+    assert issubclass(CredentialDecryptionError, ValueError)
+    try:
+        raise CredentialDecryptionError("test")
+    except ValueError:
+        pass
+    else:
+        pytest.fail("CredentialDecryptionError should be catchable as ValueError")

--- a/tests/test_fcmpushclient_poison_message.py
+++ b/tests/test_fcmpushclient_poison_message.py
@@ -26,6 +26,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import http_ece
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
     CredentialDecryptionError,
     FcmPushClientRunState,
@@ -208,6 +209,36 @@ async def test_runtime_error_from_app_data_by_key_caught(
 
 
 @pytest.mark.asyncio
+async def test_ece_exception_from_body_decrypt_caught(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``http_ece.ECEException`` (corrupt body / bad auth tag) is poison-class.
+
+    Regression for Codex Finding 2: ``http_ece.decrypt`` raises
+    ``http_ece.ECEException``, which is a SIBLING of ``ValueError`` under
+    ``Exception`` -- not a subclass. The old ``except (ValueError, ...)``
+    poison arm let it bypass the selective-ACK + skip path entirely, so a
+    single corrupt encrypted body was redelivered forever and could
+    eventually trip the short-run crash cap. It must be treated as
+    per-message poison: ACK + skip, outer-catch untouched.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-ece-012", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [http_ece.ECEException("Decryption error: bad auth tag")]
+    )
+
+    await client._listen()
+
+    assert not _outer_catch_was_hit(caplog)
+    client._send_selective_ack.assert_awaited_once_with("poison-ece-012")
+    # Not a credential fault: no credential signal must be recorded.
+    assert client.credential_error is None
+
+
+@pytest.mark.asyncio
 async def test_rate_limit_kicks_in_after_threshold(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -298,32 +329,48 @@ async def test_connection_error_during_selective_ack_falls_through(
 
 
 @pytest.mark.asyncio
-async def test_credential_decryption_error_propagates_to_outer_catch(
+async def test_credential_decryption_error_surfaces_distinct_signal(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Cred/key-material errors must NOT be swallowed by Defense 1.
+    """Cred/key-material errors surface a DISTINCT credential signal.
 
     CredentialDecryptionError (typed exception) propagates past the
-    per-message ValueError catch. This is the iter-3 contract: the
-    discriminator is the exception TYPE, not a string-prefix marker.
+    per-message poison catch (iter-3 contract: the discriminator is the
+    exception TYPE). It is then caught by ``_listen``'s dedicated
+    ``except CredentialDecryptionError`` arm, which records
+    ``client.credential_error`` and logs a credential-specific error --
+    NOT the generic "Unknown error in listener" outer-catch (Codex
+    Finding 1). The supervisor reads ``credential_error`` to invalidate
+    the bad key material and re-register, instead of restarting against
+    the same poison credentials until the short-run crash cap fires.
     """
     caplog.set_level(logging.DEBUG)
     client = FcmPushClientSlim()
     msg = make_poison_data_message("poison-010", kind="value")
     client._receive_msg = _stream_messages(client, [msg])
-    client._handle_message = _make_handle_side_effect(
-        [CredentialDecryptionError("Credentials missing FCM key material")]
-    )
+    cred_err = CredentialDecryptionError("Credentials missing FCM key material")
+    client._handle_message = _make_handle_side_effect([cred_err])
 
     await client._listen()
 
-    # The outer ``except Exception`` block must have logged the error so the
-    # supervisor knows the worker stopped intentionally; selective-ack must NOT
-    # have been sent (this is a config fault, not a per-message poison).
-    assert _outer_catch_was_hit(caplog)
+    # (a) The generic outer ``except Exception`` arm must NOT have run: a
+    #     credential fault is no longer degraded to "Unknown error".
+    assert not _outer_catch_was_hit(caplog)
+    # (b) The distinct credential signal is recorded for the supervisor.
+    assert client.credential_error is cred_err
+    # (c) A credential-specific ERROR is logged (re-registration required).
+    cred_errors = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.ERROR
+        and "credential material is corrupt" in r.getMessage()
+    ]
+    assert len(cred_errors) == 1
+    # (d) Selective-ack must NOT be sent (config fault, not per-message poison).
     assert client._send_selective_ack.await_count == 0
-    # Worker reaches its terminal state via the finally block.
+    # (e) Worker reaches its terminal state via the finally block.
     assert client.run_state == FcmPushClientRunState.STOPPED
+    assert client.do_listen is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_fcmpushclient_poison_message.py
+++ b/tests/test_fcmpushclient_poison_message.py
@@ -1,0 +1,433 @@
+# tests/test_fcmpushclient_poison_message.py
+"""Defense 1 (CA-CASCADING-FAILURE-001) Inner-Loop-Hardening tests.
+
+Verifies that ``FcmPushClient._listen`` survives per-message decode failures
+(``binascii.Error`` padding faults under Python 3.14 strict mode,
+``RuntimeError`` from ``_app_data_by_key`` key lookups, generic ``ValueError``
+decode errors) by skipping the offending message with a selective-ack instead
+of crashing the worker loop. Also verifies the cred-error propagation contract:
+``CredentialDecryptionError`` (credential material is missing, structurally
+invalid, fails base64 decode, or fails DER private-key parse) is re-raised so
+the supervisor surfaces it via STOPPED. Plain ``ValueError`` without that type
+is treated as per-message poison (selective-ACK + skip).
+
+The Aggregate-Anti-Cascading-Invariant test runs 100 poison messages followed
+by one valid sentinel and proves Defense 1 prevents the supervisor-restart
+cascade reported on Home Assistant Core 2026.6.x.
+"""
+from __future__ import annotations
+
+import binascii
+import logging
+import ssl
+from collections.abc import Iterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    CredentialDecryptionError,
+    FcmPushClientRunState,
+)
+from tests.helpers.fcm_poison_stub import (
+    FcmPushClientSlim,
+    make_poison_data_message,
+    make_valid_data_message,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _stream_messages(
+    client: FcmPushClientSlim, messages: list[SimpleNamespace]
+) -> AsyncMock:
+    """Build an ``_receive_msg`` mock that yields ``messages`` then stops the loop.
+
+    After the last message the next call returns ``None`` *and* sets
+    ``client.do_listen = False`` so the worker leaves the ``while`` cleanly,
+    just as a real stream end would. Without this the test would hang.
+    """
+    it: Iterator[SimpleNamespace] = iter(messages)
+
+    async def _next() -> SimpleNamespace | None:
+        try:
+            return next(it)
+        except StopIteration:
+            client.do_listen = False
+            return None
+
+    mock = AsyncMock(side_effect=_next)
+    return mock
+
+
+def _make_handle_side_effect(
+    plan: list[BaseException | None],
+    record_handled: list[str] | None = None,
+) -> AsyncMock:
+    """Build a ``_handle_message`` mock that walks ``plan`` per call.
+
+    Each list entry is either an exception instance (raised on that call) or
+    ``None`` (treated as a successful decrypt). If ``record_handled`` is given,
+    successful decrypts append ``msg.persistent_id`` to it.
+    """
+    it = iter(plan)
+
+    async def _impl(msg: SimpleNamespace) -> None:
+        try:
+            step = next(it)
+        except StopIteration as exc:  # plan exhausted -> test bug
+            raise AssertionError(
+                "_handle_message called more often than the plan allows"
+            ) from exc
+        if isinstance(step, BaseException):
+            raise step
+        if record_handled is not None:
+            record_handled.append(msg.persistent_id)
+
+    return AsyncMock(side_effect=_impl)
+
+
+def _outer_catch_was_hit(caplog: pytest.LogCaptureFixture) -> bool:
+    """True iff the ``except Exception`` block at the bottom of ``_listen`` ran.
+
+    Defense 1 must keep the loop from ever reaching that block, so this is the
+    central anti-cascading invariant.
+    """
+    return any(
+        record.levelno == logging.ERROR
+        and "Unknown error in listener" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defense 1: per-message decode failures must not stop the worker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poison_message_does_not_stop_worker(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A ``binascii.Error`` decrypt failure leaves the outer-catch untouched."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-001", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    assert not _outer_catch_was_hit(caplog)
+    assert client._send_selective_ack.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_poison_message_triggers_selective_ack(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The skipped message is acknowledged so the FCM server stops resending."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-042", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    client._send_selective_ack.assert_awaited_once_with("poison-042")
+
+
+@pytest.mark.asyncio
+async def test_poison_message_logs_warning_not_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The skip path emits a rate-limited WARN, never a traceback ERROR."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-003", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert errors == []
+    assert len(warnings) >= 1
+
+
+@pytest.mark.asyncio
+async def test_poison_message_continues_to_next_message(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """After skipping a poison message the loop processes the next one normally."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    poison = make_poison_data_message("poison-004", kind="padding")
+    valid = make_valid_data_message("valid-005")
+    client._receive_msg = _stream_messages(client, [poison, valid])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding"), None]
+    )
+
+    await client._listen()
+
+    assert client._handle_message.await_count == 2
+    # First call: poison; second call: valid message passed through.
+    second_call_args = client._handle_message.await_args_list[1].args
+    assert second_call_args[0].persistent_id == "valid-005"
+
+
+@pytest.mark.asyncio
+async def test_runtime_error_from_app_data_by_key_caught(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``RuntimeError`` from ``_app_data_by_key`` is treated as poison-class."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-006", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [RuntimeError("couldn't find in app_data crypto-key")]
+    )
+
+    await client._listen()
+
+    assert not _outer_catch_was_hit(caplog)
+    client._send_selective_ack.assert_awaited_once_with("poison-006")
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_kicks_in_after_threshold(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``log_warn_limit`` caps WARN spam at default 5 while still acking each message."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    # Default log_warn_limit in FcmPushClientConfig is 5.
+    assert client.config.log_warn_limit == 5
+
+    messages = [
+        make_poison_data_message(f"poison-{i:03d}", kind="padding")
+        for i in range(20)
+    ]
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")] * 20
+    )
+
+    await client._listen()
+
+    # Format string identical for every iteration -> rate limiter applies once.
+    skip_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "Skipping FCM message that failed to decrypt" in r.getMessage()
+    ]
+    assert len(skip_warnings) == 5
+    # All 20 messages must still be acknowledged (rate limit applies to logs only).
+    assert client._send_selective_ack.await_count == 20
+
+
+@pytest.mark.asyncio
+async def test_writer_dead_during_selective_ack_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An OSError during ack-send stops the loop so the supervisor reconnects."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-007", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=OSError("writer half-dead"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_ssl_error_during_selective_ack_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``ssl.SSLError`` is not always an ``OSError`` subclass -> separate catch."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-008", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=ssl.SSLError("tls dead"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_connection_error_during_selective_ack_falls_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``ConnectionError`` during ack triggers the same shutdown path."""
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-009", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=ConnectionError("peer gone"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+
+
+@pytest.mark.asyncio
+async def test_credential_decryption_error_propagates_to_outer_catch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Cred/key-material errors must NOT be swallowed by Defense 1.
+
+    CredentialDecryptionError (typed exception) propagates past the
+    per-message ValueError catch. This is the iter-3 contract: the
+    discriminator is the exception TYPE, not a string-prefix marker.
+    """
+    caplog.set_level(logging.DEBUG)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-010", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [CredentialDecryptionError("Credentials missing FCM key material")]
+    )
+
+    await client._listen()
+
+    # The outer ``except Exception`` block must have logged the error so the
+    # supervisor knows the worker stopped intentionally; selective-ack must NOT
+    # have been sent (this is a config fault, not a per-message poison).
+    assert _outer_catch_was_hit(caplog)
+    assert client._send_selective_ack.await_count == 0
+    # Worker reaches its terminal state via the finally block.
+    assert client.run_state == FcmPushClientRunState.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_unmarked_value_error_is_treated_as_per_message_poison(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Plain ValueError without CredentialDecryptionError type = per-message poison.
+
+    Regression for the iter-2 stealth-drop class (CA-CRED-VS-MSG-DECRYPT-001
+    iter-3): under the old string-prefix marker discipline a plain ValueError
+    from upstream libraries (e.g. cryptography.load_der_private_key raising
+    "Could not deserialize key data") would silently drop EVERY incoming
+    message while the listener stayed "healthy". After the iter-3 fix the
+    discriminator is the exception TYPE: untyped ValueError is treated as
+    per-message poison (ACK + skip), only CredentialDecryptionError escalates.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-011", kind="value")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [ValueError("Could not deserialize key data (the data may be in an "
+                    "incorrect format, the provided password may be incorrect, "
+                    "it may be encrypted with an unsupported algorithm, or it "
+                    "may be an unsupported key type)")]
+    )
+
+    await client._listen()
+
+    # Per-message-poison path: outer catch NOT hit, ACK sent, worker keeps running
+    # until the stream end (do_listen=False from _stream_messages).
+    assert not _outer_catch_was_hit(caplog)
+    client._send_selective_ack.assert_awaited_once_with("poison-011")
+
+
+# ---------------------------------------------------------------------------
+# Aggregate Anti-Cascading-Invariant (Iteration-2-L1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_cascading_on_repeated_poison_messages(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """100 poison messages must not cascade into a supervisor restart storm.
+
+    Proves the bug class as a whole: alternating ``binascii.Error`` and
+    ``RuntimeError`` failures on 100 consecutive messages keep the worker in
+    its operational state, every message is acked in order, and the
+    outer-catch is never entered. A final valid sentinel message is processed
+    normally to show the worker is still responsive after the cascade attempt.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+
+    poison_messages = [
+        make_poison_data_message(
+            persistent_id=f"poison-{i:03d}",
+            kind="padding" if i % 2 == 0 else "value",
+        )
+        for i in range(100)
+    ]
+    sentinel = make_valid_data_message("valid-001")
+    messages = poison_messages + [sentinel]
+
+    handled: list[str] = []
+
+    # Per-iteration run_state snapshot via _handle_message side_effect.
+    iter_states: list[FcmPushClientRunState] = []
+
+    plan: list[BaseException | None] = []
+    for i in range(100):
+        if i % 2 == 0:
+            plan.append(binascii.Error("Incorrect padding"))
+        else:
+            plan.append(RuntimeError("couldn't find in app_data crypto-key"))
+    plan.append(None)  # sentinel: valid message passes through
+
+    plan_iter = iter(plan)
+
+    async def _instrumented_handle(msg: SimpleNamespace) -> None:
+        iter_states.append(client.run_state)
+        try:
+            step = next(plan_iter)
+        except StopIteration as exc:
+            raise AssertionError("plan exhausted") from exc
+        if isinstance(step, BaseException):
+            raise step
+        handled.append(msg.persistent_id)
+
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = AsyncMock(side_effect=_instrumented_handle)
+
+    await client._listen()
+
+    # (a) run_state stays STARTED throughout the poison cascade.
+    assert all(state == FcmPushClientRunState.STARTED for state in iter_states), (
+        f"run_state drift during cascade: {iter_states!r}"
+    )
+    # (b) All 100 poison messages acked in order.
+    expected_acks = [f"poison-{i:03d}" for i in range(100)]
+    actual_acks = [call.args[0] for call in client._send_selective_ack.await_args_list]
+    assert actual_acks == expected_acks
+    # (c) Outer catch never entered.
+    assert not _outer_catch_was_hit(caplog)
+    # (d) Sentinel valid message processed normally after the cascade.
+    assert handled == ["valid-001"]

--- a/tests/test_init_basics.py
+++ b/tests/test_init_basics.py
@@ -1,0 +1,878 @@
+# tests/test_init_basics.py
+"""Basics coverage for :mod:`custom_components.googlefindmy.__init__` (Phase 4 AP-K).
+
+Leverage rationale (CA-COV-HEBEL-001): ``__init__.py`` is the largest module in the
+codebase (~4266 statements, 63 % baseline). Sixteen pure-function helpers are
+currently completely untested. They split into five families, all of which are
+risk-prioritized per Aniche RV-G3 because they execute on every config-entry
+setup/unload cycle:
+
+1. Entity-deduplication scoring (``_compute_entity_score`` /
+   ``_pick_canonical_entity_entry``): silent canonical-entity drift would hide
+   duplicate trackers from the user.
+2. Config-entry health scoring (``_entry_schema_score`` /
+   ``_entry_creation_timestamp``): drives the coalesce algorithm that decides
+   which legacy entry survives a merge.
+3. Platform/subentry identifier helpers (``_feature_name_from_platform`` /
+   ``_subentry_entry_id`` / ``_default_button_subentry_identifier``): mapping
+   bugs would route entities to the wrong subentry and corrupt the device
+   registry.
+4. Domain-data accessors (``_get_fcm_refcount`` / ``_get_nova_refcount`` and
+   their setters / receivers map / ``_sync_receiver_default_entry``): wrong
+   refcount math leaks FCM connections; this is exactly the bug class behind
+   the open memory-leak report on HA Core 2026.6.x.
+5. Button unique-id parsing and tracker identifier candidates
+   (``_normalize_legacy_button_remainder`` / ``_parse_button_unique_id`` /
+   ``_iter_tracker_identifier_candidates`` / ``_normalize_device_identifier``):
+   these power the button-relink heuristics across schema migrations.
+
+Pre-Push-Sweep (testing-strategien.md § 18.1) and CA-MOCK-001 + CA-ASSERTION-
+EMPIRIE-001 enforce that every assertion is grounded against the production
+source ranges (``__init__.py`` lines 564-784, 1053-1092, 2296-2316, 2882-3142,
+3230-3258, 3537-3704). No ``asyncio.run`` is used (CA-ASYNCIO-RUN-001) — all
+async helpers covered here are deliberately exercised through their synchronous
+contract or via ``pytest.mark.asyncio``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+
+from custom_components.googlefindmy import (
+    _DEFAULT_SUBENTRY_IDENTIFIER,
+    ConfigEntrySubentryDefinition,
+    RuntimeData,
+    _ButtonUniqueIdParts,
+    _compute_entity_score,
+    _default_button_subentry_identifier,
+    _entry_creation_timestamp,
+    _entry_schema_score,
+    _feature_name_from_platform,
+    _get_fcm_refcount,
+    _get_fcm_refcounts,
+    _get_nova_refcount,
+    _get_retry_attempts,
+    _get_retry_handles,
+    _iter_tracker_identifier_candidates,
+    _normalize_device_identifier,
+    _normalize_legacy_button_remainder,
+    _parse_button_unique_id,
+    _pick_canonical_entity_entry,
+    _runtime_data,
+    _set_fcm_refcount,
+    _set_nova_refcount,
+    _subentry_entry_id,
+    _sync_receiver_default_entry,
+)
+from custom_components.googlefindmy.const import (
+    CONF_OAUTH_TOKEN,
+    DATA_AAS_TOKEN,
+    DATA_AUTH_METHOD,
+    DATA_SECRET_BUNDLE,
+    DOMAIN,
+    SUBENTRY_TYPE_TRACKER,
+)
+
+# ---------------------------------------------------------------------------
+# Lightweight fakes (no Home Assistant fixtures needed for pure helpers)
+# ---------------------------------------------------------------------------
+
+
+class _FakeStates:
+    """Minimal ``hass.states`` substitute returning a configurable state."""
+
+    def __init__(self, mapping: dict[str, Any] | None = None) -> None:
+        self._mapping = mapping or {}
+
+    def get(self, entity_id: str) -> Any:
+        return self._mapping.get(entity_id)
+
+
+def _make_hass(states: dict[str, Any] | None = None) -> SimpleNamespace:
+    """Return a lightweight ``hass`` double exposing only ``.states.get``."""
+
+    return SimpleNamespace(states=_FakeStates(states or {}))
+
+
+def _make_entity(
+    entity_id: str,
+    *,
+    translation_key: str | None = None,
+    disabled_by: Any = None,
+) -> SimpleNamespace:
+    """Return a registry-entry double covering the score-relevant attributes."""
+
+    return SimpleNamespace(
+        entity_id=entity_id,
+        translation_key=translation_key,
+        disabled_by=disabled_by,
+    )
+
+
+def _make_state(state: str = "on") -> SimpleNamespace:
+    """Return a state object whose ``.state`` attribute is the supplied string."""
+
+    return SimpleNamespace(state=state)
+
+
+def _make_entry(
+    *,
+    data: dict[str, Any] | None = None,
+    options: dict[str, Any] | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+    entry_id: str = "entry-1",
+) -> SimpleNamespace:
+    """Return a config-entry double exposing the attributes touched by helpers."""
+
+    return SimpleNamespace(
+        entry_id=entry_id,
+        data=data or {},
+        options=options or {},
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Block A — Entity duplicate scoring (Lines 669-705)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeEntityScoreBasics:
+    """``_compute_entity_score`` weights translation_key (4) + active (3) + state (3)."""
+
+    @pytest.mark.parametrize(
+        ("translation_key", "disabled_by", "state_value", "expected"),
+        [
+            (None, "user", None, 0),  # nothing
+            ("my_key", "user", None, 4),  # translation_key only
+            (None, None, None, 3),  # enabled only
+            (None, "user", "on", 3),  # active state only
+            ("my_key", None, "on", 10),  # full house
+            (
+                "my_key",
+                None,
+                STATE_UNAVAILABLE,
+                7,
+            ),  # state unavailable strips +3
+            (
+                "my_key",
+                None,
+                STATE_UNKNOWN,
+                7,
+            ),  # state unknown strips +3
+            ("my_key", "user", "off", 7),  # disabled strips +3
+        ],
+    )
+    def test_score_components_combine_additively(
+        self,
+        translation_key: str | None,
+        disabled_by: Any,
+        state_value: str | None,
+        expected: int,
+    ) -> None:
+        entity = _make_entity(
+            "sensor.foo",
+            translation_key=translation_key,
+            disabled_by=disabled_by,
+        )
+        states = {"sensor.foo": _make_state(state_value)} if state_value else {}
+        hass = _make_hass(states)
+
+        assert _compute_entity_score(hass, entity) == expected
+
+    def test_missing_state_object_does_not_credit_state_points(self) -> None:
+        """A state lookup miss must not award the +3 active-state points."""
+
+        entity = _make_entity("sensor.never_seen", translation_key="k", disabled_by=None)
+        hass = _make_hass({})  # no state recorded
+
+        # translation_key (+4) + enabled (+3) + no state ⇒ 7
+        assert _compute_entity_score(hass, entity) == 7
+
+
+class TestPickCanonicalEntityEntryBasics:
+    """``_pick_canonical_entity_entry`` keeps the highest-scoring entry; ties stay first."""
+
+    def test_returns_first_when_all_scores_tie(self) -> None:
+        first = _make_entity("sensor.a")
+        second = _make_entity("sensor.b")
+        hass = _make_hass({})
+
+        assert _pick_canonical_entity_entry(hass, [first, second]) is first
+
+    def test_prefers_higher_score(self) -> None:
+        weaker = _make_entity("sensor.weak", disabled_by="user")
+        stronger = _make_entity("sensor.strong", translation_key="k", disabled_by=None)
+        hass = _make_hass({"sensor.strong": _make_state("on")})
+
+        canonical = _pick_canonical_entity_entry(
+            hass, [weaker, stronger]
+        )
+
+        assert canonical is stronger
+
+    def test_single_entry_returns_itself(self) -> None:
+        only = _make_entity("sensor.only", translation_key="k")
+        hass = _make_hass({})
+
+        assert _pick_canonical_entity_entry(hass, [only]) is only
+
+
+# ---------------------------------------------------------------------------
+# Block B — Config-entry health scoring (Lines 751-784)
+# ---------------------------------------------------------------------------
+
+
+class TestEntrySchemaScoreBasics:
+    """``_entry_schema_score`` sums bundle, auth, oauth, aas, and option counts."""
+
+    def test_empty_entry_scores_zero(self) -> None:
+        entry = _make_entry(data={}, options={})
+
+        assert _entry_schema_score(entry) == 0
+
+    def test_mapping_bundle_scores_five(self) -> None:
+        entry = _make_entry(
+            data={DATA_SECRET_BUNDLE: {"secrets_data": {"x": 1}}},
+            options={},
+        )
+
+        # bundle is Mapping ⇒ +5; no auth/oauth/aas ⇒ total 5
+        assert _entry_schema_score(entry) == 5
+
+    def test_non_mapping_bundle_scores_two(self) -> None:
+        entry = _make_entry(
+            data={DATA_SECRET_BUNDLE: "raw-string-bundle"},
+            options={},
+        )
+
+        # bundle not Mapping but truthy ⇒ +2
+        assert _entry_schema_score(entry) == 2
+
+    def test_auth_oauth_aas_all_add(self) -> None:
+        entry = _make_entry(
+            data={
+                DATA_AUTH_METHOD: "secrets_json",
+                CONF_OAUTH_TOKEN: "oauth-x",
+                DATA_AAS_TOKEN: "aas-x",
+            },
+            options={},
+        )
+
+        # +2 (auth) +1 (oauth) +1 (aas) ⇒ 4
+        assert _entry_schema_score(entry) == 4
+
+    def test_options_length_is_added_separately(self) -> None:
+        entry = _make_entry(
+            data={},
+            options={"opt_a": 1, "opt_b": 2, "opt_c": 3},
+        )
+
+        # options-Mapping container scans through all 5 checks (zero), then
+        # len(entry.options) ⇒ 3 is added at the end
+        assert _entry_schema_score(entry) == 3
+
+    def test_non_mapping_data_is_skipped(self) -> None:
+        """Non-Mapping ``entry.data`` must short-circuit without errors."""
+
+        entry = SimpleNamespace(data="not-a-mapping", options={})
+
+        # Only ``len(entry.options) == 0`` remains. Production source line 768
+        # short-circuits the non-Mapping container with ``continue``.
+        assert _entry_schema_score(entry) == 0
+
+
+class TestEntryCreationTimestampBasics:
+    """``_entry_creation_timestamp`` prefers ``created_at`` then ``updated_at`` then inf."""
+
+    def test_created_at_takes_precedence(self) -> None:
+        created = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        updated = datetime(2030, 1, 1, 12, 0, tzinfo=UTC)
+        entry = _make_entry(created_at=created, updated_at=updated)
+
+        assert _entry_creation_timestamp(entry) == created.timestamp()
+
+    def test_falls_back_to_updated_at_when_created_missing(self) -> None:
+        updated = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        entry = _make_entry(created_at=None, updated_at=updated)
+
+        assert _entry_creation_timestamp(entry) == updated.timestamp()
+
+    def test_returns_inf_when_no_timestamp_available(self) -> None:
+        entry = _make_entry(created_at=None, updated_at=None)
+
+        assert _entry_creation_timestamp(entry) == float("inf")
+
+    def test_non_datetime_falls_back_to_updated_at(self) -> None:
+        """A string ``created_at`` triggers the ``updated_at`` fallback path."""
+
+        updated = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        entry = SimpleNamespace(created_at="2026-01-01", updated_at=updated)
+
+        assert _entry_creation_timestamp(entry) == updated.timestamp()
+
+
+# ---------------------------------------------------------------------------
+# Block C — Platform / subentry identifier helpers (Lines 1053-1092, 3537-3548)
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureNameFromPlatformBasics:
+    """``_feature_name_from_platform`` returns the platform's domain string."""
+
+    def test_enum_with_string_value_returns_value(self) -> None:
+        platform = SimpleNamespace(value="sensor")
+
+        assert _feature_name_from_platform(platform) == "sensor"
+
+    def test_strips_dotted_prefix_when_value_missing(self) -> None:
+        class _Stub:
+            def __str__(self) -> str:
+                return "Platform.SENSOR"
+
+        # No ``.value`` attribute (slots not used here, no fallback string).
+        platform = _Stub()
+
+        assert _feature_name_from_platform(platform) == "sensor"
+
+    def test_lowercases_plain_str_repr(self) -> None:
+        class _Stub:
+            def __str__(self) -> str:
+                return "SENSOR"
+
+        assert _feature_name_from_platform(_Stub()) == "sensor"
+
+    def test_non_string_value_is_ignored(self) -> None:
+        """A non-string ``.value`` must fall through to the ``__str__`` path."""
+
+        class _Stub:
+            value = 42
+
+            def __str__(self) -> str:
+                return "domain.button"
+
+        # Value is int, so the first branch is skipped; ``str()`` yields the
+        # dotted form that gets split.
+        assert _feature_name_from_platform(_Stub()) == "button"
+
+
+class TestSubentryEntryIdBasics:
+    """``_subentry_entry_id`` prefers ``subentry_id`` then ``entry_id`` then ``None``."""
+
+    def test_returns_subentry_id_when_present(self) -> None:
+        subentry = SimpleNamespace(subentry_id="sub-1", entry_id="entry-1")
+
+        assert _subentry_entry_id(subentry) == "sub-1"
+
+    def test_falls_back_to_entry_id(self) -> None:
+        subentry = SimpleNamespace(subentry_id=None, entry_id="entry-1")
+
+        assert _subentry_entry_id(subentry) == "entry-1"
+
+    def test_returns_none_when_both_missing(self) -> None:
+        subentry = SimpleNamespace(subentry_id=None, entry_id=None)
+
+        assert _subentry_entry_id(subentry) is None
+
+    def test_empty_string_is_rejected(self) -> None:
+        """Empty strings must not satisfy the truthiness guard."""
+
+        subentry = SimpleNamespace(subentry_id="", entry_id="")
+
+        assert _subentry_entry_id(subentry) is None
+
+    def test_non_string_subentry_id_falls_through(self) -> None:
+        """``isinstance(str)`` check forces the fallback when type mismatches."""
+
+        subentry = SimpleNamespace(subentry_id=42, entry_id="entry-1")
+
+        assert _subentry_entry_id(subentry) == "entry-1"
+
+
+class TestDefaultButtonSubentryIdentifierBasics:
+    """``_default_button_subentry_identifier`` checks button → device_tracker → default."""
+
+    def test_returns_button_identifier_when_present(self) -> None:
+        result = _default_button_subentry_identifier(
+            {"button": "btn-id", "device_tracker": "tracker-id"}
+        )
+
+        assert result == "btn-id"
+
+    def test_falls_back_to_device_tracker(self) -> None:
+        result = _default_button_subentry_identifier(
+            {"device_tracker": "tracker-id"}
+        )
+
+        assert result == "tracker-id"
+
+    def test_returns_module_default_when_both_missing(self) -> None:
+        result = _default_button_subentry_identifier({})
+
+        assert result == _DEFAULT_SUBENTRY_IDENTIFIER
+        assert result == "core_tracking"  # empirisch: __init__.py Z. 4951
+
+    def test_skips_non_string_identifier(self) -> None:
+        """Non-string identifiers must not satisfy the truthy/type guard."""
+
+        result = _default_button_subentry_identifier(
+            {"button": 0, "device_tracker": ""}
+        )
+
+        # Both candidates fail the ``isinstance(str) and identifier`` guard, so
+        # the module-default fires.
+        assert result == _DEFAULT_SUBENTRY_IDENTIFIER
+
+
+# ---------------------------------------------------------------------------
+# Block D — RuntimeData accessors (Lines 2296-2316)
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeDataAccessorBasics:
+    """``_runtime_data`` / ``_get_retry_attempts`` / ``_get_retry_handles`` route via runtime_data."""
+
+    def _make_runtime(self) -> RuntimeData:
+        # RuntimeData is a slots dataclass — fill required fields with magic
+        # mocks because the helpers under test only touch ``subentry_retry_*``.
+        return RuntimeData(
+            coordinator=MagicMock(),
+            token_cache=MagicMock(),
+            subentry_manager=MagicMock(),
+        )
+
+    def test_runtime_data_returns_runtime_data_object(self) -> None:
+        runtime = self._make_runtime()
+        entry = SimpleNamespace(runtime_data=runtime)
+
+        assert _runtime_data(entry) is runtime
+
+    def test_runtime_data_asserts_on_wrong_type(self) -> None:
+        entry = SimpleNamespace(runtime_data="not a RuntimeData")
+
+        with pytest.raises(AssertionError):
+            _runtime_data(entry)
+
+    def test_get_retry_attempts_returns_runtime_field(self) -> None:
+        runtime = self._make_runtime()
+        runtime.subentry_retry_attempts["sub-1"] = {"forward": 2}
+        entry = SimpleNamespace(runtime_data=runtime)
+
+        attempts = _get_retry_attempts(entry)
+
+        assert attempts is runtime.subentry_retry_attempts
+        assert attempts["sub-1"]["forward"] == 2
+
+    def test_get_retry_handles_returns_runtime_field(self) -> None:
+        runtime = self._make_runtime()
+        handle = MagicMock()
+        runtime.subentry_retry_handles["sub-1"] = handle
+        entry = SimpleNamespace(runtime_data=runtime)
+
+        handles = _get_retry_handles(entry)
+
+        assert handles is runtime.subentry_retry_handles
+        assert handles["sub-1"] is handle
+
+
+# ---------------------------------------------------------------------------
+# Block E — Domain-data accessors: FCM refcounts (Lines 3076-3122)
+# ---------------------------------------------------------------------------
+
+
+class TestFcmRefcountsBasics:
+    """``_get_fcm_refcount`` / ``_set_fcm_refcount`` enforce per-entry refcounting."""
+
+    def test_get_fcm_refcounts_normalizes_invalid_entries(self) -> None:
+        bucket: dict[str, Any] = {
+            "fcm_refcounts": {
+                "good": 3,
+                42: 5,  # non-string key
+                "bad-value": "not-an-int",
+            }
+        }
+
+        refcounts = _get_fcm_refcounts(bucket)  # type: ignore[arg-type]
+
+        # Production source line 3083 keeps only str→int pairs.
+        assert refcounts == {"good": 3}
+        # ``bucket`` is mutated in place to hold the sanitized dict.
+        assert bucket["fcm_refcounts"] is refcounts
+
+    def test_get_fcm_refcounts_creates_dict_when_missing(self) -> None:
+        bucket: dict[str, Any] = {}
+
+        refcounts = _get_fcm_refcounts(bucket)  # type: ignore[arg-type]
+
+        assert refcounts == {}
+        assert bucket["fcm_refcounts"] is refcounts
+
+    def test_get_fcm_refcount_returns_value_for_existing_entry(self) -> None:
+        bucket: dict[str, Any] = {"fcm_refcounts": {"entry-1": 7}}
+
+        assert _get_fcm_refcount(bucket, "entry-1") == 7  # type: ignore[arg-type]
+
+    def test_get_fcm_refcount_returns_zero_for_unknown_entry(self) -> None:
+        bucket: dict[str, Any] = {"fcm_refcounts": {"entry-1": 7}}
+
+        assert _get_fcm_refcount(bucket, "entry-2") == 0  # type: ignore[arg-type]
+
+    def test_set_fcm_refcount_writes_and_mirrors_default(self) -> None:
+        bucket: dict[str, Any] = {}
+
+        _set_fcm_refcount(bucket, "default", 4)  # type: ignore[arg-type]
+
+        assert bucket["fcm_refcounts"]["default"] == 4
+        # default-entry must mirror to legacy ``fcm_refcount`` key (line 3105)
+        assert bucket["fcm_refcount"] == 4
+
+    def test_set_fcm_refcount_does_not_touch_legacy_for_non_default(self) -> None:
+        bucket: dict[str, Any] = {}
+
+        _set_fcm_refcount(bucket, "entry-x", 9)  # type: ignore[arg-type]
+
+        assert bucket["fcm_refcounts"]["entry-x"] == 9
+        assert "fcm_refcount" not in bucket
+
+
+class TestNovaRefcountBasics:
+    """``_get_nova_refcount`` / ``_set_nova_refcount`` cover the Nova session counter."""
+
+    def test_get_returns_stored_int(self) -> None:
+        bucket: dict[str, Any] = {"nova_refcount": 5}
+
+        assert _get_nova_refcount(bucket) == 5  # type: ignore[arg-type]
+
+    def test_get_returns_zero_when_missing(self) -> None:
+        assert _get_nova_refcount({}) == 0  # type: ignore[arg-type]
+
+    def test_get_returns_zero_when_value_is_not_int(self) -> None:
+        """A corrupt non-int stored value must not crash the helper."""
+
+        bucket: dict[str, Any] = {"nova_refcount": "not-an-int"}
+
+        assert _get_nova_refcount(bucket) == 0  # type: ignore[arg-type]
+
+    def test_set_persists_value(self) -> None:
+        bucket: dict[str, Any] = {}
+
+        _set_nova_refcount(bucket, 3)  # type: ignore[arg-type]
+
+        assert bucket["nova_refcount"] == 3
+
+
+class TestSyncReceiverDefaultEntryBasics:
+    """``_sync_receiver_default_entry`` prefers ``set_default_entry_id`` over setattr."""
+
+    def test_uses_setter_when_available(self) -> None:
+        setter = MagicMock()
+        receiver = SimpleNamespace(set_default_entry_id=setter)
+
+        _sync_receiver_default_entry(receiver, "entry-1")
+
+        setter.assert_called_once_with("entry-1")
+
+    def test_falls_back_to_setattr_when_setter_missing(self) -> None:
+        receiver = SimpleNamespace()
+
+        _sync_receiver_default_entry(receiver, "entry-2")
+
+        assert receiver.default_entry_id == "entry-2"
+
+    def test_none_entry_is_silently_ignored(self) -> None:
+        setter = MagicMock()
+        receiver = SimpleNamespace(set_default_entry_id=setter)
+
+        _sync_receiver_default_entry(receiver, None)
+
+        setter.assert_not_called()
+        assert not hasattr(receiver, "default_entry_id")
+
+    def test_setter_exception_falls_through_to_attribute_assignment(self) -> None:
+        """When the setter raises, the helper still writes ``default_entry_id``."""
+
+        setter = MagicMock(side_effect=RuntimeError("boom"))
+        receiver = SimpleNamespace(set_default_entry_id=setter)
+
+        _sync_receiver_default_entry(receiver, "entry-x")
+
+        # Fallback path (line 3138-3141) writes the attribute despite the
+        # setter failure.
+        assert receiver.default_entry_id == "entry-x"
+
+
+# ---------------------------------------------------------------------------
+# Block F — Device identifier normalization (Lines 3230-3258)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeDeviceIdentifierBasics:
+    """``_normalize_device_identifier`` strips entry/subentry prefixes from device IDs."""
+
+    def test_empty_identifier_returns_unchanged(self) -> None:
+        assert _normalize_device_identifier(SimpleNamespace(), "") == ""
+
+    def test_identifier_without_colon_passes_through(self) -> None:
+        device = SimpleNamespace(config_entries=set())
+
+        assert (
+            _normalize_device_identifier(device, "integration_entry-1")
+            == "integration_entry-1"
+        )
+
+    def test_strips_known_config_entry_prefix(self) -> None:
+        device = SimpleNamespace(config_entries={"entry-1"})
+
+        assert (
+            _normalize_device_identifier(
+                device, "entry-1:sub-1:google-device-7"
+            )
+            == "google-device-7"
+        )
+
+    def test_only_last_segment_is_returned(self) -> None:
+        """Without matching config_entries, last segment after split is kept."""
+
+        device = SimpleNamespace(config_entries=set())
+
+        assert (
+            _normalize_device_identifier(device, "foo:bar:baz") == "baz"
+        )
+
+    def test_trailing_empty_segment_falls_back_to_ident(self) -> None:
+        """Empty last segment must not blank the identifier."""
+
+        device = SimpleNamespace(config_entries=set())
+
+        result = _normalize_device_identifier(device, "foo:")
+
+        # ``last or ident`` (production line 3258) returns the original.
+        assert result == "foo:"
+
+
+# ---------------------------------------------------------------------------
+# Block G — Legacy button remainder + button unique-id parser (Lines 3569-3704)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeLegacyButtonRemainderBasics:
+    """``_normalize_legacy_button_remainder`` strips legacy ``tracker_`` prefixes."""
+
+    def test_no_action_suffix_returns_remainder_unchanged(self) -> None:
+        result = _normalize_legacy_button_remainder(
+            "tracker_devicexlocate",
+            identifier="core_tracking",
+            suffixes=("play_sound", "stop_sound", "locate_device"),
+        )
+
+        # No matching suffix ⇒ early return.
+        assert result == "tracker_devicexlocate"
+
+    def test_strips_legacy_tracker_prefix_when_action_matches(self) -> None:
+        result = _normalize_legacy_button_remainder(
+            "tracker_device123play_sound",
+            identifier="core_tracking",
+            suffixes=("play_sound",),
+        )
+
+        # Production line 3594: returns ``{trimmed}{action_suffix}``.
+        assert result == "device123play_sound"
+
+    def test_keeps_remainder_when_payload_already_identifier_prefixed(self) -> None:
+        result = _normalize_legacy_button_remainder(
+            "core_tracking_device123play_sound",
+            identifier="core_tracking",
+            suffixes=("play_sound",),
+        )
+
+        # Payload starts with ``{identifier}_`` ⇒ early return at line 3587.
+        assert result == "core_tracking_device123play_sound"
+
+    def test_legacy_prefix_with_empty_remainder_falls_through(self) -> None:
+        """Trimming to empty must NOT strip the legacy prefix."""
+
+        result = _normalize_legacy_button_remainder(
+            "tracker_play_sound",
+            identifier="core_tracking",
+            suffixes=("play_sound",),
+        )
+
+        # ``trimmed`` ⇒ empty after slicing ``tracker_`` ⇒ break ⇒ original
+        # remainder (line 3597 reachable only when prefix absent or trimmed
+        # empty).
+        assert result == "tracker_play_sound"
+
+
+class TestParseButtonUniqueIdBasics:
+    """``_parse_button_unique_id`` decodes legacy + namespaced unique IDs."""
+
+    def _entry(self) -> SimpleNamespace:
+        return SimpleNamespace(entry_id="entry-1")
+
+    def test_returns_none_for_empty_unique_id(self) -> None:
+        assert (
+            _parse_button_unique_id(
+                "", self._entry(), {}, "core_tracking"
+            )
+            is None
+        )
+
+    def test_returns_none_for_non_string_unique_id(self) -> None:
+        assert (
+            _parse_button_unique_id(
+                42,  # type: ignore[arg-type]
+                self._entry(),
+                {},
+                "core_tracking",
+            )
+            is None
+        )
+
+    def test_full_namespaced_unique_id(self) -> None:
+        """``<domain>_<entry_id>:<sub_id>:<device_id>_<action>`` parses cleanly."""
+
+        unique = f"{DOMAIN}_entry-1:sub-7:device-A_play_sound"
+
+        parts = _parse_button_unique_id(
+            unique, self._entry(), {}, "core_tracking"
+        )
+
+        assert parts is not None
+        assert parts.entry_id == "entry-1"
+        assert parts.subentry_id == "sub-7"
+        assert parts.google_device_id == "device-A"
+        assert parts.action == "play_sound"
+
+    def test_unknown_subentry_falls_back_to_default(self) -> None:
+        """If no subentry token resolves, ``fallback_subentry_id`` is used."""
+
+        unique = f"{DOMAIN}_entry-1_device-B_play_sound"
+
+        parts = _parse_button_unique_id(
+            unique, self._entry(), {}, fallback_subentry_id="core_tracking"
+        )
+
+        assert parts is not None
+        assert parts.subentry_id == "core_tracking"
+        assert parts.google_device_id == "device-B"
+        assert parts.action == "play_sound"
+
+    def test_subentry_map_resolves_known_token(self) -> None:
+        """``subentry_map`` values can match a longest-prefix token in the remainder."""
+
+        unique = f"{DOMAIN}_entry-1_sub-known_device-Z_play_sound"
+        subentry_map = {"button": "sub-known"}
+
+        parts = _parse_button_unique_id(
+            unique, self._entry(), subentry_map, "core_tracking"
+        )
+
+        assert parts is not None
+        assert parts.subentry_id == "sub-known"
+        assert parts.google_device_id == "device-Z"
+
+    def test_mismatched_entry_id_returns_none(self) -> None:
+        """Namespaced unique ID belonging to a different entry must not resolve."""
+
+        unique = f"{DOMAIN}_other-entry:sub-1:device_play_sound"
+
+        result = _parse_button_unique_id(
+            unique, self._entry(), {}, "core_tracking"
+        )
+
+        assert result is None
+
+    def test_unknown_action_falls_back_to_split(self) -> None:
+        """When no known action suffix matches, ``rsplit('_', 1)`` is used."""
+
+        unique = "entry-1_device-X_custom"  # ``custom`` is not in suffix tuple
+
+        parts = _parse_button_unique_id(
+            unique, self._entry(), {}, "core_tracking"
+        )
+
+        assert parts is not None
+        assert parts.action == "custom"
+        assert parts.google_device_id == "device-X"
+
+    def test_returns_none_for_unparseable_unique_id(self) -> None:
+        """Single-token unique IDs without underscore must fail cleanly."""
+
+        result = _parse_button_unique_id(
+            "lonely-token", self._entry(), {}, "core_tracking"
+        )
+
+        assert result is None
+
+    def test_empty_entry_id_returns_none(self) -> None:
+        """``entry.entry_id`` must be a non-empty string (line 3635)."""
+
+        entry = SimpleNamespace(entry_id="")
+
+        result = _parse_button_unique_id(
+            f"{DOMAIN}_entry-1_device_play_sound",
+            entry,
+            {},
+            "core_tracking",
+        )
+
+        assert result is None
+
+
+class TestIterTrackerIdentifierCandidatesBasics:
+    """``_iter_tracker_identifier_candidates`` yields three layered registry lookups."""
+
+    def test_returns_three_layered_candidates(self) -> None:
+        parts = _ButtonUniqueIdParts(
+            entry_id="entry-1",
+            subentry_id="sub-7",
+            google_device_id="device-A",
+            action="play_sound",
+        )
+
+        candidates = _iter_tracker_identifier_candidates(parts)
+
+        assert candidates == (
+            (DOMAIN, "entry-1:sub-7:device-A"),
+            (DOMAIN, "entry-1:device-A"),
+            (DOMAIN, "device-A"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Block H — ConfigEntrySubentryDefinition dataclass smoke (Lines 1095-1108)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigEntrySubentryDefinitionBasics:
+    """``ConfigEntrySubentryDefinition`` defaults to the tracker subentry type."""
+
+    def test_default_subentry_type_is_tracker(self) -> None:
+        definition = ConfigEntrySubentryDefinition(
+            key="trackers",
+            title="Trackers",
+            data={"some": "data"},
+        )
+
+        assert definition.key == "trackers"
+        assert definition.title == "Trackers"
+        assert definition.data == {"some": "data"}
+        assert definition.subentry_type == SUBENTRY_TYPE_TRACKER
+
+    def test_subentry_type_can_be_overridden(self) -> None:
+        definition = ConfigEntrySubentryDefinition(
+            key="trackers",
+            title="Trackers",
+            data={},
+            subentry_type="custom_type",
+        )
+
+        assert definition.subentry_type == "custom_type"


### PR DESCRIPTION
## Summary

Forward-ports the stranded Class-A coverage suite onto `1.7.0-7`, adds the
#1086 FCM listener-lifecycle / re-auth-escalation hardening, and recalibrates
the coverage regression floor to match the new measured baseline.

## Commits

- `9d195248` — test: forward-port stranded Class-A coverage suite from cov-integ (17 files: 8 stubs + 9 modules). `pytest --collect-only` exit 0, no fixture/name collisions with `1.7.0-7` tests.
- `2fd4556e` — feat(fcm): harden listener lifecycle and re-auth escalation (#1086 forward-port).
- `2f58f8bf` — chore(coverage): recalibrate `fail_under` floor 63 → 67.

## FCM hardening (`2fd4556e`)

- Lossless forward-port of `fcm_receiver_ha.py` + `fcmpushclient.py` (**0 diff** vs `cov-integ`), carrying the 10 #1086 hardening commits verbatim (latch-restoration, `_has_been_started` observable subclass, `CRASH_LOOP_FATAL_PREFIX`).
- Surgical `polling.py` delta: 3-way `_classify_fcm_fatal` dispatch on the existing escalation machinery. The crash-loop class no longer falls through to the auth re-escalation path (it resets the partial counter instead of raising). #1095 / log-demote lines preserved (`POLL_DEVICE_OUTER_TIMEOUT_S` intact).
- New CA-6 wiring tests (no-raise + counter-reset), mutation-proven: breaking the delta turns both tests red.
- `mypy --strict` (CI pin 1.19.1) green on package (120) + tests (233); `ruff` green; owasp gate PASS (trust boundary clean, no prefix spoofing, fail-safe default).

## Coverage floor (`2f58f8bf`)

Local full-suite scoped coverage measured **68.33 %** (3696 passed). The
regression floor is raised `63 → floor(68) − 1 = 67` (1 Pp jitter margin),
clamped to `[63, CI total]`. Three local entity tests error on a root-owned
`.storage` path that CI does not hit, so CI scoped coverage is `≥ 68.33 %`
and the 67 floor stays green. The 95 % quality-scale target remains separate
follow-up work; this floor only guards against regressions.

## Test plan

- Full local suite: **3696 passed, 20 skipped** (the 2 failed / 3 errored are
  environment artifacts — `mypy`/`ruff` invoked as subprocesses absent in the
  local venv, and a root-owned `.storage` path; both reproduce on the base
  commit without these changes).
- `mypy --strict` + `ruff` green on all changed files.
