### PR TITLE
Surface stale shared-key failures as reauth and normalize pasted-secret whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ The manifest classifies Google Find My Device as a **hub** integration. Home Ass
 
 ### <ins>Authentication Part 1 (External Steps)</ins>
 1. Navigate to [GoogleFindMyTools](https://github.com/leonboe1/GoogleFindMyTools?tab=readme-ov-file#how-to-use) repository and follow the directions on "How to use" the main.py script.
+   > [!IMPORTANT]
+   > Run the authentication script from the **same public IP address / network** that your Home Assistant instance uses, and sign in with the **same Google account** that owns the trackers. Google ties the end-to-end encryption keys in `secrets.json` to the account and may revoke them when requests arrive from a different IP or region. A mismatch produces a bundle that lists your devices and can ring them, but cannot decrypt any location reports — see [Devices appear but no location updates](#authentication-expires-repeatedly).
 2. **CRITICAL STEP!**  Complete the **ENTIRE** authentication process to generate `Auth/secrets.json`
 > [!WARNING]
 >While going through the process in main.py to authenticate, you **MUST** go through **2 login processes!**  After the first login is successful, your available devices will be listed.  You must complete the next step to display location data for one of your devices.  You will then login again.  After you complete this step, you should see valid location data for your device, followed by several errors that are not important.  ONLY at this point are you ready to move on to the next step!

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -2963,6 +2963,35 @@ class FcmReceiverHA:
 
     # -------------------- Decode helper --------------------
 
+    def _note_decrypt_failure_for_entry(
+        self, entry_id: str, *, stale: bool, error: Exception
+    ) -> None:
+        """Feed a background-path decryption failure into the matching coordinator(s).
+
+        Mirrors the poll path so a push-only setup escalates to re-authentication
+        identically (one shared counter, no second divergent code path). Because the
+        background decode runs outside a coordinator update cycle, an escalation
+        cannot be surfaced by raising ``ConfigEntryAuthFailed`` here; instead the
+        entry's reauth flow is started directly -- the same synchronous ``@callback``
+        mechanism repairs.py and coordinator/locate.py already use. It is idempotent:
+        Home Assistant does not duplicate an already-open reauth flow.
+
+        This must never break the push path, so all failures are swallowed to debug.
+        """
+        hass = self._hass
+        for coordinator in self._coordinators_for_entries({entry_id}):
+            try:
+                escalate = coordinator.note_decrypt_failure(stale=stale, error=error)
+            except Exception as err:  # noqa: BLE001 - never break the push path
+                _LOGGER.debug(
+                    "note_decrypt_failure failed for entry %s: %s", entry_id, err
+                )
+                continue
+            if escalate and hass is not None:
+                entry = getattr(coordinator, "config_entry", None)
+                if entry is not None:
+                    entry.async_start_reauth(hass)
+
     async def _decode_background_location_async(  # noqa: PLR0911
         self, entry_id: str, hex_string: str
     ) -> JSONDict:
@@ -2991,18 +3020,25 @@ class FcmReceiverHA:
                     raw_locations = await async_decrypt_location_response_locations(
                         device_update, cache=cache
                     )
-                except StaleOwnerKeyError:
+                except StaleOwnerKeyError as stale_err:
                     _LOGGER.info(
-                        "Background location update skipped (stale key) for entry %s",
+                        "Background location update skipped (stale tracker key) for "
+                        "entry %s",
                         entry_id,
+                    )
+                    self._note_decrypt_failure_for_entry(
+                        entry_id, stale=True, error=stale_err
                     )
                     return {}
                 except DecryptionError as dec_err:
                     _LOGGER.warning(
                         "Background location decryption failed for entry %s: %s. "
-                        "This may resolve after re-authentication or key refresh.",
+                        "Escalates to re-authentication if it persists.",
                         entry_id,
                         dec_err,
+                    )
+                    self._note_decrypt_failure_for_entry(
+                        entry_id, stale=False, error=dec_err
                     )
                     return {}
                 except InvalidTag:

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -243,7 +243,59 @@ class DecryptionError(RuntimeError):
 
 
 class StaleOwnerKeyError(DecryptionError):
-    """Raised when the tracker was encrypted with an older owner key version."""
+    """Raised when the tracker was encrypted with an older owner key version.
+
+    Per-tracker condition: a single tracker still encrypts reports with an
+    owner-key version that is no longer current. An account-wide re-auth does NOT
+    fix it; the tracker must be removed and re-paired. Kept distinct from the
+    account-wide shared-key failures below so the coordinator can escalate each
+    differently (per-tracker repair issue vs. ConfigEntryAuthFailed).
+    """
+
+
+class SharedKeyMismatchError(DecryptionError):
+    """Raised when the shared key cannot decrypt the owner key (AES-GCM InvalidTag).
+
+    Account-wide: the bundle's shared key is stale or incompatible with the
+    server-side owner key. Only a fresh secrets.json obtained via the interactive
+    browser flow can fix this; force_refresh of the owner key cannot, because the
+    shared key itself is the wrong one.
+    """
+
+
+class SharedKeyMissingError(DecryptionError):
+    """Raised when the shared key is absent or empty (incomplete bundle import).
+
+    Account-wide: the secrets.json did not provide a usable shared key. A complete
+    re-import / fresh secrets.json is required.
+    """
+
+
+def _classify_owner_key_failure(exc: Exception, *, context: str) -> DecryptionError:
+    """Map a low-level owner-key lookup failure to a specific DecryptionError.
+
+    ``async_get_owner_key`` collapses distinct root causes into either an
+    ``InvalidTag`` (wrong/stale shared key) or a ``RuntimeError`` (missing/empty
+    shared key, or a generic failure). This helper restores the discriminator as a
+    typed subclass so the failure class name appears in logs and the coordinator
+    can pick the correct recovery path. The caller preserves the original error
+    via ``raise ... from exc``.
+    """
+    if isinstance(exc, InvalidTag):
+        return SharedKeyMismatchError(
+            f"Owner key decryption failed (InvalidTag) during {context}: the shared "
+            "key is stale or incompatible with this account. A fresh secrets.json "
+            "is required (re-authentication)."
+        )
+    if isinstance(exc, RuntimeError) and "missing or empty" in str(exc):
+        return SharedKeyMissingError(
+            f"Shared key is missing or empty during {context} (incomplete bundle). "
+            "Re-import a complete secrets.json."
+        )
+    return DecryptionError(
+        f"Owner key decryption failed during {context} (shared key may be stale). "
+        "Re-authenticate to refresh crypto keys."
+    )
 
 
 async def _unwrap_encrypted_identity_key(
@@ -378,10 +430,7 @@ async def async_retrieve_identity_key(
     try:
         owner_key_info: OwnerKeyInfo = await async_get_owner_key(cache=cache)
     except (InvalidTag, RuntimeError) as exc:
-        raise DecryptionError(
-            "Owner key decryption failed (shared key may be stale). "
-            "Re-authenticate with --reauth to refresh crypto keys."
-        ) from exc
+        raise _classify_owner_key_failure(exc, context="initial lookup") from exc
 
     # --- Proactive Owner Key Version Mismatch Check ---
     # If the tracker requires a newer owner key version than what we have cached,
@@ -403,10 +452,7 @@ async def async_retrieve_identity_key(
                 cache=cache, force_refresh=True
             )
         except (InvalidTag, RuntimeError) as exc:
-            raise DecryptionError(
-                "Owner key refresh failed (InvalidTag). "
-                "Re-authenticate with --reauth to refresh crypto keys."
-            ) from exc
+            raise _classify_owner_key_failure(exc, context="forced refresh") from exc
 
     # Build key sources list (matches eid_resolver pattern: try owner + shared)
     key_sources: list[tuple[str, bytes]] = [("owner", owner_key_info.key)]

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -887,6 +887,12 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     - Robust against partial/invalid reports (log and continue).
     - No prints or process termination; errors bubble or are logged with context.
 
+    Raises:
+        DecryptionError: if the device has its own encrypted reports and every
+            one of them fails authentication (no own-report success). This is an
+            account-wide stale-key signal; foreign/crowdsourced failures and
+            report-less devices never raise (they return ``[]``/metadata-only).
+
     Args:
         device_update_protobuf: Raw protobuf payload containing encrypted locations.
         cache: Entry-scoped TokenCache forwarded to key/EID helpers.
@@ -1252,6 +1258,14 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     wrapped: list[WrappedLocation] = []
     _auth_failures = 0  # Track MAC / InvalidTag failures across all reports
     _encrypted_report_count = 0  # Count non-SEMANTIC reports attempted
+    # Diff-Review #1: Own-report-only failure tracking. Unlike the mixed
+    # counters above (which include foreign/crowdsourced reports that legitimately
+    # fail when decrypted with another account's key), these track ONLY the
+    # device's own reports (public_key_random == b""). Exhausting every own report
+    # is the one account-wide auth signal that warrants reauth escalation.
+    _own_encrypted_report_count = 0  # Own (Owner-key) reports attempted
+    _own_auth_failures = 0  # Own-report MAC / InvalidTag failures
+    _own_report_success = False  # At least one own report authenticated OK
 
     # FIX #155: Prepare all identity key candidates for multi-candidate retry.
     # async_retrieve_identity_key can return multiple candidates (MCU bit-flip
@@ -1310,11 +1324,22 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             public_key_random = enc.publicKeyRandom
 
             if public_key_random == b"":  # Own report
+                _own_encrypted_report_count += 1
                 if active_identity_key is None:
+                    # Unreachable in practice: a None identity_key already raised
+                    # DecryptionError at function entry, and active_identity_key
+                    # falls back to the non-None identity_key. Kept as a defensive
+                    # guard. Intentionally a ValueError (config error, not an auth
+                    # signal) so it is NOT counted as an own auth failure and does
+                    # not trigger stale-key reauth escalation.
                     raise ValueError("No identity key available for own-report decryption")
                 decrypted_location_raw = await _offload_decrypt_aes(
                     active_identity_key, encrypted_location
                 )
+                # Authentication passed: the cached identity key still matches the
+                # server's own reports. One success proves the key is healthy, so
+                # foreign-report failures must not trigger account-wide escalation.
+                _own_report_success = True
             else:
                 # FIX #155: Foreign/crowdsourced reports use ECDH + AES-EAX
                 # with a different key derivation path than own reports.
@@ -1387,6 +1412,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         except InvalidTag:
             # InvalidTag means AES-GCM authentication failed during decryption.
             _auth_failures += 1
+            if public_key_random == b"":  # Own-report auth failure
+                _own_auth_failures += 1
             _LOGGER.warning(
                 "Decryption auth failed (InvalidTag) for %s report "
                 "(time_offset=%s, key_len=%s, candidates=%d): "
@@ -1404,6 +1431,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             # meaning to InvalidTag from the cryptography library.
             if "mac" in str(ve).lower():
                 _auth_failures += 1
+                if public_key_random == b"":  # Own-report auth failure
+                    _own_auth_failures += 1
                 _LOGGER.warning(
                     "Decryption auth failed (MAC check) for %s report "
                     "(time_offset=%s, key_len=%s, candidates=%d): %s",
@@ -1459,6 +1488,25 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 "derivation may be failing. Re-authenticate the account.",
                 _auth_failures,
             )
+
+    # Diff-Review #1: When the device HAS its own encrypted reports and EVERY
+    # one of them failed authentication (with not a single own-report success),
+    # the cached identity key no longer matches the server's reports. This is a
+    # genuine account-wide auth failure, distinct from the masked retrieve path
+    # above and from foreign/crowdsourced failures (which legitimately fail with
+    # other accounts' keys and must NOT escalate). Raise DecryptionError so the
+    # existing escalation machinery (coordinator poll/locate handlers and the FCM
+    # push handler, all gated by per-cycle counting + cooldown) can surface a
+    # reauth repair instead of silently returning empty every cycle.
+    if (
+        _own_encrypted_report_count > 0
+        and _own_auth_failures >= _own_encrypted_report_count
+        and not _own_report_success
+    ):
+        raise DecryptionError(
+            "All own-report decryptions failed; the cached identity key no "
+            "longer matches the server reports."
+        )
 
     if not wrapped:
         _LOGGER.info("[DecryptLocations] No locations found.")

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -604,6 +604,15 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
     except Exception as err:  # pragma: no cover - defensive logging
         _LOGGER.debug("Failed to persist contributor mode timestamp: %s", err)
 
+    # Bind the decryption exception type locally: this module imports
+    # decrypt_locations lazily (see _import_decrypt_locations_module) to avoid a
+    # heavy import cycle, so the name is not available at module scope. It is used
+    # below to surface an auth-fatal stale-key failure instead of swallowing it.
+    decrypt_module = _import_decrypt_locations_module()
+    DecryptionError = cast(
+        type[Exception], getattr(decrypt_module, "DecryptionError")
+    )
+
     try:
         # Generate request UUID
         request_uuid = generate_random_uuid()
@@ -715,6 +724,14 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
                 raise ctx.error
             if isinstance(ctx.error, SpotAuthPermanentError):
                 raise ctx.error
+            # A stale/incompatible shared key (SharedKeyMismatchError /
+            # SharedKeyMissingError) or a per-tracker stale owner key
+            # (StaleOwnerKeyError) is an auth-fatal crypto condition, not a
+            # transient miss. Surface it so the API layer and coordinator can
+            # escalate to a reauth flow (or a per-tracker repair issue) instead of
+            # silently returning no location. DecryptionError covers all subclasses.
+            if isinstance(ctx.error, DecryptionError):
+                raise ctx.error
 
         data = ctx.data or []
         if data and data[0].get("canonic_id", "").lower() == canonic_device_id.lower():
@@ -743,6 +760,12 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
     except NovaAuthError:
         # Re-raise auth errors (permanent or transient) so api.py can handle appropriately.
         # Transient errors will be tracked by the coordinator; permanent ones trigger reauth.
+        raise
+    except DecryptionError:
+        # Auth-fatal crypto failure surfaced from ctx.error above: must propagate so
+        # the coordinator can escalate (reauth or per-tracker repair). The broad
+        # `except Exception` below would otherwise swallow it back into an empty
+        # result -- that swallow is the original bug this fix removes.
         raise
     except Exception as e:
         _LOGGER.error("Error requesting location for %s: %s", name, e)

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -195,11 +195,13 @@ async def _retrieve_owner_key(
         owner_key: Any = await _run_in_executor(
             decrypt_owner_key, shared_key, encrypted_owner_key
         )
-    except InvalidTag as exc:
-        raise RuntimeError(
-            "Owner key decryption failed (InvalidTag): the shared key may be "
-            "stale or incompatible. Try re-authenticating with --reauth."
-        ) from exc
+    except InvalidTag:
+        # Propagate InvalidTag unchanged. The caller (decrypt_locations) maps it to
+        # SharedKeyMismatchError to distinguish "shared key wrong/stale" from
+        # "shared key missing" (RuntimeError). Wrapping it into RuntimeError here
+        # would erase that discriminator and collapse both root causes into one
+        # opaque message, which is exactly what hid the real cause from users.
+        raise
     owner_key_version = getattr(metadata, "ownerKeyVersion", None)
 
     if not isinstance(owner_key, (bytes, bytearray)) or len(owner_key) == 0:

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -6921,6 +6921,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
         elif isinstance(raw_secrets, Mapping):
             secrets_bundle = dict(raw_secrets)
 
+        if secrets_bundle:  # pragma: no cover - legacy one-time migration path
+            # Legacy bundles (migrated from entry.data/file) may carry copy/paste
+            # whitespace in credential values; normalize before extraction and
+            # before this path persists the bundle to the cache. Idempotent.
+            # The decryption-critical normalization is also enforced downstream by
+            # _async_save_secrets_data (covered by tests); this is defense-in-depth
+            # on the legacy one-time migration branch, which the unit harness does
+            # not drive.
+            from .shared_helpers import normalize_secrets_bundle
+
+            secrets_bundle = normalize_secrets_bundle(secrets_bundle)
+
         oauth_token_maybe = entry.data.get(CONF_OAUTH_TOKEN)
         if not isinstance(oauth_token_maybe, str):
             oauth_token_maybe = secrets_bundle.get(CONF_OAUTH_TOKEN)
@@ -7672,6 +7684,15 @@ async def _async_save_secrets_data(
         - Store JSON-serializable values *as-is*. TokenCache validates and normalizes.
         - Uses the *entry-local* cache instance (no global facade).
     """
+    from .shared_helpers import normalize_secrets_bundle
+
+    # Defense-in-depth: the config flow already normalizes bundles on entry, but
+    # this is the universal cache-write choke point. A bundle persisted by an
+    # older version or migrated from a file may still carry copy/paste whitespace
+    # in credential values (a stray space in owner_key/shared_key breaks AES-GCM
+    # decryption). normalize_secrets_bundle is idempotent, so re-normalizing an
+    # already-clean bundle is a no-op.
+    secrets_data = normalize_secrets_bundle(dict(secrets_data))
     enhanced_data = dict(secrets_data)
 
     # Normalize username key across old/new secrets variants

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -44,6 +44,7 @@ from .const import (
     DEFAULT_CONTRIBUTOR_MODE,
 )
 from .NovaApi import nova_request
+from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import DecryptionError
 from .NovaApi.ExecuteAction.LocateTracker.location_request import (
     get_location_data_for_device,
 )
@@ -1335,6 +1336,15 @@ class GoogleFindMyAPI:
                 _short_err(err),
             )
             return {}
+
+        except DecryptionError:
+            # Audit finding A1: DecryptionError is a RuntimeError subclass, so the
+            # broad `except RuntimeError` / `except Exception` below would silently
+            # swallow an auth-fatal stale-shared-key failure into an empty result.
+            # Re-raise it so the coordinator can count it and escalate to a reauth
+            # flow (or per-tracker repair). This is the layer that must stay
+            # transparent for the location_request fix to have any effect.
+            raise
 
         except RuntimeError as err:
             # Startup safety net: during cold boot, the FCM provider may not yet be registered.

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -129,6 +129,7 @@ from .integration_modules import (
     import_integration_api_module,
     import_integration_package,
 )
+from .shared_helpers import normalize_secrets_bundle
 
 _ResolveEntryEmailCallable = Callable[[ConfigEntry], tuple[str | None, str | None]]
 _CoalesceCallable = Callable[
@@ -1417,6 +1418,7 @@ def _interpret_credentials_choice(
             parsed = json.loads(secrets_json)
             if not isinstance(parsed, dict):
                 raise TypeError()
+            parsed = normalize_secrets_bundle(parsed)
         except (json.JSONDecodeError, TypeError):
             return "secrets", None, None, "invalid_json"
 
@@ -1460,6 +1462,7 @@ def _interpret_reauth_choice(
             parsed = json.loads(secrets_raw)
             if not isinstance(parsed, dict):
                 raise TypeError()
+            parsed = normalize_secrets_bundle(parsed)
         except (json.JSONDecodeError, TypeError):
             return None, None, "invalid_json"
 
@@ -1677,7 +1680,7 @@ def _normalize_and_validate_discovery_payload(
     )
     if isinstance(secrets_raw, str):
         try:
-            secrets_raw = json.loads(secrets_raw)
+            secrets_raw = normalize_secrets_bundle(json.loads(secrets_raw))
         except json.JSONDecodeError as err:
             raise DiscoveryFlowError("invalid_discovery_info") from err
 
@@ -2836,7 +2839,7 @@ class ConfigFlow(
             try:
                 parsed_candidate = json.loads(raw)
                 if isinstance(parsed_candidate, dict):
-                    parsed_secrets = parsed_candidate
+                    parsed_secrets = normalize_secrets_bundle(parsed_candidate)
                 else:
                     raise TypeError()
             except (json.JSONDecodeError, TypeError):
@@ -5833,6 +5836,7 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
                                 parsed = json.loads(user_input["new_secrets_json"])
                                 if not isinstance(parsed, dict):
                                     raise TypeError()
+                                parsed = normalize_secrets_bundle(parsed)
                             except Exception:
                                 errors["new_secrets_json"] = "invalid_json"
                             else:
@@ -5899,7 +5903,9 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
                     except Exception as err2:  # noqa: BLE001
                         if _is_multi_entry_guard_error(err2):
                             entry = self.config_entry
-                            parsed = json.loads(user_input["new_secrets_json"])
+                            parsed = normalize_secrets_bundle(
+                                json.loads(user_input["new_secrets_json"])
+                            )
                             cands = _extract_oauth_candidates_from_secrets(parsed)
                             token_first = cands[0][1] if cands else ""
                             updated_data = {

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -170,6 +170,11 @@ class _MixinBase:
     ) -> None:
         raise NotImplementedError
 
+    def note_decrypt_failure(
+        self, *, stale: bool, error: Exception, device: str | None = None
+    ) -> bool:
+        raise NotImplementedError
+
     def _short_error_message(self, exc: Exception | str) -> str:
         raise NotImplementedError
 

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -98,8 +98,9 @@ class _MixinBase:
     _consecutive_transient_auth_failures: int
     _last_transient_auth_error: str | None
     _consecutive_decrypt_failures: int
-    _last_decrypt_reauth_monotonic: float
+    _last_decrypt_reauth_monotonic: float | None
     _last_decrypt_error: str | None
+    _monotonic: Callable[[], float]
 
     # Diagnostics / statistics
     stats: dict[str, int]

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -97,6 +97,9 @@ class _MixinBase:
     _fcm_defer_started_mono: float
     _consecutive_transient_auth_failures: int
     _last_transient_auth_error: str | None
+    _consecutive_decrypt_failures: int
+    _last_decrypt_reauth_monotonic: float
+    _last_decrypt_error: str | None
 
     # Diagnostics / statistics
     stats: dict[str, int]

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -25,6 +25,10 @@ from aiohttp import ClientConnectionError, ClientError
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
 from ..const import DEFAULT_MIN_POLL_INTERVAL
+from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    StaleOwnerKeyError,
+)
 from ..NovaApi.nova_request import (
     NovaAuthError,
     NovaHTTPError,
@@ -571,6 +575,69 @@ class LocateOperations(_MixinBase):
                 )
                 self.note_error(decode_err, where="async_locate_device", device=name)
                 return {}
+            except StaleOwnerKeyError as stale_err:
+                # Per-tracker outdated owner key: an account-wide reauth would not
+                # fix a single outdated tracker. Record it through the shared entry
+                # point (per-tracker log, no account counter) and return an empty
+                # result rather than a generic HomeAssistantError. Must precede the
+                # DecryptionError handler below -- it is a subclass.
+                self.note_decrypt_failure(stale=True, error=stale_err, device=name)
+                self.note_error(stale_err, where="async_locate_device", device=name)
+                return {}
+            except DecryptionError as dec_err:
+                # Account-wide stale/missing shared key. Feed the SAME escalation
+                # counter as the poll and push paths (single source of truth) so a
+                # user clicking "Locate" contributes to -- and can trigger -- the
+                # reauth flow instead of silently swallowing into a generic error.
+                # Below threshold: graceful empty result, like the poll path keeps
+                # polling. At threshold: start reauth (HA cannot refresh the shared
+                # key itself; the user must supply a fresh secrets.json).
+                #
+                # This path only advances the shared counter, never resets it: the
+                # authoritative reset is the poll loop's whole-cycle decrypt-clean
+                # gate. A manual locate cannot prove the key is healthy (an empty
+                # result means "no pending report", which decrypts nothing), so
+                # resetting here could mask a genuinely stale key. The next clean
+                # poll cycle reconciles the counter. Locate is an additional upward
+                # evidence source, not a reset surface.
+                should_reauth = self.note_decrypt_failure(
+                    stale=False, error=dec_err, device=name
+                )
+                self.note_error(dec_err, where="async_locate_device", device=name)
+                if not should_reauth:
+                    return {}
+                self._set_auth_state(
+                    failed=True,
+                    reason=(
+                        "Location decryption keeps failing during manual locate; "
+                        "the shared key is stale and a fresh secrets.json "
+                        "(re-authentication) is required"
+                    ),
+                )
+                entry = getattr(self, "config_entry", None)
+                reauth_started = False
+                if entry is not None:
+                    try:
+                        # async_start_reauth is a synchronous @callback returning
+                        # None (it schedules the flow); awaiting it would raise on
+                        # the None result. Call it without await, mirroring the
+                        # SpotAuthPermanentError handler above.
+                        entry.async_start_reauth(self.hass)
+                        reauth_started = True
+                    except Exception as reauth_err:  # pragma: no cover - defensive
+                        _LOGGER.debug(
+                            "Failed to start reauth flow after manual locate "
+                            "decryption failure: %s",
+                            reauth_err,
+                        )
+                message = (
+                    "Google Find My Device can no longer decrypt locations "
+                    "(the shared key is stale); re-authentication has been started."
+                    if reauth_started
+                    else "Google Find My Device can no longer decrypt locations "
+                    "(the shared key is stale); please re-authenticate."
+                )
+                raise HomeAssistantError(message) from dec_err
             except Exception as err:
                 short_err = self._short_error_message(err)
                 _LOGGER.error("Manual locate for %s failed: %s", name, short_err)

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -813,8 +813,18 @@ class GoogleFindMyCoordinator(
         # counter above; the in-decrypt self-heal (force_refresh / blind refresh)
         # gets the first chance to recover an owner-key version bump without reauth.
         self._consecutive_decrypt_failures: int = 0
-        self._last_decrypt_reauth_monotonic: float = 0.0
+        # None means "never escalated yet". A real monotonic timestamp is only
+        # recorded after the first escalation, so the cooldown gate is skipped
+        # entirely on the first one. Using 0.0 as the sentinel was a bug: it is a
+        # valid monotonic value, so on a freshly booted host (process uptime below
+        # the cooldown window) ``monotonic() - 0.0 < cooldown`` would wrongly
+        # suppress the very first reauth escalation for up to the cooldown period.
+        self._last_decrypt_reauth_monotonic: float | None = None
         self._last_decrypt_error: str | None = None
+        # Injectable monotonic-clock seam. Defaults to ``time.monotonic`` in
+        # production; tests override it to drive the decrypt cooldown gate
+        # deterministically (no dependency on the host's process uptime).
+        self._monotonic: Callable[[], float] = time.monotonic
 
         # Reload guard: defer core subentry repairs once after reload-driven attach
         self._skip_repair_during_reload_refresh: bool = False

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -807,6 +807,15 @@ class GoogleFindMyCoordinator(
         self._consecutive_transient_auth_failures: int = 0
         self._last_transient_auth_error: str | None = None
 
+        # Stale/missing shared-key decryption failures escalate to a reauth flow
+        # only after several consecutive cycles, with a cooldown so the flow is not
+        # re-fired on every poll once it is already open. Mirrors the transient-auth
+        # counter above; the in-decrypt self-heal (force_refresh / blind refresh)
+        # gets the first chance to recover an owner-key version bump without reauth.
+        self._consecutive_decrypt_failures: int = 0
+        self._last_decrypt_reauth_monotonic: float = 0.0
+        self._last_decrypt_error: str | None = None
+
         # Reload guard: defer core subentry repairs once after reload-driven attach
         self._skip_repair_during_reload_refresh: bool = False
         self._reload_repair_skip_pending_release: bool = False

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1290,13 +1290,17 @@ class PollingOperations(_MixinBase):
             _any_device_got_data = False
             try:
                 cycle_failed = False
-                # Track whether any device hit an account-wide decryption failure
-                # this cycle. The consecutive-decrypt counter is reset only when the
-                # WHOLE cycle was decrypt-clean: in a multi-device account a single
-                # healthy tracker must not mask a persistently un-decryptable shared
-                # key on the others (the condition is account-wide, so the reset
-                # gate must be too).
-                cycle_had_decrypt_failure = False
+                # First account-wide decryption error seen this cycle (None == the
+                # cycle was decrypt-clean). The account-wide failure counter is a
+                # per-cycle quantity: it is advanced exactly once after the device
+                # loop, never per device. In a multi-device account a single healthy
+                # tracker must not mask a persistently un-decryptable shared key on
+                # the others, so both the escalation and the reset gate are
+                # cycle-scoped. Consequence (deliberate): in the escalation cycle the
+                # whole device loop runs to completion before the single escalation
+                # fires, so the remaining trackers still get one (failing) Nova call.
+                # That is the rare end-state cost of per-cycle counting.
+                cycle_decrypt_error: DecryptionError | None = None
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
                     dev_name = dev.get("name", dev_id)
@@ -1692,25 +1696,18 @@ class PollingOperations(_MixinBase):
                             last_exception = stale_err
                         continue
                     except DecryptionError as dec_err:
-                        # Account-wide stale/missing shared key: escalate to reauth
-                        # after _MAX_DECRYPT_FAILURES consecutive cycles (with
-                        # cooldown). Below the threshold keep polling so the
-                        # in-decrypt self-heal can still recover an owner-key bump.
-                        cycle_had_decrypt_failure = True
+                        # Account-wide stale/missing shared key. Only FLAG the cycle
+                        # here -- the account-wide failure counter is advanced exactly
+                        # once per cycle after the device loop (see below). Counting
+                        # per device would let a multi-device account cross
+                        # _MAX_DECRYPT_FAILURES within a single cycle and escalate on
+                        # the first poll, defeating the documented "consecutive
+                        # cycles" budget that gives the in-decrypt self-heal a few
+                        # cycles to recover an owner-key bump.
                         self._consecutive_timeouts = 0
-                        if self.note_decrypt_failure(
-                            stale=False, error=dec_err, device=dev_name
-                        ):
-                            cycle_failed = True
-                            self._last_poll_result = "failed"
-                            reauth_exc = ConfigEntryAuthFailed(
-                                "Location decryption keeps failing: the shared key "
-                                "is stale; a fresh secrets.json (re-authentication) "
-                                "is required"
-                            )
-                            last_exception = reauth_exc
-                            raise reauth_exc from dec_err
                         cycle_failed = True
+                        if cycle_decrypt_error is None:
+                            cycle_decrypt_error = dec_err
                         if last_exception is None:
                             last_exception = dec_err
                         continue
@@ -1729,15 +1726,33 @@ class PollingOperations(_MixinBase):
                         await asyncio.sleep(self.device_poll_delay)
 
                 _LOGGER.debug("Completed polling cycle for %d devices", len(devices))
-                # Whole cycle was decrypt-clean: clear the consecutive-decrypt
-                # counter so a recovered/healthy shared key (or a successful
-                # self-heal) does not later trip a spurious reauth. Gated on the
-                # entire cycle -- one healthy tracker must not mask a persistently
-                # stale account-wide shared key on the others.
-                if (
-                    not cycle_had_decrypt_failure
-                    and self._consecutive_decrypt_failures > 0
-                ):
+                if cycle_decrypt_error is not None:
+                    # Account-wide decrypt failure persisted this cycle: advance the
+                    # consecutive-cycle counter exactly ONCE (not once per device)
+                    # and escalate to a reauth flow when it crosses the threshold
+                    # (with cooldown). Counting once per cycle keeps a multi-device
+                    # account on the same "N consecutive cycles" budget as a
+                    # single-device account. Raised here (still inside the outer
+                    # try, before its finally) so it propagates exactly like the
+                    # former in-loop raise.
+                    if self.note_decrypt_failure(
+                        stale=False, error=cycle_decrypt_error, device=None
+                    ):
+                        cycle_failed = True
+                        self._last_poll_result = "failed"
+                        reauth_exc = ConfigEntryAuthFailed(
+                            "Location decryption keeps failing: the shared key "
+                            "is stale; a fresh secrets.json (re-authentication) "
+                            "is required"
+                        )
+                        last_exception = reauth_exc
+                        raise reauth_exc from cycle_decrypt_error
+                elif self._consecutive_decrypt_failures > 0:
+                    # Whole cycle was decrypt-clean: clear the consecutive-decrypt
+                    # counter so a recovered/healthy shared key (or a successful
+                    # self-heal) does not later trip a spurious reauth. Gated on the
+                    # entire cycle -- one healthy tracker must not mask a
+                    # persistently stale account-wide shared key on the others.
                     _LOGGER.info(
                         "Location decryption succeeded for all devices; clearing "
                         "%d decrypt failure(s).",

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1229,6 +1229,38 @@ class PollingOperations(_MixinBase):
             _LOGGER.exception("Unexpected error during coordinator update")
             raise UpdateFailed(f"{type(err).__name__}: {err}") from err
 
+    def _request_poll_reauth(self, reauth_exc: ConfigEntryAuthFailed) -> None:
+        """Start the config-entry reauth flow from the background poll cycle.
+
+        ``_async_start_poll_cycle`` runs via ``hass.async_create_task`` (fire and
+        forget), so a raised ``ConfigEntryAuthFailed`` never reaches the awaited
+        coordinator refresh and Home Assistant's automatic reauth
+        (``_async_refresh`` -> ``ConfigEntry.async_start_reauth``) is never
+        triggered. Start the entry-scoped reauth flow directly instead, mirroring
+        the manual-locate (``locate.py``) and FCM-receiver paths. The caller still
+        records ``reauth_exc`` as ``last_exception`` so the ``finally`` block marks
+        the update failed via ``async_set_update_error``.
+        """
+        entry = getattr(self, "config_entry", None)
+        if entry is None:
+            _LOGGER.debug(
+                "Cannot start reauth from poll cycle: no config entry bound."
+            )
+            return
+        try:
+            # ``ConfigEntry.async_start_reauth`` is a synchronous @callback that
+            # returns None and schedules the flow itself; awaiting it would raise
+            # TypeError. Call it without await (mirrors locate.py and
+            # fcm_receiver_ha.py).
+            entry.async_start_reauth(self.hass)
+            _LOGGER.warning(
+                "Poll cycle triggered re-authentication: %s", reauth_exc
+            )
+        except Exception as reauth_err:  # pragma: no cover - defensive
+            _LOGGER.debug(
+                "Failed to start reauth flow from poll cycle: %s", reauth_err
+            )
+
     # ---------------------------- Polling Cycle -----------------------------
     async def _async_start_poll_cycle(
         self,
@@ -1574,7 +1606,7 @@ class PollingOperations(_MixinBase):
                                     f"Location request timed out for {dev_name}"
                                 )
                                 last_exception.__cause__ = terr
-                    except SpotAuthPermanentError as auth_err:
+                    except SpotAuthPermanentError:
                         _LOGGER.warning(
                             "Authentication failed for %s; triggering reauth flow.",
                             dev_name,
@@ -1590,7 +1622,8 @@ class PollingOperations(_MixinBase):
                             "Google session invalid; re-authentication required"
                         )
                         last_exception = reauth_exc
-                        raise reauth_exc from auth_err
+                        self._request_poll_reauth(reauth_exc)
+                        return
                     except SpotApiEmptyResponseError:
                         _LOGGER.warning(
                             "Authentication failed for %s; triggering reauth flow.",
@@ -1607,7 +1640,8 @@ class PollingOperations(_MixinBase):
                             "Google session invalid; re-authentication required"
                         )
                         last_exception = reauth_exc
-                        raise reauth_exc
+                        self._request_poll_reauth(reauth_exc)
+                        return
                     except NovaAuthPermanentError as perm_err:
                         # Permanent auth failure (AAS token invalid) - immediate reauth
                         _LOGGER.error(
@@ -1627,7 +1661,8 @@ class PollingOperations(_MixinBase):
                             "Google credentials invalid; re-authentication required"
                         )
                         last_exception = reauth_exc
-                        raise reauth_exc from perm_err
+                        self._request_poll_reauth(reauth_exc)
+                        return
                     except NovaAuthError as transient_err:
                         # Transient auth failure - may self-heal in subsequent poll cycles.
                         # Only trigger reauth after multiple consecutive failures.
@@ -1656,7 +1691,8 @@ class PollingOperations(_MixinBase):
                                 f"Authentication failed after {self._consecutive_transient_auth_failures} attempts; re-authentication required"
                             )
                             last_exception = reauth_exc
-                            raise reauth_exc from transient_err
+                            self._request_poll_reauth(reauth_exc)
+                            return
 
                         # Not yet at threshold - log warning and continue to next device
                         _LOGGER.warning(
@@ -1672,7 +1708,14 @@ class PollingOperations(_MixinBase):
                             last_exception = transient_err
                         continue  # Try next device instead of aborting entire cycle
                     except ConfigEntryAuthFailed as auth_exc:
-                        # Mark auth failures to HA; abort remaining devices by re-raising.
+                        # A pre-converted ConfigEntryAuthFailed (e.g. raised directly
+                        # by api.async_get_device_location on HTTP 401/403 or a
+                        # permanent Nova auth failure) reaches here without going
+                        # through the typed SpotAuth/NovaAuth handlers above. Mark
+                        # auth failed and abort remaining devices. Start reauth
+                        # directly instead of re-raising: this poll cycle runs as a
+                        # fire-and-forget task, so a re-raise would never reach the
+                        # awaited coordinator refresh and HA's reauth would not fire.
                         self._set_auth_state(
                             failed=True,
                             reason=f"Auth failed during poll for {dev_name}: {auth_exc}",
@@ -1681,7 +1724,8 @@ class PollingOperations(_MixinBase):
                         self._last_poll_result = "failed"
                         self._consecutive_timeouts = 0
                         last_exception = auth_exc
-                        raise
+                        self._request_poll_reauth(auth_exc)
+                        return
                     except StaleOwnerKeyError as stale_err:
                         # Per-tracker owner-key version mismatch (D2): an account-wide
                         # reauth would not help -- only this tracker is outdated. Log
@@ -1746,7 +1790,8 @@ class PollingOperations(_MixinBase):
                             "is required"
                         )
                         last_exception = reauth_exc
-                        raise reauth_exc from cycle_decrypt_error
+                        self._request_poll_reauth(reauth_exc)
+                        return
                 elif self._consecutive_decrypt_failures > 0:
                     # Whole cycle was decrypt-clean: clear the consecutive-decrypt
                     # counter so a recovered/healthy shared key (or a successful

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -330,15 +330,18 @@ class PollingOperations(_MixinBase):
             )
             return False
 
-        now = time.monotonic()
-        if (now - self._last_decrypt_reauth_monotonic) < _DECRYPT_REAUTH_COOLDOWN_S:
-            # Threshold reached but a recent escalation is still cooling down: keep
-            # logging but do not re-fire the reauth flow on every poll cycle.
+        now = self._monotonic()
+        last = self._last_decrypt_reauth_monotonic
+        if last is not None and (now - last) < _DECRYPT_REAUTH_COOLDOWN_S:
+            # A previous escalation exists and is still cooling down: keep logging
+            # but do not re-fire the reauth flow on every poll cycle. The first
+            # escalation (last is None) never enters this branch, so it can never
+            # be suppressed by the host's process uptime.
             _LOGGER.debug(
                 "Decryption still failing for %s but reauth escalation is in "
                 "cooldown (%.0fs since last).",
                 device or "?",
-                now - self._last_decrypt_reauth_monotonic,
+                now - last,
             )
             return False
 

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -51,6 +51,10 @@ from ..const import (
     DOMAIN,
     POLL_DEVICE_OUTER_TIMEOUT_S,
 )
+from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    StaleOwnerKeyError,
+)
 from ..NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
 from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
     SpotApiEmptyResponseError,
@@ -127,6 +131,17 @@ _EMPTY_LIST_QUORUM = 2
 
 # Maximum number of transient auth failures before triggering re-auth
 _MAX_TRANSIENT_AUTH_FAILURES = 3
+
+# Maximum consecutive stale/missing shared-key decryption failures before
+# escalating to a reauth flow. Gives the in-decrypt self-heal (force_refresh /
+# blind refresh) a chance first; only a persistently un-decryptable shared key
+# escalates to ConfigEntryAuthFailed.
+_MAX_DECRYPT_FAILURES = 3
+
+# Cooldown between decrypt-triggered reauth escalations (seconds). Once the reauth
+# flow is open, the un-fixable condition persists every cycle; this prevents
+# re-firing the escalation on each poll until the user supplies a fresh bundle.
+_DECRYPT_REAUTH_COOLDOWN_S = 6 * 3600
 
 # FCM error retry threshold before triggering re-auth
 _FCM_ERROR_RETRY_THRESHOLD = 3
@@ -258,6 +273,91 @@ class PollingOperations(_MixinBase):
     def last_poll_result(self) -> str | None:
         """Return the last recorded poll result ("success"/"failed")."""
         return self._last_poll_result
+
+    def note_decrypt_failure(
+        self, *, stale: bool, error: Exception, device: str | None = None
+    ) -> bool:
+        """Record a location-decryption failure and decide whether to escalate.
+
+        Single entry point shared by the poll path and the FCM push path so a
+        push-only setup escalates identically (no second, divergent code path).
+
+        A stale/incompatible or missing shared key is an auth-fatal condition: the
+        bundle can no longer decrypt the server-side owner key, so every location
+        report fails. Home Assistant cannot refresh the shared key itself (it is
+        derived from the user's lock-screen knowledge factor via the interactive
+        browser flow), so the only correct automatic action is to open the reauth
+        flow and let the user supply a fresh secrets.json.
+
+        Args:
+            stale: True for a per-tracker ``StaleOwnerKeyError`` (owner-key version
+                mismatch). Such failures are NOT account-wide and must not drive
+                the account-wide reauth counter -- an account reauth would not fix a
+                single outdated tracker.
+            error: The decryption error, kept for diagnostics/logging.
+            device: Optional device name for log context.
+
+        Returns:
+            True if the caller should escalate to ``ConfigEntryAuthFailed`` now
+            (account-wide shared-key failure persisted past the threshold and the
+            cooldown allows a fresh escalation); False otherwise.
+        """
+        self._last_decrypt_error = f"{type(error).__name__}: {error}"
+
+        if stale:
+            # Per-tracker outdated owner key: log per occurrence, do not touch the
+            # account-wide counter, never escalate to reauth here. The full
+            # user-facing repair issue is added with the diagnostic sensor work.
+            _LOGGER.warning(
+                "Tracker %s is encrypted with an outdated owner key version (%s); "
+                "remove and re-pair this tracker. Other devices are unaffected.",
+                device or "?",
+                type(error).__name__,
+            )
+            return False
+
+        self._consecutive_decrypt_failures += 1
+        if self._consecutive_decrypt_failures < _MAX_DECRYPT_FAILURES:
+            # Below threshold: give the in-decrypt self-heal (force_refresh / blind
+            # refresh) another cycle before escalating to reauth.
+            _LOGGER.warning(
+                "Location decryption failed for %s (%d/%d): %s. Will retry on the "
+                "next cycle before any re-authentication.",
+                device or "?",
+                self._consecutive_decrypt_failures,
+                _MAX_DECRYPT_FAILURES,
+                error,
+            )
+            return False
+
+        now = time.monotonic()
+        if (now - self._last_decrypt_reauth_monotonic) < _DECRYPT_REAUTH_COOLDOWN_S:
+            # Threshold reached but a recent escalation is still cooling down: keep
+            # logging but do not re-fire the reauth flow on every poll cycle.
+            _LOGGER.debug(
+                "Decryption still failing for %s but reauth escalation is in "
+                "cooldown (%.0fs since last).",
+                device or "?",
+                now - self._last_decrypt_reauth_monotonic,
+            )
+            return False
+
+        self._last_decrypt_reauth_monotonic = now
+        self._consecutive_decrypt_failures = 0
+        self._set_auth_state(
+            failed=True,
+            reason=(
+                "Location decryption keeps failing; the shared key is stale and a "
+                "fresh secrets.json (re-authentication) is required"
+            ),
+        )
+        _LOGGER.error(
+            "Location decryption failed %d times in a row (%s); escalating to "
+            "re-authentication. A fresh secrets.json is required.",
+            _MAX_DECRYPT_FAILURES,
+            error,
+        )
+        return True
 
     def _is_on_hass_loop(self) -> bool:
         """Return True if currently executing on the HA event loop thread."""
@@ -1187,6 +1287,13 @@ class PollingOperations(_MixinBase):
             _any_device_got_data = False
             try:
                 cycle_failed = False
+                # Track whether any device hit an account-wide decryption failure
+                # this cycle. The consecutive-decrypt counter is reset only when the
+                # WHOLE cycle was decrypt-clean: in a multi-device account a single
+                # healthy tracker must not mask a persistently un-decryptable shared
+                # key on the others (the condition is account-wide, so the reset
+                # gate must be too).
+                cycle_had_decrypt_failure = False
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
                     dev_name = dev.get("name", dev_id)
@@ -1568,6 +1675,42 @@ class PollingOperations(_MixinBase):
                         self._consecutive_timeouts = 0
                         last_exception = auth_exc
                         raise
+                    except StaleOwnerKeyError as stale_err:
+                        # Per-tracker owner-key version mismatch (D2): an account-wide
+                        # reauth would not help -- only this tracker is outdated. Log
+                        # and keep polling other devices; do NOT touch the
+                        # account-wide decrypt counter (no reauth storm).
+                        self.note_decrypt_failure(
+                            stale=True, error=stale_err, device=dev_name
+                        )
+                        cycle_failed = True
+                        self._consecutive_timeouts = 0
+                        if last_exception is None:
+                            last_exception = stale_err
+                        continue
+                    except DecryptionError as dec_err:
+                        # Account-wide stale/missing shared key: escalate to reauth
+                        # after _MAX_DECRYPT_FAILURES consecutive cycles (with
+                        # cooldown). Below the threshold keep polling so the
+                        # in-decrypt self-heal can still recover an owner-key bump.
+                        cycle_had_decrypt_failure = True
+                        self._consecutive_timeouts = 0
+                        if self.note_decrypt_failure(
+                            stale=False, error=dec_err, device=dev_name
+                        ):
+                            cycle_failed = True
+                            self._last_poll_result = "failed"
+                            reauth_exc = ConfigEntryAuthFailed(
+                                "Location decryption keeps failing: the shared key "
+                                "is stale; a fresh secrets.json (re-authentication) "
+                                "is required"
+                            )
+                            last_exception = reauth_exc
+                            raise reauth_exc from dec_err
+                        cycle_failed = True
+                        if last_exception is None:
+                            last_exception = dec_err
+                        continue
                     except Exception as err:
                         _LOGGER.error(
                             "Failed to get location for %s: %s", dev_name, err
@@ -1583,6 +1726,22 @@ class PollingOperations(_MixinBase):
                         await asyncio.sleep(self.device_poll_delay)
 
                 _LOGGER.debug("Completed polling cycle for %d devices", len(devices))
+                # Whole cycle was decrypt-clean: clear the consecutive-decrypt
+                # counter so a recovered/healthy shared key (or a successful
+                # self-heal) does not later trip a spurious reauth. Gated on the
+                # entire cycle -- one healthy tracker must not mask a persistently
+                # stale account-wide shared key on the others.
+                if (
+                    not cycle_had_decrypt_failure
+                    and self._consecutive_decrypt_failures > 0
+                ):
+                    _LOGGER.info(
+                        "Location decryption succeeded for all devices; clearing "
+                        "%d decrypt failure(s).",
+                        self._consecutive_decrypt_failures,
+                    )
+                    self._consecutive_decrypt_failures = 0
+                    self._last_decrypt_error = None
             finally:
                 # Update scheduling baseline and clear flag, then push end snapshot.
                 # Always advance the poll baseline to prevent high-frequency

--- a/custom_components/googlefindmy/shared_helpers.py
+++ b/custom_components/googlefindmy/shared_helpers.py
@@ -110,6 +110,68 @@ def safe_fcm_health_snapshots(receiver: Any) -> dict[str, dict[str, Any]]:
         return {}
 
 
+# Credential keys whose values are base64 / base64url / hex / JWT tokens.
+# Those alphabets never contain a legitimate space, so ALL whitespace (including
+# interior characters introduced by a line-wrapped copy/paste) is stripped from
+# their values. Every other key keeps interior whitespace and is only trimmed at
+# the edges, so values that may legitimately contain spaces (display names,
+# email addresses) are never corrupted.
+_SECRET_WHITELIST_KEYS: frozenset[str] = frozenset(
+    {
+        "owner_key",
+        "shared_key",
+        "aas_token",
+        "oauth_token",
+        "oauthToken",
+        "OAuthToken",
+        "access_token",
+        "token",
+        "adm_token",
+        "admToken",
+        "Auth",
+    }
+)
+
+
+def _normalize_secret_value(key: str, value: str) -> str:
+    """Normalize one string value from a secrets bundle.
+
+    Whitelisted credential keys have *all* whitespace removed; any other key is
+    only stripped of leading/trailing whitespace. See ``_SECRET_WHITELIST_KEYS``
+    for the security rationale behind the asymmetry.
+    """
+    if key in _SECRET_WHITELIST_KEYS:
+        return "".join(value.split())
+    return value.strip()
+
+
+def normalize_secrets_bundle(data: Any) -> Any:
+    """Return a whitespace-normalized deep copy of a secrets.json bundle.
+
+    Copy/paste of ``secrets.json`` into the config flow can inject stray
+    whitespace into credential values (a single space in ``owner_key`` breaks
+    AES-GCM decryption). This walks the bundle recursively and normalizes every
+    string value via :func:`_normalize_secret_value`, descending into nested
+    dicts (e.g. ``fcm_credentials``) and lists.
+
+    The function is idempotent and never mutates its input, so it is safe to
+    apply to ``MappingProxyType``-wrapped structures. Non-string scalars are
+    returned unchanged.
+    """
+    if isinstance(data, Mapping):
+        return {
+            key: (
+                _normalize_secret_value(key, value)
+                if isinstance(value, str)
+                else normalize_secrets_bundle(value)
+            )
+            for key, value in data.items()
+        }
+    if isinstance(data, list):
+        return [normalize_secrets_bundle(item) for item in data]
+    return data
+
+
 def normalize_fcm_entry_snapshot(entry_id: str, snap: dict[str, Any]) -> dict[str, Any]:
     """Normalize a single FCM health snapshot entry.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,6 +142,62 @@ def disable_http_server() -> Iterable[None]:
         yield
 
 
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown() -> None:
+    """Heal the lazy ``GoogleFindMyCoordinator`` symbol after each test.
+
+    The integration package binds ``GoogleFindMyCoordinator`` lazily: it starts
+    as a placeholder class and ``_ensure_runtime_imports()`` swaps in the real
+    class while flipping ``_RUNTIME_IMPORTS_LOADED`` to ``True`` (a direct global
+    assignment, invisible to ``monkeypatch``). Several tests ``monkeypatch`` that
+    symbol while it is still the placeholder; if real runtime imports run during
+    the test, teardown restores the *placeholder* as the symbol's value while
+    ``_RUNTIME_IMPORTS_LOADED`` stays ``True``. The guard then never rebinds the
+    real class, so every later ``isinstance(obj, GoogleFindMyCoordinator)`` check
+    silently fails. Under xdist this leaks across tests in a worker and breaks
+    unrelated ones (observed: ``test_device_identifier_normalization`` skipping
+    its purge_device branch).
+
+    This runs as a ``trylast`` teardown hook (not a fixture) so it executes after
+    every fixture finalizer, in particular after ``monkeypatch`` has restored the
+    placeholder. It detects the inconsistent state (guard set, yet any lazily
+    bound symbol is still a placeholder) and clears the guard so the next
+    ``_ensure_runtime_imports()`` rebinds the real classes. All four lazily bound
+    classes are checked, not only the coordinator, because the same monkeypatch
+    trap applies symmetrically to ``DiscoveryManager`` and the two map views.
+    """
+
+    integration = sys.modules.get("custom_components.googlefindmy")
+    if integration is None:
+        return
+    if not getattr(integration, "_RUNTIME_IMPORTS_LOADED", False):
+        return
+
+    lazy_symbols = (
+        "GoogleFindMyCoordinator",
+        "DiscoveryManager",
+        "GoogleFindMyMapView",
+        "GoogleFindMyMapRedirectView",
+    )
+    any_placeholder = any(
+        "Placeholder" in getattr(getattr(integration, name, None), "__name__", "")
+        for name in lazy_symbols
+    )
+    if not any_placeholder:
+        return
+
+    # Open the guard so the real classes get rebound. If rebinding fails (e.g. a
+    # test left an incomplete submodule stub in sys.modules), the state stays
+    # {loaded=False, placeholder}, which is consistent and self-heals on the next
+    # _ensure_runtime_imports() call; swallowing avoids reddening an unrelated
+    # test's teardown over that benign, recoverable condition.
+    integration._RUNTIME_IMPORTS_LOADED = False
+    try:
+        integration._ensure_runtime_imports()
+    except Exception:  # noqa: BLE001 - see comment above; left state is consistent
+        integration._RUNTIME_IMPORTS_LOADED = False
+
+
 _CONST_MODULE = load_googlefindmy_const_module()
 _SERVICE_DEVICE_NAME: str = getattr(
     _CONST_MODULE, "SERVICE_DEVICE_NAME", "Google Find My Integration"

--- a/tests/helpers/homeassistant.py
+++ b/tests/helpers/homeassistant.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import FrozenInstanceError, dataclass, field
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
@@ -166,6 +167,7 @@ class GoogleFindMyConfigEntryStub:
         "source",
         "version",
         "minor_version",
+        "async_start_reauth",
         "_unload_callbacks",
     )
 
@@ -205,6 +207,10 @@ class GoogleFindMyConfigEntryStub:
         self.source = source
         self.version = 1
         self.minor_version = 1
+        # Mirror the real ``ConfigEntry.async_start_reauth`` (synchronous @callback
+        # returning None). A Mock lets poll-cycle tests assert the reauth flow was
+        # started; tests may also re-assign their own Mock to this slot.
+        self.async_start_reauth = Mock()
         self._unload_callbacks: list[Callable[[], None]] = []
 
     def async_on_unload(self, callback: Callable[[], None]) -> None:

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -40,6 +40,11 @@ from custom_components.googlefindmy.const import (
     DEFAULT_CONTRIBUTOR_MODE,
 )
 from custom_components.googlefindmy.exceptions import MissingTokenCacheError
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    StaleOwnerKeyError,
+)
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
     NovaError,
@@ -1110,6 +1115,26 @@ class TestAsyncDeviceLocationErrorMapping:
         self._patch_request(monkeypatch, RuntimeError("other"))
         api = _make_api_with_session()
         assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            SharedKeyMismatchError("stale shared key"),
+            StaleOwnerKeyError("tracker key outdated"),
+            DecryptionError("generic decrypt failure"),
+        ],
+    )
+    def test_decryption_error_is_reraised_not_swallowed(
+        self, monkeypatch: pytest.MonkeyPatch, exc: DecryptionError
+    ) -> None:
+        """Audit finding A1: ``DecryptionError`` is a ``RuntimeError`` subclass, so the
+        broad ``except RuntimeError`` / ``except Exception`` handlers would otherwise
+        swallow an auth-fatal stale-shared-key failure into an empty dict. It must
+        propagate instead so the coordinator can escalate to a reauth flow."""
+        self._patch_request(monkeypatch, exc)
+        api = _make_api_with_session()
+        with pytest.raises(DecryptionError):
+            run_coro(api.async_get_device_location("d", "name"))
 
     def test_unexpected_exception_returns_empty_dict(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_config_flow_secrets_normalization.py
+++ b/tests/test_config_flow_secrets_normalization.py
@@ -1,0 +1,213 @@
+"""Tests for whitespace normalization of pasted secrets.json bundles.
+
+Copy/paste of a ``secrets.json`` into the config flow can inject stray
+whitespace into credential values. A single space inside ``owner_key`` breaks
+AES-GCM owner-key decryption ("Owner key decryption failed"), and the user had
+to delete that space manually. ``normalize_secrets_bundle`` removes whitespace
+from credential values while preserving interior spaces in free-text fields.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any
+
+import pytest
+from homeassistant.helpers import frame
+
+from custom_components.googlefindmy import config_flow
+from custom_components.googlefindmy.const import (
+    CONF_GOOGLE_EMAIL,
+    CONF_OAUTH_TOKEN,
+    DATA_SECRET_BUNDLE,
+)
+from custom_components.googlefindmy.shared_helpers import normalize_secrets_bundle
+from tests.helpers.config_flow import (
+    ConfigEntriesDomainUniqueIdLookupMixin,
+    attach_config_entries_flow_manager,
+    prepare_flow_hass_config_entries,
+    set_config_flow_unique_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("AABBCC", "AABBCC"),  # already clean -> unchanged
+        (" AABBCC", "AABBCC"),  # leading space
+        ("AABBCC ", "AABBCC"),  # trailing space
+        ("AA BB CC", "AABBCC"),  # interior spaces (wrapped paste)
+        ("AA\nBB\tCC", "AABBCC"),  # interior newline/tab
+        ("  AA BB  ", "AABB"),  # combined leading/trailing/interior
+    ],
+)
+def test_credential_value_all_whitespace_removed(raw: str, expected: str) -> None:
+    """Whitelisted credential keys lose ALL whitespace, including interior."""
+    assert normalize_secrets_bundle({"owner_key": raw})["owner_key"] == expected
+    assert normalize_secrets_bundle({"shared_key": raw})["shared_key"] == expected
+
+
+def test_non_credential_value_only_edge_trimmed() -> None:
+    """Free-text fields keep interior spaces and are only edge-trimmed."""
+    result = normalize_secrets_bundle(
+        {"username": "  Jane Doe  ", "Email": " a b@x.io "}
+    )
+    assert result["username"] == "Jane Doe"
+    assert result["Email"] == "a b@x.io"
+
+
+def test_nested_fcm_token_normalized() -> None:
+    """Whitelisted keys nested under fcm_credentials are normalized too."""
+    bundle = {
+        "fcm_credentials": {
+            "installation": {"token": " inst alled "},
+            "fcm": {"registration": {"token": "reg\nistration"}},
+        }
+    }
+    result = normalize_secrets_bundle(bundle)
+    assert result["fcm_credentials"]["installation"]["token"] == "installed"
+    assert result["fcm_credentials"]["fcm"]["registration"]["token"] == "registration"
+
+
+def test_idempotent() -> None:
+    """Applying the normalization twice yields the same result."""
+    bundle = {
+        "owner_key": " AA BB ",
+        "username": "  Jane Doe  ",
+        "fcm_credentials": {"installation": {"token": " t ok "}},
+    }
+    once = normalize_secrets_bundle(bundle)
+    assert normalize_secrets_bundle(once) == once
+
+
+def test_input_not_mutated() -> None:
+    """The input mapping is never mutated (safe for MappingProxyType)."""
+    bundle = {"owner_key": " AA BB ", "nested": {"aas_token": " x y "}}
+    normalize_secrets_bundle(bundle)
+    assert bundle["owner_key"] == " AA BB "
+    assert bundle["nested"]["aas_token"] == " x y "
+
+
+def test_list_values_recursed() -> None:
+    """Lists are walked element-wise, dicts inside them are normalized."""
+    bundle = {"items": [{"token": " a b "}, {"username": "  keep me  "}]}
+    result = normalize_secrets_bundle(bundle)
+    assert result["items"][0]["token"] == "ab"
+    assert result["items"][1]["username"] == "keep me"
+
+
+def test_non_string_scalars_unchanged() -> None:
+    """Non-string scalar values pass through unchanged."""
+    bundle = {"count": 3, "enabled": True, "missing": None, "owner_key": " A B "}
+    result = normalize_secrets_bundle(bundle)
+    assert result["count"] == 3
+    assert result["enabled"] is True
+    assert result["missing"] is None
+    assert result["owner_key"] == "AB"
+
+
+def test_non_mapping_input_returned_unchanged() -> None:
+    """A non-mapping top-level value is returned unchanged."""
+    assert normalize_secrets_bundle("plain") == "plain"
+    assert normalize_secrets_bundle(None) is None
+
+
+@pytest.mark.asyncio
+async def test_config_flow_round_trip_strips_owner_key_space(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a pasted owner_key with a stray space is persisted clean.
+
+    This is the regression guard for the reported bug: the user pasted a valid
+    secrets.json but a copy/paste space inside owner_key broke decryption. The
+    persisted secrets bundle must contain the whitespace-free owner_key.
+    """
+    secrets_payload = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+        "owner_key": "AA BB\nCC ",
+        "shared_key": " DD EE ",
+        "username": "  Keep Me  ",
+    }
+
+    async def _fake_pick(
+        hass: Any,
+        email: str,
+        candidates: list[tuple[str, str]],
+        *,
+        secrets_bundle: dict[str, Any] | None = None,
+    ) -> str | None:
+        # The bundle handed downstream is already normalized.
+        assert secrets_bundle is not None
+        assert secrets_bundle["owner_key"] == "AABBCC"
+        return candidates[0][1]
+
+    monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+    class _ConfigEntries(ConfigEntriesDomainUniqueIdLookupMixin):
+        def __init__(self) -> None:
+            attach_config_entries_flow_manager(self)
+
+        def async_entries(self, domain: str) -> list[Any]:
+            assert domain == config_flow.DOMAIN
+            return []
+
+    class _FlowHass:
+        def __init__(self) -> None:
+            prepare_flow_hass_config_entries(
+                self,
+                _ConfigEntries,
+                frame_module=frame,
+            )
+
+    captured: dict[str, Any] = {}
+
+    async def _create_entry(
+        *,
+        title: str,
+        data: dict[str, Any],
+        options: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        captured["result"] = {"title": title, "data": data, "options": options}
+        return {"type": "create_entry", "title": title, "data": data}
+
+    hass = _FlowHass()
+    flow = config_flow.ConfigFlow()
+    flow.hass = hass  # type: ignore[assignment]
+    flow.context = {}
+    flow._available_devices = [("Device", "device-id")]  # type: ignore[attr-defined]
+    set_config_flow_unique_id(flow, None)
+
+    async def _set_unique_id(value: str, *, raise_on_progress: bool = False) -> None:
+        set_config_flow_unique_id(flow, value)
+
+    flow.async_set_unique_id = _set_unique_id  # type: ignore[assignment]
+    flow._abort_if_unique_id_configured = lambda **_: None  # type: ignore[attr-defined]
+    flow.async_create_entry = _create_entry  # type: ignore[assignment]
+
+    first = await flow.async_step_secrets_json(
+        {"secrets_json": json.dumps(secrets_payload)}
+    )
+    if inspect.isawaitable(first):
+        first = await first
+    assert isinstance(first, dict)
+    assert first.get("type") == "form"
+
+    final = await flow.async_step_device_selection({})
+    if inspect.isawaitable(final):
+        final = await final
+    assert isinstance(final, dict)
+    assert final.get("type") == "create_entry"
+
+    payload = captured.get("result")
+    assert payload, "Expected config entry payload to be captured"
+    data = payload["data"]
+    bundle = data[DATA_SECRET_BUNDLE]
+    assert bundle["owner_key"] == "AABBCC"
+    assert bundle["shared_key"] == "DDEE"
+    # Free-text field keeps interior spaces, only edge-trimmed.
+    assert bundle["username"] == "Keep Me"
+    # Token persisted from the (clean) aas_token.
+    assert data[CONF_OAUTH_TOKEN] == "aas_et/FROM_SECRETS"
+    assert data[CONF_GOOGLE_EMAIL] == "user@example.com"

--- a/tests/test_config_flow_secrets_normalization.py
+++ b/tests/test_config_flow_secrets_normalization.py
@@ -1,3 +1,4 @@
+# tests/test_config_flow_secrets_normalization.py
 """Tests for whitespace normalization of pasted secrets.json bundles.
 
 Copy/paste of a ``secrets.json`` into the config flow can inject stray

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -1,3 +1,4 @@
+# tests/test_coordinator_decrypt_reauth_escalation.py
 """Decrypt-failure escalation in the polling coordinator.
 
 These tests prove the bug fix for the "stale shared key" condition: repeated

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -1,0 +1,135 @@
+"""Decrypt-failure escalation in the polling coordinator.
+
+These tests prove the bug fix for the "stale shared key" condition: repeated
+location-decryption failures must escalate to a Home Assistant reauth flow
+(``ConfigEntryAuthFailed``) after ``_MAX_DECRYPT_FAILURES`` consecutive cycles,
+while a single transient failure or a successful self-heal must NOT trigger it.
+
+The escalation decision lives in ``PollingOperations.note_decrypt_failure`` (a
+synchronous, side-effect-light method), so it is exercised directly via the
+``PollingStub`` mixin harness. Cross-mixin ``_set_auth_state`` is mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import polling as polling_mod
+from custom_components.googlefindmy.coordinator.polling import (
+    _MAX_DECRYPT_FAILURES,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    SharedKeyMissingError,
+    StaleOwnerKeyError,
+)
+
+from .helpers.polling_mixin_stub import PollingStub
+
+
+def _make_stub() -> PollingStub:
+    """Return a PollingStub seeded with the decrypt-escalation state fields."""
+    stub = PollingStub()
+    stub._consecutive_decrypt_failures = 0
+    stub._last_decrypt_reauth_monotonic = 0.0
+    stub._last_decrypt_error = None
+    stub._set_auth_state = MagicMock()
+    return stub
+
+
+def test_t4_escalates_after_threshold_consecutive_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T4: the Nth consecutive account-wide decrypt failure escalates to reauth.
+
+    Failures 1..N-1 only warn and return False (keep polling, let self-heal try);
+    failure N returns True and marks the auth state as failed so the caller raises
+    ConfigEntryAuthFailed.
+    """
+    # Freeze monotonic clock far past any cooldown so the threshold is the only gate.
+    monkeypatch.setattr(polling_mod.time, "monotonic", lambda: 1_000_000.0)
+    stub = _make_stub()
+    err = SharedKeyMismatchError("stale shared key")
+
+    # Below threshold: no escalation, no auth-state change.
+    for attempt in range(1, _MAX_DECRYPT_FAILURES):
+        assert stub.note_decrypt_failure(stale=False, error=err, device="dev") is False
+        assert stub._consecutive_decrypt_failures == attempt
+    stub._set_auth_state.assert_not_called()
+
+    # Threshold reached: escalate.
+    assert stub.note_decrypt_failure(stale=False, error=err, device="dev") is True
+    stub._set_auth_state.assert_called_once()
+    assert stub._set_auth_state.call_args.kwargs.get("failed") is True
+    # Counter resets after escalation so it does not grow unbounded.
+    assert stub._consecutive_decrypt_failures == 0
+
+
+def test_t5_success_reset_prevents_premature_escalation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T5: a reset (successful cycle) clears the counter, so later failures must
+    again reach the full threshold before escalating."""
+    monkeypatch.setattr(polling_mod.time, "monotonic", lambda: 1_000_000.0)
+    stub = _make_stub()
+    err = DecryptionError("boom")
+
+    # Two failures, then a reset (what the success path does).
+    stub.note_decrypt_failure(stale=False, error=err)
+    stub.note_decrypt_failure(stale=False, error=err)
+    assert stub._consecutive_decrypt_failures == 2
+    stub._consecutive_decrypt_failures = 0  # success path reset
+    stub._last_decrypt_error = None
+
+    # Two fresh failures must NOT escalate (threshold is 3, not 1).
+    assert stub.note_decrypt_failure(stale=False, error=err) is False
+    assert stub.note_decrypt_failure(stale=False, error=err) is False
+    stub._set_auth_state.assert_not_called()
+
+
+def test_t6_stale_owner_key_does_not_escalate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T6: a per-tracker StaleOwnerKeyError never drives the account-wide counter
+    and never escalates to an account reauth (it needs a per-tracker re-pair)."""
+    monkeypatch.setattr(polling_mod.time, "monotonic", lambda: 1_000_000.0)
+    stub = _make_stub()
+    stale = StaleOwnerKeyError("tracker v1 < v2")
+
+    for _ in range(_MAX_DECRYPT_FAILURES + 2):
+        assert stub.note_decrypt_failure(stale=True, error=stale, device="tag") is False
+
+    assert stub._consecutive_decrypt_failures == 0
+    stub._set_auth_state.assert_not_called()
+
+
+def test_t8_cooldown_suppresses_refire(monkeypatch: pytest.MonkeyPatch) -> None:
+    """T8: once escalated, the reauth flow is not re-fired on every poll while the
+    cooldown window is open (the un-fixable condition persists each cycle)."""
+    clock = {"now": 1_000_000.0}
+    monkeypatch.setattr(polling_mod.time, "monotonic", lambda: clock["now"])
+    stub = _make_stub()
+    err = SharedKeyMissingError("missing")
+
+    # Reach the threshold -> first escalation.
+    for _ in range(_MAX_DECRYPT_FAILURES):
+        result = stub.note_decrypt_failure(stale=False, error=err)
+    assert result is True
+    assert stub._set_auth_state.call_count == 1
+
+    # Immediately hit the threshold again within the cooldown window: no re-fire.
+    for _ in range(_MAX_DECRYPT_FAILURES):
+        result = stub.note_decrypt_failure(stale=False, error=err)
+    assert result is False
+    assert stub._set_auth_state.call_count == 1  # unchanged
+
+    # The counter keeps growing while suppressed (it is not reset in the cooldown
+    # branch), so once the cooldown window elapses the very next failure -- already
+    # past the threshold -- escalates again. This yields "at most one escalation
+    # per cooldown window".
+    clock["now"] += polling_mod._DECRYPT_REAUTH_COOLDOWN_S + 1.0
+    assert stub.note_decrypt_failure(stale=False, error=err) is True
+    assert stub._set_auth_state.call_count == 2

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -8,13 +8,17 @@ while a single transient failure or a successful self-heal must NOT trigger it.
 The escalation decision lives in ``PollingOperations.note_decrypt_failure`` (a
 synchronous, side-effect-light method), so it is exercised directly via the
 ``PollingStub`` mixin harness. Cross-mixin ``_set_auth_state`` is mocked.
+
+The cooldown gate reads the clock through the injectable ``_monotonic`` seam
+instead of the ambient ``time.monotonic``; tests drive it deterministically so
+the outcome never depends on the host's process uptime (the bug that slipped
+through CI: a 0.0 sentinel made the first escalation uptime-dependent).
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import MagicMock
-
-import pytest
 
 from custom_components.googlefindmy.coordinator import polling as polling_mod
 from custom_components.googlefindmy.coordinator.polling import (
@@ -30,27 +34,32 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_
 from .helpers.polling_mixin_stub import PollingStub
 
 
-def _make_stub() -> PollingStub:
-    """Return a PollingStub seeded with the decrypt-escalation state fields."""
+def _make_stub(monotonic: Callable[[], float] | None = None) -> PollingStub:
+    """Return a PollingStub seeded with the decrypt-escalation state fields.
+
+    Args:
+        monotonic: Optional clock callable for the cooldown gate. Defaults to a
+            fixed value far past any cooldown so the threshold is the only gate;
+            pass a mutable clock to exercise the cooldown window itself.
+    """
     stub = PollingStub()
     stub._consecutive_decrypt_failures = 0
-    stub._last_decrypt_reauth_monotonic = 0.0
+    # None == "never escalated yet"; the first escalation must never consult the
+    # cooldown gate (and therefore never depend on the clock value).
+    stub._last_decrypt_reauth_monotonic = None
     stub._last_decrypt_error = None
+    stub._monotonic = monotonic if monotonic is not None else (lambda: 1_000_000.0)
     stub._set_auth_state = MagicMock()
     return stub
 
 
-def test_t4_escalates_after_threshold_consecutive_failures(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_t4_escalates_after_threshold_consecutive_failures() -> None:
     """T4: the Nth consecutive account-wide decrypt failure escalates to reauth.
 
     Failures 1..N-1 only warn and return False (keep polling, let self-heal try);
     failure N returns True and marks the auth state as failed so the caller raises
     ConfigEntryAuthFailed.
     """
-    # Freeze monotonic clock far past any cooldown so the threshold is the only gate.
-    monkeypatch.setattr(polling_mod.time, "monotonic", lambda: 1_000_000.0)
     stub = _make_stub()
     err = SharedKeyMismatchError("stale shared key")
 
@@ -68,12 +77,9 @@ def test_t4_escalates_after_threshold_consecutive_failures(
     assert stub._consecutive_decrypt_failures == 0
 
 
-def test_t5_success_reset_prevents_premature_escalation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_t5_success_reset_prevents_premature_escalation() -> None:
     """T5: a reset (successful cycle) clears the counter, so later failures must
     again reach the full threshold before escalating."""
-    monkeypatch.setattr(polling_mod.time, "monotonic", lambda: 1_000_000.0)
     stub = _make_stub()
     err = DecryptionError("boom")
 
@@ -90,12 +96,9 @@ def test_t5_success_reset_prevents_premature_escalation(
     stub._set_auth_state.assert_not_called()
 
 
-def test_t6_stale_owner_key_does_not_escalate(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_t6_stale_owner_key_does_not_escalate() -> None:
     """T6: a per-tracker StaleOwnerKeyError never drives the account-wide counter
     and never escalates to an account reauth (it needs a per-tracker re-pair)."""
-    monkeypatch.setattr(polling_mod.time, "monotonic", lambda: 1_000_000.0)
     stub = _make_stub()
     stale = StaleOwnerKeyError("tracker v1 < v2")
 
@@ -106,12 +109,11 @@ def test_t6_stale_owner_key_does_not_escalate(
     stub._set_auth_state.assert_not_called()
 
 
-def test_t8_cooldown_suppresses_refire(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_t8_cooldown_suppresses_refire() -> None:
     """T8: once escalated, the reauth flow is not re-fired on every poll while the
     cooldown window is open (the un-fixable condition persists each cycle)."""
     clock = {"now": 1_000_000.0}
-    monkeypatch.setattr(polling_mod.time, "monotonic", lambda: clock["now"])
-    stub = _make_stub()
+    stub = _make_stub(lambda: clock["now"])
     err = SharedKeyMissingError("missing")
 
     # Reach the threshold -> first escalation.
@@ -133,3 +135,30 @@ def test_t8_cooldown_suppresses_refire(monkeypatch: pytest.MonkeyPatch) -> None:
     clock["now"] += polling_mod._DECRYPT_REAUTH_COOLDOWN_S + 1.0
     assert stub.note_decrypt_failure(stale=False, error=err) is True
     assert stub._set_auth_state.call_count == 2
+
+
+def test_t9_first_escalation_is_independent_of_process_uptime() -> None:
+    """T9 (regression): the first escalation must fire on a freshly booted host.
+
+    Reproduces the CI flake/production bug: with a 0.0 sentinel the cooldown gate
+    computed ``monotonic() - 0.0 < cooldown`` and, while process uptime was below
+    the cooldown window, wrongly suppressed the very first reauth escalation. With
+    the None sentinel the first escalation skips the cooldown gate entirely, so a
+    low monotonic value (simulated fresh boot) must still escalate.
+    """
+    # Monotonic far below the 6h cooldown window -> a fresh-boot runner.
+    fresh_boot_clock = 100.0
+    assert fresh_boot_clock < polling_mod._DECRYPT_REAUTH_COOLDOWN_S
+    stub = _make_stub(lambda: fresh_boot_clock)
+    err = SharedKeyMismatchError("stale shared key")
+
+    results = [
+        stub.note_decrypt_failure(stale=False, error=err, device="dev")
+        for _ in range(_MAX_DECRYPT_FAILURES)
+    ]
+
+    # Failures 1..N-1 hold, failure N escalates -- regardless of the low clock.
+    assert results == [False] * (_MAX_DECRYPT_FAILURES - 1) + [True]
+    stub._set_auth_state.assert_called_once()
+    # The escalation timestamp is now recorded (no longer the None sentinel).
+    assert stub._last_decrypt_reauth_monotonic == fresh_boot_clock

--- a/tests/test_coordinator_locate_basics.py
+++ b/tests/test_coordinator_locate_basics.py
@@ -14,10 +14,17 @@ from __future__ import annotations
 
 import asyncio
 import math
+from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.googlefindmy.const import DEFAULT_MIN_POLL_INTERVAL
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    StaleOwnerKeyError,
+)
 from tests.helpers.config_entries_stub import make_config_entry
 from tests.helpers.locate_mixin_stub import LocateStub
 
@@ -252,6 +259,77 @@ class TestAsyncLocateDeviceGating:
         }
         result = await coord.async_locate_device("dev-1")
         assert result == {}
+
+
+class TestAsyncLocateDeviceDecryptFailure:
+    """Codex P2: manual locate must handle stale/missing shared-key failures the
+    same way the poll path does (feed the shared escalation counter, start reauth),
+    not swallow ``DecryptionError`` into a generic ``HomeAssistantError``."""
+
+    @pytest.fixture(autouse=True)
+    def _pass_cooldown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Move the clock past every cooldown gate so the Nova call is reached."""
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+
+    async def test_stale_owner_key_records_per_tracker_no_reauth(
+        self, coord: LocateStub
+    ) -> None:
+        """A per-tracker StaleOwnerKeyError feeds note_decrypt_failure(stale=True),
+        never starts an account reauth, and returns an empty result."""
+        coord.note_decrypt_failure = MagicMock(return_value=False)
+        coord.config_entry.async_start_reauth = MagicMock()
+        coord.api.async_get_device_location.side_effect = StaleOwnerKeyError(
+            "tracker v1 < v2"
+        )
+
+        result = await coord.async_locate_device("dev-1")
+
+        assert result == {}
+        coord.note_decrypt_failure.assert_called_once()
+        assert coord.note_decrypt_failure.call_args.kwargs.get("stale") is True
+        coord.config_entry.async_start_reauth.assert_not_called()
+
+    async def test_decrypt_failure_below_threshold_returns_empty(
+        self, coord: LocateStub
+    ) -> None:
+        """Below the escalation threshold the manual locate degrades gracefully to
+        an empty result (mirrors the poll path that keeps polling), and must not
+        start a reauth flow."""
+        coord.note_decrypt_failure = MagicMock(return_value=False)
+        coord.config_entry.async_start_reauth = MagicMock()
+        coord.api.async_get_device_location.side_effect = SharedKeyMismatchError(
+            "stale shared key"
+        )
+
+        result = await coord.async_locate_device("dev-1")
+
+        assert result == {}
+        coord.note_decrypt_failure.assert_called_once()
+        assert coord.note_decrypt_failure.call_args.kwargs.get("stale") is False
+        coord.config_entry.async_start_reauth.assert_not_called()
+
+    async def test_decrypt_failure_at_threshold_starts_reauth(
+        self, coord: LocateStub
+    ) -> None:
+        """When the shared counter says escalate (note_decrypt_failure True), manual
+        locate marks the auth state failed, starts the reauth flow, and surfaces a
+        user-facing HomeAssistantError instead of an empty result."""
+        coord.note_decrypt_failure = MagicMock(return_value=True)
+        coord.config_entry.async_start_reauth = MagicMock()
+        coord.api.async_get_device_location.side_effect = DecryptionError(
+            "shared key gone"
+        )
+
+        with pytest.raises(HomeAssistantError) as excinfo:
+            await coord.async_locate_device("dev-1")
+
+        assert "re-authentication has been started" in str(excinfo.value)
+        coord._set_auth_state.assert_called_once()
+        assert coord._set_auth_state.call_args.kwargs.get("failed") is True
+        coord.config_entry.async_start_reauth.assert_called_once()
 
 
 class TestAsyncPlaySoundGating:

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -3,16 +3,24 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
 
 from custom_components.googlefindmy.const import OPT_SEMANTIC_LOCATIONS
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
-from custom_components.googlefindmy.coordinator.polling import _MAX_DECRYPT_FAILURES
+from custom_components.googlefindmy.coordinator.polling import (
+    _MAX_DECRYPT_FAILURES,
+    _MAX_TRANSIENT_AUTH_FAILURES,
+)
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     SharedKeyMismatchError,
     StaleOwnerKeyError,
+)
+from custom_components.googlefindmy.NovaApi.nova_request import (
+    NovaAuthError,
+    NovaAuthPermanentError,
 )
 from tests.helpers.homeassistant import GoogleFindMyConfigEntryStub
 
@@ -339,9 +347,13 @@ async def test_poll_cycle_escalates_persistent_decrypt_failure_to_reauth() -> No
     assert not any(kw.get("failed") for kw in auth_calls)
     assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
 
-    # Threshold cycle: escalate to a reauth flow.
-    with pytest.raises(ConfigEntryAuthFailed):
-        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    # Threshold cycle: escalate to a reauth flow. The poll cycle runs as a
+    # fire-and-forget task, so it starts the entry reauth flow directly rather
+    # than raising (a raised ConfigEntryAuthFailed would never reach the awaited
+    # coordinator refresh and HA's automatic reauth would never fire).
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
     assert any(kw.get("failed") for kw in auth_calls)
 
 
@@ -436,8 +448,9 @@ async def test_poll_cycle_partial_decrypt_failure_still_escalates() -> None:
     # The healthy device must NOT have reset the account-wide counter.
     assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
 
-    with pytest.raises(ConfigEntryAuthFailed):
-        await coordinator._async_start_poll_cycle(devices)
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    await coordinator._async_start_poll_cycle(devices)
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
     assert any(kw.get("failed") for kw in auth_calls)
 
 
@@ -475,6 +488,81 @@ async def test_poll_cycle_counts_multi_device_decrypt_failure_once() -> None:
     assert not any(kw.get("failed") for kw in auth_calls)
 
     # Third consecutive cycle reaches the threshold -> escalate exactly once.
-    with pytest.raises(ConfigEntryAuthFailed):
-        await coordinator._async_start_poll_cycle(devices)
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    await coordinator._async_start_poll_cycle(devices)
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
+    assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_nova_permanent_auth_starts_reauth() -> None:
+    """A permanent Nova auth failure in the background poll cycle starts the entry
+    reauth flow directly. The cycle runs as a fire-and-forget task
+    (``hass.async_create_task``), so a raised ConfigEntryAuthFailed would never reach
+    the awaited coordinator refresh and HA's automatic reauth would never fire."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(NovaAuthPermanentError(401, "perm"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
+    assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_transient_nova_auth_starts_reauth_after_threshold() -> None:
+    """A transient Nova auth failure escalates only after
+    _MAX_TRANSIENT_AUTH_FAILURES consecutive cycles, then starts the entry reauth
+    flow directly (the fire-and-forget poll task cannot raise into HA)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(NovaAuthError(401, "transient"))
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    # Below threshold: keep polling, no reauth escalation yet.
+    for _ in range(_MAX_TRANSIENT_AUTH_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    coordinator.config_entry.async_start_reauth.assert_not_called()
+
+    # Threshold cycle escalates exactly once.
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_reauth_noop_without_config_entry() -> None:
+    """Defensive guard: with no config entry bound the poll cycle cannot start
+    reauth, but it must not crash (``_request_poll_reauth`` no-entry branch)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator.config_entry = None
+
+    # Drive to the escalation threshold; the helper hits its no-entry guard.
+    for _ in range(_MAX_DECRYPT_FAILURES):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    # No crash, and the auth state was still flagged at the threshold cycle.
+    assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_direct_config_entry_auth_failed_starts_reauth() -> None:
+    """A ConfigEntryAuthFailed raised directly by the API (e.g. HTTP 401/403 in
+    async_get_device_location) reaches the poll loop's ConfigEntryAuthFailed handler
+    without passing through the typed SpotAuth/NovaAuth handlers. It must start the
+    entry reauth flow directly rather than re-raising into the fire-and-forget poll
+    task, where the exception would never reach HA."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(ConfigEntryAuthFailed("session expired"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
     assert any(kw.get("failed") for kw in auth_calls)

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -5,9 +5,15 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from homeassistant.config_entries import ConfigEntryAuthFailed
 
 from custom_components.googlefindmy.const import OPT_SEMANTIC_LOCATIONS
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+from custom_components.googlefindmy.coordinator.polling import _MAX_DECRYPT_FAILURES
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    SharedKeyMismatchError,
+    StaleOwnerKeyError,
+)
 from tests.helpers.homeassistant import GoogleFindMyConfigEntryStub
 
 
@@ -75,6 +81,9 @@ def _base_coordinator(
     coordinator._consecutive_timeouts = 0
     coordinator._consecutive_transient_auth_failures = 0
     coordinator._last_transient_auth_error = None
+    coordinator._consecutive_decrypt_failures = 0
+    coordinator._last_decrypt_reauth_monotonic = 0.0
+    coordinator._last_decrypt_error = None
     coordinator.location_poll_interval = 0
     coordinator.data = []
     coordinator._last_device_list = []
@@ -289,3 +298,139 @@ async def test_semantic_labels_are_recorded_with_device_ids() -> None:
     observations = coordinator.get_observed_semantic_labels()
     assert [obs.label for obs in observations] == ["Lobby"]
     assert observations[0].devices == {"dev-3"}
+
+
+class _DecryptFailAPI:
+    """API stub whose location lookup always raises the given decryption error.
+
+    Used to drive the coordinator poll loop through the decrypt-failure handlers
+    end to end (the isolated escalation logic is unit-tested separately in
+    tests/test_coordinator_decrypt_reauth_escalation.py).
+    """
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_escalates_persistent_decrypt_failure_to_reauth() -> None:
+    """End-to-end: a persistent account-wide stale shared key escalates the poll
+    loop to ConfigEntryAuthFailed after _MAX_DECRYPT_FAILURES cycles, so Home
+    Assistant shows the reauth card. The cycles before the threshold must NOT
+    escalate (self-heal still gets a chance)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+
+    # Below threshold: keep polling, no reauth escalation yet.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert not any(kw.get("failed") for kw in auth_calls)
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # Threshold cycle: escalate to a reauth flow.
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_stale_owner_key_never_escalates() -> None:
+    """End-to-end: a per-tracker StaleOwnerKeyError must never escalate to an
+    account-wide reauth (an account reauth would not fix one outdated tracker) and
+    must not drive the account-wide decrypt counter."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(StaleOwnerKeyError("tracker v1 < v2"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+
+    for _ in range(_MAX_DECRYPT_FAILURES + 2):
+        await coordinator._async_start_poll_cycle([{"id": "tag", "name": "Tag"}])
+
+    assert coordinator._consecutive_decrypt_failures == 0
+    assert not any(kw.get("failed") for kw in auth_calls)
+
+
+class _DecryptThenSucceedAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then succeeds.
+
+    Used to prove the consecutive-decrypt-failure counter resets on a successful
+    cycle (self-heal / recovered shared key), so a later isolated failure does not
+    trip a premature reauth.
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        return {}  # success with no decryptable report (still clears the counter)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_decrypt_counter_resets_on_success() -> None:
+    """A successful poll cycle clears the consecutive-decrypt-failure counter, so a
+    recovered shared key (or self-heal) does not later trip a spurious reauth."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenSucceedAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles raise no reauth and accumulate the counter.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # A successful cycle resets the counter back to zero.
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == 0
+
+
+class _PerDeviceDecryptAPI:
+    """Raises a decryption error for one device id, succeeds (empty) for others."""
+
+    def __init__(self, exc: Exception, failing_id: str) -> None:
+        self._exc = exc
+        self._failing = failing_id
+
+    async def async_get_device_location(
+        self, device_id: str, _device_name: str, *_args: Any, **_kwargs: Any
+    ) -> dict[str, Any]:
+        if device_id == self._failing:
+            raise self._exc
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_partial_decrypt_failure_still_escalates() -> None:
+    """Multi-device: one tracker decrypts fine while another keeps failing with a
+    stale account-wide shared key. A per-device reset would null the counter every
+    cycle (one healthy tracker masking the others) and never escalate; the
+    cycle-gated reset preserves the count so escalation still fires after the
+    threshold. Regression guard for the independent-review finding."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceDecryptAPI(
+        SharedKeyMismatchError("stale shared key"), failing_id="bad"
+    )
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    devices = [{"id": "good", "name": "Good"}, {"id": "bad", "name": "Bad"}]
+
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle(devices)
+    # The healthy device must NOT have reset the account-wide counter.
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_start_poll_cycle(devices)
+    assert any(kw.get("failed") for kw in auth_calls)

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -439,3 +439,42 @@ async def test_poll_cycle_partial_decrypt_failure_still_escalates() -> None:
     with pytest.raises(ConfigEntryAuthFailed):
         await coordinator._async_start_poll_cycle(devices)
     assert any(kw.get("failed") for kw in auth_calls)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_counts_multi_device_decrypt_failure_once() -> None:
+    """Codex P2 regression: one poll cycle in which several trackers all hit the
+    same account-wide stale shared key must advance the consecutive-failure counter
+    exactly ONCE, not once per device.
+
+    Counting per device let a multi-device account cross _MAX_DECRYPT_FAILURES
+    within the first cycle and escalate to reauth immediately, defeating the
+    documented "N consecutive cycles" budget that gives the in-decrypt self-heal a
+    few cycles before re-authentication."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    # More failing trackers in a single cycle than the escalation threshold: a
+    # per-device counter would already escalate here.
+    devices = [
+        {"id": "dev-1", "name": "One"},
+        {"id": "dev-2", "name": "Two"},
+        {"id": "dev-3", "name": "Three"},
+    ]
+    assert len(devices) >= _MAX_DECRYPT_FAILURES
+
+    # First cycle: counter advances by one, no escalation despite 3 failing devices.
+    await coordinator._async_start_poll_cycle(devices)
+    assert coordinator._consecutive_decrypt_failures == 1
+    assert not any(kw.get("failed") for kw in auth_calls)
+
+    # Second cycle: still below threshold (2/3).
+    await coordinator._async_start_poll_cycle(devices)
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+    assert not any(kw.get("failed") for kw in auth_calls)
+
+    # Third consecutive cycle reaches the threshold -> escalate exactly once.
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_start_poll_cycle(devices)
+    assert any(kw.get("failed") for kw in auth_calls)

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -82,8 +82,13 @@ def _base_coordinator(
     coordinator._consecutive_transient_auth_failures = 0
     coordinator._last_transient_auth_error = None
     coordinator._consecutive_decrypt_failures = 0
-    coordinator._last_decrypt_reauth_monotonic = 0.0
+    coordinator._last_decrypt_reauth_monotonic = None
     coordinator._last_decrypt_error = None
+    # Deliberately low monotonic value: simulates a freshly booted runner (process
+    # uptime below the reauth cooldown). With the None sentinel the first escalation
+    # must fire regardless, so this pins the whole loop-test class against the
+    # uptime-dependent flake that slipped through CI.
+    coordinator._monotonic = lambda: 100.0
     coordinator.location_poll_interval = 0
     coordinator.data = []
     coordinator._last_device_list = []

--- a/tests/test_coordinator_timeout.py
+++ b/tests/test_coordinator_timeout.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
@@ -147,7 +147,11 @@ def test_poll_auth_failure_raises_auth_failed(monkeypatch: pytest.MonkeyPatch) -
 
     coordinator = GoogleFindMyCoordinator(hass, cache=_DummyCache())
     coordinator.config_entry = SimpleNamespace(
-        entry_id="entry-id", options={}, data={}, title="Test Entry"
+        entry_id="entry-id",
+        options={},
+        data={},
+        title="Test Entry",
+        async_start_reauth=Mock(),
     )
     coordinator.api = _AuthFailureAPI()
     coordinator._get_google_home_filter = lambda: None
@@ -171,16 +175,20 @@ def test_poll_auth_failure_raises_auth_failed(monkeypatch: pytest.MonkeyPatch) -
     coordinator.async_set_update_error = _set_update_error
     coordinator.async_set_updated_data = _set_updated_data
 
-    with pytest.raises(ConfigEntryAuthFailed):
-        try:
-            loop.run_until_complete(
-                coordinator._async_start_poll_cycle(
-                    [{"id": "dev-1", "name": "Device"}], force=True
-                )
+    # The poll cycle runs as a fire-and-forget task, so it starts the entry reauth
+    # flow directly rather than raising (a raised ConfigEntryAuthFailed would never
+    # reach the awaited coordinator refresh). It still records last_exception so the
+    # finally block marks the update failed.
+    try:
+        loop.run_until_complete(
+            coordinator._async_start_poll_cycle(
+                [{"id": "dev-1", "name": "Device"}], force=True
             )
-        finally:
-            drain_loop(loop)
+        )
+    finally:
+        drain_loop(loop)
 
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
     assert coordinator.last_update_success is False
     assert isinstance(coordinator.last_exception, ConfigEntryAuthFailed)
 

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 
 import pytest
+from cryptography.exceptions import InvalidTag
 
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
     decrypt_locations,
@@ -396,3 +397,277 @@ async def test_pair_date_microseconds_normalization_and_future_rejection(
     )
 
     assert future_pair_date is None
+
+
+# ---------------------------------------------------------------------------
+# Diff-Review #1 (Variant C): own-report exhaustion escalates to DecryptionError,
+# while foreign-only failures and report-less devices never escalate.
+# ---------------------------------------------------------------------------
+
+
+def _valid_location_bytes() -> bytes:
+    """Serialize a small, in-bounds Location proto for a successful decrypt."""
+
+    loc = DeviceUpdate_pb2.Location()
+    loc.latitude = int(48.0 * 1e7)
+    loc.longitude = int(11.0 * 1e7)
+    loc.altitude = ALTITUDE_METERS
+    return loc.SerializeToString()
+
+
+def _add_report(
+    update: DeviceUpdate_pb2.DeviceUpdate,
+    *,
+    public_key_random: bytes,
+    encrypted_location: bytes,
+    is_own_report: bool,
+    base_now: float,
+) -> None:
+    """Append one encrypted report; empty public_key_random marks an own report."""
+
+    reports = (
+        update.deviceMetadata.information.locationInformation.reports.recentLocationAndNetworkLocations
+    )
+    network_location = reports.networkLocations.add()
+    network_location.status = Common_pb2.Status.LAST_KNOWN
+    network_location.geoLocation.accuracy = ACCURACY_METERS
+    enc = network_location.geoLocation.encryptedReport
+    enc.publicKeyRandom = public_key_random
+    enc.encryptedLocation = encrypted_location
+    enc.isOwnReport = is_own_report
+    # A matching timestamp is required, otherwise the report is dropped before
+    # the decrypt attempt (zip_longest pads missing timestamps with None).
+    reports.networkLocationTimestamps.add().seconds = int(base_now - 10)
+
+
+async def test_all_own_reports_failing_auth_raises_decryption_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D1: every own report fails authentication → escalate via DecryptionError.
+
+    This is the account-wide stale-key signal: the cached identity key no longer
+    matches the server's own reports, so the function must raise instead of
+    silently returning empty (which the coordinator would never escalate).
+    """
+
+    base_now = 1_700_000_000.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-ciphertext",
+        is_own_report=True,
+        base_now=base_now,
+    )
+
+    with pytest.raises(decrypt_locations.DecryptionError):
+        await decrypt_locations.async_decrypt_location_response_locations(
+            update, cache=object()
+        )
+
+
+async def test_foreign_failures_with_own_success_do_not_escalate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D2: own report succeeds, foreign reports fail → no escalation.
+
+    Foreign/crowdsourced reports legitimately fail with another account's key.
+    A single own-report success proves the key is healthy, so they must not
+    raise an account-wide DecryptionError (regression guard for Befund #2/#4).
+    """
+
+    base_now = 1_700_000_500.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        return _valid_location_bytes()
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        raise ValueError("MAC check failed")
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-ok",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    _add_report(
+        update,
+        public_key_random=b"\x10\x11\x12\x13",
+        encrypted_location=b"foreign-bad",
+        is_own_report=False,
+        base_now=base_now,
+    )
+
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+
+    # Own report decoded; no exception despite the foreign auth failure.
+    assert any(entry.get("metadata_only") is not True for entry in result)
+
+
+async def test_foreign_only_failure_does_not_escalate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D3: device with no own reports → never escalate, even if foreign fails.
+
+    With ``_own_encrypted_report_count == 0`` the own-exhaustion gate is closed,
+    so a failing foreign-only report returns gracefully instead of raising.
+    """
+
+    base_now = 1_700_001_000.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        raise ValueError("MAC check failed")
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"\x20\x21\x22\x23",
+        encrypted_location=b"foreign-bad",
+        is_own_report=False,
+        base_now=base_now,
+    )
+
+    # Must not raise: no own reports means no account-wide signal.
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+    assert isinstance(result, list)
+
+
+async def test_partial_own_success_self_heals_without_escalation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D4: one own report fails but another succeeds → no escalation.
+
+    A single own-report success means the key still works, so a transient
+    per-report failure must self-heal rather than escalate.
+    """
+
+    base_now = 1_700_001_500.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+
+    calls = {"n": 0}
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise InvalidTag
+        return _valid_location_bytes()
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-bad",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-ok",
+        is_own_report=True,
+        base_now=base_now,
+    )
+
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+
+    # The successful own report suppresses escalation entirely.
+    assert any(entry.get("metadata_only") is not True for entry in result)
+
+
+async def test_own_report_mac_valueerror_counts_as_own_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D5: an own-report MAC ValueError counts as an own failure and escalates.
+
+    Own reports use AES-GCM (which raises InvalidTag), but the MAC-ValueError
+    handler is mirrored defensively for any future own-report path that surfaces
+    a PyCryptodome-style ``ValueError("MAC check failed")``. This guards that the
+    defensive symmetry still feeds the own-only escalation counter.
+    """
+
+    base_now = 1_700_002_000.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise ValueError("MAC check failed")
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-mac-fail",
+        is_own_report=True,
+        base_now=base_now,
+    )
+
+    with pytest.raises(decrypt_locations.DecryptionError):
+        await decrypt_locations.async_decrypt_location_response_locations(
+            update, cache=object()
+        )

--- a/tests/test_decrypt_owner_key_discriminator.py
+++ b/tests/test_decrypt_owner_key_discriminator.py
@@ -1,3 +1,4 @@
+# tests/test_decrypt_owner_key_discriminator.py
 """Discriminator for stale-vs-missing shared key in owner-key decryption.
 
 When ``async_get_owner_key`` fails, the root cause (wrong shared key vs. missing

--- a/tests/test_decrypt_owner_key_discriminator.py
+++ b/tests/test_decrypt_owner_key_discriminator.py
@@ -1,0 +1,103 @@
+"""Discriminator for stale-vs-missing shared key in owner-key decryption.
+
+When ``async_get_owner_key`` fails, the root cause (wrong shared key vs. missing
+shared key vs. generic failure) is otherwise collapsed into a single opaque
+message. These tests pin ``_classify_owner_key_failure``, which restores the
+discriminator as a typed ``DecryptionError`` subclass, and the Liskov property
+that keeps every existing ``except DecryptionError`` handler working.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    decrypt_locations as _dl,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    SharedKeyMissingError,
+    StaleOwnerKeyError,
+    _classify_owner_key_failure,
+)
+from custom_components.googlefindmy.ProtoDecoders import DeviceUpdate_pb2
+
+
+def test_liskov_subclasses_are_decryption_errors() -> None:
+    """All specific shared-key errors stay DecryptionError subclasses so existing
+    ``except DecryptionError`` handlers keep catching them (no silent breakage)."""
+    assert issubclass(SharedKeyMismatchError, DecryptionError)
+    assert issubclass(SharedKeyMissingError, DecryptionError)
+    assert issubclass(StaleOwnerKeyError, DecryptionError)
+
+
+def test_t2_invalid_tag_maps_to_shared_key_mismatch() -> None:
+    """InvalidTag (AES-GCM auth failure) => wrong/stale shared key."""
+    result = _classify_owner_key_failure(InvalidTag(), context="initial lookup")
+    assert isinstance(result, SharedKeyMismatchError)
+    assert "InvalidTag" in str(result)
+    assert "initial lookup" in str(result)
+
+
+def test_t2_missing_runtime_maps_to_shared_key_missing() -> None:
+    """RuntimeError mentioning 'missing or empty' => incomplete bundle."""
+    exc = RuntimeError("Shared key is missing or empty; cannot decrypt owner key")
+    result = _classify_owner_key_failure(exc, context="initial lookup")
+    assert isinstance(result, SharedKeyMissingError)
+
+
+def test_t2_generic_runtime_maps_to_plain_decryption_error() -> None:
+    """Any other RuntimeError => generic DecryptionError (still escalates, but is
+    not mis-labelled as a specific shared-key cause)."""
+    result = _classify_owner_key_failure(RuntimeError("boom"), context="x")
+    assert type(result) is DecryptionError
+
+
+@pytest.mark.asyncio
+async def test_owner_key_invalid_tag_propagates_as_shared_key_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Integration: an InvalidTag from the owner-key lookup surfaces from
+    async_retrieve_identity_key as SharedKeyMismatchError (the path that used to
+    collapse into an opaque, swallowed DecryptionError)."""
+
+    async def _boom(**_kwargs: object) -> object:
+        raise InvalidTag()
+
+    monkeypatch.setattr(_dl, "async_get_owner_key", _boom)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x00" * 60
+
+    with pytest.raises(SharedKeyMismatchError):
+        await _dl.async_retrieve_identity_key(registration, cache=object())
+
+
+@pytest.mark.asyncio
+async def test_owner_key_forced_refresh_invalid_tag_maps_to_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Integration: when a newer owner-key version triggers a forced refresh and
+    that refresh also fails with InvalidTag, the failure still surfaces as
+    SharedKeyMismatchError (the forced-refresh wrap path)."""
+    from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+        OwnerKeyInfo,
+    )
+
+    async def _owner(*, cache: object, force_refresh: bool = False, **_kw: object) -> object:
+        if force_refresh:
+            raise InvalidTag()
+        return OwnerKeyInfo(key=b"\x00" * 32, version=1)
+
+    monkeypatch.setattr(_dl, "async_get_owner_key", _owner)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x00" * 60
+    registration.encryptedUserSecrets.ownerKeyVersion = 5  # > cached version 1
+
+    with pytest.raises(SharedKeyMismatchError):
+        await _dl.async_retrieve_identity_key(registration, cache=object())

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -1,3 +1,4 @@
+# tests/test_fcm_receiver_decrypt_escalation.py
 """Background-push decrypt-failure escalation in :class:`FcmReceiverHA`.
 
 A push-only setup must escalate to a reauth flow identically to the poll path.

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -1,0 +1,124 @@
+"""Background-push decrypt-failure escalation in :class:`FcmReceiverHA`.
+
+A push-only setup must escalate to a reauth flow identically to the poll path.
+Because the background decode runs outside a coordinator update cycle, the
+receiver cannot raise ``ConfigEntryAuthFailed``; instead it starts the entry's
+reauth flow directly when the shared counter (driven through the coordinator's
+``note_decrypt_failure``) reports that the threshold was reached.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth import fcm_receiver_ha
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    StaleOwnerKeyError,
+)
+
+
+def _receiver_with_coordinator(*, escalate: bool) -> tuple[FcmReceiverHA, MagicMock, MagicMock]:
+    receiver = FcmReceiverHA()
+    hass = MagicMock()
+    receiver._hass = hass
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.async_start_reauth = MagicMock()
+    coordinator = MagicMock()
+    coordinator.config_entry = entry
+    coordinator.note_decrypt_failure = MagicMock(return_value=escalate)
+    receiver.coordinators = [coordinator]
+    return receiver, coordinator, entry
+
+
+def test_push_decrypt_failure_starts_reauth_when_threshold_reached() -> None:
+    """When the coordinator reports escalation, the entry's reauth flow is started
+    (the only way to surface a reauth from the background push path)."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    err = DecryptionError("stale shared key")
+
+    receiver._note_decrypt_failure_for_entry("entry-1", stale=False, error=err)
+
+    coordinator.note_decrypt_failure.assert_called_once_with(stale=False, error=err)
+    entry.async_start_reauth.assert_called_once_with(receiver._hass)
+
+
+def test_push_decrypt_failure_below_threshold_does_not_start_reauth() -> None:
+    """Below threshold (escalate=False), the counter is fed but no reauth is fired.
+    A per-tracker stale key (stale=True) likewise never starts an account reauth."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+
+    receiver._note_decrypt_failure_for_entry(
+        "entry-1", stale=True, error=StaleOwnerKeyError("tracker outdated")
+    )
+
+    coordinator.note_decrypt_failure.assert_called_once()
+    entry.async_start_reauth.assert_not_called()
+
+
+def test_push_decrypt_failure_swallows_coordinator_errors() -> None:
+    """The push path must never break: a misbehaving coordinator is swallowed."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    coordinator.note_decrypt_failure = MagicMock(side_effect=RuntimeError("boom"))
+
+    # Must not raise.
+    receiver._note_decrypt_failure_for_entry(
+        "entry-1", stale=False, error=DecryptionError("x")
+    )
+    entry.async_start_reauth.assert_not_called()
+
+
+def test_push_decrypt_failure_no_coordinator_for_entry_is_noop() -> None:
+    """Unknown entry id: nothing to feed, no crash."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+
+    receiver._note_decrypt_failure_for_entry(
+        "other-entry", stale=False, error=DecryptionError("x")
+    )
+
+    coordinator.note_decrypt_failure.assert_not_called()
+    entry.async_start_reauth.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "expect_reauth"),
+    [
+        (DecryptionError("stale shared key"), True),
+        (StaleOwnerKeyError("tracker outdated"), False),
+    ],
+)
+async def test_decode_background_location_feeds_counter_on_decrypt_error(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception, expect_reauth: bool
+) -> None:
+    """The background decode path must funnel decryption failures into the shared
+    counter (and start reauth when the account-wide threshold is reached) instead
+    of silently returning an empty result."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    receiver._entry_caches["entry-1"] = MagicMock()
+    # Model the real hook contract: a per-tracker stale key never escalates.
+    coordinator.note_decrypt_failure = MagicMock(
+        side_effect=lambda *, stale, error: not stale
+    )
+
+    # Parse step returns a harmless object; the decrypt step raises.
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(side_effect=exc),
+    )
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    assert result == {}
+    coordinator.note_decrypt_failure.assert_called_once()
+    assert entry.async_start_reauth.called is expect_reauth

--- a/tests/test_get_owner_key.py
+++ b/tests/test_get_owner_key.py
@@ -27,7 +27,7 @@ Each ``RL-*`` test pins one member of the eight bug families distilled from the
     RL-12  missing/empty shared_key -> RuntimeError
     RL-13  missing encryptedOwnerKeyAndMetadata -> RuntimeError
     RL-14  missing/empty encryptedOwnerKey -> RuntimeError
-    RL-15  InvalidTag from decrypt -> RuntimeError (actionable message)
+    RL-15  InvalidTag from decrypt -> propagated unwrapped (discriminator)
     RL-16  decrypted owner_key empty/wrong type -> RuntimeError
     RL-17  hex happy path -> OwnerKeyInfo(32 bytes, version)
     RL-18  base64url fallback + self-heal: cache normalized to hex
@@ -366,14 +366,21 @@ async def test_rl14_missing_encrypted_owner_key_raises(
         )
 
 
-async def test_rl15_invalid_tag_maps_to_runtime_error(
+async def test_rl15_invalid_tag_propagates_unwrapped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """RL-15: an AES-GCM InvalidTag during owner-key decryption propagates
+    unchanged instead of being wrapped into RuntimeError.
+
+    decrypt_locations relies on the unwrapped InvalidTag to map the failure to
+    SharedKeyMismatchError and distinguish a wrong/stale shared key from a missing
+    one. Wrapping it here would erase that discriminator.
+    """
     monkeypatch.setattr(
         gok, "decrypt_owner_key", MagicMock(side_effect=gok.InvalidTag())
     )
     cache = _FakeCache()
-    with pytest.raises(RuntimeError, match="InvalidTag"):
+    with pytest.raises(gok.InvalidTag):
         await gok.async_get_owner_key(
             cache=cache, username="g@acct.example.com", **_getters()
         )

--- a/tests/test_hass_data_layout.py
+++ b/tests/test_hass_data_layout.py
@@ -530,7 +530,9 @@ async def test_async_setup_entry_hijacks_legacy_credentials_when_cache_empty(
     cache = harness.cache
     username_key = integration.username_string
     assert cache.values[username_key] == "legacyuser@example.com"
-    assert cache.values[DATA_SECRET_BUNDLE]["email"] == "LegacyUser@Example.com "
+    # The secrets-bundle normalizer edge-trims non-credential fields (case is
+    # preserved, only the pasted trailing space is removed).
+    assert cache.values[DATA_SECRET_BUNDLE]["email"] == "LegacyUser@Example.com"
     assert cache.values[CONF_OAUTH_TOKEN] == "outer-oauth-token"
     assert cache.values[DATA_AAS_TOKEN] == "legacy-aas-token"
 

--- a/tests/test_options_flow_credentials_cache.py
+++ b/tests/test_options_flow_credentials_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 from collections.abc import Awaitable
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -21,6 +22,7 @@ from custom_components.googlefindmy.const import (
     CONF_GOOGLE_EMAIL,
     CONF_OAUTH_TOKEN,
     DATA_AAS_TOKEN,
+    DATA_SECRET_BUNDLE,
     DOMAIN,
     SERVICE_SUBENTRY_KEY,
     SUBENTRY_TYPE_SERVICE,
@@ -419,5 +421,127 @@ def test_play_stop_sound_uses_entry_cache(  # noqa: PLR0915
         assert cache_primary.get_calls[-1] == "entry-one:ttl2"
         await stop_set("ttl2", "value2")
         assert ("entry-one:ttl2", "value2") in cache_primary.set_calls
+
+    asyncio.run(_exercise())
+
+
+def test_options_flow_secrets_reauth_strips_owner_key_space(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Options reauth with a pasted secrets bundle strips owner_key whitespace."""
+
+    async def _exercise() -> None:
+        cache = _MemoryCache()
+        entry = _DummyEntry(
+            entry_id="entry-1",
+            data={
+                CONF_GOOGLE_EMAIL: "user@example.com",
+                CONF_OAUTH_TOKEN: "oauth-original-token-123456",
+            },
+            cache=cache,
+        )
+        hass = _DummyHass(entry, cache)
+
+        flow = config_flow.OptionsFlowHandler()
+        flow.hass = hass  # type: ignore[assignment]
+        flow.config_entry = entry  # type: ignore[attr-defined]
+
+        async def _fake_pick(
+            hass: Any,
+            email: str,
+            candidates: list[tuple[str, str]],
+            *,
+            secrets_bundle: dict[str, Any] | None = None,
+        ) -> str | None:
+            # The bundle handed downstream is already whitespace-normalized.
+            assert secrets_bundle is not None
+            assert secrets_bundle["owner_key"] == "AABBCC"
+            return candidates[0][1] if candidates else None
+
+        monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+        payload = {
+            "google_email": "user@example.com",
+            "oauth_token": "oauth-token-from-secrets-123456",
+            "owner_key": "AA BB\nCC ",
+            "username": "  Keep Me  ",
+        }
+        result = await flow.async_step_credentials(
+            {"new_secrets_json": json.dumps(payload), "subentry": TRACKER_SUBENTRY_KEY}
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        assert isinstance(result, dict)
+
+        updated = hass.config_entries.updated_payloads[-1]
+        bundle = updated[DATA_SECRET_BUNDLE]
+        assert bundle["owner_key"] == "AABBCC"
+        assert bundle["username"] == "Keep Me"
+        await hass.drain_tasks()
+
+    asyncio.run(_exercise())
+
+
+def test_options_flow_secrets_reauth_guard_error_fallback_normalizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The multi-entry-guard fallback path also normalizes the bundle."""
+
+    async def _exercise() -> None:
+        cache = _MemoryCache()
+        entry = _DummyEntry(
+            entry_id="entry-1",
+            data={
+                CONF_GOOGLE_EMAIL: "user@example.com",
+                CONF_OAUTH_TOKEN: "oauth-original-token-123456",
+            },
+            cache=cache,
+        )
+        hass = _DummyHass(entry, cache)
+
+        # Force the first update to raise a multi-entry guard error so the
+        # fallback branch (which re-parses and re-normalizes) is exercised.
+        calls = {"n": 0}
+        original_update = hass.config_entries.async_update_entry
+
+        def _maybe_raise(entry_: Any, *, data: dict[str, Any]) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("Multiple config entries active for this domain")
+            original_update(entry_, data=data)
+
+        hass.config_entries.async_update_entry = _maybe_raise  # type: ignore[assignment]
+
+        flow = config_flow.OptionsFlowHandler()
+        flow.hass = hass  # type: ignore[assignment]
+        flow.config_entry = entry  # type: ignore[attr-defined]
+
+        async def _fake_pick(
+            hass: Any,
+            email: str,
+            candidates: list[tuple[str, str]],
+            *,
+            secrets_bundle: dict[str, Any] | None = None,
+        ) -> str | None:
+            return candidates[0][1] if candidates else None
+
+        monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+        payload = {
+            "google_email": "user@example.com",
+            "oauth_token": "oauth-token-from-secrets-123456",
+            "owner_key": "AA BB CC",
+        }
+        result = await flow.async_step_credentials(
+            {"new_secrets_json": json.dumps(payload), "subentry": TRACKER_SUBENTRY_KEY}
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        assert isinstance(result, dict)
+        # First update raised, fallback re-attempted the update.
+        assert calls["n"] >= 2
+        updated = hass.config_entries.updated_payloads[-1]
+        assert updated[DATA_SECRET_BUNDLE]["owner_key"] == "AABBCC"
+        await hass.drain_tasks()
 
     asyncio.run(_exercise())

--- a/tests/test_spot_grpc_client.py
+++ b/tests/test_spot_grpc_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import grpclib.client as grpclib_client
 import grpclib.exceptions
@@ -382,7 +382,11 @@ def _prepare_coordinator(loop: asyncio.AbstractEventLoop) -> GoogleFindMyCoordin
     hass = _DummyHass(loop)
     coordinator = GoogleFindMyCoordinator(hass, cache=_DummyCacheProtocol())
     coordinator.config_entry = SimpleNamespace(
-        entry_id="entry-id", options={}, data={}, title="Test Entry"
+        entry_id="entry-id",
+        options={},
+        data={},
+        title="Test Entry",
+        async_start_reauth=Mock(),
     )
     coordinator._get_google_home_filter = lambda: None
     coordinator._is_fcm_ready_soft = lambda: True
@@ -409,7 +413,14 @@ def _prepare_coordinator(loop: asyncio.AbstractEventLoop) -> GoogleFindMyCoordin
 def test_poll_spot_auth_error_triggers_config_entry_auth_failed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """SpotAuthPermanentError should propagate as ConfigEntryAuthFailed in polling."""
+    """SpotAuthPermanentError in polling should start the entry reauth flow.
+
+    The poll cycle runs as a fire-and-forget task (``hass.async_create_task``), so a
+    raised ``ConfigEntryAuthFailed`` would never reach the awaited coordinator
+    refresh and HA's automatic reauth would never fire. The cycle therefore starts
+    the entry-scoped reauth flow directly and still records ``last_exception`` so
+    the ``finally`` block marks the update failed.
+    """
 
     loop = asyncio.new_event_loop()
     hass_coordinator = _prepare_coordinator(loop)
@@ -420,17 +431,19 @@ def test_poll_spot_auth_error_triggers_config_entry_auth_failed(
         AsyncMock(return_value=None),
     )
 
-    with pytest.raises(ConfigEntryAuthFailed):
-        try:
-            loop.run_until_complete(
-                hass_coordinator._async_start_poll_cycle(
-                    [{"id": "dev-1", "name": "Device"}], force=True
-                )
+    try:
+        loop.run_until_complete(
+            hass_coordinator._async_start_poll_cycle(
+                [{"id": "dev-1", "name": "Device"}], force=True
             )
-        finally:
-            drain_loop(loop)
-            loop.close()
+        )
+    finally:
+        drain_loop(loop)
+        loop.close()
 
+    hass_coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        hass_coordinator.hass
+    )
     assert isinstance(hass_coordinator.last_exception, ConfigEntryAuthFailed)
 
 

--- a/tests/test_spot_grpc_resilience.py
+++ b/tests/test_spot_grpc_resilience.py
@@ -320,7 +320,13 @@ async def test_non_teardown_attribute_error_is_reraised(
 
 
 def test_polling_path_translates_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """SpotAuthPermanentError from the API should surface as ConfigEntryAuthFailed."""
+    """SpotAuthPermanentError from the API should start the entry reauth flow.
+
+    The poll cycle runs as a fire-and-forget task, so it starts the entry-scoped
+    reauth flow directly rather than raising (a raised ``ConfigEntryAuthFailed``
+    would never reach the awaited coordinator refresh). It still records
+    ``last_exception`` so the ``finally`` block marks the update failed.
+    """
 
     loop = asyncio.new_event_loop()
     hass_coordinator = _prepare_coordinator(loop)
@@ -331,19 +337,21 @@ def test_polling_path_translates_auth_error(monkeypatch: pytest.MonkeyPatch) -> 
         AsyncMock(return_value=None),
     )
 
-    with pytest.raises(ConfigEntryAuthFailed):
-        try:
-            loop.run_until_complete(
-                hass_coordinator._async_start_poll_cycle(
-                    [{"id": "dev-1", "name": "Device"}], force=True
-                )
+    try:
+        loop.run_until_complete(
+            hass_coordinator._async_start_poll_cycle(
+                [{"id": "dev-1", "name": "Device"}], force=True
             )
-        finally:
-            from tests.helpers import drain_loop
+        )
+    finally:
+        from tests.helpers import drain_loop
 
-            drain_loop(loop)
-            loop.close()
+        drain_loop(loop)
+        loop.close()
 
+    hass_coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        hass_coordinator.hass
+    )
     assert isinstance(hass_coordinator.last_exception, ConfigEntryAuthFailed)
 
 


### PR DESCRIPTION
## Summary

Two related robustness fixes for end-to-end-encryption (E2EE) credential handling. Both address the same real-world failure: devices are visible and can ring, but **no location ever decrypts** and the user is **never prompted to re-authenticate**.

1. **Escalate stale/wrong shared-key decryption failures to a reauth flow.** A broken account-wide shared key currently fails owner-key decryption silently and indefinitely. The fatal auth condition was swallowed at three separate layers and never raised to `ConfigEntryAuthFailed`, so Home Assistant never showed the reauth card.
2. **Normalize whitespace in pasted secret bundles.** A stray space introduced by copy/paste into a credential value (e.g. `owner_key`) silently broke `unhexlify`/AES-GCM and produced exactly the same "everything fails to decrypt" symptom. Trimming credential values is the integration's job, not the user's.

## Problem & root cause

### 1. Silent stale-key swallow

Diagnostics showed the contradictory pair *FCM "Disconnected"* but *Nova API auth "OK"*, while the log filled with (1321 occurrences):

```
Failed to process location data for <device>: Owner key decryption failed
(shared key may be stale). Re-authenticate with --reauth to refresh crypto keys.
```

All devices fail simultaneously, which is the signature of a broken **shared key** (the top, account-wide stage of the `Shared Key -> Owner Key -> EIK -> Location` chain), not a single stale tracker. The fatal `DecryptionError` was caught and discarded at:

- `location_request.py` — only `Spot*` errors were re-raised; `DecryptionError` stayed in `ctx.error` and was dropped.
- `api.py` — a broad `except RuntimeError` caught `DecryptionError` (a `RuntimeError` subclass) and returned `{}`.
- `fcm_receiver_ha.py` — the background push path swallowed the same error independently.

Because the condition never reached the coordinator as an auth failure, HA never opened reauth. Automatic `--reauth` is **not possible** in HA mode: the shared key is anchored to the user's lock-screen knowledge factor and can only be obtained through the interactive browser flow, so the only correct headless behavior is to surface the reauth card.

### 2. Whitespace in pasted secrets

The existing `.strip()` in `config_flow.py` trimmed only the **whole** JSON text, not the **individual** values inside the bundle. A space embedded in a credential value survived all six parse points and was persisted verbatim, where `get_owner_key.py` `unhexlify` then failed. The user had to manually delete a space to make `owner_key` work.

## Changes

**Escalation (commit 1):**
- `get_owner_key.py`: propagate `InvalidTag` instead of wrapping it into a generic `RuntimeError`, so the cause survives.
- `decrypt_locations.py`: classify owner-key failures into typed `DecryptionError` subclasses — `SharedKeyMismatchError` (wrong key / `InvalidTag`) vs. `SharedKeyMissingError` (empty key) — so the log discriminates "wrong" from "missing" by class name.
- `location_request.py`, `api.py`: let `DecryptionError` propagate through instead of swallowing it.
- `coordinator/polling.py` (+ `_mixin_typing.py`, `coordinator/main.py`): new `note_decrypt_failure` hook with a per-config-entry consecutive-failure counter (threshold 3) and a 6-hour cooldown, mirroring the existing transient-auth-failure pattern. On threshold it raises `ConfigEntryAuthFailed`. The counter resets **per cycle** when the whole poll cycle is decryption-clean, so a single healthy device in a multi-device account cannot mask the escalation. A per-tracker `StaleOwnerKeyError` deliberately does **not** trigger an account-wide reauth.
- `fcm_receiver_ha.py`: the push path feeds the same counter and starts the reauth flow via `async_start_reauth` (a background task cannot `raise`).
- `README.md`: note to generate `secrets.json` from the **same account / same public IP** as the HA host.

**Whitespace normalization (commit 2):**
- `shared_helpers.py`: new idempotent `normalize_secrets_bundle`. Credential fields (`owner_key`, `shared_key`, all tokens, nested FCM tokens) have **all** whitespace removed (base64/hex/JWT never contain legitimate spaces, so leading, trailing, and internal spaces are all handled). Non-credential fields (username, email) are only edge-trimmed, so internal characters are never corrupted. The input is not mutated.
- `config_flow.py`: wired at all parse points.
- `__init__.py`: defense-in-depth normalization at the cache-write choke point and at the legacy-migration path.

**Escalation robustness (commits 3-5):**
- **Uptime independence (commit 3):** the consecutive-failure cooldown previously compared against a `0.0` default for the last-reauth timestamp, so on a freshly booted process the very first decryption failure could be masked by a low `time.monotonic()` value. The timestamp now uses a `None` sentinel and the cooldown reads through an injectable monotonic seam, so escalation no longer depends on process uptime and the boot-time path is deterministically testable.
- **Per-cycle counting and manual-locate path (commit 4, addressing Codex review):** the decrypt-failure counter was incremented inside the per-device loop, so an account with several trackers sharing one stale key escalated within a single cycle instead of after N cycles, defeating self-repair. Counting and escalation now happen exactly once per poll cycle from a single source of truth; the per-device handler only flags. The manual `async_locate_device` path, which previously caught the now-propagating `DecryptionError` in a broad `except Exception` and raised a generic `HomeAssistantError`, now mirrors the poll path: typed `StaleOwnerKeyError`/`DecryptionError` handlers feed the same counter and start reauth at the threshold.
- **Own-report decryption exhaustion (commit 5):** if the per-request identity key was unwrapped successfully but then failed to decrypt **all** of the account's own encrypted reports, `decrypt_locations.py` invalidated the EIK cache and returned empty **without** raising, so the coordinator never escalated and the failure repeated silently every cycle. The function now counts own reports (`public_key_random == b""`) separately and raises `DecryptionError` only when own encrypted reports existed, all of them failed, and none succeeded. This reuses the existing escalation/counter/cooldown path (no parallel logic), leaves foreign/crowdsourced reports and report-less devices untouched, and closes the gap independently of the early-key or normal path.

**Poll-cycle reauth wiring (commit 6, addressing Codex review):** the scheduled poll cycle runs as a fire-and-forget task (`hass.async_create_task(..., name=f"{DOMAIN}.poll_cycle")`), so Home Assistant never sees exceptions raised inside it — its reauth handling only reacts to `ConfigEntryAuthFailed` bubbling out of the awaited coordinator refresh. This was a **bug family**: all six escalation sites in the poll cycle (five typed `raise reauth_exc` plus one bare `raise` re-raising a `ConfigEntryAuthFailed` from `api.async_get_device_location` on HTTP 401/403) died in the background task, not just the own-report-exhaustion site Codex flagged. Every site now routes through a small `_request_poll_reauth` helper that calls `config_entry.async_start_reauth(self.hass)` directly, mirroring the pattern already used in `locate.py` and `fcm_receiver_ha.py`. The coordinator error state is preserved via the existing `finally` block (`last_exception` → `async_set_update_error`); only the dead `raise` is replaced by a direct reauth start plus `return`.

**Test-suite hygiene (commit 7):** a latent cross-test state leak — unrelated to production code — could make `test_async_remove_config_entry_device_normalizes_identifier` fail deterministically under xdist (a monkeypatch-vs-lazy-global trap: a test restores a lazy-import symbol to its placeholder while the `_RUNTIME_IMPORTS_LOADED` guard stays True, so later `isinstance` checks fail for the rest of the worker). A `trylast` `pytest_runtest_teardown` hook in `tests/conftest.py` (running after monkeypatch finalizers) detects the inconsistent state and reopens the guard so the next `_ensure_runtime_imports()` rebinds the real classes; generalised to all four lazy symbols. The integration's CI runs pytest sequentially, where this never triggered.

## Testing

- New suites cover: failure discriminator + Liskov invariant, sink pass-through at every layer (`api.py` re-raise regression for the `{}` bug), end-to-end coordinator loop (persistent `SharedKeyMismatchError` -> `ConfigEntryAuthFailed` after 3 cycles; `StaleOwnerKeyError` -> never reauth; sub-threshold -> self-repair untouched; fail->success resets the counter; multi-device partial-failure does not mask escalation), the FCM push path, and full whitespace normalization (leading/trailing/internal on credentials, non-credential fields untouched, nested tokens, idempotency, no input mutation, config-flow and options-reauth round trips).
- **Changed-code coverage:** 100% of changed lines in `config_flow.py`, `shared_helpers.py`, `__init__.py`; ~99% in the escalation path (the only uncovered lines are pure `raise` re-wiring in `location_request.py`, whose effect is proven end-to-end through the `api.py` and loop layers). One legacy-migration defense-in-depth line is marked `# pragma: no cover` with justification.
- Escalation-robustness suites additionally cover: the boot-time path now fails deterministically with the monotonic seam (previously only red on a fresh boot); multi-device per-cycle counting (3 trackers with one stale key escalate after N cycles, not within the first); the manual-locate typed handlers (stale-key reauth, sub-threshold graceful empty); and own-report exhaustion (all own reports fail -> raise; MAC-`ValueError` variant; foreign-only never raises; one own success suppresses; report-less devices stay `metadata_only`).
- **Mutation checks:** reverting the `api.py` re-raise turns the pass-through tests red; reverting the escalation threshold return turns both the unit and loop tests red; neutralizing normalization turns the whitespace tests red; re-introducing per-device counting turns the multi-device cycle test red; using the mixed counter instead of own-only turns the foreign-only test red; disabling the own-exhaustion raise turns the core test red.
- Poll-cycle reauth wiring (commit 6): the six escalation sites now assert `config_entry.async_start_reauth` is started (instead of expecting a raised exception); new tests cover the Nova permanent, Nova transient-threshold and bare-re-raise sites plus the helper `None`-guard. Mutation checks: reverting any site back to `raise` turns its co-change test red; neutralizing the helper turns the start-reauth assertions red.
- Test-suite hygiene (commit 7): the previously flaky test is now green across repeated 4-worker xdist runs (was ~2/3 red before the fix); both polluting tests are deterministically healed in isolation. The CI-exact **sequential** full run is green (`rc=0`, 3936 passed, 20 skipped, coverage 70.04% ≥ 69%).
- `ruff check` and `mypy` clean across all changed files.

## User-facing impact

- A stale/wrong account shared key now surfaces the HA reauth card after a short backoff instead of failing silently forever; self-repair (`force_refresh` / blind refresh) keeps its chance first.
- A stray space pasted into a secret value is normalized automatically; users no longer have to hand-edit `secrets.json`.
- No entity/`unique_id`/migration changes.