### PR TITLE
fix(spot): classify the asyncio SSL-transport teardown race in the gRPC path

### DIFF
--- a/custom_components/googlefindmy/SpotApi/spot_grpc_transport.py
+++ b/custom_components/googlefindmy/SpotApi/spot_grpc_transport.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 def is_ssl_transport_teardown_error(exc: BaseException) -> bool:
-    """Return True for the asyncio SSL-transport teardown race (AP9, Befund 6a).
+    """Return True for the asyncio SSL-transport teardown race (AP9, finding 6a).
 
     During a connection teardown there is a narrow window in which asyncio has
     already detached the SSL transport (``_SSLProtocolTransport._ssl_protocol``

--- a/custom_components/googlefindmy/SpotApi/spot_grpc_transport.py
+++ b/custom_components/googlefindmy/SpotApi/spot_grpc_transport.py
@@ -7,7 +7,28 @@ from typing import Final
 from grpclib.client import Channel
 from grpclib.encoding.base import CodecBase
 
-__all__ = ["RawCodec", "SpotGrpcTransport", "SPOT_GRPC_TRANSPORT"]
+__all__ = [
+    "RawCodec",
+    "SpotGrpcTransport",
+    "SPOT_GRPC_TRANSPORT",
+    "is_ssl_transport_teardown_error",
+]
+
+
+def is_ssl_transport_teardown_error(exc: BaseException) -> bool:
+    """Return True for the asyncio SSL-transport teardown race (AP9, Befund 6a).
+
+    During a connection teardown there is a narrow window in which asyncio has
+    already detached the SSL transport (``_SSLProtocolTransport._ssl_protocol``
+    is ``None``) but grpclib's ``handler.connection_lost`` flag is not set yet.
+    A write that lands in that window raises
+    ``AttributeError: 'NoneType' object has no attribute '_write_appdata'`` from
+    deep inside ``asyncio.sslproto`` — code we do not own, so we cannot attach a
+    custom exception type at the throw site. Isolating the fragile asyncio
+    signature in this single predicate is the legitimate boundary discriminator:
+    every other ``AttributeError`` is a real bug and must propagate.
+    """
+    return isinstance(exc, AttributeError) and "_write_appdata" in str(exc)
 
 
 class RawCodec(CodecBase):

--- a/custom_components/googlefindmy/SpotApi/spot_request.py
+++ b/custom_components/googlefindmy/SpotApi/spot_request.py
@@ -66,6 +66,7 @@ from custom_components.googlefindmy.exceptions import MissingTokenCacheError
 from custom_components.googlefindmy.SpotApi.spot_grpc_transport import (
     SPOT_GRPC_TRANSPORT,
     SpotGrpcTransport,
+    is_ssl_transport_teardown_error,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -286,6 +287,27 @@ async def async_spot_request(
                 await _async_sleep(_compute_delay(attempt))
                 continue
             raise SpotNetworkError("Fatal transport error after retries.") from err
+
+        except AttributeError as err:
+            # AP9 (Befund 6a): asyncio SSL-transport teardown race. grpclib
+            # wrote to an SSL transport whose protocol was already detached
+            # (idle/serverside close, GOAWAY, or a concurrent reset), raising
+            # ``AttributeError: 'NoneType' ... '_write_appdata'`` from inside
+            # asyncio.sslproto. Treat it like the other transient transport
+            # failures: reset the (possibly poisoned) channel and retry within
+            # budget, converting to SpotNetworkError when exhausted. Any other
+            # AttributeError is a genuine bug in our own stream handling and is
+            # re-raised unchanged.
+            if not is_ssl_transport_teardown_error(err):
+                raise
+            await active_transport.reset()
+            if retries_used < _SPOT_MAX_RETRIES:
+                retries_used += 1
+                await _async_sleep(_compute_delay(attempt))
+                continue
+            raise SpotNetworkError(
+                "SSL transport teardown after retries."
+            ) from err
 
         except TimeoutError as err:
             if retries_used < _SPOT_MAX_RETRIES:

--- a/custom_components/googlefindmy/SpotApi/spot_request.py
+++ b/custom_components/googlefindmy/SpotApi/spot_request.py
@@ -289,7 +289,7 @@ async def async_spot_request(
             raise SpotNetworkError("Fatal transport error after retries.") from err
 
         except AttributeError as err:
-            # AP9 (Befund 6a): asyncio SSL-transport teardown race. grpclib
+            # AP9 (finding 6a): asyncio SSL-transport teardown race. grpclib
             # wrote to an SSL transport whose protocol was already detached
             # (idle/serverside close, GOAWAY, or a concurrent reset), raising
             # ``AttributeError: 'NoneType' ... '_write_appdata'`` from inside

--- a/custom_components/googlefindmy/fmdn_finder/google_uploader.py
+++ b/custom_components/googlefindmy/fmdn_finder/google_uploader.py
@@ -310,7 +310,7 @@ async def _try_grpc_upload(
         ) from err
 
     except AttributeError as err:
-        # AP9 (Befund 6a): same asyncio SSL-transport teardown race as
+        # AP9 (finding 6a): same asyncio SSL-transport teardown race as
         # async_spot_request. This is a per-call transport with no retry loop
         # (and the upload path is disabled without DroidGuard attestation), so
         # classify it like the other connection failures instead of letting the

--- a/custom_components/googlefindmy/fmdn_finder/google_uploader.py
+++ b/custom_components/googlefindmy/fmdn_finder/google_uploader.py
@@ -265,7 +265,10 @@ async def _try_grpc_upload(
         RuntimeError: If grpclib not available
         ValueError: If upload fails
     """
-    from ..SpotApi.spot_grpc_transport import SpotGrpcTransport  # noqa: PLC0415
+    from ..SpotApi.spot_grpc_transport import (  # noqa: PLC0415
+        SpotGrpcTransport,
+        is_ssl_transport_teardown_error,
+    )
     from ..SpotApi.spot_request import (  # noqa: PLC0415
         SpotGrpcStatusError,
         _pick_auth_token_async,
@@ -304,6 +307,19 @@ async def _try_grpc_upload(
         # UNIMPLEMENTED likely means missing attestation, not wrong endpoint
         raise SpotGrpcStatusError(
             f"gRPC error: {status_name} (likely missing DroidGuard attestation)"
+        ) from err
+
+    except AttributeError as err:
+        # AP9 (Befund 6a): same asyncio SSL-transport teardown race as
+        # async_spot_request. This is a per-call transport with no retry loop
+        # (and the upload path is disabled without DroidGuard attestation), so
+        # classify it like the other connection failures instead of letting the
+        # raw AttributeError escape. Any other AttributeError is a real bug and
+        # is re-raised.
+        if not is_ssl_transport_teardown_error(err):
+            raise
+        raise ValueError(
+            f"Connection to {server} failed (SSL transport teardown): {err}"
         ) from err
 
     except (OSError, ConnectionError, TimeoutError) as err:

--- a/tests/test_google_uploader_teardown.py
+++ b/tests/test_google_uploader_teardown.py
@@ -1,5 +1,5 @@
 # tests/test_google_uploader_teardown.py
-"""AP9 (Befund 6a): SSL-transport teardown-race classification in the FMDN uploader.
+"""AP9 (finding 6a): SSL-transport teardown-race classification in the FMDN uploader.
 
 ``fmdn_finder/google_uploader._try_grpc_upload`` is the second grpclib stream
 write site that shared the unclassified ``AttributeError`` teardown race fixed in

--- a/tests/test_google_uploader_teardown.py
+++ b/tests/test_google_uploader_teardown.py
@@ -1,0 +1,98 @@
+"""AP9 (Befund 6a): SSL-transport teardown-race classification in the FMDN uploader.
+
+``fmdn_finder/google_uploader._try_grpc_upload`` is the second grpclib stream
+write site that shared the unclassified ``AttributeError`` teardown race fixed in
+``SpotApi/spot_request.py``. These guards pin that it now classifies the asyncio
+``_write_appdata`` race as a ``ValueError`` (the path's existing failure type)
+while re-raising any unrelated ``AttributeError`` as a real bug.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.googlefindmy.fmdn_finder.google_uploader import (
+    _try_grpc_upload,
+)
+from custom_components.googlefindmy.SpotApi import spot_request as spot_request_module
+from custom_components.googlefindmy.SpotApi.spot_grpc_transport import (
+    SpotGrpcTransport,
+)
+
+_SSL_TEARDOWN_MSG = "'NoneType' object has no attribute '_write_appdata'"
+
+
+class _RaisingStream:
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def __aenter__(self) -> _RaisingStream:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    async def send_message(self, _msg: bytes, end: bool = True) -> None:
+        return None
+
+    async def recv_message(self) -> bytes:
+        raise self._exc
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    import grpclib.client  # noqa: PLC0415
+
+    class _StubMethod:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            return None
+
+        def open(self, metadata: Any = None, timeout: float | None = None) -> _RaisingStream:
+            return _RaisingStream(exc)
+
+    monkeypatch.setattr(grpclib.client, "UnaryUnaryMethod", _StubMethod)
+    monkeypatch.setattr(
+        spot_request_module,
+        "_pick_auth_token_async",
+        AsyncMock(return_value=("token", "kind", "user")),
+    )
+    monkeypatch.setattr(
+        SpotGrpcTransport, "get_channel", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(SpotGrpcTransport, "async_close", AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_upload_ssl_teardown_error_becomes_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The asyncio teardown race is classified as the path's ValueError failure."""
+    _install(monkeypatch, AttributeError(_SSL_TEARDOWN_MSG))
+
+    with pytest.raises(ValueError, match="SSL transport teardown"):
+        await _try_grpc_upload(
+            cache=object(),  # type: ignore[arg-type]
+            payload=b"payload",
+            server="spot-pa.googleapis.com",
+            service="google.internal.spot.v1.SpotService",
+            method="UploadLocationReports",
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_unrelated_attribute_error_is_reraised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrelated AttributeError must not be masked as a connection failure."""
+    _install(monkeypatch, AttributeError("totally unrelated"))
+
+    with pytest.raises(AttributeError, match="totally unrelated"):
+        await _try_grpc_upload(
+            cache=object(),  # type: ignore[arg-type]
+            payload=b"payload",
+            server="spot-pa.googleapis.com",
+            service="google.internal.spot.v1.SpotService",
+            method="UploadLocationReports",
+        )

--- a/tests/test_google_uploader_teardown.py
+++ b/tests/test_google_uploader_teardown.py
@@ -1,3 +1,4 @@
+# tests/test_google_uploader_teardown.py
 """AP9 (Befund 6a): SSL-transport teardown-race classification in the FMDN uploader.
 
 ``fmdn_finder/google_uploader._try_grpc_upload`` is the second grpclib stream

--- a/tests/test_spot_grpc_resilience.py
+++ b/tests/test_spot_grpc_resilience.py
@@ -244,7 +244,7 @@ _SSL_TEARDOWN_ERR = AttributeError(
 async def test_ssl_teardown_error_resets_and_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AP9 (Befund 6a): the SSL-transport teardown race resets and retries.
+    """AP9 (finding 6a): the SSL-transport teardown race resets and retries.
 
     grpclib writing to a detached SSL transport raises
     ``AttributeError('... _write_appdata')`` from asyncio.sslproto. The new
@@ -296,7 +296,7 @@ async def test_ssl_teardown_error_exhausts_to_network_error(
 async def test_non_teardown_attribute_error_is_reraised(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """AP9 (Wächter B): an unrelated AttributeError must NOT be masked.
+    """AP9 (guard B): an unrelated AttributeError must NOT be masked.
 
     The discriminator only matches the asyncio ``_write_appdata`` signature;
     any other AttributeError is a genuine bug and is re-raised without a reset.

--- a/tests/test_spot_grpc_resilience.py
+++ b/tests/test_spot_grpc_resilience.py
@@ -235,6 +235,90 @@ async def test_protocol_error_triggers_reset(monkeypatch: pytest.MonkeyPatch) ->
     transport.reset.assert_awaited_once()
 
 
+_SSL_TEARDOWN_ERR = AttributeError(
+    "'NoneType' object has no attribute '_write_appdata'"
+)
+
+
+@pytest.mark.asyncio
+async def test_ssl_teardown_error_resets_and_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP9 (Befund 6a): the SSL-transport teardown race resets and retries.
+
+    grpclib writing to a detached SSL transport raises
+    ``AttributeError('... _write_appdata')`` from asyncio.sslproto. The new
+    handler must treat it like the other transient transport errors: reset the
+    (possibly poisoned) channel and retry within budget.
+    """
+    plan: list[Exception | bytes | None] = [_SSL_TEARDOWN_ERR, b"reply"]
+    _install_stub_method(monkeypatch, plan)
+    transport = AsyncMock()
+    transport.get_channel = AsyncMock(return_value=object())
+    transport.reset = AsyncMock()
+    cache = _DummyCache()
+
+    result = await spot_request_module.async_spot_request(
+        "Scope",
+        b"payload",
+        cache=cache,
+        transport=transport,  # type: ignore[arg-type]
+    )
+
+    assert result == b"reply"
+    transport.reset.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_ssl_teardown_error_exhausts_to_network_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP9: a persistent teardown race converts to SpotNetworkError after retries."""
+    plan: list[Exception | bytes | None] = [_SSL_TEARDOWN_ERR]
+    _install_stub_method(monkeypatch, plan)
+    transport = AsyncMock()
+    transport.get_channel = AsyncMock(return_value=object())
+    transport.reset = AsyncMock()
+    cache = _DummyCache()
+
+    with pytest.raises(spot_request_module.SpotNetworkError):
+        await spot_request_module.async_spot_request(
+            "Scope",
+            b"payload",
+            cache=cache,
+            transport=transport,  # type: ignore[arg-type]
+        )
+
+    assert transport.reset.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_non_teardown_attribute_error_is_reraised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP9 (Wächter B): an unrelated AttributeError must NOT be masked.
+
+    The discriminator only matches the asyncio ``_write_appdata`` signature;
+    any other AttributeError is a genuine bug and is re-raised without a reset.
+    """
+    plan: list[Exception | bytes | None] = [AttributeError("totally unrelated")]
+    _install_stub_method(monkeypatch, plan)
+    transport = AsyncMock()
+    transport.get_channel = AsyncMock(return_value=object())
+    transport.reset = AsyncMock()
+    cache = _DummyCache()
+
+    with pytest.raises(AttributeError, match="totally unrelated"):
+        await spot_request_module.async_spot_request(
+            "Scope",
+            b"payload",
+            cache=cache,
+            transport=transport,  # type: ignore[arg-type]
+        )
+
+    assert transport.reset.await_count == 0
+
+
 def test_polling_path_translates_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """SpotAuthPermanentError from the API should surface as ConfigEntryAuthFailed."""
 

--- a/tests/test_spot_grpc_transport.py
+++ b/tests/test_spot_grpc_transport.py
@@ -247,7 +247,7 @@ async def test_ssl_context_created_lazily_via_to_thread(
 
 
 def test_is_ssl_transport_teardown_error_signature() -> None:
-    """AP9 (Befund 6a): the predicate isolates the fragile asyncio signature.
+    """AP9 (finding 6a): the predicate isolates the fragile asyncio signature.
 
     It must match exactly the SSL-transport teardown ``AttributeError`` and
     nothing else, so every other AttributeError keeps propagating as a real bug.

--- a/tests/test_spot_grpc_transport.py
+++ b/tests/test_spot_grpc_transport.py
@@ -13,6 +13,7 @@ import pytest
 from custom_components.googlefindmy.SpotApi.spot_grpc_transport import (
     RawCodec,
     SpotGrpcTransport,
+    is_ssl_transport_teardown_error,
 )
 
 
@@ -243,3 +244,23 @@ async def test_ssl_context_created_lazily_via_to_thread(
     await transport.get_channel()
 
     assert to_thread.await_count == 1
+
+
+def test_is_ssl_transport_teardown_error_signature() -> None:
+    """AP9 (Befund 6a): the predicate isolates the fragile asyncio signature.
+
+    It must match exactly the SSL-transport teardown ``AttributeError`` and
+    nothing else, so every other AttributeError keeps propagating as a real bug.
+    Acts as an early-warning unit test should a future CPython rename the
+    internal ``_write_appdata`` attribute.
+    """
+    assert (
+        is_ssl_transport_teardown_error(
+            AttributeError("'NoneType' object has no attribute '_write_appdata'")
+        )
+        is True
+    )
+    # Wrong type / wrong signature / non-exception input must not match.
+    assert is_ssl_transport_teardown_error(AttributeError("other attribute")) is False
+    assert is_ssl_transport_teardown_error(ValueError("_write_appdata")) is False
+    assert is_ssl_transport_teardown_error(RuntimeError("_write_appdata")) is False


### PR DESCRIPTION
## Problem

A connection-teardown race leaves asyncio's SSL transport detached (`_SSLProtocolTransport._ssl_protocol is None`) while grpclib's `handler.connection_lost` flag is not set yet. A write landing in that window raises `AttributeError: 'NoneType' object has no attribute '_write_appdata'` from deep inside `asyncio.sslproto`.

That `AttributeError` was in **no** `except` branch of the SPOT gRPC retry loop (`async_spot_request` handles `GRPCError`, `ProtocolError`/`StreamTerminatedError`/`ConnectionResetError`/`BrokenPipeError`, `TimeoutError`, `OSError`), so it propagated unclassified: **no retry, no `reset()`**, failing a whole locate/decrypt cycle on the critical `get_owner_key.py` path. The visible log line (`decrypt_locations.py:525 Failed to retrieve E2EE metadata for diagnostics: ... '_write_appdata'`) is only the best-effort catch, not the root.

Severity is honestly **low–medium**: grpclib self-heals the cached singleton channel on the next call (`_connected` checks `handler.connection_lost`), so it is transient and not permanently poisoned — but the affected call dies without a retry.

## Fix (DRY + boundary discriminator)

- **`is_ssl_transport_teardown_error()`** predicate in `spot_grpc_transport.py` isolates the fragile asyncio signature (`isinstance(exc, AttributeError) and "_write_appdata" in str(exc)`) at one unit-testable place. We do **not** own the throw site (asyncio), so a signature check is the legitimate boundary discriminator rather than a forbidden string marker on our own code (cf. the project's extract-before-extending guidance).
- **`async_spot_request`** gains an `except AttributeError` branch (between the transport-error and timeout handlers): on a signature match it `reset()`s the channel and retries within budget, converting to `SpotNetworkError` when exhausted. Any other `AttributeError` is **re-raised** so real bugs are never masked.
- **`fmdn_finder/google_uploader._try_grpc_upload`** — the only other grpclib stream write site (per-call transport, no retry loop, upload disabled without DroidGuard) — classifies the same predicate into its existing `ValueError` failure path, for symmetry.

Code-Architekt sweep (Tier-1): exactly **two** instances of this class, no third.

### Considered and rejected
A broader structural liveness check (instead of the signature) was rejected: grpclib exposes no clean public liveness API and it would raise coupling. The central predicate keeps the fragility in one place — if a future CPython renames `_write_appdata`, only the predicate unit test fails (early warning), not production silently.

## Tests
- `test_spot_grpc_resilience.py`: teardown race → `reset()` + retry; persistent teardown → `SpotNetworkError`; unrelated `AttributeError` → re-raised without `reset()`.
- `test_spot_grpc_transport.py`: predicate unit test (matches the signature, rejects wrong message/type).
- `test_google_uploader_teardown.py`: teardown → `ValueError`; unrelated `AttributeError` → re-raised.

Each fix empirically proven (revert → red). Patch coverage **100%**; full suite green (**3784 passed, 20 skipped**); ruff + mypy clean; no PLR regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)