### PR TITLE
fix(fcm): complete per-entry state purge symmetry and guard the teardown race

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1035,29 +1035,41 @@ class FcmReceiverHA:
         if cache is not None:
             self._ensure_cache_entry_id(cache, entry_id)
         async with self._lock:
-            if entry_id in self.pcs:
-                return self.pcs[entry_id]
-
-            # AP6 (finding 5): this is the single client-build chokepoint, and
-            # everything below RE-CREATES per-entry state (``self.creds`` on the
-            # cache load, ``self.pcs``/``self.creds`` on store). Drop the build
-            # when the entry is tombstoned or this supervisor's generation is
-            # superseded. The race: ``register_coordinator`` dispatches the
-            # supervisor asynchronously; if ``unregister_coordinator`` tombstones
-            # the entry before that queued coroutine runs (unload-before-dispatch),
-            # the first loop iteration would otherwise revive a torn-down entry's
-            # ``self.pcs``/``self.creds``. The generation guard in
-            # ``_register_for_fcm_entry`` fires one step too late -- the client is
-            # already stored by then. Placed AFTER the existing-client early
-            # return: returning an already-built client is a read, not a
-            # re-creation, so it stays teardown-safe (idempotent contract).
+            # AP6 (finding 5 + finding 6): gate BEFORE the existing-client fast
+            # path. A tombstoned entry or a superseded supervisor generation
+            # must never receive a client handle -- not even an already-built
+            # one. Two races collapse into this single chokepoint:
+            #
+            #   * finding 5 (build path): ``register_coordinator`` dispatches the
+            #     supervisor asynchronously; if ``unregister_coordinator``
+            #     tombstones the entry before that queued coroutine runs
+            #     (unload-before-dispatch), the build below would revive a
+            #     torn-down entry's ``self.pcs``/``self.creds``.
+            #   * finding 6 (read path): after a fast reload the new incarnation
+            #     installs a fresh client under ``entry_id``; a stale supervisor
+            #     (old generation) then calls in here. If the existing-client
+            #     early return ran first it would hand that stale supervisor the
+            #     LIVE client, which it later stops + discards on its own
+            #     suppression branch. ``_discard_own_client`` compares by
+            #     identity, but the handle IS the live client, so the identity
+            #     guard cannot save it -- the new incarnation loses its client.
+            #
+            # The generation guard in ``_register_for_fcm_entry`` fires one step
+            # too late for both. Gating first closes the build path AND the read
+            # path here. The supervisor loop treats this None as terminal (it
+            # built no own client, so there is nothing to clean up).
             if self._entry_writes_suppressed(entry_id, generation):
                 _LOGGER.debug(
-                    "[entry=%s] Skipping FCM client build for suppressed entry "
+                    "[entry=%s] Skipping FCM client handover for suppressed entry "
                     "(tombstoned or superseded generation)",
                     entry_id,
                 )
                 return None
+
+            # Idempotent read: an already-built client for a live, current
+            # generation is returned as-is (a read, not a re-creation).
+            if entry_id in self.pcs:
+                return self.pcs[entry_id]
 
             # Load entry-scoped credentials if present
             creds = self.creds.get(entry_id)
@@ -1241,6 +1253,16 @@ class FcmReceiverHA:
                         entry_id, cache, generation
                     )
                     if not pc:
+                        # finding 6: the build chokepoint now returns None for a
+                        # tombstoned entry or a superseded generation BEFORE
+                        # handing out any client. That is terminal for this
+                        # supervisor -- it must stop, not spin: no own client was
+                        # built (nothing to clean up) and the outer finally is
+                        # suppression-aware. A None from a transient build
+                        # failure (push-client support absent, factory error) is
+                        # NOT suppression and keeps retrying with backoff.
+                        if self._entry_writes_suppressed(entry_id, generation):
+                            break
                         nudged = await _nudge_sleep(backoff)
                         if nudged:
                             backoff = 1.0

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -2569,6 +2569,21 @@ class FcmReceiverHA:
 
     def _on_credentials_updated_for_entry(self, entry_id: str, creds: Any) -> None:
         """Update in-memory creds for the entry and persist asynchronously."""
+        # AP4 race guard: the old FCM client is not awaited during the
+        # synchronous teardown in ``unregister_coordinator``, so it can still
+        # fire this credentials-updated callback *after* ``_purge_entry_tokens``
+        # cleared the entry. Without this guard the callback would re-write
+        # ``self.creds[entry_id]``, restore token routing and queue persistence /
+        # pending creds, making a removed entry look known again to
+        # ``async_reregister_fcm``. Drop the late write while the entry is
+        # tombstoned; ``register_coordinator`` clears the tombstone on the next
+        # setup so a genuine reload still accepts fresh credentials.
+        if self._entry_writes_suppressed(entry_id):
+            _LOGGER.debug(
+                "[entry=%s] Ignoring credentials-updated callback for tombstoned entry",
+                entry_id,
+            )
+            return
         normalized: Any = creds
         if isinstance(normalized, str):
             try:

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1023,6 +1023,42 @@ class FcmReceiverHA:
         _LOGGER.info("FCM receiver initialized (multi-client ready)")
         return True
 
+    async def _load_entry_creds_for_build(
+        self, entry_id: str, cache: TokenCache | None
+    ) -> tuple[MutableJSONMapping | None, bool]:
+        """Resolve entry creds for a client build (the sole suspension point).
+
+        Returns ``(creds, loaded_from_cache)``. ``creds`` falls back to the
+        in-memory map, then the pending-creds buffer, then is overridden by a
+        successful awaited cache read. ``loaded_from_cache`` is True only when
+        that read produced a fresh credentials dict, so the caller knows it may
+        pop the pending-creds entry as part of its guarded commit.
+
+        The ``await`` here is the only suspension point in
+        ``_ensure_client_for_entry``'s critical section; the caller MUST
+        re-validate ``_entry_writes_suppressed`` after this returns, because a
+        synchronous teardown can land while this coroutine is parked on it.
+        """
+        creds = self.creds.get(entry_id)
+        if creds is None:
+            pending = self._pending_creds.get(entry_id)
+            if isinstance(pending, dict):
+                creds = pending
+        loaded_from_cache = False
+        try:
+            if cache is not None:
+                val = await cache.get("fcm_credentials")
+                if isinstance(val, str):
+                    val = json.loads(val)
+                if isinstance(val, dict):
+                    creds = val
+                    loaded_from_cache = True
+        except Exception as err:  # noqa: BLE001 - best-effort creds load
+            _LOGGER.debug(
+                "Failed to load entry-scoped FCM creds for %s: %s", entry_id, err
+            )
+        return creds, loaded_from_cache
+
     async def _ensure_client_for_entry(
         self, entry_id: str, cache: TokenCache | None, generation: int | None = None
     ) -> FcmPushClient[Any] | None:
@@ -1071,25 +1107,36 @@ class FcmReceiverHA:
             if entry_id in self.pcs:
                 return self.pcs[entry_id]
 
-            # Load entry-scoped credentials if present
-            creds = self.creds.get(entry_id)
-            if creds is None:
-                pending = self._pending_creds.get(entry_id)
-                if isinstance(pending, dict):
-                    creds = pending
-            try:
-                if cache is not None:
-                    val = await cache.get("fcm_credentials")
-                    if isinstance(val, str):
-                        val = json.loads(val)
-                    if isinstance(val, dict):
-                        creds = val
-                        self.creds[entry_id] = creds
-                        self._pending_creds.pop(entry_id, None)
-            except Exception as err:
+            # Resolve entry creds at the sole suspension point (the awaited cache
+            # read). Extracted into a named seam so this build chokepoint stays
+            # within its branch budget and the await is isolated; the store into
+            # ``self.creds[entry_id]`` is deferred to the single guarded commit
+            # below, because writing entry-state mid-method would let a teardown
+            # landing during the await re-create exactly what it just purged.
+            creds, loaded_from_cache = await self._load_entry_creds_for_build(
+                entry_id, cache
+            )
+
+            # AP7 (finding 7): re-validate suppression AFTER the await, BEFORE any
+            # per-entry store. ``self._lock`` is an asyncio lock -- it serialises
+            # other coroutines but does NOT exclude the SYNCHRONOUS
+            # ``unregister_coordinator`` (``async_on_unload``), which takes no
+            # lock. The ``await cache.get(...)`` above is the sole suspension
+            # point in this critical section; while parked there a teardown can
+            # tombstone the entry and ``_purge_entry_tokens`` it, so the first
+            # gate's verdict is stale on resume. Committing the stores below now
+            # would resurrect the purged ``self.pcs``/``self.creds`` -- the
+            # TOCTOU-over-await sibling of the fast-path race the first gate
+            # closes. Drop the handover; live callers treat None gracefully and a
+            # superseded supervisor terminates on it.
+            if self._entry_writes_suppressed(entry_id, generation):
                 _LOGGER.debug(
-                    "Failed to load entry-scoped FCM creds for %s: %s", entry_id, err
+                    "[entry=%s] Dropping FCM client handover after creds load; "
+                    "entry was suppressed (tombstoned or superseded) during the "
+                    "cache await",
+                    entry_id,
                 )
+                return None
 
             # Build register config (shared across entries)
             if not HAVE_FCM_PUSH_CLIENT:
@@ -1137,8 +1184,14 @@ class FcmReceiverHA:
                 )
                 return None
 
+            # Single guarded commit: every per-entry store happens here, after
+            # the post-await re-validation -- never mid-method. The pending-creds
+            # pop is part of the commit because it only applies when the cache
+            # load above produced fresh credentials.
             self.pcs[entry_id] = pc
             self.creds[entry_id] = creds if isinstance(creds, dict) else None
+            if loaded_from_cache:
+                self._pending_creds.pop(entry_id, None)
             return pc
 
     def _discard_own_client(

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -2909,6 +2909,22 @@ class FcmReceiverHA:
         Returns True if re-registration was initiated (supervisor restarted),
         False if the entry is not known to this receiver.
         """
+        # A torn-down entry must never be revived from here. unregister_coordinator
+        # (sync, via async_on_unload) tombstones the entry and purges its creds, but
+        # it cannot await pc.stop(), so the live client lingers in self.pcs until the
+        # cancelled supervisor (or async_stop) drains it. The creds/pcs membership
+        # guard below would still pass on that residual client and restart a
+        # supervisor for an entry mid-teardown (zombie). _unregistered is the single
+        # source of truth for "torn down" (see _entry_writes_suppressed); consult it
+        # first and bail before doing any teardown work. Cleared by
+        # register_coordinator on the next setup.
+        if entry_id in self._unregistered:
+            _LOGGER.debug(
+                "[entry=%s] Cannot re-register FCM: entry torn down (tombstoned)",
+                entry_id,
+            )
+            return False
+
         if entry_id not in self.pcs and entry_id not in self.creds:
             _LOGGER.warning(
                 "[entry=%s] Cannot re-register FCM: entry not known to receiver",

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -423,7 +423,7 @@ class FcmReceiverHA:
         # latch lifetime, even across non-cap fatal overwrites.
         self._short_run_cap_messages: dict[str, str] = {}
 
-        # AP4 (Befund 4a): tombstone set of entry_ids whose synchronous
+        # AP4 (finding 4a): tombstone set of entry_ids whose synchronous
         # teardown (``unregister_coordinator``) has already purged their
         # per-entry state. ``unregister_coordinator`` does not await the
         # still-running supervisor task, which writes per-entry state (fatal
@@ -1821,7 +1821,7 @@ class FcmReceiverHA:
         if entry is None:
             return
 
-        # AP4 (Befund 4a): a setup (initial or reload) un-tombstones the entry
+        # AP4 (finding 4a): a setup (initial or reload) un-tombstones the entry
         # so its supervisor writes take effect again. This is the single reset
         # point: it runs synchronously before the supervisor is (re)dispatched
         # below, and the prior supervisor was already cancelled by request_stop
@@ -1944,7 +1944,7 @@ class FcmReceiverHA:
                 self._entry_caches[entry_id] = replacement
             else:
                 self._entry_caches.pop(entry_id, None)
-                # AP4 (Befund 4a): tombstone the entry BEFORE purging so any
+                # AP4 (finding 4a): tombstone the entry BEFORE purging so any
                 # write from the still-running supervisor task (this method is
                 # synchronous and does not await it) is dropped instead of
                 # re-creating the state purged below. Cleared by
@@ -2788,23 +2788,23 @@ class FcmReceiverHA:
     def _purge_entry_tokens(self, entry_id: str) -> None:
         """Remove all routing references and per-entry runtime state for an entry."""
         self._entry_last_activity_monotonic.pop(entry_id, None)
-        # AP1 (Befund 2a): fatal retry counters are only cleared on the success
+        # AP1 (finding 2a): fatal retry counters are only cleared on the success
         # path (registration ok), so they leak per teardown without this.
         self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
         self._fatal_retry_counts.pop(f"{entry_id}:endpoint", None)
-        # AP2 (Befund 2b): per-entry health snapshots are written by
+        # AP2 (finding 2b): per-entry health snapshots are written by
         # _update_entry_health but never purged; a stale snapshot makes the
         # first healthy transition after a same-id reload look like a no-change
         # and suppresses its listener push.
         self._entry_health.pop(entry_id, None)
         self._entry_last_connected_wall.pop(entry_id, None)
-        # AP3 (Befund 2c): in-memory creds keep async_reregister_fcm's guard
+        # AP3 (finding 2c): in-memory creds keep async_reregister_fcm's guard
         # (entry_id in self.creds) True after teardown, which can revive a dead
         # entry (zombie supervisor). The on-disk cache is untouched, so a reload
         # reloads creds via _ensure_client_for_entry.
         self.creds.pop(entry_id, None)
         self._pending_creds.pop(entry_id, None)
-        # AP7 (Befund 2d): cancel pending debounce flush tasks and drop their
+        # AP7 (finding 2d): cancel pending debounce flush tasks and drop their
         # payloads so a flush cannot fire at an already-removed coordinator.
         self._purge_entry_debounce(entry_id)
         tokens = self._entry_to_tokens.pop(entry_id, set())

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1751,7 +1751,14 @@ class FcmReceiverHA:
             if token_or_creds:
                 _LOGGER.info("[entry=%s] FCM registered successfully", entry_id)
                 token = self.get_fcm_token(entry_id)
-                if token:
+                # AP4 race guard: a teardown may have purged this entry while
+                # this registration attempt was in flight. The routing writes
+                # below RE-CREATE per-entry state ``_purge_entry_tokens`` just
+                # removed, so skip them while the entry is tombstoned; without
+                # this guard a successful in-flight (re-)registration would
+                # resurrect routable stale tokens for a removed/reloading entry.
+                # The clears below only REMOVE state and stay teardown-safe.
+                if token and not self._entry_writes_suppressed(entry_id):
                     self._update_token_routing(token, {entry_id})
                     await self._persist_routing_token(entry_id, token)
                 self._clear_fatal_error_for_entry(

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -423,6 +423,26 @@ class FcmReceiverHA:
         # latch lifetime, even across non-cap fatal overwrites.
         self._short_run_cap_messages: dict[str, str] = {}
 
+        # AP4 (Befund 4a): tombstone set of entry_ids whose synchronous
+        # teardown (``unregister_coordinator``) has already purged their
+        # per-entry state. ``unregister_coordinator`` does not await the
+        # still-running supervisor task, which writes per-entry state (fatal
+        # counts, cap latch, creds) largely outside ``self._lock`` and could
+        # otherwise re-create exactly what the purge removed. While an entry is
+        # tombstoned those supervisor writes are skipped; ``register_coordinator``
+        # clears the tombstone on the next setup so a reload restores normal
+        # writes while a real removal stays clean.
+        self._unregistered: set[str] = set()
+
+    def _entry_writes_suppressed(self, entry_id: str) -> bool:
+        """Return True while *entry_id* is tombstoned by a teardown (AP4).
+
+        Used by the supervisor's per-entry write paths to drop post-purge
+        writes that would otherwise resurrect state ``_purge_entry_tokens``
+        just cleared.
+        """
+        return entry_id in self._unregistered
+
     def _clear_fatal_error_for_entry(
         self,
         entry_id: str,
@@ -1136,7 +1156,14 @@ class FcmReceiverHA:
                         fatal_count = (
                             self._fatal_retry_counts.get(counter_key, 0) + 1
                         )
-                        self._fatal_retry_counts[counter_key] = fatal_count
+                        # AP4 race guard: if the entry was torn down mid-flight,
+                        # do not re-create the fatal-retry counters the purge
+                        # just removed. The count stays effectively 1 while
+                        # suppressed, so the give-up branches below (which write
+                        # _fatal_errors and raise the reauth repair) are never
+                        # reached for a dead entry.
+                        if not self._entry_writes_suppressed(entry_id):
+                            self._fatal_retry_counts[counter_key] = fatal_count
 
                         if is_auth:
                             # 401: Token renewal while preserving android_id
@@ -1441,30 +1468,37 @@ class FcmReceiverHA:
                                 f"(persistent poison message suspected)"
                             )
                             _LOGGER.error("[entry=%s] %s", entry_id, message)
-                            self._fatal_errors[entry_id] = message
-                            # Defense 2 iter-8: latch the cap state. While
-                            # this latch is set, ``_clear_fatal_error_for_entry``
-                            # is a no-op (registration / credential-update paths
-                            # cannot clear the fatal map or the Repairs issue
-                            # before a real healthy supervisor run proves the
-                            # poison message is gone).
-                            self._short_run_cap_latched.add(entry_id)
-                            # Iter-16 (Codex follow-up): snapshot the
-                            # cap-fire message so the pass-through clear
-                            # branch in ``_clear_fatal_error_for_entry`` can
-                            # restore it after a non-cap fatal overwrote
-                            # ``_fatal_errors[entry_id]``. Released in the
-                            # same two places that release the latch.
-                            self._short_run_cap_messages[entry_id] = message
-                            if self._hass:
-                                ir.async_create_issue(
-                                    self._hass,
-                                    DOMAIN,
-                                    f"fcm_short_run_crash_loop_{entry_id}",
-                                    is_fixable=False,
-                                    severity=ir.IssueSeverity.ERROR,
-                                    translation_key="fcm_short_run_crash_loop",
-                                )
+                            # AP4 race guard: a teardown may have purged this
+                            # entry while the monitor loop was running. Skip the
+                            # cap latch / fatal map / Repairs issue so they are
+                            # not resurrected for a dead entry; the terminal
+                            # break below still stops this supervisor.
+                            if not self._entry_writes_suppressed(entry_id):
+                                self._fatal_errors[entry_id] = message
+                                # Defense 2 iter-8: latch the cap state. While
+                                # this latch is set,
+                                # ``_clear_fatal_error_for_entry`` is a no-op
+                                # (registration / credential-update paths cannot
+                                # clear the fatal map or the Repairs issue before
+                                # a real healthy supervisor run proves the poison
+                                # message is gone).
+                                self._short_run_cap_latched.add(entry_id)
+                                # Iter-16 (Codex follow-up): snapshot the
+                                # cap-fire message so the pass-through clear
+                                # branch in ``_clear_fatal_error_for_entry`` can
+                                # restore it after a non-cap fatal overwrote
+                                # ``_fatal_errors[entry_id]``. Released in the
+                                # same two places that release the latch.
+                                self._short_run_cap_messages[entry_id] = message
+                                if self._hass:
+                                    ir.async_create_issue(
+                                        self._hass,
+                                        DOMAIN,
+                                        f"fcm_short_run_crash_loop_{entry_id}",
+                                        is_fixable=False,
+                                        severity=ir.IssueSeverity.ERROR,
+                                        translation_key="fcm_short_run_crash_loop",
+                                    )
                             # Cleanup the client before breaking out so
                             # the loop exit doesn't leave a half-stopped pc.
                             try:
@@ -1590,6 +1624,11 @@ class FcmReceiverHA:
         ``reregister_keeping_identity()`` to get fresh FCM tokens with
         the same android_id/security_token.
         """
+        # AP4 race guard: never persist creds for an entry the teardown already
+        # purged (a still-running supervisor must not write back the credentials
+        # _purge_entry_tokens dropped).
+        if self._entry_writes_suppressed(entry_id):
+            return
         creds = self.creds.get(entry_id)
         if creds and isinstance(creds, dict):
             # Remove FCM-related parts, keep GCM device identity
@@ -1782,6 +1821,13 @@ class FcmReceiverHA:
         if entry is None:
             return
 
+        # AP4 (Befund 4a): a setup (initial or reload) un-tombstones the entry
+        # so its supervisor writes take effect again. This is the single reset
+        # point: it runs synchronously before the supervisor is (re)dispatched
+        # below, and the prior supervisor was already cancelled by request_stop
+        # on unload, so no stale supervisor can clear it prematurely.
+        self._unregistered.discard(entry.entry_id)
+
         self._entry_to_tokens.setdefault(entry.entry_id, set())
 
         if cache is not None:
@@ -1898,6 +1944,12 @@ class FcmReceiverHA:
                 self._entry_caches[entry_id] = replacement
             else:
                 self._entry_caches.pop(entry_id, None)
+                # AP4 (Befund 4a): tombstone the entry BEFORE purging so any
+                # write from the still-running supervisor task (this method is
+                # synchronous and does not await it) is dropped instead of
+                # re-creating the state purged below. Cleared by
+                # register_coordinator on the next setup (reload-safe).
+                self._unregistered.add(entry_id)
                 self._purge_entry_tokens(entry_id)
                 # Hard-reset on unregister: this fires via ``async_on_unload``
                 # on EVERY unload (reload AND removal), so it only resets the
@@ -2693,9 +2745,53 @@ class FcmReceiverHA:
         self.last_stop_monotonic = time.monotonic()
         _LOGGER.info("FCM receiver stopped")
 
+    def _purge_entry_debounce(self, entry_id: str) -> None:
+        """Cancel and drop the debounce trias for *entry_id*'s keys (AP7).
+
+        The push-path debounce maps (``_pending`` / ``_pending_targets`` /
+        ``_flush_tasks``) are keyed by ``(entry_id, device_id)`` and are only
+        ever cleaned per key inside ``_flush``. No teardown path iterates them
+        by entry, so a flush task still pending at unregister keeps running and
+        may write to an already-removed coordinator, while ``_pending`` /
+        ``_pending_targets`` leak until the next flush. Only this entry's keys
+        are touched (``key[0] == entry_id``); ``task.cancel()`` is safe from
+        sync code and idempotent.
+        """
+        for key in [key for key in self._flush_tasks if key[0] == entry_id]:
+            task = self._flush_tasks.pop(key, None)
+            if task is not None:
+                task.cancel()
+        pending_keys = {
+            key
+            for key in (*self._pending, *self._pending_targets)
+            if key[0] == entry_id
+        }
+        for key in pending_keys:
+            self._pending.pop(key, None)
+            self._pending_targets.pop(key, None)
+
     def _purge_entry_tokens(self, entry_id: str) -> None:
-        """Remove all routing references for a given entry."""
+        """Remove all routing references and per-entry runtime state for an entry."""
         self._entry_last_activity_monotonic.pop(entry_id, None)
+        # AP1 (Befund 2a): fatal retry counters are only cleared on the success
+        # path (registration ok), so they leak per teardown without this.
+        self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
+        self._fatal_retry_counts.pop(f"{entry_id}:endpoint", None)
+        # AP2 (Befund 2b): per-entry health snapshots are written by
+        # _update_entry_health but never purged; a stale snapshot makes the
+        # first healthy transition after a same-id reload look like a no-change
+        # and suppresses its listener push.
+        self._entry_health.pop(entry_id, None)
+        self._entry_last_connected_wall.pop(entry_id, None)
+        # AP3 (Befund 2c): in-memory creds keep async_reregister_fcm's guard
+        # (entry_id in self.creds) True after teardown, which can revive a dead
+        # entry (zombie supervisor). The on-disk cache is untouched, so a reload
+        # reloads creds via _ensure_client_for_entry.
+        self.creds.pop(entry_id, None)
+        self._pending_creds.pop(entry_id, None)
+        # AP7 (Befund 2d): cancel pending debounce flush tasks and drop their
+        # payloads so a flush cannot fire at an already-removed coordinator.
+        self._purge_entry_debounce(entry_id)
         tokens = self._entry_to_tokens.pop(entry_id, set())
         self._pending_routing_tokens.pop(entry_id, None)
         if not tokens:

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1024,14 +1024,40 @@ class FcmReceiverHA:
         return True
 
     async def _ensure_client_for_entry(
-        self, entry_id: str, cache: TokenCache | None
+        self, entry_id: str, cache: TokenCache | None, generation: int | None = None
     ) -> FcmPushClient[Any] | None:
-        """Create or return the FCM client for the given entry (idempotent)."""
+        """Create or return the FCM client for the given entry (idempotent).
+
+        ``generation`` is the supervisor's captured generation snapshot (or
+        ``None`` for live callers such as manual-locate registration). It gates
+        the *build* path through ``_entry_writes_suppressed`` (finding 5).
+        """
         if cache is not None:
             self._ensure_cache_entry_id(cache, entry_id)
         async with self._lock:
             if entry_id in self.pcs:
                 return self.pcs[entry_id]
+
+            # AP6 (finding 5): this is the single client-build chokepoint, and
+            # everything below RE-CREATES per-entry state (``self.creds`` on the
+            # cache load, ``self.pcs``/``self.creds`` on store). Drop the build
+            # when the entry is tombstoned or this supervisor's generation is
+            # superseded. The race: ``register_coordinator`` dispatches the
+            # supervisor asynchronously; if ``unregister_coordinator`` tombstones
+            # the entry before that queued coroutine runs (unload-before-dispatch),
+            # the first loop iteration would otherwise revive a torn-down entry's
+            # ``self.pcs``/``self.creds``. The generation guard in
+            # ``_register_for_fcm_entry`` fires one step too late -- the client is
+            # already stored by then. Placed AFTER the existing-client early
+            # return: returning an already-built client is a read, not a
+            # re-creation, so it stays teardown-safe (idempotent contract).
+            if self._entry_writes_suppressed(entry_id, generation):
+                _LOGGER.debug(
+                    "[entry=%s] Skipping FCM client build for suppressed entry "
+                    "(tombstoned or superseded generation)",
+                    entry_id,
+                )
+                return None
 
             # Load entry-scoped credentials if present
             creds = self.creds.get(entry_id)
@@ -1211,7 +1237,9 @@ class FcmReceiverHA:
             entry_start: float = 0.0
             try:
                 while not stop_evt.is_set():
-                    pc = await self._ensure_client_for_entry(entry_id, cache)
+                    pc = await self._ensure_client_for_entry(
+                        entry_id, cache, generation
+                    )
                     if not pc:
                         nudged = await _nudge_sleep(backoff)
                         if nudged:

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -434,14 +434,48 @@ class FcmReceiverHA:
         # writes while a real removal stays clean.
         self._unregistered: set[str] = set()
 
-    def _entry_writes_suppressed(self, entry_id: str) -> bool:
-        """Return True while *entry_id* is tombstoned by a teardown (AP4).
+        # AP4 (finding 4b): per-entry supervisor generation. The boolean
+        # tombstone above is cleared by ``register_coordinator`` on the next
+        # setup, but every unload also calls ``request_stop()`` which only
+        # *cancels* the prior supervisor without awaiting it. A fast reload can
+        # therefore clear the tombstone while the cancelled supervisor is still
+        # unwinding, re-opening the teardown race for that stale task. Each
+        # teardown bumps this counter; a supervisor captures the value current
+        # when it starts, so a superseded supervisor's writes stay suppressed by
+        # generation even after the tombstone is cleared for the new
+        # incarnation. The credentials-updated callback intentionally does NOT
+        # use this: its FCM client is reused across a reload and legitimately
+        # serves the new incarnation, so it follows the boolean tombstone only.
+        self._entry_generation: dict[str, int] = {}
 
-        Used by the supervisor's per-entry write paths to drop post-purge
-        writes that would otherwise resurrect state ``_purge_entry_tokens``
-        just cleared.
+    def _entry_writes_suppressed(
+        self, entry_id: str, generation: int | None = None
+    ) -> bool:
+        """Return True when a per-entry write must be dropped (AP4).
+
+        Two independent conditions suppress a write:
+
+        * The entry is tombstoned by a synchronous teardown (boolean
+          ``_unregistered``); cleared by ``register_coordinator`` on the next
+          setup. This covers the teardown window and the reused FCM client's
+          credentials callback.
+        * A ``generation`` is supplied and no longer matches the entry's current
+          generation, meaning the caller belongs to a superseded supervisor that
+          was cancelled but is still unwinding. This keeps a stale supervisor's
+          writes suppressed even after the tombstone is cleared for a new
+          incarnation (finding 4b).
+
+        Callers without a captured generation (e.g. the credentials callback)
+        pass ``None`` and get the pure tombstone-window behaviour.
         """
-        return entry_id in self._unregistered
+        if entry_id in self._unregistered:
+            return True
+        if (
+            generation is not None
+            and generation != self._entry_generation.get(entry_id, 0)
+        ):
+            return True
+        return False
 
     def _clear_fatal_error_for_entry(
         self,
@@ -1090,6 +1124,13 @@ class FcmReceiverHA:
         if entry_id in self.supervisors and not self.supervisors[entry_id].done():
             return
 
+        # AP4 (finding 4b): capture the generation current at start. Every
+        # per-entry write below is gated on this snapshot, so once a teardown
+        # bumps the generation this (now superseded) supervisor stops writing
+        # even after ``register_coordinator`` clears the boolean tombstone for
+        # the next incarnation.
+        generation = self._entry_generation.get(entry_id, 0)
+
         stop_evt = self._stop_evts.setdefault(entry_id, asyncio.Event())
 
         async def _supervisor() -> None:  # noqa: PLR0912, PLR0915
@@ -1125,7 +1166,9 @@ class FcmReceiverHA:
                         continue
 
                     try:
-                        ok_reg = await self._register_for_fcm_entry(entry_id)
+                        ok_reg = await self._register_for_fcm_entry(
+                            entry_id, generation
+                        )
                     except FatalRegistrationError as err:
                         message = str(err) or "FCM registration failed"
                         # Publish to ``_fatal_errors`` only once the retry
@@ -1162,7 +1205,7 @@ class FcmReceiverHA:
                         # suppressed, so the give-up branches below (which write
                         # _fatal_errors and raise the reauth repair) are never
                         # reached for a dead entry.
-                        if not self._entry_writes_suppressed(entry_id):
+                        if not self._entry_writes_suppressed(entry_id, generation):
                             self._fatal_retry_counts[counter_key] = fatal_count
 
                         if is_auth:
@@ -1187,7 +1230,7 @@ class FcmReceiverHA:
                                 )
                                 break
 
-                            await self._invalidate_fcm_tokens(entry_id)
+                            await self._invalidate_fcm_tokens(entry_id, generation)
 
                             delay = 60.0 * fatal_count
                             _LOGGER.warning(
@@ -1328,8 +1371,25 @@ class FcmReceiverHA:
                         state = getattr(pc, "run_state", None)
                         do_listen = getattr(pc, "do_listen", False)
                         monotonic_now = time.monotonic()
-                        last_activity = self._update_last_activity_for_entry(
-                            entry_id, pc, monotonic_now
+                        # AP4 (finding 4b, related sweep): a superseded or
+                        # tombstoned supervisor must not refresh per-entry
+                        # activity/health here. Those writes resurrect exactly
+                        # the snapshots ``_purge_entry_tokens`` dropped -- a stale
+                        # ``_entry_health`` makes the first healthy transition of
+                        # the next incarnation look like a no-change and
+                        # suppresses its listener push (the AP2 class named in
+                        # finding 2b). Skip the writes while suppressed; the
+                        # restart decision below still uses ``state`` /
+                        # ``do_listen``.
+                        writes_suppressed = self._entry_writes_suppressed(
+                            entry_id, generation
+                        )
+                        last_activity = (
+                            None
+                            if writes_suppressed
+                            else self._update_last_activity_for_entry(
+                                entry_id, pc, monotonic_now
+                            )
                         )
                         stale_after = max(self._activity_stale_after_s, 0.0)
                         # Iter-11: track ``became_started`` symmetrically to
@@ -1365,7 +1425,8 @@ class FcmReceiverHA:
                                 or (monotonic_now - last_activity <= stale_after)
                             )
                         )
-                        self._update_entry_health(entry_id, healthy)
+                        if not writes_suppressed:
+                            self._update_entry_health(entry_id, healthy)
                         if state is None:
                             _LOGGER.info(
                                 "[entry=%s] FCM client state unknown; scheduling restart",
@@ -1442,7 +1503,7 @@ class FcmReceiverHA:
                             entry_id,
                             credential_error,
                         )
-                        await self._invalidate_fcm_tokens(entry_id)
+                        await self._invalidate_fcm_tokens(entry_id, generation)
                         short_run_counter = 0
                     elif not became_started:
                         # Pre-start failure (no connected/listening state
@@ -1473,7 +1534,7 @@ class FcmReceiverHA:
                             # cap latch / fatal map / Repairs issue so they are
                             # not resurrected for a dead entry; the terminal
                             # break below still stops this supervisor.
-                            if not self._entry_writes_suppressed(entry_id):
+                            if not self._entry_writes_suppressed(entry_id, generation):
                                 self._fatal_errors[entry_id] = message
                                 # Defense 2 iter-8: latch the cap state. While
                                 # this latch is set,
@@ -1508,7 +1569,13 @@ class FcmReceiverHA:
                             finally:
                                 async with self._lock:
                                     self.pcs.pop(entry_id, None)
-                                self._update_entry_health(entry_id, False)
+                                # AP4 (finding 4b, related sweep): suppress the
+                                # stale-health write for a superseded/tombstoned
+                                # supervisor (resurrection class, finding 2b).
+                                if not self._entry_writes_suppressed(
+                                    entry_id, generation
+                                ):
+                                    self._update_entry_health(entry_id, False)
                             # Defense 2 iter-9 (Codex follow-up): the cap is
                             # a TERMINAL state for this supervisor. ``break``
                             # alone only exits the inner monitor loop and
@@ -1589,7 +1656,11 @@ class FcmReceiverHA:
                     finally:
                         async with self._lock:
                             self.pcs.pop(entry_id, None)
-                        self._update_entry_health(entry_id, False)
+                        # AP4 (finding 4b, related sweep): suppress the
+                        # stale-health write for a superseded/tombstoned
+                        # supervisor (resurrection class, finding 2b).
+                        if not self._entry_writes_suppressed(entry_id, generation):
+                            self._update_entry_health(entry_id, False)
 
                     if not stop_evt.is_set():
                         delay = backoff + random.uniform(0.1, 0.3) * backoff  # nosec B311
@@ -1608,7 +1679,16 @@ class FcmReceiverHA:
                 _LOGGER.error("[entry=%s] FCM supervisor crashed: %s", entry_id, err)
             finally:
                 _LOGGER.info("[entry=%s] FCM supervisor stopped", entry_id)
-                self._update_entry_health(entry_id, False)
+                # AP4 (finding 4b, related sweep): a supervisor cancelled by a
+                # teardown/reload must not write a stale "unhealthy" snapshot
+                # here -- ``_purge_entry_tokens`` just dropped ``_entry_health``
+                # for this entry, and re-creating it as False would suppress the
+                # first healthy transition of the next incarnation (the AP2
+                # resurrection class). Skip the write once this supervisor is
+                # superseded or the entry is tombstoned; a genuine shutdown
+                # (no generation bump, no tombstone) still records it.
+                if not self._entry_writes_suppressed(entry_id, generation):
+                    self._update_entry_health(entry_id, False)
                 self._retry_nudge_evts.pop(entry_id, None)
 
         task = asyncio.create_task(
@@ -1617,17 +1697,24 @@ class FcmReceiverHA:
         self.supervisors[entry_id] = task
         _LOGGER.info("Started FCM supervisor for entry %s", entry_id)
 
-    async def _invalidate_fcm_tokens(self, entry_id: str) -> None:
+    async def _invalidate_fcm_tokens(
+        self, entry_id: str, generation: int | None = None
+    ) -> None:
         """Clear renewable FCM tokens while preserving GCM device identity.
 
         After this, the next registration attempt will use
         ``reregister_keeping_identity()`` to get fresh FCM tokens with
         the same android_id/security_token.
+
+        ``generation`` is the supervisor's captured generation (AP4 finding 4b).
+        The public ``async_reregister_fcm`` path is a live operation and passes
+        ``None`` (tombstone-window check only); a supervisor passes its snapshot
+        so a superseded run cannot write back the creds the teardown dropped.
         """
         # AP4 race guard: never persist creds for an entry the teardown already
-        # purged (a still-running supervisor must not write back the credentials
-        # _purge_entry_tokens dropped).
-        if self._entry_writes_suppressed(entry_id):
+        # purged (a still-running or superseded supervisor must not write back
+        # the credentials _purge_entry_tokens dropped).
+        if self._entry_writes_suppressed(entry_id, generation):
             return
         creds = self.creds.get(entry_id)
         if creds and isinstance(creds, dict):
@@ -1724,8 +1811,16 @@ class FcmReceiverHA:
             err,
         )
 
-    async def _register_for_fcm_entry(self, entry_id: str) -> bool:
-        """Single registration attempt for a specific entry."""
+    async def _register_for_fcm_entry(
+        self, entry_id: str, generation: int | None = None
+    ) -> bool:
+        """Single registration attempt for a specific entry.
+
+        ``generation`` is the supervisor's captured generation (AP4 finding 4b);
+        it gates the success-path routing writes so a superseded supervisor
+        cannot resurrect routing state after the boolean tombstone is cleared.
+        Callers outside a supervisor pass ``None`` (tombstone-window check only).
+        """
         pc = self.pcs.get(entry_id)
         if not pc:
             return False
@@ -1758,7 +1853,7 @@ class FcmReceiverHA:
                 # this guard a successful in-flight (re-)registration would
                 # resurrect routable stale tokens for a removed/reloading entry.
                 # The clears below only REMOVE state and stay teardown-safe.
-                if token and not self._entry_writes_suppressed(entry_id):
+                if token and not self._entry_writes_suppressed(entry_id, generation):
                     self._update_token_routing(token, {entry_id})
                     await self._persist_routing_token(entry_id, token)
                 self._clear_fatal_error_for_entry(
@@ -1829,10 +1924,16 @@ class FcmReceiverHA:
             return
 
         # AP4 (finding 4a): a setup (initial or reload) un-tombstones the entry
-        # so its supervisor writes take effect again. This is the single reset
-        # point: it runs synchronously before the supervisor is (re)dispatched
-        # below, and the prior supervisor was already cancelled by request_stop
-        # on unload, so no stale supervisor can clear it prematurely.
+        # so the *new* incarnation's writes take effect again. This is the
+        # single reset point: it runs synchronously before the supervisor is
+        # (re)dispatched below. Clearing the boolean tombstone alone would
+        # re-open the race for a prior supervisor that request_stop only
+        # cancelled (not awaited) and which is still unwinding; finding 4b
+        # closes that gap via the generation captured per supervisor, so a
+        # superseded run stays suppressed by generation even though the
+        # tombstone is cleared here. The generation is intentionally NOT reset:
+        # the next supervisor reads the post-teardown value and is allowed,
+        # while the stale one keeps its old (now mismatched) snapshot.
         self._unregistered.discard(entry.entry_id)
 
         self._entry_to_tokens.setdefault(entry.entry_id, set())
@@ -1957,6 +2058,15 @@ class FcmReceiverHA:
                 # re-creating the state purged below. Cleared by
                 # register_coordinator on the next setup (reload-safe).
                 self._unregistered.add(entry_id)
+                # AP4 (finding 4b): bump the generation BEFORE the tombstone is
+                # later cleared by ``register_coordinator``. ``request_stop()``
+                # only cancels the prior supervisor without awaiting it, so this
+                # bump is what keeps that cancelled-but-unwinding supervisor's
+                # writes suppressed once the tombstone is gone -- it captured the
+                # old generation, which no longer matches.
+                self._entry_generation[entry_id] = (
+                    self._entry_generation.get(entry_id, 0) + 1
+                )
                 self._purge_entry_tokens(entry_id)
                 # Hard-reset on unregister: this fires via ``async_on_unload``
                 # on EVERY unload (reload AND removal), so it only resets the
@@ -2768,16 +2878,30 @@ class FcmReceiverHA:
         _LOGGER.info("FCM receiver stopped")
 
     def _purge_entry_debounce(self, entry_id: str) -> None:
-        """Cancel and drop the debounce trias for *entry_id*'s keys (AP7).
+        """Cancel and drop the debounce trias for *entry_id* (AP7).
 
         The push-path debounce maps (``_pending`` / ``_pending_targets`` /
-        ``_flush_tasks``) are keyed by ``(entry_id, device_id)`` and are only
+        ``_flush_tasks``) are keyed by ``(source_entry, device_id)`` and are only
         ever cleaned per key inside ``_flush``. No teardown path iterates them
         by entry, so a flush task still pending at unregister keeps running and
         may write to an already-removed coordinator, while ``_pending`` /
-        ``_pending_targets`` leak until the next flush. Only this entry's keys
-        are touched (``key[0] == entry_id``); ``task.cancel()`` is safe from
-        sync code and idempotent.
+        ``_pending_targets`` leak until the next flush. ``task.cancel()`` is safe
+        from sync code and idempotent.
+
+        Two membership relations matter (Codex follow-up):
+
+        * **Keyed by this entry** (``key[0] == entry_id``): drop the whole trias.
+        * **A recipient of another entry's flush** (``entry_id`` is a member of
+          ``_pending_targets[key]`` for a key owned by a *different* source
+          entry): the debounce key is the source entry, not every recipient, so
+          a fan-out keyed elsewhere can still target this entry. Remove it from
+          those target sets; if that empties the set the flush has no remaining
+          recipients, so cancel and drop it (an empty set fans out to no one,
+          while ``None`` means broadcast). Broadcast fallbacks (target set is
+          ``None``) are device-scoped, not entry-scoped, and are left untouched.
+
+        Without the second relation a reload within the debounce window could
+        deliver a pre-teardown payload to the new coordinator of this entry.
         """
         for key in [key for key in self._flush_tasks if key[0] == entry_id]:
             task = self._flush_tasks.pop(key, None)
@@ -2791,6 +2915,23 @@ class FcmReceiverHA:
         for key in pending_keys:
             self._pending.pop(key, None)
             self._pending_targets.pop(key, None)
+
+        # Drop this entry from the target sets of flushes keyed by other
+        # entries. Keys owned by this entry were already removed above, so any
+        # key remaining here is keyed by a different source entry.
+        for key in list(self._pending_targets):
+            targets = self._pending_targets.get(key)
+            if not targets or entry_id not in targets:
+                continue  # broadcast (None) or not a recipient
+            targets.discard(entry_id)
+            if targets:
+                continue  # other recipients remain; keep the flush
+            # No recipients left: cancel and drop the orphaned flush.
+            self._pending_targets.pop(key, None)
+            self._pending.pop(key, None)
+            task = self._flush_tasks.pop(key, None)
+            if task is not None:
+                task.cancel()
 
     def _purge_entry_tokens(self, entry_id: str) -> None:
         """Remove all routing references and per-entry runtime state for an entry."""

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -161,6 +161,26 @@ else:
 _LOGGER = logging.getLogger(__name__)
 
 
+# AP4 (finding 4c): the driving supervisor generation for the in-flight FCM
+# handshake. The vendored ``firebase_messaging`` client invokes
+# ``credentials_updated_callback`` SYNCHRONOUSLY from inside
+# ``checkin_or_register`` / ``reregister_keeping_identity`` (same task). The
+# credentials callback closure is bound at client-build time and is shared
+# across a fast reload (``unregister_coordinator`` bumps the generation but does
+# NOT pop the reused client), so the closure alone cannot tell which supervisor
+# drives the current handshake. ``_register_for_fcm_entry`` publishes its
+# captured generation here for the duration of the await; the callback reads it
+# and gates its writes on the *triggering* generation. A ContextVar (not a plain
+# attribute) is required: many awaits inside firebase separate the publish from
+# the callback, so a concurrent supervisor task must not clobber the value --
+# task-local isolation does exactly that. Outside any handshake (a live-
+# connection cred refresh) the default ``None`` preserves the historical
+# tombstone-only behaviour.
+_FCM_DRIVING_GENERATION: contextvars.ContextVar[tuple[str, int | None] | None] = (
+    contextvars.ContextVar("fcm_driving_generation", default=None)
+)
+
+
 # Iter-12 (Codex follow-up): the short-run crash cap needs to know
 # whether the FCM client ever reached ``FcmPushClientRunState.STARTED``
 # during a run, even when the entire CREATED -> STARTED -> CRASH
@@ -443,9 +463,16 @@ class FcmReceiverHA:
         # teardown bumps this counter; a supervisor captures the value current
         # when it starts, so a superseded supervisor's writes stay suppressed by
         # generation even after the tombstone is cleared for the new
-        # incarnation. The credentials-updated callback intentionally does NOT
-        # use this: its FCM client is reused across a reload and legitimately
-        # serves the new incarnation, so it follows the boolean tombstone only.
+        # incarnation. The credentials-updated callback cannot capture this at
+        # build time (its FCM client -- and the bound closure -- is reused across
+        # a fast reload, so the build-time snapshot would suppress the LIVE
+        # incarnation's legitimate writes). Instead it reads the *driving*
+        # generation that ``_register_for_fcm_entry`` publishes in
+        # ``_FCM_DRIVING_GENERATION`` around each handshake (finding 4c): a
+        # cancelled-but-unwinding supervisor that fires the callback mid-checkin
+        # is then recognised as superseded, while a live handshake (matching
+        # generation) or an out-of-band refresh (no driving generation -> the
+        # boolean tombstone window only) still writes.
         self._entry_generation: dict[str, int] = {}
 
     def _entry_writes_suppressed(
@@ -811,6 +838,26 @@ class FcmReceiverHA:
                     _CACHE_PROVIDER.reset(token)
                 except Exception as err:  # noqa: BLE001
                     _LOGGER.debug("Cache provider reset failed: %s", err)
+
+    @contextmanager
+    def _driving_generation_scope(
+        self, entry_id: str, generation: int | None
+    ) -> Iterator[None]:
+        """Publish the driving supervisor generation for one FCM handshake.
+
+        ``firebase_messaging`` fires ``credentials_updated_callback``
+        synchronously from inside the awaited ``checkin_or_register`` /
+        ``reregister_keeping_identity`` (same task). The callback closure is
+        shared across a fast reload, so it gates on this published generation
+        instead of a stale build-time snapshot. See ``_FCM_DRIVING_GENERATION``
+        for the full rationale (finding 4c). Reset in ``finally`` so a nested or
+        sibling handshake never inherits a leaked value.
+        """
+        token = _FCM_DRIVING_GENERATION.set((entry_id, generation))
+        try:
+            yield
+        finally:
+            _FCM_DRIVING_GENERATION.reset(token)
 
     def _monotonic_from_wall_time(
         self, wall_time: float, monotonic_now: float
@@ -2098,15 +2145,19 @@ class FcmReceiverHA:
                 and "gcm" in creds
                 and "fcm" not in creds
             )
-            if needs_reregister:
-                _LOGGER.info(
-                    "[entry=%s] Partial credentials detected; "
-                    "re-registering with existing device identity",
-                    entry_id,
-                )
-                token_or_creds = await pc.reregister_keeping_identity()
-            else:
-                token_or_creds = await pc.checkin_or_register()
+            # Publish this supervisor's captured generation for the handshake so
+            # the synchronously-fired credentials callback gates on the driving
+            # generation, not the reused client's stale build-time one (4c).
+            with self._driving_generation_scope(entry_id, generation):
+                if needs_reregister:
+                    _LOGGER.info(
+                        "[entry=%s] Partial credentials detected; "
+                        "re-registering with existing device identity",
+                        entry_id,
+                    )
+                    token_or_creds = await pc.reregister_keeping_identity()
+                else:
+                    token_or_creds = await pc.checkin_or_register()
 
             if token_or_creds:
                 _LOGGER.info("[entry=%s] FCM registered successfully", entry_id)
@@ -3007,18 +3058,35 @@ class FcmReceiverHA:
 
     def _on_credentials_updated_for_entry(self, entry_id: str, creds: Any) -> None:
         """Update in-memory creds for the entry and persist asynchronously."""
-        # AP4 race guard: the old FCM client is not awaited during the
-        # synchronous teardown in ``unregister_coordinator``, so it can still
+        # AP4 race guard (two tiers): the old FCM client is not awaited during
+        # the synchronous teardown in ``unregister_coordinator``, so it can still
         # fire this credentials-updated callback *after* ``_purge_entry_tokens``
         # cleared the entry. Without this guard the callback would re-write
         # ``self.creds[entry_id]``, restore token routing and queue persistence /
         # pending creds, making a removed entry look known again to
-        # ``async_reregister_fcm``. Drop the late write while the entry is
-        # tombstoned; ``register_coordinator`` clears the tombstone on the next
-        # setup so a genuine reload still accepts fresh credentials.
-        if self._entry_writes_suppressed(entry_id):
+        # ``async_reregister_fcm``.
+        #
+        # The tombstone alone is insufficient on a fast reload (finding 4c):
+        # ``unregister_coordinator`` bumps the generation but does NOT pop the
+        # reused client, and ``register_coordinator`` clears the tombstone for
+        # the new incarnation while a cancelled-but-unwinding supervisor is still
+        # inside ``checkin_or_register`` on that same client. Its synchronously-
+        # fired callback would then pass a tombstone-only gate and clobber the
+        # LIVE generation's creds, routing and fatal latch -- exactly the writes
+        # ``_register_for_fcm_entry`` guards post-await. Resolve the *driving*
+        # generation published by the supervisor for this handshake and gate on
+        # it: a superseded supervisor is suppressed, a live handshake (matching
+        # generation) and an out-of-band refresh (no driving generation -> pure
+        # tombstone window) still write. ``register_coordinator`` clears the
+        # tombstone on the next setup so a genuine reload still accepts creds.
+        driving = _FCM_DRIVING_GENERATION.get()
+        generation = (
+            driving[1] if driving is not None and driving[0] == entry_id else None
+        )
+        if self._entry_writes_suppressed(entry_id, generation):
             _LOGGER.debug(
-                "[entry=%s] Ignoring credentials-updated callback for tombstoned entry",
+                "[entry=%s] Ignoring credentials-updated callback for suppressed "
+                "entry (tombstoned or superseded generation)",
                 entry_id,
             )
             return

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1103,6 +1103,26 @@ class FcmReceiverHA:
             self.creds[entry_id] = creds if isinstance(creds, dict) else None
             return pc
 
+    def _discard_own_client(
+        self, entry_id: str, pc: FcmPushClient[Any]
+    ) -> None:
+        """Remove *pc* from ``self.pcs`` only if it is still the live client.
+
+        A supervisor cleans up the client it built by popping ``self.pcs``
+        under ``self._lock``. A key-only ``pop(entry_id)`` is identity-blind:
+        when a fast reload bumps the generation and the new incarnation has
+        already installed a fresh client under the same ``entry_id`` (via
+        ``_ensure_client_for_entry``), a stale supervisor reaching its cleanup
+        would evict the LIVE client, leaving the new generation without an FCM
+        client until its next restart. Comparing by identity ensures each
+        supervisor only discards the client it owns; a superseded supervisor
+        leaves the live client untouched.
+
+        Caller must hold ``self._lock``.
+        """
+        if self.pcs.get(entry_id) is pc:
+            self.pcs.pop(entry_id, None)
+
     def _async_raise_reauth_issue(self, entry_id: str, *, reason: str) -> None:
         """Surface a fixable repair that drives the user into the reauth flow.
 
@@ -1223,7 +1243,7 @@ class FcmReceiverHA:
                             pass
                         finally:
                             async with self._lock:
-                                self.pcs.pop(entry_id, None)
+                                self._discard_own_client(entry_id, pc)
 
                         is_auth = getattr(err, "is_auth_error", False)
                         counter_key = (
@@ -1346,7 +1366,7 @@ class FcmReceiverHA:
                             pass
                         finally:
                             async with self._lock:
-                                self.pcs.pop(entry_id, None)
+                                self._discard_own_client(entry_id, pc)
                         break
 
                     if not ok_reg:
@@ -1356,7 +1376,7 @@ class FcmReceiverHA:
                             pass
                         finally:
                             async with self._lock:
-                                self.pcs.pop(entry_id, None)
+                                self._discard_own_client(entry_id, pc)
                         delay = backoff + random.uniform(0.1, 0.3) * backoff  # nosec B311
                         if backoff >= _BACKOFF_WARNING_THRESHOLD_S:
                             _LOGGER.warning(
@@ -1637,7 +1657,7 @@ class FcmReceiverHA:
                                 pass
                             finally:
                                 async with self._lock:
-                                    self.pcs.pop(entry_id, None)
+                                    self._discard_own_client(entry_id, pc)
                                 # AP4 (finding 4b, related sweep): suppress the
                                 # stale-health write for a superseded/tombstoned
                                 # supervisor (resurrection class, finding 2b).
@@ -1737,7 +1757,7 @@ class FcmReceiverHA:
                         pass
                     finally:
                         async with self._lock:
-                            self.pcs.pop(entry_id, None)
+                            self._discard_own_client(entry_id, pc)
                         # AP4 (finding 4b, related sweep): suppress the
                         # stale-health write for a superseded/tombstoned
                         # supervisor (resurrection class, finding 2b).

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -1324,6 +1324,31 @@ class FcmReceiverHA:
                             await asyncio.sleep(delay)
                             continue
 
+                    # AP4 (finding: stale registration success at the caller).
+                    # ``_register_for_fcm_entry`` guards its own per-entry writes,
+                    # but its boolean return cannot tell this caller that the
+                    # generation was superseded (or the entry tombstoned)
+                    # mid-flight. Without this guard a stale supervisor would run
+                    # the success path below -- deleting the LIVE generation's
+                    # reauth repair issue, bumping start metrics and
+                    # (re)starting + monitoring the stale client -- or, on a
+                    # transient ``ok_reg`` False, burn the shared retry budget for
+                    # an entry it no longer owns. Returning False instead would be
+                    # wrong: it routes into the backoff/retry path, but a
+                    # superseded generation must terminate, not retry. Bail out
+                    # like the fatal-retry break above; the surrounding finally
+                    # skips the stale health write under the same suppression
+                    # guard.
+                    if self._entry_writes_suppressed(entry_id, generation):
+                        try:
+                            await pc.stop()
+                        except Exception:
+                            pass
+                        finally:
+                            async with self._lock:
+                                self.pcs.pop(entry_id, None)
+                        break
+
                     if not ok_reg:
                         try:
                             await pc.stop()

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -467,15 +467,39 @@ class FcmReceiverHA:
 
         Callers without a captured generation (e.g. the credentials callback)
         pass ``None`` and get the pure tombstone-window behaviour.
+
+        Use this to gate *write* side effects that RE-CREATE per-entry state
+        (token routing, fatal-error publication, cap-fire). For *removal* side
+        effects that are teardown-safe in the tombstone window but harmful only
+        when a stale generation would clobber the live incarnation, gate on
+        ``_entry_generation_superseded`` instead.
         """
         if entry_id in self._unregistered:
             return True
-        if (
+        return self._entry_generation_superseded(entry_id, generation)
+
+    def _entry_generation_superseded(
+        self, entry_id: str, generation: int | None
+    ) -> bool:
+        """Return True when ``generation`` belongs to a superseded supervisor.
+
+        This checks ONLY the generation-mismatch condition (a stale supervisor
+        that captured an old generation and lost ownership to a live incarnation
+        after a fast reload), NOT the boolean tombstone window. A caller without
+        a captured generation (the public re-register / credentials path) is a
+        live operation and is never "superseded", so it returns False.
+
+        It is the narrow guard for *removal* side effects (clearing the fatal
+        latch, deleting the reauth repair, resetting shared retry counters):
+        those are teardown-safe while an entry is merely tombstoned (it is going
+        away and ``unregister_coordinator`` already reset it), but must be
+        skipped when an old generation would wipe the LIVE generation's
+        diagnostics.
+        """
+        return (
             generation is not None
             and generation != self._entry_generation.get(entry_id, 0)
-        ):
-            return True
-        return False
+        )
 
     def _clear_fatal_error_for_entry(
         self,
@@ -1210,14 +1234,22 @@ class FcmReceiverHA:
                         fatal_count = (
                             self._fatal_retry_counts.get(counter_key, 0) + 1
                         )
-                        # AP4 race guard: if the entry was torn down mid-flight,
-                        # do not re-create the fatal-retry counters the purge
-                        # just removed. The count stays effectively 1 while
-                        # suppressed, so the give-up branches below (which write
-                        # _fatal_errors and raise the reauth repair) are never
-                        # reached for a dead entry.
-                        if not self._entry_writes_suppressed(entry_id, generation):
-                            self._fatal_retry_counts[counter_key] = fatal_count
+                        # AP4 race guard: a teardown or a supersede may have
+                        # purged/re-owned this entry mid-flight. A suppressed
+                        # supervisor is stale for the ENTIRE retry-budget
+                        # handling, not just the counter write below: the give-up
+                        # branches publish ``_fatal_error`` / ``_fatal_errors``
+                        # and raise the reauth repair, and ``fatal_count`` is read
+                        # from the shared ``_fatal_retry_counts`` map the LIVE
+                        # generation may already own after a fast reload. Letting
+                        # a stale generation reach the give-up branches would
+                        # surface a reauth/fatal error against the live entry.
+                        # Bail out entirely; the supervisor terminates via the
+                        # surrounding loop's finally cleanup (the failed client
+                        # was already stopped and popped above).
+                        if self._entry_writes_suppressed(entry_id, generation):
+                            break
+                        self._fatal_retry_counts[counter_key] = fatal_count
 
                         if is_auth:
                             # 401: Token renewal while preserving android_id
@@ -1629,36 +1661,49 @@ class FcmReceiverHA:
                         # ``self._hass is not None`` and intentionally also
                         # runs when no latch was set (cheap idempotent UI
                         # cleanup).
-                        cap_was_latched = entry_id in self._short_run_cap_latched
-                        if cap_was_latched:
-                            self._short_run_cap_latched.discard(entry_id)
-                            # Iter-16: a healthy run is also the moment to
-                            # retire the cap-fire snapshot so the
-                            # pass-through clear branch cannot re-introduce
-                            # it after the latch is gone.
-                            self._short_run_cap_messages.pop(entry_id, None)
-                            cap_message = self._fatal_errors.get(entry_id)
-                            if cap_message and cap_message.startswith(
-                                CRASH_LOOP_FATAL_PREFIX
-                            ):
-                                self._fatal_errors.pop(entry_id, None)
-                                self._fatal_error = next(
-                                    iter(self._fatal_errors.values()), None
-                                )
-                                _LOGGER.info(
-                                    "[entry=%s] FCM short-run cap latch released "
-                                    "by healthy supervisor run",
-                                    entry_id,
-                                )
-                        if self._hass is not None:
-                            try:
-                                ir.async_delete_issue(
-                                    self._hass,
-                                    DOMAIN,
-                                    f"fcm_short_run_crash_loop_{entry_id}",
-                                )
-                            except Exception:  # noqa: BLE001
-                                pass
+                        # AP4 (finding 4b, related sweep): a superseded or
+                        # tombstoned supervisor must not release the LIVE
+                        # generation's cap latch / fatal map / Repairs issue.
+                        # This mirrors the cap-FIRE guard above: a stale healthy
+                        # run is not proof the live incarnation's poison-message
+                        # condition is gone, and an old generation finishing a
+                        # healthy run after a fast reload would otherwise wipe the
+                        # new generation's diagnostics. The closure-local
+                        # ``short_run_counter`` reset above stays unguarded (it
+                        # cannot leak across incarnations).
+                        if not self._entry_writes_suppressed(entry_id, generation):
+                            cap_was_latched = (
+                                entry_id in self._short_run_cap_latched
+                            )
+                            if cap_was_latched:
+                                self._short_run_cap_latched.discard(entry_id)
+                                # Iter-16: a healthy run is also the moment to
+                                # retire the cap-fire snapshot so the
+                                # pass-through clear branch cannot re-introduce
+                                # it after the latch is gone.
+                                self._short_run_cap_messages.pop(entry_id, None)
+                                cap_message = self._fatal_errors.get(entry_id)
+                                if cap_message and cap_message.startswith(
+                                    CRASH_LOOP_FATAL_PREFIX
+                                ):
+                                    self._fatal_errors.pop(entry_id, None)
+                                    self._fatal_error = next(
+                                        iter(self._fatal_errors.values()), None
+                                    )
+                                    _LOGGER.info(
+                                        "[entry=%s] FCM short-run cap latch "
+                                        "released by healthy supervisor run",
+                                        entry_id,
+                                    )
+                            if self._hass is not None:
+                                try:
+                                    ir.async_delete_issue(
+                                        self._hass,
+                                        DOMAIN,
+                                        f"fcm_short_run_crash_loop_{entry_id}",
+                                    )
+                                except Exception:  # noqa: BLE001
+                                    pass
 
                     # Cleanup before restart
                     try:
@@ -1917,23 +1962,32 @@ class FcmReceiverHA:
 
             if token_or_creds:
                 _LOGGER.info("[entry=%s] FCM registered successfully", entry_id)
-                token = self.get_fcm_token(entry_id)
-                # AP4 race guard: a teardown may have purged this entry while
-                # this registration attempt was in flight. The routing writes
-                # below RE-CREATE per-entry state ``_purge_entry_tokens`` just
-                # removed, so skip them while the entry is tombstoned; without
-                # this guard a successful in-flight (re-)registration would
-                # resurrect routable stale tokens for a removed/reloading entry.
-                # The clears below only REMOVE state and stay teardown-safe.
-                if token and not self._entry_writes_suppressed(entry_id, generation):
-                    self._update_token_routing(token, {entry_id})
-                    await self._persist_routing_token(entry_id, token)
-                self._clear_fatal_error_for_entry(
-                    entry_id, reason="Registration succeeded"
-                )
-                # Reset fatal retry counters on success
-                self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
-                self._fatal_retry_counts.pop(f"{entry_id}:endpoint", None)
+                # AP4 race guard (two tiers): a teardown or a supersede may have
+                # purged or re-owned this entry while this attempt was in flight.
+                #
+                # * Routing writes RE-CREATE the per-entry state
+                #   ``_purge_entry_tokens`` removed, so they are skipped whenever
+                #   writes are suppressed (tombstone window OR superseded gen).
+                # * The clears / counter resets only REMOVE state, so they stay
+                #   teardown-safe in the pure-tombstone window (the entry is going
+                #   away and ``unregister_coordinator`` already reset it). But a
+                #   SUPERSEDED generation finishing after a fast reload must NOT
+                #   run them: that would wipe the LIVE generation's fatal latch,
+                #   reauth repair and retry counters (finding: guard all stale
+                #   success side effects). Gate them on the narrow generation
+                #   check so the documented teardown-safe-clear behaviour is kept.
+                if not self._entry_writes_suppressed(entry_id, generation):
+                    token = self.get_fcm_token(entry_id)
+                    if token:
+                        self._update_token_routing(token, {entry_id})
+                        await self._persist_routing_token(entry_id, token)
+                if not self._entry_generation_superseded(entry_id, generation):
+                    self._clear_fatal_error_for_entry(
+                        entry_id, reason="Registration succeeded"
+                    )
+                    # Reset fatal retry counters on success
+                    self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
+                    self._fatal_retry_counts.pop(f"{entry_id}:endpoint", None)
                 return True
             _LOGGER.warning("[entry=%s] FCM registration returned no token", entry_id)
             return False

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -494,6 +494,33 @@ async def test_supervisor_bails_out_for_superseded_generation(
 
 
 @pytest.mark.asyncio
+async def test_discard_own_client_spares_live_client_after_reload() -> None:
+    """``_discard_own_client`` evicts only the client it was handed.
+
+    Every supervisor cleanup path funnels its ``pcs`` removal through this
+    helper. A fast reload can install a fresh client under the same
+    ``entry_id`` while a stale supervisor reaches its cleanup; an identity-blind
+    ``pcs.pop`` would evict the LIVE client and leave the new generation without
+    an FCM client. The helper compares by identity, so the live client survives
+    and a supervisor only removes the client it owns.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-discard"
+    stale_pc = SimpleNamespace(label="stale")
+    live_pc = SimpleNamespace(label="live")
+
+    # The live incarnation already owns the slot; the stale supervisor cleans up
+    # with its own (superseded) client object -> the live client must survive.
+    receiver.pcs[entry_id] = live_pc
+    receiver._discard_own_client(entry_id, stale_pc)
+    assert receiver.pcs[entry_id] is live_pc
+
+    # When the stored client IS the caller's own client, it is removed.
+    receiver._discard_own_client(entry_id, live_pc)
+    assert entry_id not in receiver.pcs
+
+
+@pytest.mark.asyncio
 async def test_credentials_update_clears_latched_fatal_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -583,6 +583,41 @@ async def test_ensure_client_skips_build_for_suppressed_entry(
 
 
 @pytest.mark.asyncio
+async def test_ensure_client_does_not_hand_live_client_to_stale_supervisor() -> None:
+    """A stale supervisor must never receive the live incarnation's client.
+
+    Fast-reload race (Codex finding 6): the new incarnation already installed a
+    fresh client under ``entry_id`` (live generation 4). A stale supervisor that
+    captured generation 3 then calls in here. If the existing-client fast path
+    ran before the suppression guard it would hand that stale supervisor the LIVE
+    client, which it later stops + discards on its own suppression branch --
+    ``_discard_own_client`` compares by identity, but the handle IS the live
+    client, so the identity guard cannot save it and the new incarnation loses
+    its client. The build chokepoint therefore gates on
+    ``_entry_writes_suppressed`` BEFORE the existing-client return: the stale
+    supervisor gets ``None`` and the live client stays untouched.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-stale-handover"
+    live_pc = SimpleNamespace(label="live")
+
+    # New incarnation owns the slot at the current (live) generation.
+    receiver.pcs[entry_id] = live_pc
+    receiver._entry_generation[entry_id] = 4
+
+    # Stale supervisor (captured generation 3) must NOT be handed the live client.
+    stale = await receiver._ensure_client_for_entry(entry_id, None, 3)
+    assert stale is None
+    assert receiver.pcs[entry_id] is live_pc  # live client untouched
+
+    # Idempotent read still works for the live, current generation: a matching
+    # caller receives the existing client as-is (no re-creation, no None).
+    current = await receiver._ensure_client_for_entry(entry_id, None, 4)
+    assert current is live_pc
+    assert receiver.pcs[entry_id] is live_pc
+
+
+@pytest.mark.asyncio
 async def test_credentials_update_clears_latched_fatal_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -385,6 +385,63 @@ async def test_register_success_skips_routing_writes_for_tombstoned_entry(
 
 
 @pytest.mark.asyncio
+async def test_register_success_skips_clears_for_superseded_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A success finishing under a SUPERSEDED generation must not clear the
+    LIVE generation's diagnostics (Codex: guard all stale success side effects).
+
+    Distinct from the pure-tombstone case: here the entry is NOT tombstoned (a
+    fast reload already cleared the tombstone and bumped the generation), so the
+    old generation's success would otherwise wipe the new incarnation's fatal
+    latch and retry counters. Both the routing writes AND the clears must be
+    skipped for the stale generation, while the attempt still reports success.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-superseded"
+    # State owned by the LIVE (new) generation after a fast reload.
+    receiver._fatal_errors[entry_id] = "BadAuthentication"
+    receiver._fatal_error = "BadAuthentication"
+    receiver._fatal_retry_counts[f"{entry_id}:auth"] = 2
+    # The new incarnation bumped the generation; this in-flight attempt still
+    # carries the old (now superseded) snapshot. No tombstone is set.
+    receiver._entry_generation[entry_id] = 5
+    stale_generation = 4
+
+    class _DummyPc:
+        async def checkin_or_register(self) -> dict[str, str]:
+            return {"ok": "true"}
+
+    receiver.pcs[entry_id] = _DummyPc()
+
+    token_routes: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver,
+        "_update_token_routing",
+        lambda token, entries: token_routes.append((token, set(entries))),
+    )
+
+    persisted_tokens: list[tuple[str, str]] = []
+
+    async def _persist(entry_arg: str, token_arg: str) -> None:
+        persisted_tokens.append((entry_arg, token_arg))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _entry_id=None: "token-123")
+
+    result = await receiver._register_for_fcm_entry(entry_id, stale_generation)
+
+    assert result is True
+    # Routing writes stay suppressed for the superseded generation...
+    assert token_routes == []
+    assert persisted_tokens == []
+    # ...and so do the clears: the LIVE generation's diagnostics survive.
+    assert receiver._fatal_errors[entry_id] == "BadAuthentication"
+    assert receiver._fatal_error == "BadAuthentication"
+    assert receiver._fatal_retry_counts[f"{entry_id}:auth"] == 2
+
+
+@pytest.mark.asyncio
 async def test_credentials_update_clears_latched_fatal_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -331,6 +331,58 @@ async def test_register_clears_latched_fatal_error(
 
 
 @pytest.mark.asyncio
+async def test_register_success_skips_routing_writes_for_tombstoned_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registration attempt that finishes after the entry was torn down must
+    not resurrect token routing for the tombstoned entry (AP4 teardown race).
+
+    The routing writes RE-CREATE the per-entry state ``_purge_entry_tokens``
+    just removed, so they must be skipped while the entry is tombstoned. The
+    fatal/repair clears only REMOVE state, so they stay teardown-safe and still
+    run, and the attempt still reports success.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-tombstoned"
+    receiver._fatal_errors[entry_id] = "BadAuthentication"
+    receiver._fatal_error = "BadAuthentication"
+    # The synchronous teardown purged this entry while this in-flight
+    # registration was still running.
+    receiver._unregistered.add(entry_id)
+
+    class _DummyPc:
+        async def checkin_or_register(self) -> dict[str, str]:
+            return {"ok": "true"}
+
+    receiver.pcs[entry_id] = _DummyPc()
+
+    token_routes: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver,
+        "_update_token_routing",
+        lambda token, entries: token_routes.append((token, set(entries))),
+    )
+
+    persisted_tokens: list[tuple[str, str]] = []
+
+    async def _persist(entry_arg: str, token_arg: str) -> None:
+        persisted_tokens.append((entry_arg, token_arg))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _entry_id=None: "token-123")
+
+    result = await receiver._register_for_fcm_entry(entry_id)
+
+    assert result is True
+    # Routing writes are suppressed for the tombstoned entry...
+    assert token_routes == []
+    assert persisted_tokens == []
+    # ...but the teardown-safe clears still run.
+    assert entry_id not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+
+
+@pytest.mark.asyncio
 async def test_credentials_update_clears_latched_fatal_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -490,3 +490,176 @@ async def test_register_keeps_transient_runtime_error_transient() -> None:
 
     assert result is False
     assert entry_id not in receiver._fatal_errors
+
+
+def test_entry_writes_suppressed_generation_and_tombstone() -> None:
+    """``_entry_writes_suppressed`` combines the boolean tombstone with the
+    per-entry generation (finding 4b).
+
+    The tombstone suppresses regardless of generation; a mismatched generation
+    suppresses even without a tombstone; ``None`` falls back to tombstone-only.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-gen"
+
+    # Fresh entry: generation 0 matches, no tombstone -> writes allowed.
+    assert receiver._entry_writes_suppressed(entry_id, 0) is False
+
+    # The tombstone suppresses regardless of the supplied generation.
+    receiver._unregistered.add(entry_id)
+    assert receiver._entry_writes_suppressed(entry_id, 0) is True
+    receiver._unregistered.discard(entry_id)
+
+    # A teardown bumped the generation; a stale supervisor (captured 0) is
+    # suppressed even though the tombstone was cleared by the reload.
+    receiver._entry_generation[entry_id] = 1
+    assert receiver._entry_writes_suppressed(entry_id, 0) is True
+    # The current incarnation (captured 1) writes again.
+    assert receiver._entry_writes_suppressed(entry_id, 1) is False
+    # Callers without a captured generation get tombstone-only behaviour.
+    assert receiver._entry_writes_suppressed(entry_id, None) is False
+
+
+@pytest.mark.asyncio
+async def test_register_success_skips_routing_writes_for_superseded_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registration attempt from a superseded supervisor must not resurrect
+    routing even after the boolean tombstone was cleared by a reload (finding 4b).
+
+    This is the gap left by the tombstone-only guard: ``request_stop`` cancels
+    the old supervisor without awaiting it, and ``register_coordinator`` clears
+    ``_unregistered`` for the new incarnation, so only the generation keeps the
+    stale supervisor's success-path writes suppressed.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-superseded"
+    # Teardown bumped the generation; the reload then cleared the tombstone.
+    receiver._entry_generation[entry_id] = 1
+    assert entry_id not in receiver._unregistered
+
+    class _DummyPc:
+        async def checkin_or_register(self) -> dict[str, str]:
+            return {"ok": "true"}
+
+    receiver.pcs[entry_id] = _DummyPc()
+
+    token_routes: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver,
+        "_update_token_routing",
+        lambda token, entries: token_routes.append((token, set(entries))),
+    )
+
+    persisted_tokens: list[tuple[str, str]] = []
+
+    async def _persist(entry_arg: str, token_arg: str) -> None:
+        persisted_tokens.append((entry_arg, token_arg))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _entry_id=None: "token-123")
+
+    # Stale supervisor captured generation 0; current is 1 -> writes suppressed.
+    result = await receiver._register_for_fcm_entry(entry_id, 0)
+    assert result is True
+    assert token_routes == []
+    assert persisted_tokens == []
+
+    # The current incarnation (generation 1) still writes routing.
+    result_current = await receiver._register_for_fcm_entry(entry_id, 1)
+    assert result_current is True
+    assert token_routes == [("token-123", {entry_id})]
+    assert persisted_tokens == [(entry_id, "token-123")]
+
+
+def test_unregister_bumps_generation_and_suppresses_old_supervisor() -> None:
+    """A real removal bumps the entry generation so a supervisor that captured
+    the prior value stays suppressed once the tombstone is cleared (finding 4b).
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-bumped"
+    coordinator = SimpleNamespace(
+        config_entry=make_config_entry(entry_id=entry_id), cache=None
+    )
+    receiver.coordinators.append(coordinator)
+
+    # A supervisor for this entry captured generation 0 before the teardown.
+    assert receiver._entry_generation.get(entry_id, 0) == 0
+
+    receiver.unregister_coordinator(coordinator)
+
+    # Teardown tombstoned the entry and bumped the generation.
+    assert entry_id in receiver._unregistered
+    assert receiver._entry_generation[entry_id] == 1
+    # Simulate the reload clearing the tombstone; the old supervisor (gen 0)
+    # must remain suppressed purely by generation.
+    receiver._unregistered.discard(entry_id)
+    assert receiver._entry_writes_suppressed(entry_id, 0) is True
+    assert receiver._entry_writes_suppressed(entry_id, 1) is False
+
+
+def test_purge_entry_debounce_drops_entry_from_foreign_target_set() -> None:
+    """A flush keyed by another source entry that also targets the purged entry
+    must drop the purged entry from its target set while keeping the flush for
+    the remaining recipients (Codex follow-up, finding for shared targets).
+    """
+    receiver = FcmReceiverHA()
+    source = "entry-source"
+    victim = "entry-victim"
+    other = "entry-other"
+    key = (source, "device-1")
+    receiver._pending[key] = {"latitude": 1.0}
+    receiver._pending_targets[key] = {source, victim, other}
+
+    receiver._purge_entry_debounce(victim)
+
+    # Victim removed from the foreign target set; flush kept for the rest.
+    assert receiver._pending_targets[key] == {source, other}
+    assert key in receiver._pending
+
+
+@pytest.mark.asyncio
+async def test_purge_entry_debounce_cancels_orphaned_flush_when_targets_empty() -> None:
+    """When the purged entry is the sole recipient of a foreign-keyed flush, the
+    whole flush is cancelled and dropped (an empty target set would otherwise
+    fan out to no one and leak).
+    """
+    receiver = FcmReceiverHA()
+    source = "entry-source"
+    victim = "entry-victim"
+    key = (source, "device-1")
+    receiver._pending[key] = {"latitude": 1.0}
+    receiver._pending_targets[key] = {victim}
+
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_never())
+    receiver._flush_tasks[key] = task
+
+    receiver._purge_entry_debounce(victim)
+
+    assert key not in receiver._pending_targets
+    assert key not in receiver._pending
+    assert key not in receiver._flush_tasks
+    # Let the cancellation settle, then confirm the orphaned flush was cancelled.
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+
+
+def test_purge_entry_debounce_leaves_broadcast_targets() -> None:
+    """Broadcast fallbacks (target set is ``None``) are device-scoped, not
+    entry-scoped, so a purge must leave them untouched.
+    """
+    receiver = FcmReceiverHA()
+    source = "entry-source"
+    victim = "entry-victim"
+    key = (source, "device-1")
+    receiver._pending[key] = {"latitude": 1.0}
+    receiver._pending_targets[key] = None
+
+    receiver._purge_entry_debounce(victim)
+
+    assert key in receiver._pending_targets
+    assert receiver._pending_targets[key] is None

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -933,6 +933,7 @@ async def test_classify_registration_exception_branches(
     assert calls == [entry_id, entry_id, entry_id]
 
 
+@pytest.mark.asyncio
 async def test_classify_registration_exception_forwards_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -442,6 +442,58 @@ async def test_register_success_skips_clears_for_superseded_generation(
 
 
 @pytest.mark.asyncio
+async def test_supervisor_bails_out_for_superseded_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supervisor whose generation is superseded mid-flight must terminate,
+    not run the caller-level success path (Codex: stale registration success).
+
+    ``_register_for_fcm_entry`` already guards its in-method writes, but its
+    boolean return cannot signal the caller that the generation was superseded.
+    Here a fast reload bumps the generation while registration is in flight, so
+    the (now stale) supervisor must NOT delete the live reauth issue, bump start
+    metrics or (re)start + monitor the old client; it stops the client and exits.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-sup-superseded"
+    # Generation captured by the supervisor at start.
+    receiver._entry_generation[entry_id] = 1
+
+    fake_pc = SimpleNamespace(
+        start=AsyncMock(),
+        stop=AsyncMock(),
+        run_state=None,
+        do_listen=False,
+    )
+
+    async def _ensure(_entry_id: str, _cache: object) -> object:
+        return fake_pc
+
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
+
+    async def _register(_entry_id: str, _generation: int | None = None) -> bool:
+        # A live incarnation took over (fast reload) while this attempt ran.
+        receiver._entry_generation[_entry_id] = 2
+        return True
+
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", _register)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    task = receiver.supervisors[entry_id]
+    # The bail-out terminates the supervisor; without it the stale supervisor
+    # would enter the monitor loop and never finish (so the timeout also pins
+    # the regression).
+    await asyncio.wait_for(task, timeout=2)
+
+    # Caller-level success side effects must NOT have run for the stale gen.
+    fake_pc.start.assert_not_awaited()
+    assert receiver.start_count == 0
+    # The stale client is stopped and dropped on bail-out.
+    fake_pc.stop.assert_awaited()
+    assert entry_id not in receiver.pcs
+
+
+@pytest.mark.asyncio
 async def test_credentials_update_clears_latched_fatal_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -618,6 +618,76 @@ async def test_ensure_client_does_not_hand_live_client_to_stale_supervisor() -> 
 
 
 @pytest.mark.asyncio
+async def test_ensure_client_drops_handover_on_teardown_during_cache_await(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A teardown during the credential-load await must not resurrect state.
+
+    Slow-cache race (Codex finding 7): ``_ensure_client_for_entry`` holds the
+    asyncio ``self._lock``, but ``unregister_coordinator`` is synchronous and
+    takes no lock, so it runs to completion while this method is suspended on
+    ``await cache.get("fcm_credentials")``. The single suppression check before
+    that await is stale on resume; committing the per-entry stores afterwards
+    would re-create exactly the ``self.pcs``/``self.creds`` state the teardown
+    purged. The post-await re-check drops the handover instead, while the
+    no-teardown path still performs every store the inline writes used to.
+    """
+    built: list[object] = []
+
+    class DummyPushClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            built.append(self)
+            self.run_state = None
+            self.do_listen = False
+
+    monkeypatch.setattr(fcm_receiver_ha, "FcmPushClient", DummyPushClient)
+    monkeypatch.setattr(fcm_receiver_ha, "HAVE_FCM_PUSH_CLIENT", True)
+
+    receiver = FcmReceiverHA()
+    entry_id = "entry-slow-cache-teardown"
+    creds_payload = {"fcm": {"registration": {"token": "creds-from-cache"}}}
+
+    class _TeardownDuringGetCache:
+        """A cache whose awaited ``get`` lets a sync teardown land mid-flight."""
+
+        def __init__(self, *, tombstone: bool) -> None:
+            self.entry_id = entry_id
+            self._tombstone = tombstone
+
+        async def get(self, _key: str) -> dict[str, object]:
+            if self._tombstone:
+                # The synchronous async_on_unload teardown running while this
+                # coroutine is suspended: tombstone the entry exactly as
+                # ``unregister_coordinator`` does before it purges.
+                receiver._unregistered.add(entry_id)
+            return dict(creds_payload)
+
+    # Negative case: teardown lands during the await -> handover dropped, no
+    # per-entry state resurrected, build never reached.
+    receiver._pending_creds[entry_id] = {"stale": "pending"}
+    dropped = await receiver._ensure_client_for_entry(
+        entry_id, _TeardownDuringGetCache(tombstone=True), None
+    )
+    assert dropped is None
+    assert entry_id not in receiver.pcs
+    assert entry_id not in receiver.creds
+    assert built == []  # no client constructed for a torn-down entry
+
+    # Positive control: no teardown -> client built, creds committed from the
+    # cache load, and the consumed pending-creds entry popped. This proves the
+    # deferred single commit still performs every store the inline writes did.
+    receiver._unregistered.discard(entry_id)
+    live = await receiver._ensure_client_for_entry(
+        entry_id, _TeardownDuringGetCache(tombstone=False), None
+    )
+    assert isinstance(live, DummyPushClient)
+    assert receiver.pcs[entry_id] is live
+    assert receiver.creds[entry_id] == creds_payload
+    assert entry_id not in receiver._pending_creds  # loaded_from_cache popped it
+    assert len(built) == 1
+
+
+@pytest.mark.asyncio
 async def test_credentials_update_clears_latched_fatal_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -466,7 +466,9 @@ async def test_supervisor_bails_out_for_superseded_generation(
         do_listen=False,
     )
 
-    async def _ensure(_entry_id: str, _cache: object) -> object:
+    async def _ensure(
+        _entry_id: str, _cache: object, _generation: int | None = None
+    ) -> object:
         return fake_pc
 
     monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure)
@@ -518,6 +520,66 @@ async def test_discard_own_client_spares_live_client_after_reload() -> None:
     # When the stored client IS the caller's own client, it is removed.
     receiver._discard_own_client(entry_id, live_pc)
     assert entry_id not in receiver.pcs
+
+
+@pytest.mark.asyncio
+async def test_ensure_client_skips_build_for_suppressed_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_ensure_client_for_entry`` must not re-create state for a suppressed entry.
+
+    ``register_coordinator`` dispatches the supervisor asynchronously. If
+    ``unregister_coordinator`` tombstones the entry before that queued coroutine
+    runs (unload-before-dispatch), the supervisor's first iteration would
+    otherwise revive the torn-down entry's ``self.pcs``/``self.creds`` -- the
+    generation guard in ``_register_for_fcm_entry`` fires one step too late
+    (after the client is already stored). The build chokepoint gates on
+    ``_entry_writes_suppressed`` so a suppressed entry returns ``None`` and
+    writes nothing (Codex finding 5).
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-build-suppressed"
+
+    built: list[object] = []
+
+    class DummyPushClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            built.append(self)
+            self.run_state = None
+            self.do_listen = False
+
+    monkeypatch.setattr(fcm_receiver_ha, "FcmPushClient", DummyPushClient)
+    monkeypatch.setattr(fcm_receiver_ha, "HAVE_FCM_PUSH_CLIENT", True)
+
+    # Positive control: a live entry (no tombstone, matching generation) builds
+    # and stores a client. This proves the suppression branch -- not some
+    # unrelated early return -- is what blocks the two cases below.
+    receiver._entry_generation[entry_id] = 3
+    live = await receiver._ensure_client_for_entry(entry_id, None, 3)
+    assert isinstance(live, DummyPushClient)
+    assert receiver.pcs[entry_id] is live
+    assert len(built) == 1
+
+    # Tombstone path: a torn-down entry must not be revived. Clear the stored
+    # client/creds first so only a fresh build could repopulate the maps.
+    receiver.pcs.clear()
+    receiver.creds.clear()
+    receiver._unregistered.add(entry_id)
+    suppressed = await receiver._ensure_client_for_entry(entry_id, None, 3)
+    assert suppressed is None
+    assert entry_id not in receiver.pcs
+    assert entry_id not in receiver.creds
+    assert len(built) == 1  # no new client constructed
+
+    # Superseded-generation path: the tombstone is cleared (a new incarnation
+    # is set up) but a stale supervisor holding an old generation snapshot must
+    # still be blocked from clobbering the live generation's state.
+    receiver._unregistered.discard(entry_id)
+    receiver._entry_generation[entry_id] = 4  # live incarnation moved on
+    stale = await receiver._ensure_client_for_entry(entry_id, None, 3)
+    assert stale is None
+    assert entry_id not in receiver.pcs
+    assert len(built) == 1
 
 
 @pytest.mark.asyncio
@@ -828,7 +890,7 @@ async def test_supervisor_restart_installs_fresh_stop_event(
 
     ran = asyncio.Event()
 
-    async def _ensure(eid: str, _cache: Any) -> None:
+    async def _ensure(eid: str, _cache: Any, _generation: int | None = None) -> None:
         ran.set()
         # Terminate the loop deterministically after one body execution.
         receiver._stop_evts[eid].set()

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -1719,7 +1719,7 @@ def test_factory_honours_monkeypatched_fcm_push_client_symbol(
 
 
 def test_purge_entry_tokens_clears_fatal_retry_counts() -> None:
-    """AP1 (Befund 2a): the teardown purge drops both fatal-retry counters."""
+    """AP1 (finding 2a): the teardown purge drops both fatal-retry counters."""
     receiver = FcmReceiverHA()
     eid = "entry-purge-counts"
     receiver._fatal_retry_counts[f"{eid}:auth"] = 4
@@ -1734,7 +1734,7 @@ def test_purge_entry_tokens_clears_fatal_retry_counts() -> None:
 
 
 def test_purge_entry_tokens_clears_entry_health() -> None:
-    """AP2 (Befund 2b): per-entry health snapshots are purged on teardown."""
+    """AP2 (finding 2b): per-entry health snapshots are purged on teardown."""
     receiver = FcmReceiverHA()
     eid = "entry-purge-health"
     receiver._entry_health[eid] = True
@@ -1747,7 +1747,7 @@ def test_purge_entry_tokens_clears_entry_health() -> None:
 
 
 def test_purge_entry_tokens_clears_creds() -> None:
-    """AP3 (Befund 2c): in-memory creds + pending creds are purged on teardown."""
+    """AP3 (finding 2c): in-memory creds + pending creds are purged on teardown."""
     receiver = FcmReceiverHA()
     eid = "entry-purge-creds"
     receiver.creds[eid] = {"gcm": {"token": "x"}}
@@ -1780,7 +1780,7 @@ async def test_reregister_returns_false_after_purge() -> None:
 
 @pytest.mark.asyncio
 async def test_purge_cancels_pending_debounce_flush_tasks() -> None:
-    """AP7 (Befund 2d): pending flush tasks are cancelled and the trias dropped."""
+    """AP7 (finding 2d): pending flush tasks are cancelled and the trias dropped."""
     receiver = FcmReceiverHA()
     eid = "entry-debounce"
     key = (eid, "device-1")
@@ -1817,7 +1817,7 @@ async def test_purge_cancels_pending_debounce_flush_tasks() -> None:
 
 
 def test_unregister_coordinator_tombstones_and_purges() -> None:
-    """AP4 (Befund 4a): unregister tombstones the entry and purges its state."""
+    """AP4 (finding 4a): unregister tombstones the entry and purges its state."""
     receiver = FcmReceiverHA()
     eid = "entry-unreg-tombstone"
     coord = SimpleNamespace(
@@ -1838,7 +1838,7 @@ def test_unregister_coordinator_tombstones_and_purges() -> None:
 def test_register_coordinator_clears_tombstone(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AP4 (Befund 4a, Wächter B): a setup un-tombstones the entry."""
+    """AP4 (finding 4a, guard B): a setup un-tombstones the entry."""
     receiver = FcmReceiverHA()
     receiver.attach_hass(SimpleNamespace())
     eid = "entry-reload"
@@ -1863,7 +1863,7 @@ def test_register_coordinator_clears_tombstone(
 
 @pytest.mark.asyncio
 async def test_invalidate_fcm_tokens_skipped_when_tombstoned() -> None:
-    """AP4 (Befund 4a): _invalidate_fcm_tokens does not persist for a dead entry."""
+    """AP4 (finding 4a): _invalidate_fcm_tokens does not persist for a dead entry."""
     receiver = FcmReceiverHA()
     eid = "entry-invalidate"
     creds = {"gcm": {"token": "keep"}, "fcm": {"x": 1}}
@@ -1879,7 +1879,7 @@ async def test_invalidate_fcm_tokens_skipped_when_tombstoned() -> None:
 def test_credentials_callback_suppressed_when_tombstoned(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AP4 (Befund 4a, Codex follow-up): a late creds callback cannot resurrect.
+    """AP4 (finding 4a, Codex follow-up): a late creds callback cannot resurrect.
 
     The old FCM client is not awaited during ``unregister_coordinator``'s
     synchronous teardown, so it can still fire ``_on_credentials_updated_for_entry``
@@ -1919,7 +1919,7 @@ def test_credentials_callback_suppressed_when_tombstoned(
 async def test_tombstone_suppresses_cap_latch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AP4 (Befund 4a, Wächter A): a post-unregister supervisor write is dropped.
+    """AP4 (finding 4a, guard A): a post-unregister supervisor write is dropped.
 
     The short-run cap fires while the entry is tombstoned (it was torn down
     mid-flight). The cap latch, the fatal-error map and the Repairs issue must
@@ -1953,7 +1953,7 @@ async def test_tombstone_suppresses_cap_latch(
 async def test_tombstone_suppresses_fatal_retry_counts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AP4 (Befund 4a, Wächter A): the fatal-retry counter is not re-created.
+    """AP4 (finding 4a, guard A): the fatal-retry counter is not re-created.
 
     A tombstoned entry hitting the endpoint-404 fatal path must not repopulate
     ``_fatal_retry_counts`` (which the teardown just purged).

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -293,7 +293,10 @@ async def test_credential_error_invalidates_tokens_and_bypasses_cap(
 
     # Every credential-error run escalated to re-registration ...
     assert invalidate_mock.await_count == _MAX_CONSECUTIVE_SHORT_RUNS + 2
-    invalidate_mock.assert_awaited_with(entry_id)
+    # AP4 (finding 4b): the supervisor passes its captured generation (0 here,
+    # no teardown occurred) so a superseded run cannot write back invalidated
+    # creds after the tombstone is cleared.
+    invalidate_mock.assert_awaited_with(entry_id, 0)
     # ... and NONE of them tripped the short-run crash cap.
     assert create_issue.call_count == 0
     assert entry_id not in receiver._fatal_errors

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -1876,6 +1876,45 @@ async def test_invalidate_fcm_tokens_skipped_when_tombstoned() -> None:
     assert receiver.creds[eid]["fcm"] == {"x": 1}
 
 
+def test_credentials_callback_suppressed_when_tombstoned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (Befund 4a, Codex follow-up): a late creds callback cannot resurrect.
+
+    The old FCM client is not awaited during ``unregister_coordinator``'s
+    synchronous teardown, so it can still fire ``_on_credentials_updated_for_entry``
+    after ``_purge_entry_tokens`` cleared the entry. While tombstoned the callback
+    must not re-write ``self.creds[entry_id]``, restore routing or queue
+    persistence — otherwise the removed entry looks known to ``async_reregister_fcm``
+    again. Once the tombstone is cleared (a real reload), fresh creds are accepted.
+    """
+    receiver = FcmReceiverHA()
+    eid = "entry-creds-callback"
+
+    dispatched: list[str | None] = []
+
+    def _capture(coro: object, *, label: str | None = None) -> None:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        dispatched.append(label)
+
+    monkeypatch.setattr(receiver, "_dispatch_to_hass_loop", _capture)
+
+    # Tombstoned: the late callback is dropped wholesale.
+    receiver._unregistered.add(eid)
+    receiver._on_credentials_updated_for_entry(eid, {"fcm": {"token": "late"}})
+
+    assert eid not in receiver.creds
+    assert eid not in receiver._pending_creds
+    assert dispatched == []  # no routing/persistence dispatch happened
+
+    # Real reload clears the tombstone; the next callback is honoured again.
+    receiver._unregistered.discard(eid)
+    receiver._on_credentials_updated_for_entry(eid, {"fcm": {"token": "fresh"}})
+
+    assert receiver.creds[eid] == {"fcm": {"token": "fresh"}}
+
+
 @pytest.mark.asyncio
 async def test_tombstone_suppresses_cap_latch(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -1948,6 +1948,120 @@ def test_credentials_callback_suppressed_when_tombstoned(
     assert receiver.creds[eid] == {"fcm": {"token": "fresh"}}
 
 
+def test_credentials_callback_gates_on_driving_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (finding 4c): a superseded supervisor's mid-handshake callback is dropped.
+
+    On a fast reload ``unregister_coordinator`` bumps the generation but does NOT
+    pop the reused client, and ``register_coordinator`` clears the tombstone for
+    the new incarnation. A cancelled-but-unwinding supervisor still inside
+    ``checkin_or_register`` fires the synchronous credentials callback; the
+    tombstone is already gone, so a tombstone-only gate would let it clobber the
+    LIVE generation's creds and fatal latch. The callback must instead gate on
+    the *driving* generation published by the supervisor for the handshake: a
+    superseded generation is suppressed, the matching live generation writes.
+    """
+    receiver = FcmReceiverHA()
+    eid = "entry-driving-gen"
+
+    dispatched: list[str | None] = []
+
+    def _capture(coro: object, *, label: str | None = None) -> None:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+        dispatched.append(label)
+
+    monkeypatch.setattr(receiver, "_dispatch_to_hass_loop", _capture)
+    # Isolate the callback's own effects from the supervisor routing block.
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda _eid=None: None)
+
+    # Live incarnation: tombstone cleared, generation bumped to 1, fatal latched.
+    receiver._unregistered.discard(eid)
+    receiver._entry_generation[eid] = 1
+    receiver._fatal_errors[eid] = "BadAuthentication"
+    receiver._fatal_error = "BadAuthentication"
+
+    # A superseded supervisor (captured generation 0) drives the handshake.
+    with receiver._driving_generation_scope(eid, 0):
+        receiver._on_credentials_updated_for_entry(eid, {"fcm": {"token": "stale"}})
+
+    # Dropped wholesale: no creds resurrection, no dispatch, LIVE latch survives.
+    assert eid not in receiver.creds
+    assert eid not in receiver._pending_creds
+    assert dispatched == []
+    assert receiver._fatal_errors[eid] == "BadAuthentication"
+    assert receiver._fatal_error == "BadAuthentication"
+
+    # The live supervisor (matching generation 1) is honoured: creds written,
+    # latch cleared, persistence dispatched.
+    with receiver._driving_generation_scope(eid, 1):
+        receiver._on_credentials_updated_for_entry(eid, {"fcm": {"token": "live"}})
+
+    assert receiver.creds[eid] == {"fcm": {"token": "live"}}
+    assert eid not in receiver._fatal_errors
+    assert receiver._fatal_error is None
+    assert dispatched  # save_credentials dispatch happened
+
+
+@pytest.mark.asyncio
+async def test_register_handshake_publishes_generation_for_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (finding 4c): the handshake publishes its generation end to end.
+
+    ``firebase_messaging`` fires the credentials callback synchronously from
+    inside ``checkin_or_register``. This pins the wiring: a superseded supervisor
+    running ``_register_for_fcm_entry`` must suppress that mid-handshake callback,
+    while a live supervisor's identical callback writes. A plain instance
+    attribute could not survive firebase's internal awaits without a concurrent
+    task clobbering it; the task-local ContextVar is what makes this hold.
+    """
+    eid = "entry-handshake-gen"
+
+    def _build_receiver() -> FcmReceiverHA:
+        receiver = FcmReceiverHA()
+        monkeypatch.setattr(receiver, "get_fcm_token", lambda _eid=None: None)
+
+        def _capture(coro: object, *, label: str | None = None) -> None:
+            if asyncio.iscoroutine(coro):
+                coro.close()
+
+        monkeypatch.setattr(receiver, "_dispatch_to_hass_loop", _capture)
+        receiver._unregistered.discard(eid)
+        return receiver
+
+    class _FakePc:
+        """Mimics firebase firing the creds callback synchronously mid-checkin."""
+
+        credentials = {"gcm": {"t": 1}, "fcm": {"t": 2}}  # not a re-register path
+
+        def __init__(self, receiver: FcmReceiverHA) -> None:
+            self._receiver = receiver
+
+        async def checkin_or_register(self) -> dict[str, dict[str, str]]:
+            # Yield like the real client so the ContextVar must survive an await.
+            await asyncio.sleep(0)
+            self._receiver._on_credentials_updated_for_entry(
+                eid, {"fcm": {"token": "from-handshake"}}
+            )
+            return {"fcm": {"token": "from-handshake"}}
+
+    # Superseded supervisor (captured generation 0; a reload bumped it to 1).
+    superseded = _build_receiver()
+    superseded._entry_generation[eid] = 1
+    superseded.pcs[eid] = _FakePc(superseded)
+    assert await superseded._register_for_fcm_entry(eid, generation=0) is True
+    assert eid not in superseded.creds  # mid-handshake callback was suppressed
+
+    # Live supervisor (captured generation matches current).
+    live = _build_receiver()
+    live._entry_generation[eid] = 0
+    live.pcs[eid] = _FakePc(live)
+    assert await live._register_for_fcm_entry(eid, generation=0) is True
+    assert live.creds[eid] == {"fcm": {"token": "from-handshake"}}
+
+
 @pytest.mark.asyncio
 async def test_tombstone_suppresses_cap_latch(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -164,7 +164,7 @@ def _install_supervisor_mocks(
 
     ensure_iter = iter(ensure_clients)
 
-    async def _ensure(entry_id: str, cache):  # noqa: ARG001
+    async def _ensure(entry_id: str, cache, generation=None):  # noqa: ARG001
         # Codex Iter-7 (PR #1086): modelling exhaustion as ``None`` mirrors
         # production's ``if not pc`` path, which is designed to back off and
         # retry **forever**. The non-cap tests (long-run reset,
@@ -1182,7 +1182,7 @@ async def test_cap_fire_terminates_outer_loop_without_helper_safety_net(
     ensure_iter = iter(clients)
     ensure_call_count = 0
 
-    async def _ensure(entry_id_inner: str, cache):  # noqa: ARG001
+    async def _ensure(entry_id_inner: str, cache, generation=None):  # noqa: ARG001
         # NOTE: no StopIteration->stop_evt.set() escape hatch here. If the
         # production cap fails to terminate the supervisor, this returns the
         # 11th client and we explicitly fail the test below.

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -24,6 +24,7 @@ from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
     DOMAIN,
     FcmReceiverHA,
 )
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 class _MonoClock:
@@ -1853,7 +1854,7 @@ def test_unregister_coordinator_tombstones_and_purges() -> None:
     receiver = FcmReceiverHA()
     eid = "entry-unreg-tombstone"
     coord = SimpleNamespace(
-        config_entry=SimpleNamespace(entry_id=eid), cache=None
+        config_entry=make_config_entry(entry_id=eid), cache=None
     )
     receiver._fatal_retry_counts[f"{eid}:auth"] = 3
     receiver._entry_health[eid] = True
@@ -1876,7 +1877,7 @@ def test_register_coordinator_clears_tombstone(
     eid = "entry-reload"
     receiver._unregistered.add(eid)
     coord = SimpleNamespace(
-        config_entry=SimpleNamespace(entry_id=eid), cache=None
+        config_entry=make_config_entry(entry_id=eid), cache=None
     )
 
     # The supervisor dispatch is irrelevant here; neutralise it so the test

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -1782,6 +1782,35 @@ async def test_reregister_returns_false_after_purge() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reregister_returns_false_when_tombstoned_with_residual_client() -> None:
+    """Codex follow-up to AP3: a tombstoned entry whose live client still lingers.
+
+    unregister_coordinator runs synchronously and cannot await ``pc.stop()``, so the
+    client survives in ``self.pcs`` until the cancelled supervisor (or async_stop)
+    drains it. The creds purge alone left the ``entry_id in self.pcs`` half of the
+    reregister guard open, so a reregister in that window restarted a zombie
+    supervisor for an entry mid-teardown. The tombstone (``_unregistered``) is the
+    single source of truth for "torn down" and now blocks the revival.
+
+    Distinct from a tombstoned supervisor that is *already running*: that one is
+    allowed to terminate with its writes suppressed (see
+    ``test_tombstone_suppresses_cap_latch``). Only the external revival path
+    (``async_reregister_fcm``) is refused here.
+    """
+    receiver = FcmReceiverHA()
+    eid = "entry-zombie-residual"
+    # Post-unregister_coordinator state: creds purged, tombstone set, but the live
+    # client still lingers in self.pcs (sync teardown could not await pc.stop()).
+    receiver._unregistered.add(eid)
+    receiver.pcs[eid] = object()  # residual client; must not be revived
+
+    assert await receiver.async_reregister_fcm(eid) is False
+    # The residual client is left untouched for the running supervisor / async_stop
+    # to drain; the revival path must not have started reconstructing it.
+    assert eid not in receiver.supervisors
+
+
+@pytest.mark.asyncio
 async def test_purge_cancels_pending_debounce_flush_tasks() -> None:
     """AP7 (finding 2d): pending flush tasks are cancelled and the trias dropped."""
     receiver = FcmReceiverHA()

--- a/tests/test_fcm_receiver_ha_short_run_cap.py
+++ b/tests/test_fcm_receiver_ha_short_run_cap.py
@@ -1711,3 +1711,239 @@ def test_factory_honours_monkeypatched_fcm_push_client_symbol(
         assert not isinstance(pc, fcm_receiver_ha._ObservableFcmPushClientCls)
     assert captured["args"][0] == "callback"
     assert captured["kwargs"]["http_client_session"] == "session"
+
+
+# --------------------------------------------------------------------------
+# PR A — entry-state purge symmetry (AP1/AP2/AP3/AP7) + race tombstone (AP4)
+# --------------------------------------------------------------------------
+
+
+def test_purge_entry_tokens_clears_fatal_retry_counts() -> None:
+    """AP1 (Befund 2a): the teardown purge drops both fatal-retry counters."""
+    receiver = FcmReceiverHA()
+    eid = "entry-purge-counts"
+    receiver._fatal_retry_counts[f"{eid}:auth"] = 4
+    receiver._fatal_retry_counts[f"{eid}:endpoint"] = 2
+    receiver._fatal_retry_counts["other:auth"] = 1  # foreign entry untouched
+
+    receiver._purge_entry_tokens(eid)
+
+    assert f"{eid}:auth" not in receiver._fatal_retry_counts
+    assert f"{eid}:endpoint" not in receiver._fatal_retry_counts
+    assert receiver._fatal_retry_counts["other:auth"] == 1
+
+
+def test_purge_entry_tokens_clears_entry_health() -> None:
+    """AP2 (Befund 2b): per-entry health snapshots are purged on teardown."""
+    receiver = FcmReceiverHA()
+    eid = "entry-purge-health"
+    receiver._entry_health[eid] = True
+    receiver._entry_last_connected_wall[eid] = 123.0
+
+    receiver._purge_entry_tokens(eid)
+
+    assert eid not in receiver._entry_health
+    assert eid not in receiver._entry_last_connected_wall
+
+
+def test_purge_entry_tokens_clears_creds() -> None:
+    """AP3 (Befund 2c): in-memory creds + pending creds are purged on teardown."""
+    receiver = FcmReceiverHA()
+    eid = "entry-purge-creds"
+    receiver.creds[eid] = {"gcm": {"token": "x"}}
+    receiver._pending_creds[eid] = {"gcm": {"token": "y"}}
+
+    receiver._purge_entry_tokens(eid)
+
+    assert eid not in receiver.creds
+    assert eid not in receiver._pending_creds
+
+
+@pytest.mark.asyncio
+async def test_reregister_returns_false_after_purge() -> None:
+    """AP3 behaviour: a purged entry can no longer be revived via reregister.
+
+    Before the creds purge, ``async_reregister_fcm``'s guard
+    (``entry_id in self.creds``) stayed True after teardown and could restart a
+    zombie supervisor for a dead entry. With the creds purged the guard now
+    correctly rejects the revival.
+    """
+    receiver = FcmReceiverHA()
+    eid = "entry-zombie"
+    receiver.creds[eid] = {"gcm": {"token": "x"}}
+    # pcs is empty (teardown stopped the client); only creds kept the guard True.
+
+    receiver._purge_entry_tokens(eid)
+
+    assert await receiver.async_reregister_fcm(eid) is False
+
+
+@pytest.mark.asyncio
+async def test_purge_cancels_pending_debounce_flush_tasks() -> None:
+    """AP7 (Befund 2d): pending flush tasks are cancelled and the trias dropped."""
+    receiver = FcmReceiverHA()
+    eid = "entry-debounce"
+    key = (eid, "device-1")
+    foreign = ("other-entry", "device-9")
+
+    async def _never() -> None:
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(_never())
+    foreign_task = asyncio.create_task(_never())
+    receiver._flush_tasks[key] = task
+    receiver._flush_tasks[foreign] = foreign_task
+    receiver._pending[key] = {"payload": 1}
+    receiver._pending_targets[key] = {"target"}
+    receiver._pending[foreign] = {"payload": 2}
+
+    try:
+        receiver._purge_entry_tokens(eid)
+
+        assert key not in receiver._flush_tasks
+        assert key not in receiver._pending
+        assert key not in receiver._pending_targets
+        assert task.cancelled() or task.cancelling()
+        # Foreign entry's debounce state is untouched.
+        assert foreign in receiver._flush_tasks
+        assert foreign in receiver._pending
+    finally:
+        foreign_task.cancel()
+        for t in (task, foreign_task):
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+
+
+def test_unregister_coordinator_tombstones_and_purges() -> None:
+    """AP4 (Befund 4a): unregister tombstones the entry and purges its state."""
+    receiver = FcmReceiverHA()
+    eid = "entry-unreg-tombstone"
+    coord = SimpleNamespace(
+        config_entry=SimpleNamespace(entry_id=eid), cache=None
+    )
+    receiver._fatal_retry_counts[f"{eid}:auth"] = 3
+    receiver._entry_health[eid] = True
+    receiver.creds[eid] = {"gcm": {}}
+
+    receiver.unregister_coordinator(coord)
+
+    assert eid in receiver._unregistered
+    assert f"{eid}:auth" not in receiver._fatal_retry_counts
+    assert eid not in receiver._entry_health
+    assert eid not in receiver.creds
+
+
+def test_register_coordinator_clears_tombstone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (Befund 4a, Wächter B): a setup un-tombstones the entry."""
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    eid = "entry-reload"
+    receiver._unregistered.add(eid)
+    coord = SimpleNamespace(
+        config_entry=SimpleNamespace(entry_id=eid), cache=None
+    )
+
+    # The supervisor dispatch is irrelevant here; neutralise it so the test
+    # does not leak an un-awaited coroutine.
+    def _consume(coro: object, *, label: str | None = None) -> None:
+        if asyncio.iscoroutine(coro):
+            coro.close()
+
+    monkeypatch.setattr(receiver, "_dispatch_to_hass_loop", _consume)
+
+    receiver.register_coordinator(coord)
+
+    assert eid not in receiver._unregistered
+    assert receiver._entry_writes_suppressed(eid) is False
+
+
+@pytest.mark.asyncio
+async def test_invalidate_fcm_tokens_skipped_when_tombstoned() -> None:
+    """AP4 (Befund 4a): _invalidate_fcm_tokens does not persist for a dead entry."""
+    receiver = FcmReceiverHA()
+    eid = "entry-invalidate"
+    creds = {"gcm": {"token": "keep"}, "fcm": {"x": 1}}
+    receiver.creds[eid] = creds
+    receiver._unregistered.add(eid)
+
+    await receiver._invalidate_fcm_tokens(eid)
+
+    # Suppressed: creds dict is left exactly as-is (fcm not stripped).
+    assert receiver.creds[eid]["fcm"] == {"x": 1}
+
+
+@pytest.mark.asyncio
+async def test_tombstone_suppresses_cap_latch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (Befund 4a, Wächter A): a post-unregister supervisor write is dropped.
+
+    The short-run cap fires while the entry is tombstoned (it was torn down
+    mid-flight). The cap latch, the fatal-error map and the Repairs issue must
+    NOT be (re-)created; the supervisor still terminates.
+    """
+    entry_id = "entry-cap-tombstoned"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._unregistered.add(entry_id)  # tombstoned before the cap fires
+
+    clock = _MonoClock(step=0.001)
+    clients = [
+        _SupervisorPushClientStub(clock=clock)
+        for _ in range(_MAX_CONSECUTIVE_SHORT_RUNS)
+    ]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    create_issue, _ = _install_ir_capture(monkeypatch)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert create_issue.call_count == 0
+    assert entry_id not in receiver._short_run_cap_latched
+    assert entry_id not in receiver._fatal_errors
+    assert entry_id not in receiver._short_run_cap_messages
+
+
+@pytest.mark.asyncio
+async def test_tombstone_suppresses_fatal_retry_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP4 (Befund 4a, Wächter A): the fatal-retry counter is not re-created.
+
+    A tombstoned entry hitting the endpoint-404 fatal path must not repopulate
+    ``_fatal_retry_counts`` (which the teardown just purged).
+    """
+    from custom_components.googlefindmy.exceptions import FatalRegistrationError
+
+    entry_id = "entry-fatal-tombstoned"
+    receiver = FcmReceiverHA()
+    receiver.attach_hass(SimpleNamespace())
+    receiver._unregistered.add(entry_id)
+
+    clock = _MonoClock(step=0.001)
+    clients = [_SupervisorPushClientStub(clock=clock) for _ in range(4)]
+    _install_supervisor_mocks(
+        monkeypatch, receiver, clock=clock, ensure_clients=clients
+    )
+    _install_ir_capture(monkeypatch)
+
+    err = FatalRegistrationError("registration failed")
+    err.is_auth_error = False  # endpoint path
+    register_mock = AsyncMock(side_effect=[err] * 4)
+    monkeypatch.setattr(receiver, "_register_for_fcm_entry", register_mock)
+
+    await receiver._start_supervisor_for_entry(entry_id, None)
+    try:
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+    except TimeoutError:  # pragma: no cover - bounded fallback
+        receiver._stop_evts[entry_id].set()
+        await asyncio.wait_for(receiver.supervisors[entry_id], timeout=5.0)
+
+    assert f"{entry_id}:endpoint" not in receiver._fatal_retry_counts
+    assert f"{entry_id}:auth" not in receiver._fatal_retry_counts

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -58,7 +58,9 @@ def test_manual_locate_registration_and_cleanup(
     start_calls: list[tuple[str, Any]] = []
     register_calls: list[str] = []
 
-    async def fake_ensure(eid: str, provided_cache: Any) -> object:
+    async def fake_ensure(
+        eid: str, provided_cache: Any, generation: int | None = None
+    ) -> object:
         ensure_calls.append((eid, provided_cache))
         return object()
 


### PR DESCRIPTION
## Problem

`unregister_coordinator` / `async_stop` purge only routing state (`_entry_to_tokens`, `_pending_routing_tokens`, `_token_to_entries`, `_entry_last_activity_monotonic`). Every other per-entry container leaks across teardown. Worse, `unregister_coordinator` is **synchronous** and does not await the still-running supervisor task, which writes per-entry state (fatal counts, cap latch, creds) largely outside `self._lock` and can **re-create** purged state right after the purge.

## Fix

**Purge symmetry** (added before the early-return in `_purge_entry_tokens`, so they also apply to entries with no routing tokens):

- **AP1** — `_fatal_retry_counts` (`{entry}:auth` / `{entry}:endpoint`); previously cleared only on the success path.
- **AP2** — `_entry_health` / `_entry_last_connected_wall` (never purged); fixes a suppressed first-`healthy=True`-transition listener push after a same-id reload.
- **AP3** — `creds` / `_pending_creds`; `async_reregister_fcm`'s guard (`entry_id in self.creds`) could otherwise revive a dead entry (zombie supervisor). On-disk cache untouched → a reload reloads creds via `_ensure_client_for_entry`.
- **AP7** — cancel pending `(entry, device)` debounce flush tasks and drop `_pending` / `_pending_targets` / `_flush_tasks` for the entry, so a flush cannot fire at an already-removed coordinator. Only the entry's own keys are touched (`key[0] == entry_id`). Extracted into `_purge_entry_debounce`.

**Race tombstone (AP4)** — a `_unregistered` set is added in `unregister_coordinator` **before** the purge and cleared in `register_coordinator` on the next setup. The supervisor's per-entry write paths (fatal-retry counters, short-run cap latch, creds invalidation) skip writes for a tombstoned entry, so a synchronous teardown can no longer be unwound by the async supervisor. The reset lives **only** in `register_coordinator` — the prior supervisor is already cancelled by `request_stop` on unload, so no stale supervisor can clear the tombstone prematurely (a reload restores normal writes; a real removal stays clean).

## Tests
`tests/test_fcm_receiver_ha_short_run_cap.py`:
- purge symmetry for AP1/AP2/AP3/AP7 (incl. foreign-entry isolation);
- `async_reregister_fcm` returns `False` after a purge;
- tombstone suppresses the cap latch (Wächter A) and the fatal-retry counters (Wächter A, supervisor-driven);
- `register_coordinator` clears the tombstone (Wächter B);
- `_invalidate_fcm_tokens` is skipped when tombstoned.

Each guard empirically proven (revert the fix → guard turns red). Patch coverage **100%**; full suite green (**3787 passed, 20 skipped**); ruff + mypy clean; no PLR regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)