### PR TITLE
feat(fcm): offer a fixable reauth repair when push stays stuck

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -955,6 +955,44 @@ class FcmReceiverHA:
             self.creds[entry_id] = creds if isinstance(creds, dict) else None
             return pc
 
+    def _async_raise_reauth_issue(self, entry_id: str, *, reason: str) -> None:
+        """Surface a fixable repair that drives the user into the reauth flow.
+
+        All three terminal give-up points collapse into a single issue id
+        (``fcm_reauth_required_{entry_id}``) because the corrective action is
+        identical: re-authenticate / re-register. The fix flow in
+        ``repairs.py`` calls ``entry.async_start_reauth`` on confirmation.
+
+        The escalation thresholds are NOT re-invented here. They are the
+        existing retry caps consumed at the call sites:
+
+        * ``_MAX_FATAL_ENDPOINT_RETRIES`` (7) -- with the ``min(300, 30*n)``
+          backoff this is ~630 s of sustained 404 endpoint exhaustion before
+          give-up; a transient Google endpoint rotation clears well before it.
+        * ``_MAX_FATAL_AUTH_RETRIES`` (3) -- 401 token-renewal exhaustion.
+        * ``_BACKOFF_WARNING_THRESHOLD_S`` (64 s, ~6 failed registrations) --
+          the registration backoff warning point.
+
+        Because the repair hangs off those existing give-up/warning points, a
+        transient failure (count still below the cap) never raises it. The
+        recovery delete on a successful (re-)registration clears it again.
+
+        ``reason`` is a non-localised diagnostic hint forwarded via ``data``
+        so the fix flow / diagnostics can tell the three origins apart; the
+        fix flow itself only consumes ``entry_id``.
+        """
+        if not self._hass:
+            return
+        ir.async_create_issue(
+            self._hass,
+            DOMAIN,
+            f"fcm_reauth_required_{entry_id}",
+            is_fixable=True,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="fcm_reauth_required",
+            data={"entry_id": entry_id, "reason": reason},
+        )
+
     async def _start_supervisor_for_entry(  # noqa: PLR0915
         self, entry_id: str, cache: TokenCache | None
     ) -> None:
@@ -1043,6 +1081,13 @@ class FcmReceiverHA:
                                     entry_id,
                                     fatal_count,
                                 )
+                                # Auth retry budget exhausted
+                                # (``_MAX_FATAL_AUTH_RETRIES``): offer the
+                                # fixable reauth repair instead of giving up
+                                # silently.
+                                self._async_raise_reauth_issue(
+                                    entry_id, reason="auth_401"
+                                )
                                 break
 
                             await self._invalidate_fcm_tokens(entry_id)
@@ -1071,6 +1116,15 @@ class FcmReceiverHA:
                                     "giving up.",
                                     entry_id,
                                     fatal_count,
+                                )
+                                # Endpoint retry budget exhausted
+                                # (``_MAX_FATAL_ENDPOINT_RETRIES`` == 7 ⇒
+                                # ~630 s of sustained 404 with the
+                                # ``min(300, 30*n)`` backoff): surface the
+                                # fixable reauth repair. This give-up was
+                                # previously a silent break with no issue.
+                                self._async_raise_reauth_issue(
+                                    entry_id, reason="endpoint_404"
                                 )
                                 break
 
@@ -1103,15 +1157,14 @@ class FcmReceiverHA:
                                 entry_id,
                                 delay,
                             )
-                            if self._hass:
-                                ir.async_create_issue(
-                                    self._hass,
-                                    DOMAIN,
-                                    f"fcm_stuck_{entry_id}",
-                                    is_fixable=False,
-                                    severity=ir.IssueSeverity.WARNING,
-                                    translation_key="fcm_connection_stuck",
-                                )
+                            # Registration backoff warning point
+                            # (``_BACKOFF_WARNING_THRESHOLD_S``): escalate to
+                            # the same fixable reauth repair as the 404/401
+                            # give-up paths (was a non-fixable ``fcm_stuck``
+                            # warning offering no action path).
+                            self._async_raise_reauth_issue(
+                                entry_id, reason="registration_backoff"
+                            )
                         else:
                             _LOGGER.info(
                                 "[entry=%s] Re-trying FCM registration in %.1fs",
@@ -1127,6 +1180,15 @@ class FcmReceiverHA:
 
                     # Telemetry (aggregate counters)
                     if self._hass:
+                        # A successful (re-)registration resolves the fixable
+                        # reauth repair. Also delete the legacy non-fixable
+                        # ``fcm_stuck`` issue so it does not linger after an
+                        # upgrade from the previous key.
+                        ir.async_delete_issue(
+                            self._hass,
+                            DOMAIN,
+                            f"fcm_reauth_required_{entry_id}",
+                        )
                         ir.async_delete_issue(
                             self._hass, DOMAIN, f"fcm_stuck_{entry_id}"
                         )

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -440,6 +440,13 @@ class FcmReceiverHA:
         condition is gone (e.g. user re-registers credentials and FCM starts
         successfully again).
 
+        On a hard-reset teardown (``force=True``) the entry-scoped *fixable*
+        reauth repairs (``fcm_reauth_required_{entry_id}`` and the legacy
+        ``fcm_stuck_{entry_id}``) are retired as well. They are normally
+        deleted by the supervisor success path, but once the entry is gone no
+        supervisor will run again, so the orphaned repair would otherwise stay
+        pinned in the Repairs panel for a config entry that no longer exists.
+
         Defense 2 iter-8 (Codex second finding): a successful FCM
         re-registration is NOT a recovery proof for the short-run crash cap.
         While ``_short_run_cap_latched`` contains *entry_id* this method must
@@ -523,15 +530,44 @@ class FcmReceiverHA:
         if removed:
             self._fatal_error = next(iter(self._fatal_errors.values()), None)
 
-        if self._hass is not None:
+        self._delete_repair_issues_for_entry(entry_id, teardown=force)
+
+    def _delete_repair_issues_for_entry(
+        self, entry_id: str, *, teardown: bool
+    ) -> None:
+        """Retire the entry-scoped Repairs issues for a cleared/torn-down entry.
+
+        Always deletes the Defense 2 short-run-crash-loop issue, which is the
+        DELETE half of its CREATE/DELETE pair with the fatal-error map.
+
+        On a hard-reset teardown (``teardown=True``) it additionally retires
+        the *fixable* reauth repairs (``fcm_reauth_required_{entry_id}`` and the
+        legacy ``fcm_stuck_{entry_id}``). Those are normally deleted by the
+        supervisor success path, but once the entry is gone no supervisor will
+        run again, so the orphaned fixable repair would otherwise stay pinned in
+        the Repairs panel for a config entry that no longer exists. Non-teardown
+        recovery clears (credentials updated) keep relying on the success-path
+        delete and leave those issues untouched.
+
+        All deletions are best-effort UI cleanup; failures are logged and
+        swallowed so a registry hiccup never blocks the in-memory state reset.
+        """
+        if self._hass is None:
+            return
+
+        issue_ids = [f"fcm_short_run_crash_loop_{entry_id}"]
+        if teardown:
+            issue_ids.append(f"fcm_reauth_required_{entry_id}")
+            issue_ids.append(f"fcm_stuck_{entry_id}")
+
+        for issue_id in issue_ids:
             try:
-                ir.async_delete_issue(
-                    self._hass, DOMAIN, f"fcm_short_run_crash_loop_{entry_id}"
-                )
+                ir.async_delete_issue(self._hass, DOMAIN, issue_id)
             except Exception:  # noqa: BLE001 - best-effort UI cleanup
                 _LOGGER.debug(
-                    "[entry=%s] Failed to delete short-run repair issue",
+                    "[entry=%s] Failed to delete repair issue %s",
                     entry_id,
+                    issue_id,
                     exc_info=True,
                 )
 

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -440,12 +440,16 @@ class FcmReceiverHA:
         condition is gone (e.g. user re-registers credentials and FCM starts
         successfully again).
 
-        On a hard-reset teardown (``force=True``) the entry-scoped *fixable*
-        reauth repairs (``fcm_reauth_required_{entry_id}`` and the legacy
-        ``fcm_stuck_{entry_id}``) are retired as well. They are normally
-        deleted by the supervisor success path, but once the entry is gone no
-        supervisor will run again, so the orphaned repair would otherwise stay
-        pinned in the Repairs panel for a config entry that no longer exists.
+        A hard-reset teardown (``force=True``) additionally releases the
+        short-run cap latch (see below). It deliberately does NOT delete the
+        entry-scoped *fixable* reauth repairs: ``force=True`` is reached from
+        ``unregister_coordinator``, which fires on EVERY unload, including the
+        reload Home Assistant performs right after a successful reauth flow.
+        Deleting them here would dismiss a still-active prompt before the new
+        supervisor has proven recovery. Those repairs are retired by the
+        supervisor success path on reload and by
+        ``async_delete_entry_repair_issues`` on actual entry removal (Codex
+        PR #1104 follow-up).
 
         Defense 2 iter-8 (Codex second finding): a successful FCM
         re-registration is NOT a recovery proof for the short-run crash cap.
@@ -530,42 +534,72 @@ class FcmReceiverHA:
         if removed:
             self._fatal_error = next(iter(self._fatal_errors.values()), None)
 
-        self._delete_repair_issues_for_entry(entry_id, teardown=force)
+        self._delete_repair_issues_for_entry(entry_id)
 
-    def _delete_repair_issues_for_entry(
-        self, entry_id: str, *, teardown: bool
-    ) -> None:
-        """Retire the entry-scoped Repairs issues for a cleared/torn-down entry.
+    def _delete_repair_issues_for_entry(self, entry_id: str) -> None:
+        """Retire the transient short-run-crash-loop repair for a cleared entry.
 
-        Always deletes the Defense 2 short-run-crash-loop issue, which is the
-        DELETE half of its CREATE/DELETE pair with the fatal-error map.
+        This is the DELETE half of the ``fcm_short_run_crash_loop_{entry_id}``
+        CREATE/DELETE pair with the fatal-error map: any path that clears the
+        in-memory latch must also delete the user-visible UI artefact, or the
+        Repairs panel keeps a stale non-fixable error after the underlying
+        condition is gone.
 
-        On a hard-reset teardown (``teardown=True``) it additionally retires
-        the *fixable* reauth repairs (``fcm_reauth_required_{entry_id}`` and the
-        legacy ``fcm_stuck_{entry_id}``). Those are normally deleted by the
-        supervisor success path, but once the entry is gone no supervisor will
-        run again, so the orphaned fixable repair would otherwise stay pinned in
-        the Repairs panel for a config entry that no longer exists. Non-teardown
-        recovery clears (credentials updated) keep relying on the success-path
-        delete and leave those issues untouched.
+        It deliberately does NOT touch the *fixable* reauth repairs
+        (``fcm_reauth_required_{entry_id}`` / legacy ``fcm_stuck_{entry_id}``).
+        Those outlive a reload on purpose and are retired only by the supervisor
+        success path (reload recovery) or
+        ``async_delete_entry_repair_issues`` (actual entry removal). See those
+        for the full lifecycle rationale (Codex PR #1104 follow-up).
 
-        All deletions are best-effort UI cleanup; failures are logged and
+        The deletion is best-effort UI cleanup; failures are logged and
         swallowed so a registry hiccup never blocks the in-memory state reset.
         """
         if self._hass is None:
             return
 
-        issue_ids = [f"fcm_short_run_crash_loop_{entry_id}"]
-        if teardown:
-            issue_ids.append(f"fcm_reauth_required_{entry_id}")
-            issue_ids.append(f"fcm_stuck_{entry_id}")
+        try:
+            ir.async_delete_issue(
+                self._hass, DOMAIN, f"fcm_short_run_crash_loop_{entry_id}"
+            )
+        except Exception:  # noqa: BLE001 - best-effort UI cleanup
+            _LOGGER.debug(
+                "[entry=%s] Failed to delete short-run crash-loop repair issue",
+                entry_id,
+                exc_info=True,
+            )
 
-        for issue_id in issue_ids:
+    @staticmethod
+    def async_delete_entry_repair_issues(hass: HomeAssistant, entry_id: str) -> None:
+        """Delete every entry-scoped FCM Repairs issue for a REMOVED config entry.
+
+        Call this ONLY from ``async_remove_entry`` (actual removal). On removal
+        no supervisor will run again, so the entry-scoped repairs must be retired
+        explicitly or they stay pinned in the Repairs panel for a config entry
+        that no longer exists. This covers the *fixable* reauth prompt
+        (``fcm_reauth_required_{entry_id}``), its legacy non-fixable predecessor
+        (``fcm_stuck_{entry_id}``) and the transient short-run crash-loop
+        diagnostic (``fcm_short_run_crash_loop_{entry_id}``).
+
+        A reload must NOT use this: there ``unregister_coordinator`` fires via
+        ``async_on_unload`` while the entry lives on, and the supervisor success
+        path clears the reauth repair once FCM re-registers. Deleting it on
+        reload would dismiss a still-active prompt before the new supervisor has
+        proven recovery (Codex PR #1104 follow-up).
+
+        All deletions are best-effort UI cleanup; failures are swallowed so a
+        registry hiccup never blocks entry removal.
+        """
+        for issue_id in (
+            f"fcm_short_run_crash_loop_{entry_id}",
+            f"fcm_reauth_required_{entry_id}",
+            f"fcm_stuck_{entry_id}",
+        ):
             try:
-                ir.async_delete_issue(self._hass, DOMAIN, issue_id)
+                ir.async_delete_issue(hass, DOMAIN, issue_id)
             except Exception:  # noqa: BLE001 - best-effort UI cleanup
                 _LOGGER.debug(
-                    "[entry=%s] Failed to delete repair issue %s",
+                    "[entry=%s] Failed to delete repair issue %s on removal",
                     entry_id,
                     issue_id,
                     exc_info=True,
@@ -1865,9 +1899,15 @@ class FcmReceiverHA:
             else:
                 self._entry_caches.pop(entry_id, None)
                 self._purge_entry_tokens(entry_id)
-                # Hard-reset on unregister: the entry is going away, so the
-                # short-run cap latch must be released together with the
-                # fatal-error map and the Repairs issue (force=True).
+                # Hard-reset on unregister: this fires via ``async_on_unload``
+                # on EVERY unload (reload AND removal), so it only resets the
+                # in-memory state -- the short-run cap latch, the fatal-error
+                # map and the transient short-run crash-loop Repairs issue
+                # (force=True). It must NOT delete the fixable reauth repairs:
+                # on a reauth-success reload the new supervisor still has to
+                # prove recovery first. Those are retired by the supervisor
+                # success path (reload) or ``async_delete_entry_repair_issues``
+                # (actual removal). See ``_clear_fatal_error_for_entry``.
                 self._clear_fatal_error_for_entry(
                     entry_id, reason="Entry unregistered", force=True
                 )

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -8520,6 +8520,20 @@ async def async_remove_entry(hass: HomeAssistant, entry: MyConfigEntry) -> None:
     except Exception as err:
         _LOGGER.debug("FCM release during async_remove_entry raised: %s", err)
 
+    # Retire any entry-scoped FCM Repairs issues now that the entry is actually
+    # being removed. The supervisor success path only deletes them on reload
+    # recovery, and the unload teardown deliberately leaves the fixable reauth
+    # prompt alone; once the entry is gone no supervisor will run again, so the
+    # orphaned repair must be cleaned up here (Codex PR #1104 follow-up).
+    try:
+        from .Auth.fcm_receiver_ha import FcmReceiverHA
+
+        FcmReceiverHA.async_delete_entry_repair_issues(hass, entry.entry_id)
+    except Exception as err:  # pragma: no cover - defensive best-effort cleanup
+        _LOGGER.debug(
+            "Deleting FCM repair issues during async_remove_entry raised: %s", err
+        )
+
     try:
         owner_index = _ensure_device_owner_index(bucket)
         stale = [cid for cid, eid in list(owner_index.items()) if eid == entry.entry_id]

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -14,7 +14,7 @@ from homeassistant.data_entry_flow import FlowResult
 _LOGGER = logging.getLogger(__name__)
 
 
-class FcmReauthRepairFlow(RepairsFlow):
+class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
     """Guide the user from the fixable ``fcm_reauth_required`` issue into reauth.
 
     The issue is raised at the FCM supervisor's terminal give-up points

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -43,28 +43,38 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
         ``async_create_entry`` would make Home Assistant's repairs manager
         delete the issue immediately -- only a non-``ABORT`` result triggers the
         delete (see ``homeassistant.components.repairs.issue_handler``). That is
-        unsafe here: the supervisor reaches this repair at its *terminal*
-        give-up points, and the 401/404 exhaustion paths ``break`` out of the
-        loop, so the supervisor will not re-raise the issue on its own. If the
-        user then cancels or fails the reauth flow, both this issue and the core
-        ``config_entry_reauth`` issue (removed by ``async_flow_removed``) would
-        vanish, stranding the account with no guidance.
+        unsafe in the *normal* case: the supervisor reaches this repair at its
+        *terminal* give-up points, and the 401/404 exhaustion paths ``break``
+        out of the loop, so the supervisor will not re-raise the issue on its
+        own. If the user then cancels or fails the reauth flow, both this issue
+        and the core ``config_entry_reauth`` issue (removed by
+        ``async_flow_removed``) would vanish, stranding the account with no
+        guidance.
 
         Returning ``async_abort`` keeps the issue. Its real resolution is owned
         by the supervisor's success path, which deletes
         ``fcm_reauth_required_{entry_id}`` on the next successful FCM
         (re-)registration once reauth has renewed credentials and reloaded the
         entry (see ``Auth/fcm_receiver_ha.py``).
+
+        The keep-open contract only holds while a supervisor can still run for
+        this entry. When the repair is *stale* -- the entry id is missing, or
+        the config entry has already been removed -- no supervisor exists to
+        ever clear this entry-scoped issue, and reauth can never start. In that
+        case ``_async_start_reauth`` reports failure and we deliberately return
+        ``async_create_entry`` so the repairs manager dismisses the orphaned
+        issue instead of leaving an unfixable repair pinned in the UI.
         """
         if user_input is not None:
-            self._async_start_reauth()
-            return self.async_abort(reason="reauth_started")
+            if self._async_start_reauth():
+                return self.async_abort(reason="reauth_started")
+            return self.async_create_entry(data={})
 
         return self.async_show_form(
             step_id="confirm", data_schema=vol.Schema({})
         )
 
-    def _async_start_reauth(self) -> None:
+    def _async_start_reauth(self) -> bool:
         """Start the config-entry reauth flow, defensively.
 
         ``ConfigEntry.async_start_reauth`` is a synchronous ``@callback`` that
@@ -75,15 +85,21 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
         guard below would then swallow while the issue is still dismissed.
 
         ``entry_id`` is used solely as a config-entry registry lookup key; it is
-        never interpreted as a path or executable input. A missing or already
-        removed entry simply dismisses the (now stale) repair without raising.
+        never interpreted as a path or executable input.
+
+        Returns ``True`` when the fixable issue must stay open: either reauth
+        was launched, or it failed transiently for an entry that still exists
+        (the user can retry and the supervisor success path can still clear the
+        issue). Returns ``False`` when the repair is *stale* -- a missing entry
+        id or an already removed config entry -- so the caller dismisses the now
+        unfixable issue instead of pinning it open forever.
         """
         if not self._entry_id:
             _LOGGER.warning(
                 "fcm_reauth_required repair confirmed without an entry_id; "
                 "dismissing stale issue"
             )
-            return
+            return False
 
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
         if entry is None:
@@ -92,7 +108,7 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
                 "gone; dismissing stale issue",
                 self._entry_id,
             )
-            return
+            return False
 
         try:
             entry.async_start_reauth(self.hass)
@@ -102,6 +118,11 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
                 self._entry_id,
                 err,
             )
+            # The entry still exists, so the issue is not stale: keep it open so
+            # the user can retry and the supervisor can still resolve it.
+            return True
+
+        return True
 
 
 async def async_create_fix_flow(

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -36,10 +36,29 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Confirm the repair and start the reauth flow for the entry."""
+        """Confirm the repair, launch reauth, and keep the issue open.
+
+        Confirming only *launches* the config-entry reauth flow; the stored
+        credentials are not renewed yet at this point. Returning
+        ``async_create_entry`` would make Home Assistant's repairs manager
+        delete the issue immediately -- only a non-``ABORT`` result triggers the
+        delete (see ``homeassistant.components.repairs.issue_handler``). That is
+        unsafe here: the supervisor reaches this repair at its *terminal*
+        give-up points, and the 401/404 exhaustion paths ``break`` out of the
+        loop, so the supervisor will not re-raise the issue on its own. If the
+        user then cancels or fails the reauth flow, both this issue and the core
+        ``config_entry_reauth`` issue (removed by ``async_flow_removed``) would
+        vanish, stranding the account with no guidance.
+
+        Returning ``async_abort`` keeps the issue. Its real resolution is owned
+        by the supervisor's success path, which deletes
+        ``fcm_reauth_required_{entry_id}`` on the next successful FCM
+        (re-)registration once reauth has renewed credentials and reloaded the
+        entry (see ``Auth/fcm_receiver_ha.py``).
+        """
         if user_input is not None:
             self._async_start_reauth()
-            return self.async_create_entry(title="", data={})
+            return self.async_abort(reason="reauth_started")
 
         return self.async_show_form(
             step_id="confirm", data_schema=vol.Schema({})

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -38,15 +38,22 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
     ) -> FlowResult:
         """Confirm the repair and start the reauth flow for the entry."""
         if user_input is not None:
-            await self._async_start_reauth()
+            self._async_start_reauth()
             return self.async_create_entry(title="", data={})
 
         return self.async_show_form(
             step_id="confirm", data_schema=vol.Schema({})
         )
 
-    async def _async_start_reauth(self) -> None:
+    def _async_start_reauth(self) -> None:
         """Start the config-entry reauth flow, defensively.
+
+        ``ConfigEntry.async_start_reauth`` is a synchronous ``@callback`` that
+        returns ``None``: it schedules the reauth flow itself, or no-ops when a
+        reauth/reconfigure flow is already active for the entry (idempotent).
+        It must therefore be called without ``await`` -- awaiting its ``None``
+        result would raise ``TypeError`` on every confirmation, which the broad
+        guard below would then swallow while the issue is still dismissed.
 
         ``entry_id`` is used solely as a config-entry registry lookup key; it is
         never interpreted as a path or executable input. A missing or already
@@ -69,8 +76,8 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
             return
 
         try:
-            await entry.async_start_reauth(self.hass)
-        except Exception as err:  # noqa: BLE001 - defensive, mirrors locate.py
+            entry.async_start_reauth(self.hass)
+        except Exception as err:  # noqa: BLE001 - defensive: keep the repair UI robust
             _LOGGER.error(
                 "Failed to start reauth flow from repair for entry %s: %s",
                 self._entry_id,

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -1,0 +1,94 @@
+# custom_components/googlefindmy/repairs.py
+"""Repair flows for the Google Find My Device integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FcmReauthRepairFlow(RepairsFlow):
+    """Guide the user from the fixable ``fcm_reauth_required`` issue into reauth.
+
+    The issue is raised at the FCM supervisor's terminal give-up points
+    (404/401 endpoint exhaustion and the registration backoff). Confirming the
+    repair starts Home Assistant's existing config-entry reauth flow, which
+    renews credentials while preserving the device identity.
+    """
+
+    def __init__(self, entry_id: str | None) -> None:
+        """Store the config entry id forwarded via the issue ``data`` payload."""
+        self._entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Entry point: show the confirmation step."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm the repair and start the reauth flow for the entry."""
+        if user_input is not None:
+            await self._async_start_reauth()
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="confirm", data_schema=vol.Schema({})
+        )
+
+    async def _async_start_reauth(self) -> None:
+        """Start the config-entry reauth flow, defensively.
+
+        ``entry_id`` is used solely as a config-entry registry lookup key; it is
+        never interpreted as a path or executable input. A missing or already
+        removed entry simply dismisses the (now stale) repair without raising.
+        """
+        if not self._entry_id:
+            _LOGGER.warning(
+                "fcm_reauth_required repair confirmed without an entry_id; "
+                "dismissing stale issue"
+            )
+            return
+
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None:
+            _LOGGER.warning(
+                "fcm_reauth_required repair confirmed but config entry %s is "
+                "gone; dismissing stale issue",
+                self._entry_id,
+            )
+            return
+
+        try:
+            await entry.async_start_reauth(self.hass)
+        except Exception as err:  # noqa: BLE001 - defensive, mirrors locate.py
+            _LOGGER.error(
+                "Failed to start reauth flow from repair for entry %s: %s",
+                self._entry_id,
+                err,
+            )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create the fix flow for a fixable Google Find My Device issue.
+
+    Currently every fixable issue (``fcm_reauth_required_{entry_id}``) maps to
+    the reauth repair. The affected entry id is read from the issue ``data``
+    payload set by ``_async_raise_reauth_issue`` in ``Auth/fcm_receiver_ha.py``.
+    """
+    entry_id_raw = (data or {}).get("entry_id")
+    entry_id = entry_id_raw if isinstance(entry_id_raw, str) else None
+    return FcmReauthRepairFlow(entry_id)

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -699,6 +699,17 @@
       "title": "FCM Push Connection Failed",
       "description": "The background connection to Google is blocked.\n\n1. Is outgoing **TCP Port 5228** allowed in your firewall?\n2. If network is fine, try regenerating your `secrets.json` (credentials might be split/revoked)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Multiple configuration entries detected",
       "description": "Google Find My Device now supports multiple configuration entries, one per Google account. If each entry targets a different account, no action is required. When the same account is added twice, Home Assistant creates a **Duplicate account entries** repair issue for the new entry so you can remove or re-enable the correct one."

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -699,6 +699,17 @@
       "title": "FCM Push-Verbindung fehlgeschlagen",
       "description": "Die Hintergrundverbindung zu Google ist blockiert.\n\n1. Ist der ausgehende **TCP Port 5228** in Ihrer Firewall freigegeben?\n2. Falls das Netzwerk okay ist: Erneuern Sie bitte Ihre `secrets.json` (Token könnte teilweise ungültig sein)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Mehrere Konfigurationseinträge erkannt",
       "description": "Google Find My Device unterstützt jetzt mehrere Konfigurationseinträge – jeweils einen pro Google-Konto. Wenn jede Instanz ein anderes Konto nutzt, ist keine Aktion erforderlich. Wird dasselbe Konto zweimal hinzugefügt, erstellt Home Assistant für den neuen Eintrag die Reparaturmeldung **Doppelte Kontoeinträge**, damit du den richtigen Eintrag entfernen oder wieder aktivieren kannst."

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -699,6 +699,17 @@
       "title": "FCM Push Connection Failed",
       "description": "The background connection to Google is blocked.\n\n1. Is outgoing **TCP Port 5228** allowed in your firewall?\n2. If network is fine, try regenerating your `secrets.json` (credentials might be split/revoked)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Multiple configuration entries detected",
       "description": "Google Find My Device now supports multiple configuration entries, one per Google account. If each entry targets a different account, no action is required. When the same account is added twice, Home Assistant creates a **Duplicate account entries** repair issue for the new entry so you can remove or re-enable the correct one."

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -699,6 +699,17 @@
       "title": "Conexión push de FCM fallida",
       "description": "La conexión en segundo plano con Google está bloqueada.\n\n1. ¿El **puerto TCP 5228** saliente está permitido en tu firewall?\n2. Si la red está bien, intenta regenerar tu `secrets.json` (las credenciales podrían estar divididas/revocadas)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Se detectaron varias entradas de configuración",
       "description": "Google Find My Device ahora admite varias entradas de configuración, una por cuenta de Google. Si cada entrada usa una cuenta diferente, no es necesario hacer nada. Cuando se añade la misma cuenta dos veces, Home Assistant crea una reparación **Entradas de cuenta duplicadas** para el nuevo registro y que así puedas retirar o reactivar el correcto."

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -699,6 +699,17 @@
       "title": "Échec de la connexion push FCM",
       "description": "La connexion en arrière-plan vers Google est bloquée.\n\n1. Le **port TCP sortant 5228** est-il autorisé par votre pare-feu ?\n2. Si le réseau est correct, essayez de régénérer votre `secrets.json` (les identifiants peuvent être partiels/révoqués)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Plusieurs entrées de configuration détectées",
       "description": "Google Find My Device prend désormais en charge plusieurs entrées de configuration, une par compte Google. Si chaque entrée cible un compte différent, aucune action n'est nécessaire. Lorsque le même compte est ajouté deux fois, Home Assistant crée une réparation **Entrées de compte en double** pour la nouvelle entrée afin que vous puissiez retirer ou réactiver la bonne."

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -699,6 +699,17 @@
       "title": "חיבור Push FCM נכשל",
       "description": "החיבור הרקעי ל-Google חסום.\n\n1. האם **TCP Port 5228** יוצא מותר בחומת האש שלך?\n2. אם הרשת תקינה, יש לנסות ליצור מחדש את `secrets.json` (ייתכן שהאישורים פוצלו/בוטלו)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "אותרו מספר רשומות תצורה",
       "description": "Google Find My Device תומך כעת במספר רשומות תצורה, אחת לכל חשבון Google. אם כל רשומה מיועדת לחשבון אחר, אין צורך בפעולה. כאשר אותו חשבון נוסף פעמיים, Home Assistant יוצר בעיית תיקון **רשומות חשבון כפולות** עבור הרשומה החדשה כך שניתן להסיר או להפעיל מחדש את הנכונה."

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -699,6 +699,17 @@
       "title": "Connessione push FCM non riuscita",
       "description": "La connessione in background a Google è bloccata.\n\n1. Il **porta TCP 5228** in uscita è consentito dal firewall?\n2. Se la rete è a posto, prova a rigenerare il tuo `secrets.json` (le credenziali potrebbero essere parziali/revocate)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Rilevate più voci di configurazione",
       "description": "Google Find My Device ora supporta più voci di configurazione, una per ogni account Google. Se ogni voce utilizza un account diverso, non è necessaria alcuna azione. Quando lo stesso account viene aggiunto due volte, Home Assistant crea una riparazione **Voci di account duplicate** per la nuova voce così da poter rimuovere o riattivare quella corretta."

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -699,6 +699,17 @@
       "title": "FCM push-verbinding mislukt",
       "description": "De achtergrondverbinding met Google is geblokkeerd.\n\n1. Is uitgaande **TCP-poort 5228** toegestaan in je firewall?\n2. Als het netwerk in orde is, probeer dan je `secrets.json` opnieuw te genereren (inloggegevens zijn mogelijk gesplitst/ingetrokken)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Meerdere configuratie-items gedetecteerd",
       "description": "Google Find My Device ondersteunt nu meerdere configuratie-items, één per Google-account. Als elk item een ander account target, is geen actie vereist. Wanneer hetzelfde account tweemaal wordt toegevoegd, maakt Home Assistant een reparatieprobleem **Dubbele accountitems** aan voor het nieuwe item, zodat je het juiste kunt verwijderen of opnieuw inschakelen."

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -699,6 +699,17 @@
       "title": "Połączenie push FCM nie powiodło się",
       "description": "Połączenie w tle z Google jest zablokowane.\n\n1. Czy wychodzący **port TCP 5228** jest dozwolony w zaporze?\n2. Jeśli sieć działa, spróbuj wygenerować ponownie plik `secrets.json` (poświadczenia mogły zostać częściowo cofnięte)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Wykryto wiele wpisów konfiguracji",
       "description": "Google Find My Device obsługuje teraz wiele wpisów konfiguracji – po jednym na każde konto Google. Jeśli każdy wpis dotyczy innego konta, nie są wymagane żadne działania. Gdy to samo konto zostanie dodane dwukrotnie, Home Assistant tworzy naprawę **Zduplikowane wpisy kont** dla nowego wpisu, aby można było usunąć lub ponownie włączyć właściwy."

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -699,6 +699,17 @@
       "title": "Falha na conexão push do FCM",
       "description": "A conexão em segundo plano com o Google está bloqueada.\n\n1. A saída pelo **porta TCP 5228** está liberada no firewall?\n2. Se a rede estiver ok, tente gerar novamente o seu `secrets.json` (as credenciais podem estar fragmentadas/revocadas)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Várias entradas de configuração detectadas",
       "description": "O Google Find My Device agora oferece suporte a várias entradas de configuração, uma por conta do Google. Se cada entrada tiver como alvo uma conta diferente, nenhuma ação é necessária. Quando a mesma conta é adicionada duas vezes, o Home Assistant cria um problema de reparação **Entradas de conta duplicadas** para a nova entrada, para que você possa remover ou reativar a correta."

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -699,6 +699,17 @@
       "title": "Falha na conexão push do FCM",
       "description": "A conexão em segundo plano com o Google está bloqueada.\n\n1. A saída pelo **porta TCP 5228** está liberada no firewall?\n2. Se a rede estiver ok, tente gerar novamente o seu `secrets.json` (as credenciais podem estar fragmentadas/revocadas)."
     },
+    "fcm_reauth_required": {
+      "title": "Google Find My Device push needs re-authentication",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate Google Find My Device",
+            "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
+          }
+        }
+      }
+    },
     "multiple_config_entries": {
       "title": "Várias entradas de configuração detectadas",
       "description": "O Google Find My Device agora oferece suporte a várias entradas de configuração, uma por conta do Google. Se cada entrada tiver como alvo uma conta diferente, nenhuma ação é necessária. Quando a mesma conta é adicionada duas vezes, o Home Assistant cria um problema de reparação **Entradas de conta duplicadas** para a nova entrada, para que você possa remover ou reativar a correta."

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -707,6 +707,9 @@
             "title": "Re-authenticate Google Find My Device",
             "description": "The background push connection to Google failed for an extended period and could not recover on its own. This usually means the stored push credentials were revoked or rotated (for example after a Google password change, or when requests arrive from a new IP address or region). Less commonly, outgoing **TCP port 5228** is blocked by a firewall.\n\nSelect **Submit** to re-authenticate this account. Your device identity is preserved. If the problem persists afterwards, make sure port 5228 is allowed and regenerate your `secrets.json`."
           }
+        },
+        "abort": {
+          "reauth_started": "Re-authentication has been started. Finish signing in to restore the background push connection. This repair stays open until the connection recovers, so the prompt is not lost if the sign-in is interrupted."
         }
       }
     },

--- a/tests/test_fcm_backoff_escalation.py
+++ b/tests/test_fcm_backoff_escalation.py
@@ -92,7 +92,7 @@ async def test_fcm_backoff_escalation_creates_and_clears_issue(
     monkeypatch.setattr(
         fcm_receiver_ha.ir,
         "IssueSeverity",
-        SimpleNamespace(WARNING="warning"),
+        SimpleNamespace(WARNING="warning", ERROR="error"),
     )
 
     await receiver._start_supervisor_for_entry(entry_id, None)
@@ -103,12 +103,19 @@ async def test_fcm_backoff_escalation_creates_and_clears_issue(
     assert create_issue.call_count == 6
     assert create_issue_attempts == [7, 8, 9, 10, 11, 12]
 
+    # The backoff path now escalates to the shared *fixable* reauth repair
+    # (same issue id / fix flow as the 404/401 give-up paths).
     for call in create_issue.call_args_list:
         assert call.args[0] is hass
         assert call.args[1] == DOMAIN
-        assert call.args[2] == f"fcm_stuck_{entry_id}"
-        assert call.kwargs["is_fixable"] is False
-        assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.WARNING
-        assert call.kwargs["translation_key"] == "fcm_connection_stuck"
+        assert call.args[2] == f"fcm_reauth_required_{entry_id}"
+        assert call.kwargs["is_fixable"] is True
+        assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.ERROR
+        assert call.kwargs["translation_key"] == "fcm_reauth_required"
+        assert call.kwargs["data"]["entry_id"] == entry_id
+        assert call.kwargs["data"]["reason"] == "registration_backoff"
 
-    delete_issue.assert_called_once_with(hass, DOMAIN, f"fcm_stuck_{entry_id}")
+    # Recovery deletes the fixable issue and cleans up any legacy
+    # ``fcm_stuck`` issue from before the key rename.
+    delete_issue.assert_any_call(hass, DOMAIN, f"fcm_reauth_required_{entry_id}")
+    delete_issue.assert_any_call(hass, DOMAIN, f"fcm_stuck_{entry_id}")

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -541,17 +541,19 @@ def test_unload_clears_fatal_errors_via_force() -> None:
     assert receiver._fatal_error is None
 
 
-def test_force_teardown_deletes_orphaned_reauth_repairs(
+def test_force_teardown_leaves_fixable_reauth_repairs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Teardown (force=True) retires ALL entry-scoped FCM repair issues.
+    """Teardown (force=True) must NOT delete the fixable reauth repairs.
 
-    Codex finding (PR #1104): on entry removal the success-path delete in the
-    supervisor loop can no longer fire, so the fixable ``fcm_reauth_required``
-    repair (and the legacy ``fcm_stuck``) would otherwise stay pinned in the
-    Repairs panel for a config entry that no longer exists. The teardown clear
-    must delete them alongside the ``fcm_short_run_crash_loop`` issue, mirroring
-    the supervisor success-path delete set.
+    Codex finding (PR #1104 follow-up): ``force=True`` is reached from
+    ``unregister_coordinator``, which fires via ``async_on_unload`` on EVERY
+    unload -- including the reload Home Assistant performs right after a
+    successful reauth flow. Deleting ``fcm_reauth_required`` / legacy
+    ``fcm_stuck`` here would dismiss a still-active prompt before the new
+    supervisor has proven recovery. Only the transient short-run crash-loop
+    issue (the DELETE half of the fatal-error CREATE/DELETE pair) is cleared.
+    Actual removal cleanup lives in ``async_delete_entry_repair_issues``.
     """
     entry_id = "entry-teardown"
     receiver = FcmReceiverHA()
@@ -561,6 +563,29 @@ def test_force_teardown_deletes_orphaned_reauth_repairs(
     receiver._clear_fatal_error_for_entry(
         entry_id, reason="Entry unregistered", force=True
     )
+
+    deleted = {call.args[2] for call in delete_issue.call_args_list}
+    assert f"fcm_short_run_crash_loop_{entry_id}" in deleted
+    assert f"fcm_reauth_required_{entry_id}" not in deleted
+    assert f"fcm_stuck_{entry_id}" not in deleted
+
+
+def test_async_delete_entry_repair_issues_retires_all_on_removal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On actual entry removal ALL entry-scoped FCM repairs are retired.
+
+    Codex finding (PR #1104): once the entry is gone no supervisor will run
+    again, so ``async_remove_entry`` must delete the fixable reauth prompt and
+    its legacy ``fcm_stuck`` predecessor alongside the transient short-run
+    issue, or they stay pinned for a config entry that no longer exists. This
+    is the removal-only counterpart to the reload-safe teardown above.
+    """
+    entry_id = "entry-removed"
+    hass = SimpleNamespace()
+    _create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    FcmReceiverHA.async_delete_entry_repair_issues(hass, entry_id)
 
     deleted = {call.args[2] for call in delete_issue.call_args_list}
     assert f"fcm_short_run_crash_loop_{entry_id}" in deleted

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -541,6 +541,57 @@ def test_unload_clears_fatal_errors_via_force() -> None:
     assert receiver._fatal_error is None
 
 
+def test_force_teardown_deletes_orphaned_reauth_repairs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Teardown (force=True) retires ALL entry-scoped FCM repair issues.
+
+    Codex finding (PR #1104): on entry removal the success-path delete in the
+    supervisor loop can no longer fire, so the fixable ``fcm_reauth_required``
+    repair (and the legacy ``fcm_stuck``) would otherwise stay pinned in the
+    Repairs panel for a config entry that no longer exists. The teardown clear
+    must delete them alongside the ``fcm_short_run_crash_loop`` issue, mirroring
+    the supervisor success-path delete set.
+    """
+    entry_id = "entry-teardown"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    _create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    receiver._clear_fatal_error_for_entry(
+        entry_id, reason="Entry unregistered", force=True
+    )
+
+    deleted = {call.args[2] for call in delete_issue.call_args_list}
+    assert f"fcm_short_run_crash_loop_{entry_id}" in deleted
+    assert f"fcm_reauth_required_{entry_id}" in deleted
+    assert f"fcm_stuck_{entry_id}" in deleted
+
+
+def test_non_teardown_clear_leaves_reauth_repair_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recovery clear (force=False) must NOT delete the reauth repairs.
+
+    Non-teardown clears (credentials updated, registration success) rely on the
+    supervisor success path to retire ``fcm_reauth_required`` / ``fcm_stuck``;
+    deleting them here would dismiss a still-valid reauth prompt before the
+    supervisor has actually re-registered successfully. Only the short-run
+    issue (the DELETE half of the fatal-error CREATE/DELETE pair) is cleared.
+    """
+    entry_id = "entry-recovery"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    _create_issue, delete_issue = _install_ir_capture(monkeypatch)
+
+    receiver._clear_fatal_error_for_entry(entry_id, reason="Credentials updated")
+
+    deleted = {call.args[2] for call in delete_issue.call_args_list}
+    assert f"fcm_short_run_crash_loop_{entry_id}" in deleted
+    assert f"fcm_reauth_required_{entry_id}" not in deleted
+    assert f"fcm_stuck_{entry_id}" not in deleted
+
+
 # --------------------------------------------------------------------------
 # Defense 2 iter-8: cap-latch lifecycle (Codex second finding)
 # --------------------------------------------------------------------------

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.googlefindmy import repairs
 from custom_components.googlefindmy.Auth import fcm_receiver_ha
@@ -211,6 +212,39 @@ async def test_fix_flow_confirm_starts_reauth() -> None:
 
     flow._async_start_reauth()
 
+    entry.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_confirm_aborts_to_keep_issue_open() -> None:
+    """T4b-2: confirming aborts (keeps the issue) instead of CREATE_ENTRY.
+
+    Home Assistant's repairs manager deletes the issue for any non-ABORT
+    result. Returning CREATE_ENTRY here would strand the account if the launched
+    reauth flow is cancelled or fails: the supervisor already broke out at its
+    terminal 401/404 give-up points and will not re-raise. The fixable issue
+    must persist until the supervisor's success path clears it after credentials
+    are actually renewed. This guard fails if production reverts to
+    ``async_create_entry``.
+    """
+    entry = SimpleNamespace(async_start_reauth=MagicMock(return_value=None))
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=lambda entry_id: (
+                entry if entry_id == "entry-id" else None
+            )
+        )
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass  # normally injected by the repairs flow manager
+    flow.flow_id = "test-flow-id"  # set by the flow manager in production
+    flow.handler = DOMAIN  # set by the flow manager in production
+
+    result = await flow.async_step_confirm(user_input={})
+
+    # ABORT keeps the fixable issue alive; the reauth flow was still launched.
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_started"
     entry.async_start_reauth.assert_called_once_with(hass)
 
 

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -1,0 +1,250 @@
+# tests/test_fcm_repair_reauth.py
+"""Tests for the fixable FCM reauth repair and its escalation thresholds.
+
+Covers the three terminal give-up points in the FCM supervisor that now raise
+the single shared fixable repair ``fcm_reauth_required_{entry_id}`` and the
+fix flow in ``custom_components/googlefindmy/repairs.py`` that drives the user
+into the config-entry reauth flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy import repairs
+from custom_components.googlefindmy.Auth import fcm_receiver_ha
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import DOMAIN, FcmReceiverHA
+from custom_components.googlefindmy.exceptions import FatalRegistrationError
+
+
+class _StubClient:
+    """Minimal FCM client stub; ``start`` ends the supervisor loop."""
+
+    def __init__(self, stop_evt: asyncio.Event) -> None:
+        self.stop_evt = stop_evt
+        self.do_listen = True
+        self.run_state = None
+        self.start_calls = 0
+        self.stop_calls = 0
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        self.stop_evt.set()
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+
+
+def _make_receiver(
+    monkeypatch: pytest.MonkeyPatch, entry_id: str
+) -> tuple[FcmReceiverHA, SimpleNamespace, MagicMock, MagicMock]:
+    """Build a receiver wired to capture issue-registry calls.
+
+    Mirrors the proven harness in ``test_fcm_backoff_escalation`` but for the
+    fatal-registration (404/401) escalation paths.
+    """
+    receiver = FcmReceiverHA()
+    hass = SimpleNamespace()
+    receiver.attach_hass(hass)
+
+    stop_evt = asyncio.Event()
+    receiver._stop_evts[entry_id] = stop_evt
+
+    pc = _StubClient(stop_evt)
+    monkeypatch.setattr(
+        receiver, "_ensure_client_for_entry", AsyncMock(return_value=pc)
+    )
+    # 404/401 give-up paths sleep between retries; make them instant.
+    monkeypatch.setattr(fcm_receiver_ha.asyncio, "sleep", AsyncMock())
+    # The 401 path renews tokens before retrying.
+    monkeypatch.setattr(receiver, "_invalidate_fcm_tokens", AsyncMock())
+    monkeypatch.setattr(
+        fcm_receiver_ha.ir,
+        "IssueSeverity",
+        SimpleNamespace(WARNING="warning", ERROR="error"),
+    )
+
+    create_issue = MagicMock()
+    delete_issue = MagicMock()
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(fcm_receiver_ha.ir, "async_delete_issue", delete_issue)
+
+    return receiver, hass, create_issue, delete_issue
+
+
+def _reauth_calls(create_issue: MagicMock, entry_id: str) -> list:
+    """Return the create_issue calls that raised the fixable reauth issue."""
+    return [
+        call
+        for call in create_issue.call_args_list
+        if len(call.args) >= 3 and call.args[2] == f"fcm_reauth_required_{entry_id}"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transient_404_below_cap_does_not_escalate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T1: 404 rotation below ``_MAX_FATAL_ENDPOINT_RETRIES`` must not escalate."""
+    entry_id = "entry-id"
+    receiver, hass, create_issue, delete_issue = _make_receiver(
+        monkeypatch, entry_id
+    )
+
+    # Three transient 404s (n=1..3, well below the cap of 7), then success.
+    register_mock = AsyncMock(
+        side_effect=[
+            FatalRegistrationError("404 endpoint", is_auth_error=False),
+            FatalRegistrationError("404 endpoint", is_auth_error=False),
+            FatalRegistrationError("404 endpoint", is_auth_error=False),
+            True,
+        ]
+    )
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert register_mock.await_count == 4
+    # No fixable issue raised: transient rotation cleared before the give-up.
+    assert _reauth_calls(create_issue, entry_id) == []
+    # On the successful registration the recovery delete still fires.
+    delete_issue.assert_any_call(
+        hass, DOMAIN, f"fcm_reauth_required_{entry_id}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_permanent_404_at_cap_raises_fixable_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T2: 404 reaching the cap raises exactly one fixable reauth issue."""
+    entry_id = "entry-id"
+    receiver, hass, create_issue, _delete_issue = _make_receiver(
+        monkeypatch, entry_id
+    )
+
+    # Seven consecutive 404s -> fatal_count == _MAX_FATAL_ENDPOINT_RETRIES (7).
+    register_mock = AsyncMock(
+        side_effect=[
+            FatalRegistrationError("404 endpoint", is_auth_error=False)
+            for _ in range(fcm_receiver_ha._MAX_FATAL_ENDPOINT_RETRIES)
+        ]
+    )
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert register_mock.await_count == fcm_receiver_ha._MAX_FATAL_ENDPOINT_RETRIES
+    calls = _reauth_calls(create_issue, entry_id)
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.args[0] is hass
+    assert call.args[1] == DOMAIN
+    assert call.kwargs["is_fixable"] is True
+    assert call.kwargs["severity"] == fcm_receiver_ha.ir.IssueSeverity.ERROR
+    assert call.kwargs["translation_key"] == "fcm_reauth_required"
+    assert call.kwargs["data"]["entry_id"] == entry_id
+    assert call.kwargs["data"]["reason"] == "endpoint_404"
+
+
+@pytest.mark.asyncio
+async def test_permanent_401_at_cap_raises_fixable_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T3: 401 reaching the auth cap raises the fixable reauth issue."""
+    entry_id = "entry-id"
+    receiver, _hass, create_issue, _delete_issue = _make_receiver(
+        monkeypatch, entry_id
+    )
+
+    # Three consecutive 401s -> fatal_count == _MAX_FATAL_AUTH_RETRIES (3).
+    register_mock = AsyncMock(
+        side_effect=[
+            FatalRegistrationError("401 auth", is_auth_error=True)
+            for _ in range(fcm_receiver_ha._MAX_FATAL_AUTH_RETRIES)
+        ]
+    )
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert register_mock.await_count == fcm_receiver_ha._MAX_FATAL_AUTH_RETRIES
+    calls = _reauth_calls(create_issue, entry_id)
+    assert len(calls) == 1
+    assert calls[0].kwargs["data"]["reason"] == "auth_401"
+    assert calls[0].kwargs["is_fixable"] is True
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_factory_returns_reauth_flow() -> None:
+    """T4a: the fix-flow factory carries the entry id from the issue data."""
+    flow = await repairs.async_create_fix_flow(
+        SimpleNamespace(), "fcm_reauth_required_entry-id", {"entry_id": "entry-id"}
+    )
+    assert isinstance(flow, repairs.FcmReauthRepairFlow)
+    assert flow._entry_id == "entry-id"
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_confirm_starts_reauth() -> None:
+    """T4b: confirming the repair starts reauth for the resolved entry."""
+    entry = SimpleNamespace(async_start_reauth=AsyncMock())
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=lambda entry_id: (
+                entry if entry_id == "entry-id" else None
+            )
+        )
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass  # normally injected by the repairs flow manager
+
+    await flow._async_start_reauth()
+
+    entry.async_start_reauth.assert_awaited_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_missing_entry_is_noop() -> None:
+    """T4c: a stale issue (entry already gone) dismisses without raising."""
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_get_entry=lambda entry_id: None)
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass
+
+    # Must not raise even though the entry cannot be resolved.
+    await flow._async_start_reauth()
+
+    flow_no_id = repairs.FcmReauthRepairFlow(None)
+    flow_no_id.hass = hass
+    await flow_no_id._async_start_reauth()
+
+
+@pytest.mark.asyncio
+async def test_successful_register_deletes_fixable_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T5: a successful (re-)registration clears the fixable issue."""
+    entry_id = "entry-id"
+    receiver, hass, _create_issue, delete_issue = _make_receiver(
+        monkeypatch, entry_id
+    )
+
+    register_mock = AsyncMock(side_effect=[True])
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    delete_issue.assert_any_call(
+        hass, DOMAIN, f"fcm_reauth_required_{entry_id}"
+    )
+    delete_issue.assert_any_call(hass, DOMAIN, f"fcm_stuck_{entry_id}")

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -195,7 +195,10 @@ async def test_fix_flow_factory_returns_reauth_flow() -> None:
 @pytest.mark.asyncio
 async def test_fix_flow_confirm_starts_reauth() -> None:
     """T4b: confirming the repair starts reauth for the resolved entry."""
-    entry = SimpleNamespace(async_start_reauth=AsyncMock())
+    # ``ConfigEntry.async_start_reauth`` is a synchronous ``@callback`` returning
+    # ``None``; mock it synchronously so the test fails if production re-adds an
+    # erroneous ``await`` on that result.
+    entry = SimpleNamespace(async_start_reauth=MagicMock(return_value=None))
     hass = SimpleNamespace(
         config_entries=SimpleNamespace(
             async_get_entry=lambda entry_id: (
@@ -206,9 +209,9 @@ async def test_fix_flow_confirm_starts_reauth() -> None:
     flow = repairs.FcmReauthRepairFlow("entry-id")
     flow.hass = hass  # normally injected by the repairs flow manager
 
-    await flow._async_start_reauth()
+    flow._async_start_reauth()
 
-    entry.async_start_reauth.assert_awaited_once_with(hass)
+    entry.async_start_reauth.assert_called_once_with(hass)
 
 
 @pytest.mark.asyncio
@@ -221,11 +224,11 @@ async def test_fix_flow_missing_entry_is_noop() -> None:
     flow.hass = hass
 
     # Must not raise even though the entry cannot be resolved.
-    await flow._async_start_reauth()
+    flow._async_start_reauth()
 
     flow_no_id = repairs.FcmReauthRepairFlow(None)
     flow_no_id.hass = hass
-    await flow_no_id._async_start_reauth()
+    flow_no_id._async_start_reauth()
 
 
 @pytest.mark.asyncio

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -210,7 +210,9 @@ async def test_fix_flow_confirm_starts_reauth() -> None:
     flow = repairs.FcmReauthRepairFlow("entry-id")
     flow.hass = hass  # normally injected by the repairs flow manager
 
-    flow._async_start_reauth()
+    # A live entry means the issue must stay open (True) until the supervisor
+    # success path clears it.
+    assert flow._async_start_reauth() is True
 
     entry.async_start_reauth.assert_called_once_with(hass)
 
@@ -257,12 +259,51 @@ async def test_fix_flow_missing_entry_is_noop() -> None:
     flow = repairs.FcmReauthRepairFlow("entry-id")
     flow.hass = hass
 
-    # Must not raise even though the entry cannot be resolved.
-    flow._async_start_reauth()
+    # Must not raise even though the entry cannot be resolved, and must report
+    # the repair as stale (False) so the caller dismisses it.
+    assert flow._async_start_reauth() is False
 
     flow_no_id = repairs.FcmReauthRepairFlow(None)
     flow_no_id.hass = hass
-    flow_no_id._async_start_reauth()
+    assert flow_no_id._async_start_reauth() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("entry_id", "async_get_entry"),
+    [
+        # Entry id present in the issue data, but the entry was already removed.
+        ("entry-id", lambda entry_id: None),
+        # The issue data never carried an entry id at all.
+        (None, lambda entry_id: None),
+    ],
+)
+async def test_fix_flow_stale_confirm_dismisses_issue(
+    entry_id: str | None, async_get_entry
+) -> None:
+    """T4c-2: confirming a *stale* repair returns CREATE_ENTRY to dismiss it.
+
+    The keep-open ABORT contract only holds while a supervisor can still run for
+    the entry and clear ``fcm_reauth_required_{entry_id}`` on its success path.
+    When the entry is gone (or was never recorded), no supervisor exists to ever
+    clear the entry-scoped issue and reauth can never start. Returning
+    CREATE_ENTRY lets Home Assistant's repairs manager delete the orphaned issue
+    (only ABORT is exempt from that delete) instead of pinning an unfixable
+    repair in the UI forever. This guard fails if production reverts to keeping
+    stale repairs open.
+    """
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(async_get_entry=async_get_entry)
+    )
+    flow = repairs.FcmReauthRepairFlow(entry_id)
+    flow.hass = hass
+    flow.flow_id = "test-flow-id"  # set by the flow manager in production
+    flow.handler = DOMAIN  # set by the flow manager in production
+
+    result = await flow.async_step_confirm(user_input={})
+
+    # CREATE_ENTRY signals the repairs manager to delete the stale issue.
+    assert result["type"] == FlowResultType.CREATE_ENTRY
 
 
 @pytest.mark.asyncio

--- a/tests/test_remove_entry_cleanup.py
+++ b/tests/test_remove_entry_cleanup.py
@@ -126,7 +126,13 @@ def test_async_remove_entry_purges_store_and_creates_issue(
 
     issue_id = f"cache_purged_{entry.entry_id}"
     assert any(item["issue_id"] == issue_id for item in issue_registry_capture.created)
-    assert issue_registry_capture.deleted == []
+
+    # Removal must retire every entry-scoped FCM repair issue, since no
+    # supervisor will run again to clear them (Codex PR #1104 follow-up).
+    deleted_ids = {iid for _domain, iid in issue_registry_capture.deleted}
+    assert f"fcm_reauth_required_{entry.entry_id}" in deleted_ids
+    assert f"fcm_stuck_{entry.entry_id}" in deleted_ids
+    assert f"fcm_short_run_crash_loop_{entry.entry_id}" in deleted_ids
 
 
 def test_async_remove_entry_respects_retention_option(


### PR DESCRIPTION
## Problem

When the FCM push connection stays broken, the integration reaches one of three terminal give-up points, none of which gives the user an actionable recovery path:

1. **404 endpoint exhaustion** (`_MAX_FATAL_ENDPOINT_RETRIES`, ~630 s of sustained 404) — broke out of the supervisor loop **silently, with no repair issue at all**.
2. **401 auth exhaustion** (`_MAX_FATAL_AUTH_RETRIES`) — only recorded a fatal error, no repair.
3. **Registration backoff** (`_BACKOFF_WARNING_THRESHOLD_S`) — raised a **non-fixable** `fcm_stuck` warning offering no action.

There was no `is_fixable=True` issue and no `repairs.py` anywhere in the integration, so a stuck push could leave updates silently dead until manual intervention.

## Change

Collapse all three give-up points into a single **fixable** repair, `fcm_reauth_required_{entry_id}`. A new `repairs.py` implements `async_create_fix_flow`; confirming the repair starts Home Assistant's existing config-entry reauth flow via `entry.async_start_reauth(hass)`, renewing credentials while preserving the device identity. A successful (re-)registration deletes the issue and also cleans up any legacy `fcm_stuck` issue from before the key rename.

### Why this is safe against spurious escalation

The escalation hangs off the **existing** retry caps — `_MAX_FATAL_ENDPOINT_RETRIES`, `_MAX_FATAL_AUTH_RETRIES`, `_BACKOFF_WARNING_THRESHOLD_S`. No new threshold is invented. A transient Google endpoint rotation (retry count still below the cap) never reaches a give-up point and therefore never raises the repair. This is asserted by a dedicated regression test (`test_transient_404_below_cap_does_not_escalate`).

## Security note

The fix flow reads `entry_id` from the issue `data` payload and uses it **solely** as a config-entry registry lookup key (`async_get_entry`); it is never interpreted as a path or executable input. A missing/removed entry dismisses the stale issue without raising. The base64 credential-decode trust boundary from #181 is not touched.

## Tests

- `tests/test_fcm_repair_reauth.py` (new): transient-below-cap (no escalation), permanent 404 at cap, permanent 401 at cap, fix-flow factory + confirm starts reauth, missing-entry no-op, recovery delete.
- `tests/test_fcm_backoff_escalation.py` (updated): asserts the new fixable issue id/attributes and the two-key recovery delete.
- i18n: `strings.json` + all locale files synced via `script/sync_translations.py`.

## Notes for reviewers

- `fcm_connection_stuck` translation key is intentionally left in place (harmless orphan) to avoid breaking any issue cached from a prior version during upgrade.
- The `fcm_short_run_crash_loop` poison cap stays `is_fixable=False` (reauth does not heal a poison-message crash loop) — out of scope by design.