### PR TITLE
chore: audit crypto misuse and arithmetic axes on five primitive files (1.7.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=67 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=69 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -347,7 +347,9 @@ skip_covered = true
 # local full run measured 68.33 % scoped (3696 passed); floor = floor(68) - 1 Pp
 # jitter margin, clamped to [63, CI total]. Three local entity tests error on a
 # root-owned .storage path that CI does not hit, so CI total is >= 68.33 %.
-fail_under = 67
+# Raised to 69 after the crypto-audit test suite (PR #1111) lifted CI total to
+# 69.14 % (measured 2026-06-16); floor tracks the new CI total to lock the gain.
+fail_under = 69
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",

--- a/tests/test_decrypt_locations_crypto.py
+++ b/tests/test_decrypt_locations_crypto.py
@@ -1,0 +1,89 @@
+# tests/test_decrypt_locations_crypto.py
+"""Audit coverage for the local AES-GCM envelope unwrap primitive.
+
+``decrypt_locations`` is dominated by network/cache orchestration and protobuf
+parsing; the only self-contained cryptographic primitive in the module is
+``_try_unwrap_aesgcm_envelope`` (the M1-Nonce audit point: nonce is the envelope
+prefix, the AAD is the device id, and any authentication failure must fail
+closed to ``None``). These tests drive that primitive against an independent
+AES-GCM oracle so a regression flips an assertion rather than passing silently.
+"""
+
+from __future__ import annotations
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    _AESGCM_NONCE_LEN,
+    _try_unwrap_aesgcm_envelope,
+)
+
+_KEY = bytes(range(32))
+_NONCE = bytes(range(_AESGCM_NONCE_LEN))
+_PLAINTEXT = b"identity-key-material-32-bytes!!"
+_DEVICE_ID = "device-canonic-id-42"
+
+
+def _seal(key: bytes, nonce: bytes, plaintext: bytes, device_id: str) -> bytes:
+    """Build an AES-GCM envelope (nonce || ciphertext) with device_id as AAD."""
+
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, device_id.encode())
+    return nonce + ciphertext
+
+
+def test_unwrap_roundtrip_with_matching_aad_returns_plaintext() -> None:
+    """A well-formed envelope with the correct key and AAD decrypts to plaintext."""
+
+    envelope = _seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID)
+    assert _try_unwrap_aesgcm_envelope(envelope, _KEY, _DEVICE_ID) == _PLAINTEXT
+
+
+def test_unwrap_nonce_is_envelope_prefix() -> None:
+    """The primitive must split nonce/ciphertext at _AESGCM_NONCE_LEN, not elsewhere.
+
+    Sealing with a distinct nonce and re-prefixing it proves the prefix is the
+    nonce actually fed to AES-GCM: shifting the split point would break the tag.
+    """
+
+    nonce = bytes([0xA5] * _AESGCM_NONCE_LEN)
+    envelope = _seal(_KEY, nonce, _PLAINTEXT, _DEVICE_ID)
+    assert envelope[:_AESGCM_NONCE_LEN] == nonce
+    assert _try_unwrap_aesgcm_envelope(envelope, _KEY, _DEVICE_ID) == _PLAINTEXT
+
+
+def test_unwrap_wrong_device_id_fails_closed() -> None:
+    """A mismatched AAD (device_id) must fail closed to None, never plaintext."""
+
+    envelope = _seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID)
+    assert _try_unwrap_aesgcm_envelope(envelope, _KEY, "other-device-id") is None
+
+
+def test_unwrap_wrong_key_fails_closed() -> None:
+    """A wrong wrapping key must fail closed to None."""
+
+    envelope = _seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID)
+    wrong_key = bytes([0xFF]) + _KEY[1:]
+    assert _try_unwrap_aesgcm_envelope(envelope, wrong_key, _DEVICE_ID) is None
+
+
+def test_unwrap_tampered_ciphertext_fails_closed() -> None:
+    """Flipping a ciphertext byte must fail the GCM tag check and return None."""
+
+    envelope = bytearray(_seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID))
+    envelope[-1] ^= 0x01
+    assert _try_unwrap_aesgcm_envelope(bytes(envelope), _KEY, _DEVICE_ID) is None
+
+
+def test_unwrap_none_device_id_is_guarded() -> None:
+    """Without a device_id there is no AAD to bind, so the primitive declines."""
+
+    envelope = _seal(_KEY, _NONCE, _PLAINTEXT, _DEVICE_ID)
+    assert _try_unwrap_aesgcm_envelope(envelope, _KEY, None) is None
+
+
+def test_unwrap_envelope_too_short_is_guarded() -> None:
+    """An envelope no longer than the nonce cannot carry ciphertext and is declined."""
+
+    too_short = bytes(_AESGCM_NONCE_LEN)  # exactly nonce length, no ciphertext
+    assert _try_unwrap_aesgcm_envelope(too_short, _KEY, _DEVICE_ID) is None
+    assert _try_unwrap_aesgcm_envelope(b"", _KEY, _DEVICE_ID) is None

--- a/tests/test_eid_generator_variants.py
+++ b/tests/test_eid_generator_variants.py
@@ -16,9 +16,20 @@ from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
     MODERN_EID_LENGTH,
     P256_ORDER,
     ROTATION_PERIOD,
+    ROTATION_PERIOD_900,
+    ROTATION_PERIOD_3600,
     EidVariant,
+    HeuristicBasis,
+    HeuristicEidResult,
+    _align_to_rotation_flexible,
+    _compute_heuristic_counter,
+    _generate_heuristic_eid_single,
+    build_heuristic_prf_input,
     build_table10_prf_input,
+    compute_flags_xor_mask,
+    generate_eid,
     generate_eid_variant,
+    generate_heuristic_eid,
     get_masked_counter,
     prf_aes_256_ecb,
 )
@@ -184,3 +195,347 @@ def test_strict_normalization_rejects_negative() -> None:
             EidVariant.LEGACY_SECP160R1_X20_BE,
             strict=True,
         )
+
+
+# =============================================================================
+# Audit coverage (AP10 Teil C): guards, flags mask, heuristic derivation.
+# Each test asserts behavior (independent recomputation for crypto paths), not
+# mere line execution, so a regression flips the assertion rather than silently
+# keeping coverage green.
+# =============================================================================
+
+
+def test_normalize_rejects_bool_and_non_int() -> None:
+    """The u32 counter must reject bool and non-int types (bool is not a counter)."""
+
+    with pytest.raises(TypeError):
+        build_table10_prf_input(True, k=FHNA_K)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        build_table10_prf_input("0x10", k=FHNA_K)  # type: ignore[arg-type]
+
+
+def test_build_table10_rejects_wrong_rotation_exponent() -> None:
+    """Only FHNA_K is a valid rotation exponent; any other k must raise."""
+
+    with pytest.raises(ValueError, match="rotation exponent"):
+        build_table10_prf_input(SAMPLE_COUNTER, k=FHNA_K + 1)
+
+
+def test_build_table10_aligned_counter_skips_mask_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An already rotation-aligned counter must not trigger the masking debug log."""
+
+    aligned = 2 * ROTATION_PERIOD  # low K bits already zero
+    with caplog.at_level(logging.DEBUG):
+        block = build_table10_prf_input(aligned, k=FHNA_K)
+
+    assert len(block) == FHNA_PRF_INPUT_LENGTH
+    assert "masked to rotation-aligned" not in caplog.text
+
+
+def test_prf_rejects_wrong_key_length() -> None:
+    """The AES-256 PRF requires a 32-byte EIK."""
+
+    prf_input = build_table10_prf_input(SAMPLE_COUNTER, k=FHNA_K)
+    with pytest.raises(ValueError, match="Identity Key"):
+        prf_aes_256_ecb(SAMPLE_EIK[:16], prf_input)
+
+
+def test_prf_rejects_wrong_input_length() -> None:
+    """The PRF input buffer must be exactly the Table 10 length."""
+
+    with pytest.raises(ValueError, match="PRF input"):
+        prf_aes_256_ecb(SAMPLE_EIK, b"\x00" * (FHNA_PRF_INPUT_LENGTH - 1))
+
+
+def test_generate_variant_rejects_wrong_key_length() -> None:
+    """generate_eid_variant must reject a short EIK before any derivation."""
+
+    with pytest.raises(ValueError, match="Identity Key"):
+        generate_eid_variant(
+            SAMPLE_EIK[:8], SAMPLE_COUNTER, EidVariant.MODERN_P256_X32_BE
+        )
+
+
+def test_generate_variant_rejects_unknown_variant() -> None:
+    """An unsupported variant token must hit the explicit guard, not derive silently."""
+
+    with pytest.raises(ValueError, match="Unsupported EID variant"):
+        generate_eid_variant(SAMPLE_EIK, SAMPLE_COUNTER, "bogus_variant")  # type: ignore[arg-type]
+
+
+def test_get_masked_counter_rejects_wrong_rotation_exponent() -> None:
+    """get_masked_counter shares the FHNA_K precondition with the PRF builder."""
+
+    with pytest.raises(ValueError, match="rotation exponent"):
+        get_masked_counter(SAMPLE_COUNTER, FHNA_K + 2)
+
+
+def _independent_flags_mask(eik: bytes, counter: int, byte_len: int, order: int) -> int:
+    """Recompute the flags XOR mask from primitives, independently of the SUT."""
+
+    import hashlib
+
+    prf_input = build_table10_prf_input(counter, k=FHNA_K, strict=False)
+    r_dash = prf_aes_256_ecb(eik, prf_input)
+    r_int = int.from_bytes(r_dash, "big", signed=False)
+    r_scalar = r_int % order
+    r_bytes = r_scalar.to_bytes(byte_len, "big")
+    return hashlib.sha256(r_bytes).digest()[-1]
+
+
+def test_compute_flags_xor_mask_legacy_matches_recomputation() -> None:
+    """Legacy (secp160r1) flags mask must equal an independent primitive recomputation."""
+
+    legacy_order = int(load_curve().order)
+    expected = _independent_flags_mask(
+        SAMPLE_EIK, SAMPLE_COUNTER, LEGACY_EID_LENGTH, legacy_order
+    )
+    actual = compute_flags_xor_mask(SAMPLE_EIK, SAMPLE_COUNTER)
+
+    assert actual == expected
+    assert 0 <= actual <= 0xFF
+
+
+def test_compute_flags_xor_mask_p256_branch_uses_supplied_order() -> None:
+    """The P-256 branch must reduce mod P256_ORDER and pad to 32 bytes."""
+
+    expected = _independent_flags_mask(
+        SAMPLE_EIK, SAMPLE_COUNTER, MODERN_EID_LENGTH, P256_ORDER
+    )
+    actual = compute_flags_xor_mask(
+        SAMPLE_EIK,
+        SAMPLE_COUNTER,
+        curve_byte_len=MODERN_EID_LENGTH,
+        curve_order=P256_ORDER,
+    )
+
+    assert actual == expected
+    # The two curve orders/paddings must generally differ -> guards against a
+    # branch collapse where the P-256 parameters are ignored.
+    legacy = compute_flags_xor_mask(SAMPLE_EIK, SAMPLE_COUNTER)
+    assert (actual, expected) == (expected, actual)  # determinism sanity
+    assert isinstance(legacy, int)
+
+
+def test_generate_eid_shim_warns_and_matches_variant() -> None:
+    """The deprecated generate_eid shim must warn and equal generate_eid_variant."""
+
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        shimmed = generate_eid(
+            SAMPLE_EIK, SAMPLE_COUNTER, variant=EidVariant.MODERN_P256_X32_BE
+        )
+
+    direct = generate_eid_variant(
+        SAMPLE_EIK, SAMPLE_COUNTER, EidVariant.MODERN_P256_X32_BE
+    )
+    assert shimmed == direct
+
+
+def test_align_flexible_rejects_nonpositive_period() -> None:
+    """Flexible alignment must reject non-positive rotation periods."""
+
+    with pytest.raises(ValueError, match="rotation_period must be positive"):
+        _align_to_rotation_flexible(1000, rotation_period=0)
+
+
+def test_align_flexible_floors_to_window_start() -> None:
+    """Flexible alignment floors a timestamp to the start of its rotation window."""
+
+    assert _align_to_rotation_flexible(1000, rotation_period=900) == 900
+    assert _align_to_rotation_flexible(1800, rotation_period=900) == 1800
+    assert _align_to_rotation_flexible(3601, rotation_period=3600) == 3600
+
+
+def test_heuristic_counter_absolute_uses_now() -> None:
+    """ABSOLUTE basis floors absolute now_unix and ignores any anchor."""
+
+    counter = _compute_heuristic_counter(
+        10_000, rotation_period=900, basis=HeuristicBasis.ABSOLUTE
+    )
+    assert counter == (10_000 // 900) * 900
+
+
+def test_heuristic_counter_relative_requires_anchor() -> None:
+    """RELATIVE basis without a valid anchor must raise."""
+
+    with pytest.raises(ValueError, match="RELATIVE basis requires"):
+        _compute_heuristic_counter(
+            10_000, rotation_period=900, basis=HeuristicBasis.RELATIVE, anchor=None
+        )
+    with pytest.raises(ValueError, match="RELATIVE basis requires"):
+        _compute_heuristic_counter(
+            10_000, rotation_period=900, basis=HeuristicBasis.RELATIVE, anchor=0
+        )
+
+
+def test_heuristic_counter_relative_clamps_negative_elapsed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A now_unix before the anchor clamps elapsed to 0 (counter 0), with a debug log."""
+
+    with caplog.at_level(logging.DEBUG):
+        counter = _compute_heuristic_counter(
+            500,
+            rotation_period=900,
+            basis=HeuristicBasis.RELATIVE,
+            anchor=1000,
+        )
+    assert counter == 0
+    assert "Negative elapsed time" in caplog.text
+
+
+def test_heuristic_counter_relative_valid_elapsed() -> None:
+    """RELATIVE basis floors (now - anchor) to the rotation window."""
+
+    counter = _compute_heuristic_counter(
+        5000,
+        rotation_period=900,
+        basis=HeuristicBasis.RELATIVE,
+        anchor=1000,
+    )
+    assert counter == ((5000 - 1000) // 900) * 900
+
+
+def test_build_heuristic_prf_input_effective_k_per_period() -> None:
+    """The effective-k marker byte must reflect the rotation period branch."""
+
+    counter = 2 * ROTATION_PERIOD
+    counter_bytes = (counter & FHNA_COUNTER_MASK).to_bytes(4, "big")
+
+    cases = {
+        ROTATION_PERIOD_900: 9,
+        ROTATION_PERIOD_3600: 12,
+        ROTATION_PERIOD: FHNA_K,
+        500: FHNA_K,  # non-standard period falls through to the FHNA_K default
+    }
+    for period, expected_k in cases.items():
+        block = build_heuristic_prf_input(counter, rotation_period=period)
+        assert len(block) == FHNA_PRF_INPUT_LENGTH
+        assert block[0:11] == b"\xff" * 11
+        assert block[11] == expected_k
+        assert block[12:16] == counter_bytes
+        assert block[16:27] == b"\x00" * 11
+        assert block[27] == expected_k
+        assert block[28:32] == counter_bytes
+
+
+def test_heuristic_single_rejects_wrong_key_length() -> None:
+    """The single-EID heuristic helper must reject a short EIK."""
+
+    with pytest.raises(ValueError, match="Identity Key"):
+        _generate_heuristic_eid_single(
+            SAMPLE_EIK[:4], 0, EidVariant.MODERN_P256_X32_BE
+        )
+
+
+def test_heuristic_single_rejects_unknown_variant() -> None:
+    """An unsupported variant reaches the explicit guard in the heuristic helper."""
+
+    with pytest.raises(ValueError, match="Unsupported EID variant"):
+        _generate_heuristic_eid_single(SAMPLE_EIK, 0, "bogus_variant")  # type: ignore[arg-type]
+
+
+def test_heuristic_single_all_variants_have_expected_lengths() -> None:
+    """Each variant emits a deterministic EID with the documented byte length."""
+
+    counter = 3 * ROTATION_PERIOD
+    for variant in EidVariant:
+        first = _generate_heuristic_eid_single(SAMPLE_EIK, counter, variant)
+        second = _generate_heuristic_eid_single(SAMPLE_EIK, counter, variant)
+        assert first == second  # deterministic
+        if variant in (
+            EidVariant.LEGACY_SECP160R1_X20_BE,
+            EidVariant.MODERN_P256_X20_TRUNC_BE,
+            EidVariant.MODERN_P256_X20_TRUNC_LE,
+        ):
+            assert len(first) == LEGACY_EID_LENGTH
+        else:
+            assert len(first) == MODERN_EID_LENGTH
+
+
+def test_heuristic_single_legacy_matches_primitive_recomputation() -> None:
+    """The legacy heuristic EID equals R=r*G x-coordinate from an independent scalar."""
+
+    counter = 3 * ROTATION_PERIOD
+    prf_input = build_heuristic_prf_input(counter, rotation_period=ROTATION_PERIOD)
+    r_dash = prf_aes_256_ecb(SAMPLE_EIK, prf_input)
+    legacy_curve = load_curve()
+    order = int(legacy_curve.order)
+    scalar = int.from_bytes(r_dash, "big", signed=False) % order
+    expected_x = int((scalar * legacy_curve.generator).x())
+    expected = expected_x.to_bytes(LEGACY_EID_LENGTH, "big")
+
+    actual = _generate_heuristic_eid_single(
+        SAMPLE_EIK, counter, EidVariant.LEGACY_SECP160R1_X20_BE
+    )
+    assert actual == expected
+
+
+def test_generate_heuristic_eid_rejects_wrong_key_length() -> None:
+    """generate_heuristic_eid must reject a short EIK before any derivation."""
+
+    with pytest.raises(ValueError, match="Identity Key"):
+        generate_heuristic_eid(
+            SAMPLE_EIK[:2],
+            10_000,
+            rotation_period=900,
+            basis=HeuristicBasis.ABSOLUTE,
+            variant=EidVariant.MODERN_P256_X32_BE,
+        )
+
+
+def test_generate_heuristic_eid_emits_normal_and_reversed_per_drift() -> None:
+    """Each drift offset yields a normal result and its byte-reversed twin."""
+
+    results = generate_heuristic_eid(
+        SAMPLE_EIK,
+        100_000,
+        rotation_period=900,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=EidVariant.MODERN_P256_X32_BE,
+        drift_offsets=(-1, 0, 1),
+    )
+    assert len(results) == 6  # 3 drifts x {normal, reversed}
+    assert all(isinstance(r, HeuristicEidResult) for r in results)
+
+    normals = [r for r in results if not r.is_reversed]
+    reverseds = [r for r in results if r.is_reversed]
+    assert len(normals) == len(reverseds) == 3
+    for normal, reversed_ in zip(normals, reverseds, strict=True):
+        assert reversed_.eid_bytes == normal.eid_bytes[::-1]
+        assert normal.basis is HeuristicBasis.ABSOLUTE
+        assert normal.rotation_period == 900
+
+
+def test_generate_heuristic_eid_skips_negative_counter() -> None:
+    """Drift offsets that push the counter below zero are skipped (no result)."""
+
+    results = generate_heuristic_eid(
+        SAMPLE_EIK,
+        0,
+        rotation_period=900,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=EidVariant.MODERN_P256_X32_BE,
+        drift_offsets=(-1,),
+    )
+    assert results == []
+
+
+def test_generate_heuristic_eid_swallows_derivation_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A per-drift derivation failure is logged and skipped, not propagated."""
+
+    with caplog.at_level(logging.DEBUG):
+        results = generate_heuristic_eid(
+            SAMPLE_EIK,
+            100_000,
+            rotation_period=900,
+            basis=HeuristicBasis.ABSOLUTE,
+            variant="bogus_variant",  # type: ignore[arg-type]
+            drift_offsets=(0,),
+        )
+    assert results == []
+    assert "Heuristic EID generation failed" in caplog.text

--- a/tests/test_eid_generator_variants.py
+++ b/tests/test_eid_generator_variants.py
@@ -208,9 +208,9 @@ def test_strict_normalization_rejects_negative() -> None:
 def test_normalize_rejects_bool_and_non_int() -> None:
     """The u32 counter must reject bool and non-int types (bool is not a counter)."""
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="must be int"):
         build_table10_prf_input(True, k=FHNA_K)  # type: ignore[arg-type]
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="must be int"):
         build_table10_prf_input("0x10", k=FHNA_K)  # type: ignore[arg-type]
 
 
@@ -299,7 +299,13 @@ def test_compute_flags_xor_mask_legacy_matches_recomputation() -> None:
 
 
 def test_compute_flags_xor_mask_p256_branch_uses_supplied_order() -> None:
-    """The P-256 branch must reduce mod P256_ORDER and pad to 32 bytes."""
+    """The P-256 branch must reduce mod P256_ORDER and pad to 32 bytes.
+
+    The independent recomputation (``expected``) is the real branch proof: if
+    the function ignored ``curve_byte_len``/``curve_order``, ``actual`` would
+    diverge from the P-256 oracle. The legacy comparison is an additional
+    collapse guard (a different order/padding must yield a different mask).
+    """
 
     expected = _independent_flags_mask(
         SAMPLE_EIK, SAMPLE_COUNTER, MODERN_EID_LENGTH, P256_ORDER
@@ -310,13 +316,13 @@ def test_compute_flags_xor_mask_p256_branch_uses_supplied_order() -> None:
         curve_byte_len=MODERN_EID_LENGTH,
         curve_order=P256_ORDER,
     )
+    legacy = compute_flags_xor_mask(SAMPLE_EIK, SAMPLE_COUNTER)
 
     assert actual == expected
-    # The two curve orders/paddings must generally differ -> guards against a
-    # branch collapse where the P-256 parameters are ignored.
-    legacy = compute_flags_xor_mask(SAMPLE_EIK, SAMPLE_COUNTER)
-    assert (actual, expected) == (expected, actual)  # determinism sanity
-    assert isinstance(legacy, int)
+    # Distinct curve order/padding must produce a distinct mask for these fixed
+    # inputs (legacy=213, p256=16): guards against a branch collapse that would
+    # ignore the supplied P-256 parameters.
+    assert actual != legacy
 
 
 def test_generate_eid_shim_warns_and_matches_variant() -> None:

--- a/tests/test_foreign_tracker_cryptor.py
+++ b/tests/test_foreign_tracker_cryptor.py
@@ -3,13 +3,22 @@
 
 from __future__ import annotations
 
+import secrets
+
 import pytest
 
-from custom_components.googlefindmy.FMDNCrypto.eid_generator import EIK_LENGTH
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    EIK_LENGTH,
+    EidVariant,
+    generate_eid_variant,
+)
 from custom_components.googlefindmy.FMDNCrypto.foreign_tracker_cryptor import (
     _COORD_LEN,
+    _get_curve,
     _require_len,
     decrypt,
+    encrypt,
+    rx_to_ry,
 )
 
 
@@ -60,3 +69,104 @@ class TestDecryptIdentityKeyLength:
             _require_len("foo", b"\x00" * 5, 10)
         # No error when length matches
         _require_len("bar", b"\x00" * 10, 10)
+
+
+def _valid_eid() -> bytes:
+    """Build a valid SECP160r1 EID (on-curve x-coordinate) for encrypt() inputs."""
+    identity_key = b"\x01" * EIK_LENGTH
+    return generate_eid_variant(
+        identity_key, 0, EidVariant.LEGACY_SECP160R1_X20_BE
+    )
+
+
+class TestNonceFreshnessContract:
+    """H1 (A7-H hardening): AES-EAX nonce uniqueness rests on caller entropy.
+
+    ``encrypt(message, random, eid)`` derives the ephemeral scalar ``s`` solely
+    from ``random``; the EAX nonce is ``LRx(8) || LSx(8)`` where ``LSx`` is the
+    low 8 bytes of ``(s*G).x``. The only production caller,
+    ``fmdn_finder/location_uploader.py:551``, passes ``secrets.token_bytes(32)``
+    as ``random``, so a fresh nonce (and HKDF key) is produced per message.
+
+    AP5 flagged this isolated function as a nonce-reuse FAIL (M1); the Tier-4
+    code verification (Regel 10) downgraded it to PASS precisely because of that
+    caller contract. These tests lock the contract so a future refactor that
+    reuses ``random`` (constant/cached bytes, a counter, etc.) — which would
+    reuse the EAX nonce and break confidentiality/integrity — turns the audited
+    PASS back into a red test instead of a silent regression.
+    """
+
+    def test_fresh_random_yields_distinct_nonce_and_ciphertext(self) -> None:
+        """Two encryptions of identical plaintext with fresh entropy must differ."""
+        eid = _valid_eid()
+        message = b"identical-plaintext-payload"
+        ct1, sx1 = encrypt(message, secrets.token_bytes(32), eid)
+        ct2, sx2 = encrypt(message, secrets.token_bytes(32), eid)
+        # Fresh entropy -> different ephemeral S -> different Sx -> different nonce.
+        assert sx1 != sx2
+        assert ct1 != ct2
+
+    def test_reused_random_repeats_nonce_mutation_guard(self) -> None:
+        """Mutation guard proving the freshness test is sharp.
+
+        If a caller violates the entropy contract and passes constant bytes,
+        the ephemeral S (hence Sx, hence the nonce) repeats and the ciphertext
+        of a fixed plaintext is identical. Asserting that equality here proves
+        the freshness test above would actually catch nonce reuse.
+        """
+        eid = _valid_eid()
+        message = b"identical-plaintext-payload"
+        fixed_random = b"\x02" * 32
+        ct1, sx1 = encrypt(message, fixed_random, eid)
+        ct2, sx2 = encrypt(message, fixed_random, eid)
+        assert sx1 == sx2  # nonce component repeats under reused entropy
+        assert ct1 == ct2
+
+
+class TestRxToRyCofactorSafety:
+    """H2 (A7-H hardening): rx_to_ry rejects off-curve X and recovers on-curve Y.
+
+    AP5 flagged a possible invalid-curve / small-subgroup attack (M4); the
+    Tier-4 verification downgraded it to PASS because SECP160r1 has cofactor 1
+    (prime order) and ``rx_to_ry`` reconstructs Y on the correct curve, raising
+    on a non-quadratic residue (the residue check in the production code). Any
+    point it returns therefore lies in the legitimate prime-order group, so no
+    small-subgroup confinement is possible.
+
+    These tests lock both halves of that argument: an X with no valid Y must
+    raise, and an on-curve X must yield a Y satisfying the curve equation. A
+    future relaxation of the residue check (which would admit off-curve points)
+    would make the negative case go red.
+    """
+
+    def test_off_curve_x_raises(self) -> None:
+        """An X whose y^2 is a non-residue has no curve point -> ValueError."""
+        curve_fp = _get_curve().curve
+        p = int(curve_fp.p())
+        a = int(curve_fp.a())
+        b = int(curve_fp.b())
+        # Find a small x whose y^2 is a quadratic non-residue (Euler's criterion
+        # gives p-1 for non-residues). Roughly half of all x qualify.
+        non_residue_x = None
+        for cand in range(2, 500):
+            ryy = (pow(cand, 3, p) + a * cand + b) % p
+            if ryy != 0 and pow(ryy, (p - 1) // 2, p) == p - 1:
+                non_residue_x = cand
+                break
+        assert non_residue_x is not None, "expected an off-curve x for the negative case"
+        with pytest.raises(ValueError, match="not on the curve"):
+            rx_to_ry(non_residue_x, curve_fp)
+
+    def test_on_curve_x_recovers_even_y(self) -> None:
+        """The generator's X is on-curve; recovered Y satisfies y^2 = x^3+ax+b."""
+        curve = _get_curve()
+        curve_fp = curve.curve
+        p = int(curve_fp.p())
+        a = int(curve_fp.a())
+        b = int(curve_fp.b())
+        gx = int(curve.generator.x())
+        y = rx_to_ry(gx, curve_fp)
+        lhs = (y * y) % p
+        rhs = (pow(gx, 3, p) + a * gx + b) % p
+        assert lhs == rhs  # recovered point lies on the curve
+        assert y % 2 == 0  # even-Y canonical form (FMDN convention)


### PR DESCRIPTION
## Scope

Systematic crypto **misuse + arithmetic** audit of the five primary crypto
files on the `1.7.1` line. Each file gets a deterministic PASS/FAIL/N-A
verdict per applicable check class, evidenced at a concrete line; a
confirmed finding gets a discriminating regression test plus a minimal fix.

Files under audit:
- `KeyBackup/lskf_hasher.py` (scrypt KDF parameter lock)
- `FMDNCrypto/eid_generator.py` (operator precedence, ECB-PRF, ECDH N/A)
- `FMDNCrypto/foreign_tracker_cryptor.py` (EAX nonce uniqueness, invalid-curve, precedence)
- `NovaApi/.../decrypt_locations.py` (AES-GCM nonce, AAD binding, ECDH delegation)
- `KeyBackup/cloud_key_decryptor.py` (CBC-no-padding oracle lock, CBC auth, ECDH)

Check classes: PREC-a (bit/byte), PREC-b (op chains), M1 nonce/IV,
M2 CBC-auth, M3 padding-oracle, M4 ECDH-point, KDF-LOCK.

## Status

Draft, **early-opened on purpose** to trigger CI and Codex review while the
audit runs. This commit is an empty marker; no production code changed yet.

### Coverage baseline (measured on 1.7.1, Python 3.13)

| File | Coverage |
|---|---|
| lskf_hasher | 100% |
| eid_generator | 57% |
| foreign_tracker_cryptor | 65% |
| decrypt_locations | 50% |
| cloud_key_decryptor | 100% |

If the audit confirms no finding, this PR closes without a code change
(audit-before-fix discipline: "no finding" is a valid result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)