### PR TITLE
fix(fcm): log server-initiated Close at INFO instead of WARNING

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -791,7 +791,15 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         self.input_stream_id += 1
 
         if isinstance(msg, Close):
-            self._log_warn_with_limit("Server sent Close message; worker stopping")
+            # A server-initiated Close is a normal part of the MCS connection
+            # life-cycle (the endpoint periodically rotates long-lived streams).
+            # Log it at INFO, consistent with the other normal worker-stop paths
+            # below ("FCM stream ended" / "FCM read ended"); the supervisor will
+            # reconnect automatically. Emitting WARNING here produced a recurring
+            # false alarm in the Home Assistant log panel.
+            self.logger.info(
+                "FCM server sent Close; worker stopping (normal, supervisor will reconnect)"
+            )
             self.do_listen = False
             return
 

--- a/tests/helpers/fcm_handle_stub.py
+++ b/tests/helpers/fcm_handle_stub.py
@@ -112,3 +112,31 @@ class FcmHandleSlim:
     _handle_data_message = FcmPushClient._handle_data_message  # type: ignore[assignment]
     _app_data_by_key = FcmPushClient._app_data_by_key  # type: ignore[assignment]
     _extract_header_param = staticmethod(FcmPushClient._extract_header_param)
+
+
+class FcmMessageSlim:
+    """Composition stub binding the real async ``_handle_message``.
+
+    Mirrors only the attributes the ``Close`` branch of ``_handle_message``
+    touches: ``last_message_time``/``input_stream_id`` (the unconditional
+    preamble), ``logger`` (the INFO emission under test), ``do_listen`` (the
+    worker-stop signal) and ``_log_warn_with_limit`` (must NOT be called on
+    this path after the WARNING -> INFO downgrade). Same additive-composition
+    discipline as ``FcmHandleSlim``: the real unbound method runs without the
+    heavy production constructor.
+    """
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(__name__ + ".FcmMessageSlim")
+        self.logger.propagate = True
+        self.last_message_time: float = 0.0
+        self.input_stream_id = 0
+        self.do_listen = True
+        # Records any rate-limited warning; the Close path must leave it empty.
+        self.warnings: list[str] = []
+
+    def _log_warn_with_limit(self, msg: str, *args: object) -> None:
+        self.warnings.append(msg)
+        self.logger.warning(msg, *args)
+
+    _handle_message = FcmPushClient._handle_message  # type: ignore[assignment]

--- a/tests/test_fcmpushclient_close_log_level.py
+++ b/tests/test_fcmpushclient_close_log_level.py
@@ -1,0 +1,65 @@
+# tests/test_fcmpushclient_close_log_level.py
+"""Regression suite for the server-initiated ``Close`` log level.
+
+A server-initiated MCS ``Close`` is a normal part of the FCM connection
+life-cycle: the worker stops cleanly and the supervisor reconnects. The
+``Close`` branch of ``FcmPushClient._handle_message`` was downgraded from a
+rate-limited WARNING to INFO so it no longer surfaces as a recurring false
+alarm in the Home Assistant log panel, matching the sibling worker-stop paths
+(``"FCM stream ended"`` / ``"FCM read ended"``) that already log at INFO.
+
+These tests pin that contract: the path logs at INFO (never WARNING), does not
+consume the warn rate-limit, and still signals the worker to stop. Before this
+suite ``_handle_message`` ran at ~0 % on the unit level (the poison stub mocks
+it away), so the changed branch had no coverage.
+"""
+from __future__ import annotations
+
+import logging
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    Close,
+)
+from tests.helpers.fcm_handle_stub import FcmMessageSlim
+
+
+class TestCloseLogLevel:
+    """Behaviour of the ``isinstance(msg, Close)`` branch of ``_handle_message``."""
+
+    async def test_close_logs_info_not_warning(
+        self, caplog: logging.LogCaptureFixture
+    ) -> None:
+        """Server ``Close`` -> single INFO record, no WARNING (false-alarm fix)."""
+        client = FcmMessageSlim()
+
+        with caplog.at_level(logging.INFO, logger=client.logger.name):
+            await client._handle_message(Close())
+
+        records = [r for r in caplog.records if r.name == client.logger.name]
+        # Exactly one record, emitted at INFO. The level IS the contract here
+        # (the WARNING -> INFO downgrade); the exact wording is deliberately not
+        # pinned so a future reword cannot break this regression test.
+        assert len(records) == 1
+        assert records[0].levelno == logging.INFO
+        assert records[0].getMessage().strip()
+        # No record at WARNING or above on this normal life-cycle path.
+        assert not [r for r in records if r.levelno >= logging.WARNING]
+
+    async def test_close_does_not_consume_warn_rate_limit(self) -> None:
+        """Close path must not call ``_log_warn_with_limit`` after the downgrade."""
+        client = FcmMessageSlim()
+
+        await client._handle_message(Close())
+
+        assert client.warnings == []
+
+    async def test_close_stops_worker(self) -> None:
+        """Close still sets ``do_listen=False`` so the supervisor reconnects."""
+        client = FcmMessageSlim()
+        assert client.do_listen is True
+
+        await client._handle_message(Close())
+
+        assert client.do_listen is False
+        # The unconditional preamble ran (message accounted for).
+        assert client.input_stream_id == 1


### PR DESCRIPTION
## Problem

The Home Assistant log shows a recurring WARNING several times a day:

```
[custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient.FcmPushClient.<id>] Server sent Close message; worker stopping
```

HA attributes it to `fcmpushclient.py:347` (the physical `logger.warning()`
call inside `_log_warn_with_limit`); the message itself is emitted from
`_handle_message` when the MCS server sends a `Close`.

## Analysis

A server-initiated `Close` is a **normal** part of the MCS connection
life-cycle: the endpoint periodically rotates long-lived streams. The
handler stops the worker cleanly (`do_listen = False; return`), the
`finally` block closes the writer, and the supervisor reconnects with
exponential backoff. Production logs confirm the recovery sequence every
time, within ~2 s:

```
... Server sent Close message; worker stopping
... FCM client stopped; scheduling restart
... Restarting FCM client in ~1.1s
... FCM registered successfully
... Successfully logged in to MCS endpoint
```

So there is **no functional bug** — stability and functionality are not
affected. The only defect is a **logging-level inconsistency**: the
semantically equivalent normal worker-stop paths in `_listen`
(`FCM stream ended` / `FCM read ended`) already log at **INFO**, while the
`Close` path logged at **WARNING**, producing a false alarm in the HA log
panel.

## Change

Downgrade the `Close` path to `logger.info`, consistent with the sibling
worker-stop paths. Control flow is unchanged.

Dropping the `_log_warn_with_limit` rate-limit on this path is harmless:
the branch sets `do_listen = False` and is reachable at most once per
worker lifetime, and reconnect frequency is bounded by the supervisor
backoff, not by `log_warn_limit`. The sibling INFO paths are likewise
un-limited, so a per-path limit would only add inconsistency.

## Verification

- `ruff check` passes; no umlauts / English-only clean.
- No test asserts on the message text, the WARNING level, or the
  `_log_warn_with_limit` call for `Close` (grep over `tests/`).
- Full `pytest`/`mypy` not run locally (repo requires Python >= 3.13.2;
  local env is 3.11) — left to CI.
- Independent diff review (D1-D6) verdict: PR-ready, 0 blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Test coverage (added in f8ab6d2)

The original fix changed the `Close` branch of `_handle_message`, but no unit
test exercised that method (the poison stub mocks `_handle_message` away), so
the changed branch ran at ~0 % coverage.

Added `FcmMessageSlim` (additive composition stub binding the real unbound
`_handle_message`) and `tests/test_fcmpushclient_close_log_level.py` with three
regression tests:

- server-initiated `Close` logs at **INFO**, never WARNING (the false-alarm fix);
- the path does **not** consume the warn rate-limit;
- it still sets `do_listen=False` so the supervisor reconnects.

Verification (Python 3.13.13, pytest 9.0.0, pytest-cov 7.0.0):

- `pytest --cov=...fcmpushclient --cov-report=term-missing`: lines 793-804
  (the changed `Close` branch) are no longer in the Missing list — the changed
  code is now 100 % covered.
- Mutation check: reverting `logger.info` back to `_log_warn_with_limit` turns
  the suite red, confirming the regression is actually caught.
- ruff, mypy, English-only all clean; full FCM suite green (327 passed).
