### PR TITLE
Add encryption-key diagnostic sensor and rename FCM connection status

### DIFF
--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -485,6 +485,9 @@ EVENT_AUTH_OK: str = f"{DOMAIN}.authentication_ok"
 # Translation key for the dedicated auth-status binary_sensor entity.
 TRANSLATION_KEY_AUTH_STATUS: str = "nova_auth_status"
 
+# Translation key for the dedicated encryption-key-status (ENUM) sensor entity.
+TRANSLATION_KEY_ENCRYPTION_KEY_STATUS: str = "encryption_key_status"
+
 # Issue key used for Repairs (translations use the same key).
 ISSUE_AUTH_EXPIRED_KEY: str = "auth_expired"
 
@@ -640,6 +643,7 @@ __all__ = [
     "EVENT_AUTH_ERROR",
     "EVENT_AUTH_OK",
     "TRANSLATION_KEY_AUTH_STATUS",
+    "TRANSLATION_KEY_ENCRYPTION_KEY_STATUS",
     "ISSUE_AUTH_EXPIRED_KEY",
     "ISSUE_MULTIPLE_CONFIG_ENTRIES",
     "TRANSLATION_KEY_CACHE_PURGED",

--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -35,6 +35,7 @@ from . import helpers
 # Re-export stats classes from helpers (commonly needed)
 from .helpers.stats import (
     ApiStatus,
+    CryptoStatus,
     DiagnosticsBuffer,
     FcmStatus,
     StatusSnapshot,
@@ -95,6 +96,7 @@ __all__ = [
     "_PREDICTION_BUFFER_S",
     # Stats classes
     "ApiStatus",
+    "CryptoStatus",
     "DiagnosticsBuffer",
     "FcmStatus",
     "StatusSnapshot",

--- a/custom_components/googlefindmy/coordinator/helpers/stats.py
+++ b/custom_components/googlefindmy/coordinator/helpers/stats.py
@@ -42,6 +42,35 @@ class FcmStatus:
     DISCONNECTED = "disconnected"
 
 
+class CryptoStatus:
+    """String constants describing end-to-end location decryption health.
+
+    These mirror the diagnostic enum sensor's ``options`` exactly (one Home
+    Assistant enum state per constant). The values are driven from a single
+    source -- the coordinator's ``note_decrypt_failure`` hook (failure states)
+    and the poll cycle's decrypt-clean outcome (``OK``) -- so the sensor never
+    drifts from the reauth escalation behaviour it visualizes.
+
+    States:
+        UNKNOWN: No decryption has been attempted yet (initial state).
+        OK: The most recent poll cycle decrypted without an account-wide failure.
+        SHARED_KEY_INVALID: The shared key no longer matches the server-side
+            owner key (``SharedKeyMismatchError`` / ``InvalidTag``); account-wide
+            reauthentication is required.
+        SHARED_KEY_MISSING: The pasted bundle is incomplete and lacks a usable
+            shared key (``SharedKeyMissingError``).
+        TRACKER_KEY_OUTDATED: A single tracker is encrypted with an outdated
+            owner-key version (``StaleOwnerKeyError``); re-pair that tracker. This
+            is per-tracker and never triggers an account-wide reauth.
+    """
+
+    UNKNOWN = "unknown"
+    OK = "ok"
+    SHARED_KEY_INVALID = "shared_key_invalid"
+    SHARED_KEY_MISSING = "shared_key_missing"
+    TRACKER_KEY_OUTDATED = "tracker_key_outdated"
+
+
 # ---------------------------------------------------------------------------
 # Status Snapshot
 # ---------------------------------------------------------------------------

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -86,6 +86,7 @@ from .helpers.geo import (
 )
 from .helpers.stats import (
     ApiStatus,
+    CryptoStatus,
     DiagnosticsBuffer,
     FcmStatus,
     format_recent_errors,
@@ -768,6 +769,12 @@ class GoogleFindMyCoordinator(
         self._fcm_status_state: str = FcmStatus.UNKNOWN
         self._fcm_status_reason: str | None = None
         self._fcm_status_changed_at: float | None = None
+        # End-to-end location decryption health (drives the diagnostic enum
+        # sensor and mirrors the reauth escalation; initial UNKNOWN -> HA renders
+        # "unknown" until the first decryption is attempted).
+        self._crypto_status_state: str = CryptoStatus.UNKNOWN
+        self._crypto_status_reason: str | None = None
+        self._crypto_status_changed_at: float | None = None
 
         # Performance metrics (timestamps, durations) & recent errors (bounded)
         self.performance_metrics: dict[str, float] = {}

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -53,6 +53,7 @@ from ..const import (
 )
 from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    SharedKeyMissingError,
     StaleOwnerKeyError,
 )
 from ..NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
@@ -62,7 +63,7 @@ from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
 from ..SpotApi.spot_request import SpotAuthPermanentError
 from ._mixin_typing import _MixinBase
 from .helpers.cache import sanitize_decoder_row as _sanitize_decoder_row
-from .helpers.stats import ApiStatus, FcmStatus, StatusSnapshot
+from .helpers.stats import ApiStatus, CryptoStatus, FcmStatus, StatusSnapshot
 from .helpers.subentry import normalize_epoch_seconds as _normalize_epoch_seconds
 from .helpers.update import (
     calculate_presence_ttl as _calculate_presence_ttl_impl,
@@ -169,6 +170,9 @@ class PollingOperations(_MixinBase):
     _fcm_status_state: str
     _fcm_status_reason: str | None
     _fcm_status_changed_at: float | None
+    _crypto_status_state: str
+    _crypto_status_reason: str | None
+    _crypto_status_changed_at: float | None
     _force_device_list_reason: str | None
     _short_retry_cancel: Callable[[], None] | None
     _fcm_error_count: int
@@ -210,6 +214,29 @@ class PollingOperations(_MixinBase):
         except Exception:
             pass
 
+    def _set_crypto_status(
+        self, status: str, *, reason: str | None = None
+    ) -> None:
+        """Update the location-decryption status while avoiding noisy churn.
+
+        Mirrors ``_set_fcm_status`` exactly. This is the single writer for the
+        diagnostic encryption-key sensor: failure states come from
+        ``note_decrypt_failure`` (one mapping for poll, push and manual locate),
+        the ``OK`` state from a decrypt-clean poll cycle. Keeping one writer
+        guarantees the sensor never diverges from the reauth escalation.
+        """
+        if status == self._crypto_status_state and reason == self._crypto_status_reason:
+            return
+
+        self._crypto_status_state = status
+        self._crypto_status_reason = reason
+        self._crypto_status_changed_at = time.time()
+
+        try:
+            self.async_set_updated_data(self.data)
+        except Exception:
+            pass
+
     @property
     def api_status(self) -> StatusSnapshot:
         """Return a snapshot describing the current API polling health."""
@@ -226,6 +253,15 @@ class PollingOperations(_MixinBase):
             state=self._fcm_status_state,
             reason=self._fcm_status_reason,
             changed_at=self._fcm_status_changed_at,
+        )
+
+    @property
+    def crypto_status(self) -> StatusSnapshot:
+        """Return a snapshot describing end-to-end location decryption health."""
+        return StatusSnapshot(
+            state=self._crypto_status_state,
+            reason=self._crypto_status_reason,
+            changed_at=self._crypto_status_changed_at,
         )
 
     @property
@@ -308,6 +344,7 @@ class PollingOperations(_MixinBase):
             # Per-tracker outdated owner key: log per occurrence, do not touch the
             # account-wide counter, never escalate to reauth here. The full
             # user-facing repair issue is added with the diagnostic sensor work.
+            self._set_crypto_status(CryptoStatus.TRACKER_KEY_OUTDATED)
             _LOGGER.warning(
                 "Tracker %s is encrypted with an outdated owner key version (%s); "
                 "remove and re-pair this tracker. Other devices are unaffected.",
@@ -315,6 +352,15 @@ class PollingOperations(_MixinBase):
                 type(error).__name__,
             )
             return False
+
+        # Account-wide shared-key failure: map the concrete error to the
+        # diagnostic state from the SAME signal that drives the escalation below
+        # (D6, single source -- no second, divergent state for the sensor).
+        self._set_crypto_status(
+            CryptoStatus.SHARED_KEY_MISSING
+            if isinstance(error, SharedKeyMissingError)
+            else CryptoStatus.SHARED_KEY_INVALID
+        )
 
         self._consecutive_decrypt_failures += 1
         if self._consecutive_decrypt_failures < _MAX_DECRYPT_FAILURES:
@@ -1333,6 +1379,16 @@ class PollingOperations(_MixinBase):
                 # fires, so the remaining trackers still get one (failing) Nova call.
                 # That is the rare end-state cost of per-cycle counting.
                 cycle_decrypt_error: DecryptionError | None = None
+                # True if any device hit a per-tracker StaleOwnerKeyError this
+                # cycle. Such cycles must NOT be reported as crypto OK even when
+                # the account-wide key is healthy, so the diagnostic sensor does
+                # not flicker away the tracker_key_outdated state.
+                cycle_had_stale_key = False
+                # True once a device returns usable location data without a
+                # DecryptionError: positive proof the shared key works. Crypto OK
+                # requires this proof, not merely the absence of a decrypt error
+                # (a cycle of pure timeouts must not flicker a stale key to OK).
+                cycle_had_successful_decrypt = False
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
                     dev_name = dev.get("name", dev_id)
@@ -1379,6 +1435,11 @@ class PollingOperations(_MixinBase):
                                 dev_id, dev_name, source="empty-result"
                             )
                             continue
+
+                        # A device returned usable location data without raising a
+                        # DecryptionError: positive proof the account-wide shared
+                        # key still decrypts. Gate the crypto OK state on this.
+                        cycle_had_successful_decrypt = True
 
                         self._record_semantic_label(location, device_id=dev_id)
                         raw_semantic_name = (
@@ -1735,6 +1796,7 @@ class PollingOperations(_MixinBase):
                             stale=True, error=stale_err, device=dev_name
                         )
                         cycle_failed = True
+                        cycle_had_stale_key = True
                         self._consecutive_timeouts = 0
                         if last_exception is None:
                             last_exception = stale_err
@@ -1792,19 +1854,30 @@ class PollingOperations(_MixinBase):
                         last_exception = reauth_exc
                         self._request_poll_reauth(reauth_exc)
                         return
-                elif self._consecutive_decrypt_failures > 0:
-                    # Whole cycle was decrypt-clean: clear the consecutive-decrypt
-                    # counter so a recovered/healthy shared key (or a successful
-                    # self-heal) does not later trip a spurious reauth. Gated on the
-                    # entire cycle -- one healthy tracker must not mask a
-                    # persistently stale account-wide shared key on the others.
-                    _LOGGER.info(
-                        "Location decryption succeeded for all devices; clearing "
-                        "%d decrypt failure(s).",
-                        self._consecutive_decrypt_failures,
-                    )
-                    self._consecutive_decrypt_failures = 0
-                    self._last_decrypt_error = None
+                else:
+                    # Whole cycle finished without an account-wide decrypt failure.
+                    if cycle_had_successful_decrypt and not cycle_had_stale_key:
+                        # At least one device actually decrypted location data this
+                        # cycle (positive proof, not just the absence of an error)
+                        # and no per-tracker stale key was seen: the account-wide
+                        # shared key is healthy. Reflect that into the diagnostic
+                        # sensor (D6 OK source, single writer). A cycle of pure
+                        # timeouts/transient errors leaves the prior state intact
+                        # rather than flickering a stale key to OK.
+                        self._set_crypto_status(CryptoStatus.OK)
+                    if self._consecutive_decrypt_failures > 0:
+                        # Clear the consecutive-decrypt counter so a recovered/
+                        # healthy shared key (or a successful self-heal) does not
+                        # later trip a spurious reauth. Gated on the entire cycle --
+                        # one healthy tracker must not mask a persistently stale
+                        # account-wide shared key on the others.
+                        _LOGGER.info(
+                            "Location decryption succeeded for all devices; clearing "
+                            "%d decrypt failure(s).",
+                            self._consecutive_decrypt_failures,
+                        )
+                        self._consecutive_decrypt_failures = 0
+                        self._last_decrypt_error = None
             finally:
                 # Update scheduling baseline and clear flag, then push end snapshot.
                 # Always advance the poll baseline to prevent high-frequency

--- a/custom_components/googlefindmy/icons.json
+++ b/custom_components/googlefindmy/icons.json
@@ -60,6 +60,9 @@
       "semantic_labels": {
         "default": "mdi:format-list-text"
       },
+      "encryption_key_status": {
+        "default": "mdi:key-alert"
+      },
       "stat_background_updates": {
         "default": "mdi:cloud-download"
       },

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -42,8 +42,10 @@ from .const import (
     SUBENTRY_TYPE_SERVICE,
     SUBENTRY_TYPE_TRACKER,
     TRACKER_SUBENTRY_KEY,
+    TRANSLATION_KEY_ENCRYPTION_KEY_STATUS,
 )
 from .coordinator import (
+    CryptoStatus,
     GoogleFindMyCoordinator,
     SemanticLabelRecord,
     _as_ha_attributes,
@@ -93,6 +95,24 @@ SEMANTIC_LABEL_DESCRIPTION = SensorEntityDescription(
     translation_key="semantic_labels",
     icon="mdi:format-list-text",
 )
+
+ENCRYPTION_KEY_STATUS_DESCRIPTION = SensorEntityDescription(
+    key=TRANSLATION_KEY_ENCRYPTION_KEY_STATUS,
+    translation_key=TRANSLATION_KEY_ENCRYPTION_KEY_STATUS,
+    device_class=SensorDeviceClass.ENUM,
+    icon="mdi:key-alert",
+)
+
+# The concrete enum states exposed by the encryption-key-status sensor. HA
+# requires ``native_value`` to be one of ``options`` or ``None``; CryptoStatus
+# UNKNOWN is deliberately omitted because it maps to HA's "unknown" (None), not
+# an explicit option. Single source for the sensor and its tests.
+ENCRYPTION_KEY_STATUS_OPTIONS: list[str] = [
+    CryptoStatus.OK,
+    CryptoStatus.SHARED_KEY_INVALID,
+    CryptoStatus.SHARED_KEY_MISSING,
+    CryptoStatus.TRACKER_KEY_OUTDATED,
+]
 
 BLE_BATTERY_DESCRIPTION = SensorEntityDescription(
     key="ble_battery",
@@ -345,6 +365,24 @@ async def async_setup_entry(
             if isinstance(semantic_unique_id, str):
                 added_unique_ids.add(semantic_unique_id)
             service_entities.append(semantic_sensor)
+
+        # Third diagnostic axis (E2EE key health). Always created alongside the
+        # semantic-label sensor, independent of the stats toggle, because the
+        # encryption-key status is a core diagnostic like Nova auth / FCM
+        # connectivity, not an optional counter.
+        crypto_sensor = GoogleFindMyEncryptionKeyStatusSensor(
+            coordinator,
+            subentry_key=scope.subentry_key,
+            subentry_identifier=identifier,
+        )
+        crypto_unique_id = getattr(crypto_sensor, "unique_id", None)
+        if not isinstance(crypto_unique_id, str) or (
+            isinstance(crypto_unique_id, str)
+            and crypto_unique_id not in added_unique_ids
+        ):
+            if isinstance(crypto_unique_id, str):
+                added_unique_ids.add(crypto_unique_id)
+            service_entities.append(crypto_sensor)
 
         if not enable_stats:
             _schedule_service_entities(service_entities, True)
@@ -900,6 +938,97 @@ class GoogleFindMySemanticLabelSensor(GoogleFindMyEntity, SensorEntity):
             )
 
         return {"labels": [item["label"] for item in attrs], "observations": attrs}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach to the service device for diagnostic grouping."""
+
+        return self.service_device_info(include_subentry_identifier=True)
+
+
+class GoogleFindMyEncryptionKeyStatusSensor(GoogleFindMyEntity, SensorEntity):
+    """Diagnostic ENUM sensor exposing end-to-end location decryption health.
+
+    This is the third diagnostic axis next to Nova auth (outgoing) and the FCM
+    connection (incoming): the E2EE key used to decrypt location reports. Its
+    state is read straight from ``coordinator.crypto_status``, which the poll,
+    push and manual-locate paths all feed through the single
+    ``note_decrypt_failure`` writer, so the sensor never diverges from the reauth
+    escalation behaviour it visualizes. Lives on the per-entry service device
+    (account-wide, like the shared key it reflects).
+    """
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_options = ENCRYPTION_KEY_STATUS_OPTIONS
+    entity_description = ENCRYPTION_KEY_STATUS_DESCRIPTION
+
+    def __init__(
+        self,
+        coordinator: GoogleFindMyCoordinator,
+        *,
+        subentry_key: str,
+        subentry_identifier: str,
+    ) -> None:
+        """Initialize the encryption-key-status sensor."""
+
+        super().__init__(
+            coordinator,
+            subentry_key=subentry_key,
+            subentry_identifier=subentry_identifier,
+        )
+        entry_id = self.entry_id or "default"
+        self._attr_unique_id = self.build_unique_id(
+            DOMAIN,
+            entry_id,
+            subentry_identifier,
+            TRANSLATION_KEY_ENCRYPTION_KEY_STATUS,
+            separator="_",
+        )
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current decryption state, or None for HA's "unknown".
+
+        HA's ENUM device class requires the value to be one of ``_attr_options``
+        or ``None``. CryptoStatus.UNKNOWN (no decryption attempted yet) is mapped
+        to ``None`` so HA renders the native "unknown" state instead of a fifth
+        explicit option.
+        """
+
+        snapshot = getattr(self.coordinator, "crypto_status", None)
+        state = getattr(snapshot, "state", None)
+        if not isinstance(state, str) or state == CryptoStatus.UNKNOWN:
+            return None
+        return state
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Expose how close the account is to a decrypt-driven reauth.
+
+        Sourced from the same coordinator fields that drive the escalation, so
+        there is no second, divergent state. ``threshold`` is intentionally not
+        exposed here to avoid coupling the entity to a private coordinator
+        constant; ``consecutive_decrypt_failures`` already shows the progress.
+        """
+
+        attributes: dict[str, Any] = {}
+
+        snapshot = getattr(self.coordinator, "crypto_status", None)
+        changed_at = getattr(snapshot, "changed_at", None)
+        if isinstance(changed_at, (int, float)):
+            attributes["changed_at"] = changed_at
+
+        failures = getattr(self.coordinator, "_consecutive_decrypt_failures", None)
+        if isinstance(failures, int):
+            attributes["consecutive_decrypt_failures"] = failures
+
+        last_error = getattr(self.coordinator, "_last_decrypt_error", None)
+        if isinstance(last_error, str) and last_error:
+            # Stored as "ClassName: message"; expose just the class for triage.
+            attributes["last_decrypt_error_class"] = last_error.split(":", 1)[0]
+
+        return attributes or None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -452,7 +452,7 @@
         "name": "Polling"
       },
       "connectivity": {
-        "name": "Connection Status",
+        "name": "FCM Connection Status",
         "state_attributes": {
           "last_poll_result": {
             "name": "Last poll result"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Semantic labels"
+      },
+      "encryption_key_status": {
+        "name": "Encryption Key Status",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Invalid (re-authentication required)",
+          "shared_key_missing": "Missing (incomplete bundle)",
+          "tracker_key_outdated": "Tracker key outdated"
+        }
       },
       "stat_background_updates": {
         "name": "Background updates"

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -452,7 +452,7 @@
         "name": "Abfrage aktiv"
       },
       "connectivity": {
-        "name": "Verbindungsstatus",
+        "name": "FCM-Verbindungsstatus",
         "state_attributes": {
           "last_poll_result": {
             "name": "Letztes Abfrageergebnis"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Semantische Bezeichnungen"
+      },
+      "encryption_key_status": {
+        "name": "Status des Verschlüsselungsschlüssels",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Ungültig (Neuanmeldung nötig)",
+          "shared_key_missing": "Fehlt (unvollständiges Bundle)",
+          "tracker_key_outdated": "Tracker-Schlüssel veraltet"
+        }
       },
       "stat_background_updates": {
         "name": "Hintergrund-Aktualisierungen"

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -452,7 +452,7 @@
         "name": "Polling"
       },
       "connectivity": {
-        "name": "Connection Status",
+        "name": "FCM Connection Status",
         "state_attributes": {
           "last_poll_result": {
             "name": "Last poll result"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Semantic labels"
+      },
+      "encryption_key_status": {
+        "name": "Encryption Key Status",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Invalid (re-authentication required)",
+          "shared_key_missing": "Missing (incomplete bundle)",
+          "tracker_key_outdated": "Tracker key outdated"
+        }
       },
       "stat_background_updates": {
         "name": "Background updates"

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -452,7 +452,7 @@
         "name": "Sondeo"
       },
       "connectivity": {
-        "name": "Estado de conexión",
+        "name": "Estado de conexión FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Resultado de la última consulta"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Etiquetas semánticas"
+      },
+      "encryption_key_status": {
+        "name": "Estado de la clave de cifrado",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "No válida (se requiere reautenticación)",
+          "shared_key_missing": "Ausente (paquete incompleto)",
+          "tracker_key_outdated": "Clave del rastreador obsoleta"
+        }
       },
       "stat_background_updates": {
         "name": "Actualizaciones en segundo plano"

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -452,7 +452,7 @@
         "name": "Interrogation"
       },
       "connectivity": {
-        "name": "État de connexion",
+        "name": "État de connexion FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Résultat du dernier sondage"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Étiquettes sémantiques"
+      },
+      "encryption_key_status": {
+        "name": "État de la clé de chiffrement",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Invalide (ré-authentification requise)",
+          "shared_key_missing": "Manquante (lot incomplet)",
+          "tracker_key_outdated": "Clé du traceur obsolète"
+        }
       },
       "stat_background_updates": {
         "name": "Mises à jour en arrière-plan"

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -452,7 +452,7 @@
         "name": "סריקה פעילה"
       },
       "connectivity": {
-        "name": "מצב חיבור",
+        "name": "מצב חיבור FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "תוצאת סריקה אחרונה"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "תוויות סמנטיות"
+      },
+      "encryption_key_status": {
+        "name": "סטטוס מפתח ההצפנה",
+        "state": {
+          "ok": "תקין",
+          "shared_key_invalid": "לא תקף (נדרש אימות מחדש)",
+          "shared_key_missing": "חסר (חבילה לא שלמה)",
+          "tracker_key_outdated": "מפתח העוקב מיושן"
+        }
       },
       "stat_background_updates": {
         "name": "עדכונים ברקע"

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -452,7 +452,7 @@
         "name": "Interrogazione"
       },
       "connectivity": {
-        "name": "Stato della connessione",
+        "name": "Stato della connessione FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Risultato dell'ultimo sondaggio"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Etichette semantiche"
+      },
+      "encryption_key_status": {
+        "name": "Stato della chiave di crittografia",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Non valida (riautenticazione necessaria)",
+          "shared_key_missing": "Mancante (bundle incompleto)",
+          "tracker_key_outdated": "Chiave del tracker obsoleta"
+        }
       },
       "stat_background_updates": {
         "name": "Aggiornamenti in background"

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -452,7 +452,7 @@
         "name": "Polling"
       },
       "connectivity": {
-        "name": "Verbindingsstatus",
+        "name": "FCM-verbindingsstatus",
         "state_attributes": {
           "last_poll_result": {
             "name": "Laatste pollresultaat"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Semantische labels"
+      },
+      "encryption_key_status": {
+        "name": "Status versleutelingssleutel",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Ongeldig (herauthenticatie vereist)",
+          "shared_key_missing": "Ontbreekt (onvolledige bundel)",
+          "tracker_key_outdated": "Trackersleutel verouderd"
+        }
       },
       "stat_background_updates": {
         "name": "Achtergrondupdates"

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -452,7 +452,7 @@
         "name": "Odpytywanie"
       },
       "connectivity": {
-        "name": "Status połączenia",
+        "name": "Status połączenia FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Wynik ostatniego odpytywania"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Etykiety semantyczne"
+      },
+      "encryption_key_status": {
+        "name": "Stan klucza szyfrowania",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Nieprawidłowy (wymagane ponowne uwierzytelnienie)",
+          "shared_key_missing": "Brak (niekompletny pakiet)",
+          "tracker_key_outdated": "Nieaktualny klucz lokalizatora"
+        }
       },
       "stat_background_updates": {
         "name": "Aktualizacje w tle"

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -452,7 +452,7 @@
         "name": "Consulta"
       },
       "connectivity": {
-        "name": "Status da conexão",
+        "name": "Status da conexão FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Resultado da última sondagem"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Rótulos semânticos"
+      },
+      "encryption_key_status": {
+        "name": "Status da chave de criptografia",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Inválida (reautenticação necessária)",
+          "shared_key_missing": "Ausente (pacote incompleto)",
+          "tracker_key_outdated": "Chave do rastreador desatualizada"
+        }
       },
       "stat_background_updates": {
         "name": "Atualizações em segundo plano"

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -452,7 +452,7 @@
         "name": "Consulta"
       },
       "connectivity": {
-        "name": "Status de conexão",
+        "name": "Status de conexão FCM",
         "state_attributes": {
           "last_poll_result": {
             "name": "Resultado da última consulta"
@@ -666,6 +666,15 @@
       },
       "semantic_labels": {
         "name": "Rótulos semânticos"
+      },
+      "encryption_key_status": {
+        "name": "Estado da chave de encriptação",
+        "state": {
+          "ok": "OK",
+          "shared_key_invalid": "Inválida (reautenticação necessária)",
+          "shared_key_missing": "Em falta (pacote incompleto)",
+          "tracker_key_outdated": "Chave do localizador desatualizada"
+        }
       },
       "stat_background_updates": {
         "name": "Atualizações em segundo plano"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1816,6 +1816,7 @@ def _stub_homeassistant() -> None:
     class SensorDeviceClass:  # pragma: no cover - stub values
         TIMESTAMP = "timestamp"
         BATTERY = "battery"
+        ENUM = "enum"
 
     class SensorStateClass:  # pragma: no cover - stub values
         TOTAL_INCREASING = "total_increasing"

--- a/tests/helpers/polling_mixin_stub.py
+++ b/tests/helpers/polling_mixin_stub.py
@@ -31,6 +31,7 @@ from unittest.mock import MagicMock
 
 from custom_components.googlefindmy.coordinator.helpers.stats import (
     ApiStatus,
+    CryptoStatus,
     FcmStatus,
 )
 from custom_components.googlefindmy.coordinator.polling import PollingOperations
@@ -83,6 +84,9 @@ class PollingStub(PollingOperations):
         self._fcm_status_state: str = FcmStatus.UNKNOWN
         self._fcm_status_reason: str | None = None
         self._fcm_status_changed_at: float | None = None
+        self._crypto_status_state: str = CryptoStatus.UNKNOWN
+        self._crypto_status_reason: str | None = None
+        self._crypto_status_changed_at: float | None = None
 
         self._consecutive_timeouts: int = 0
         self._last_poll_result: str | None = None

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -9,7 +9,10 @@ import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
 
 from custom_components.googlefindmy.const import OPT_SEMANTIC_LOCATIONS
-from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+from custom_components.googlefindmy.coordinator import (
+    CryptoStatus,
+    GoogleFindMyCoordinator,
+)
 from custom_components.googlefindmy.coordinator.polling import (
     _MAX_DECRYPT_FAILURES,
     _MAX_TRANSIENT_AUTH_FAILURES,
@@ -92,6 +95,9 @@ def _base_coordinator(
     coordinator._consecutive_decrypt_failures = 0
     coordinator._last_decrypt_reauth_monotonic = None
     coordinator._last_decrypt_error = None
+    coordinator._crypto_status_state = CryptoStatus.UNKNOWN
+    coordinator._crypto_status_reason = None
+    coordinator._crypto_status_changed_at = None
     # Deliberately low monotonic value: simulates a freshly booted runner (process
     # uptime below the reauth cooldown). With the None sentinel the first escalation
     # must fire regardless, so this pins the whole loop-test class against the
@@ -566,3 +572,110 @@ async def test_poll_cycle_direct_config_entry_auth_failed_starts_reauth() -> Non
 
     coordinator.config_entry.async_start_reauth.assert_called_once_with(coordinator.hass)
     assert any(kw.get("failed") for kw in auth_calls)
+
+
+class _MixedDecryptAPI:
+    """API stub that fails for one device id and returns a payload for others.
+
+    Drives a single poll cycle that contains both a per-tracker stale key and a
+    healthy, decrypting device, to prove the crypto sensor does not flicker the
+    tracker_key_outdated state to OK when a sibling decrypts successfully.
+    """
+
+    def __init__(self, fail_id: str, exc: Exception, ok_payload: dict[str, Any]) -> None:
+        self._fail_id = fail_id
+        self._exc = exc
+        self._ok_payload = ok_payload
+
+    async def async_get_device_location(
+        self, device_id: str, *_args: Any, **_kwargs: Any
+    ) -> dict[str, Any]:
+        if device_id == self._fail_id:
+            raise self._exc
+        return dict(self._ok_payload)
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_successful_decrypt_sets_crypto_ok() -> None:
+    """A cycle that decrypts usable location data reports crypto OK (D6 source)."""
+
+    coordinator = _polling_coordinator(
+        {}, _TrackingFilter(), {"latitude": 1.0, "longitude": 2.0, "last_seen": 100}
+    )
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    assert coordinator.crypto_status.state == CryptoStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_shared_key_failure_sets_crypto_invalid() -> None:
+    """An account-wide SharedKeyMismatchError surfaces as shared_key_invalid."""
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    assert coordinator.crypto_status.state == CryptoStatus.SHARED_KEY_INVALID
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_stale_key_sets_tracker_outdated() -> None:
+    """A per-tracker StaleOwnerKeyError surfaces as tracker_key_outdated."""
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(StaleOwnerKeyError("tracker v1 < v2"))
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_timeout_only_does_not_clear_prior_failure() -> None:
+    """A cycle without any successful decrypt must NOT downgrade a prior
+    shared_key_invalid to OK -- absence of an error is not proof of health.
+
+    Mutation guard for the ``cycle_had_successful_decrypt`` gate: replacing it
+    with the weaker ``devices`` condition turns the second assertion red.
+    """
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    # Cycle 1: account-wide failure -> shared_key_invalid (below threshold).
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator.crypto_status.state == CryptoStatus.SHARED_KEY_INVALID
+
+    # Cycle 2: idle (empty location, no successful decrypt) -> state unchanged.
+    coordinator.api = _DummyAPI({})
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator.crypto_status.state == CryptoStatus.SHARED_KEY_INVALID
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_mixed_stale_and_success_keeps_tracker_outdated() -> None:
+    """A healthy sibling in a cycle that also hit a stale key must NOT flicker the
+    sensor to OK.
+
+    Mutation guard for the ``not cycle_had_stale_key`` gate: dropping it lets the
+    successful sibling overwrite tracker_key_outdated with OK and turns this red.
+    """
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _MixedDecryptAPI(
+        "dev-stale",
+        StaleOwnerKeyError("tracker v1 < v2"),
+        {"latitude": 1.0, "longitude": 2.0, "last_seen": 100},
+    )
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-stale", "name": "Old"}, {"id": "dev-ok", "name": "Hub"}]
+    )
+
+    assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED

--- a/tests/test_encryption_key_status_sensor.py
+++ b/tests/test_encryption_key_status_sensor.py
@@ -1,0 +1,300 @@
+# tests/test_encryption_key_status_sensor.py
+"""Tests for the Encryption Key Status diagnostic sensor (AP-9 / AP-10).
+
+Four concerns:
+
+- **T9 wiring** -- ``note_decrypt_failure`` maps each decryption error type to
+  the matching ``CryptoStatus`` on the coordinator, so the sensor and the reauth
+  escalation are driven from a single source (D6).
+- **T9 sensor** -- the entity renders that state, maps ``UNKNOWN`` to ``None``
+  for Home Assistant's enum contract (``native_value`` must be one of
+  ``options`` or ``None``), and every option is covered.
+- **T10 rename non-breaking** -- the connectivity entity's identity
+  (``key`` / ``translation_key``, from which ``entity_id`` and ``unique_id``
+  derive) is independent of the translated name, so the AP-9 name change cannot
+  alter existing ``entity_id``/``unique_id`` values or break automations.
+- **T11 translation completeness** -- every shipped translation file defines the
+  new sensor (name + four states) and the renamed connectivity name, so the
+  diagnosis stays consistent across all locales.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.binary_sensor import CONNECTIVITY_DESC
+from custom_components.googlefindmy.coordinator.helpers.stats import CryptoStatus
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    SharedKeyMismatchError,
+    SharedKeyMissingError,
+    StaleOwnerKeyError,
+)
+from custom_components.googlefindmy.sensor import (
+    ENCRYPTION_KEY_STATUS_OPTIONS,
+    GoogleFindMyEncryptionKeyStatusSensor,
+)
+
+from .helpers.polling_mixin_stub import PollingStub
+
+_ROOT = Path(__file__).resolve().parents[1] / "custom_components" / "googlefindmy"
+_TRANSLATIONS_DIR = _ROOT / "translations"
+_STRINGS_JSON = _ROOT / "strings.json"
+_REQUIRED_STATES = {
+    "ok",
+    "shared_key_invalid",
+    "shared_key_missing",
+    "tracker_key_outdated",
+}
+
+
+def _make_stub() -> PollingStub:
+    """Return a PollingStub seeded for decrypt-failure bookkeeping."""
+
+    stub = PollingStub()
+    stub._consecutive_decrypt_failures = 0
+    stub._last_decrypt_reauth_monotonic = None
+    stub._last_decrypt_error = None
+    stub._monotonic = lambda: 1_000_000.0
+    stub._set_auth_state = MagicMock()
+    return stub
+
+
+def _build_sensor(coordinator: Any) -> GoogleFindMyEncryptionKeyStatusSensor:
+    """Instantiate the sensor without running the HA entity __init__ chain."""
+
+    sensor = GoogleFindMyEncryptionKeyStatusSensor.__new__(
+        GoogleFindMyEncryptionKeyStatusSensor
+    )
+    sensor.coordinator = coordinator
+    sensor._attr_unique_id = "googlefindmy_entry_service_encryption_key_status"
+    return sensor
+
+
+def _all_translation_files() -> list[Path]:
+    return sorted(_TRANSLATIONS_DIR.glob("*.json")) + [_STRINGS_JSON]
+
+
+# --------------------------------------------------------------------------- #
+# T9 wiring: decryption error type -> CryptoStatus (single source, D6)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("stale", "error", "expected"),
+    [
+        (False, SharedKeyMismatchError("bad tag"), CryptoStatus.SHARED_KEY_INVALID),
+        (False, SharedKeyMissingError("empty"), CryptoStatus.SHARED_KEY_MISSING),
+        (False, DecryptionError("own reports failed"), CryptoStatus.SHARED_KEY_INVALID),
+        (True, StaleOwnerKeyError("v2 != v3"), CryptoStatus.TRACKER_KEY_OUTDATED),
+    ],
+)
+def test_t9_note_decrypt_failure_maps_to_crypto_status(
+    stale: bool, error: Exception, expected: str
+) -> None:
+    """Each error type lands as the matching diagnostic state on the coordinator.
+
+    This is the mutation-sharp assertion: swapping the mapping in
+    ``note_decrypt_failure`` flips the expected state and turns this red.
+    """
+
+    stub = _make_stub()
+    stub.note_decrypt_failure(stale=stale, error=error, device="dev")
+    assert stub.crypto_status.state == expected
+
+
+def test_t9_crypto_status_ok_and_churn_guard() -> None:
+    """``_set_crypto_status`` updates the snapshot and no-ops on unchanged state."""
+
+    stub = _make_stub()
+    stub.note_decrypt_failure(
+        stale=False, error=SharedKeyMismatchError("x"), device="d"
+    )
+    assert stub.crypto_status.state == CryptoStatus.SHARED_KEY_INVALID
+
+    stub._set_crypto_status(CryptoStatus.OK)
+    assert stub.crypto_status.state == CryptoStatus.OK
+
+    # Churn guard: setting the same state again is a no-op (early return), the
+    # snapshot stays stable and no exception escapes.
+    stub._set_crypto_status(CryptoStatus.OK)
+    assert stub.crypto_status.state == CryptoStatus.OK
+
+
+def test_t9_crypto_status_survives_listener_failure() -> None:
+    """A listener failure during _set_crypto_status is swallowed; state persists.
+
+    Mirrors the api/fcm status setters: a very early ``async_set_updated_data``
+    failure (listeners not ready) must not lose the state transition.
+    """
+
+    stub = _make_stub()
+    stub.async_set_updated_data = MagicMock(side_effect=RuntimeError("early"))
+    stub._set_crypto_status(CryptoStatus.SHARED_KEY_MISSING, reason="startup")
+    assert stub.crypto_status.state == CryptoStatus.SHARED_KEY_MISSING
+    assert stub.crypto_status.reason == "startup"
+
+
+# --------------------------------------------------------------------------- #
+# T9 sensor: native_value rendering + HA enum contract
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_native"),
+    [
+        (CryptoStatus.UNKNOWN, None),
+        (CryptoStatus.OK, "ok"),
+        (CryptoStatus.SHARED_KEY_INVALID, "shared_key_invalid"),
+        (CryptoStatus.SHARED_KEY_MISSING, "shared_key_missing"),
+        (CryptoStatus.TRACKER_KEY_OUTDATED, "tracker_key_outdated"),
+    ],
+)
+def test_t9_sensor_native_value(state: str, expected_native: str | None) -> None:
+    """The sensor renders the coordinator state; UNKNOWN -> None (HA "unknown")."""
+
+    coordinator = SimpleNamespace(
+        crypto_status=SimpleNamespace(state=state, changed_at=1_700_000_000.0),
+        _consecutive_decrypt_failures=0,
+        _last_decrypt_error=None,
+    )
+    sensor = _build_sensor(coordinator)
+
+    assert sensor.native_value == expected_native
+    # HA enum contract: a non-None native_value MUST be a declared option.
+    if sensor.native_value is not None:
+        assert sensor.native_value in ENCRYPTION_KEY_STATUS_OPTIONS
+
+
+def test_t9_native_value_handles_missing_snapshot() -> None:
+    """A coordinator without a usable crypto_status renders as unknown (None)."""
+
+    sensor = _build_sensor(SimpleNamespace(crypto_status=None))
+    assert sensor.native_value is None
+
+
+def test_t9_sensor_attaches_to_service_device() -> None:
+    """The sensor groups under the per-entry service device (account-wide)."""
+
+    from tests.helpers.config_entries_stub import make_config_entry
+
+    sensor = GoogleFindMyEncryptionKeyStatusSensor.__new__(
+        GoogleFindMyEncryptionKeyStatusSensor
+    )
+    sensor.coordinator = SimpleNamespace(
+        config_entry=make_config_entry(entry_id="entry")
+    )
+    sensor._subentry_identifier = "service"
+    sensor._subentry_key = "service"
+
+    info = sensor.device_info
+    assert info is not None
+    assert getattr(info, "identifiers", None)
+
+
+def test_t9_options_cover_all_states_except_unknown() -> None:
+    """``options`` lists exactly the four concrete states; UNKNOWN is excluded."""
+
+    assert set(ENCRYPTION_KEY_STATUS_OPTIONS) == {
+        CryptoStatus.OK,
+        CryptoStatus.SHARED_KEY_INVALID,
+        CryptoStatus.SHARED_KEY_MISSING,
+        CryptoStatus.TRACKER_KEY_OUTDATED,
+    }
+    assert CryptoStatus.UNKNOWN not in ENCRYPTION_KEY_STATUS_OPTIONS
+
+
+def test_t9_extra_state_attributes_show_escalation_progress() -> None:
+    """Attributes expose escalation progress from the same coordinator fields."""
+
+    coordinator = SimpleNamespace(
+        crypto_status=SimpleNamespace(
+            state=CryptoStatus.SHARED_KEY_INVALID, changed_at=1_700_000_000.0
+        ),
+        _consecutive_decrypt_failures=2,
+        _last_decrypt_error="SharedKeyMismatchError: bad tag",
+    )
+    sensor = _build_sensor(coordinator)
+
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert attrs["consecutive_decrypt_failures"] == 2
+    assert attrs["last_decrypt_error_class"] == "SharedKeyMismatchError"
+    assert attrs["changed_at"] == 1_700_000_000.0
+
+
+def test_t9_extra_state_attributes_empty_when_pristine() -> None:
+    """No attributes are emitted before any decryption activity (returns None)."""
+
+    coordinator = SimpleNamespace(
+        crypto_status=SimpleNamespace(state=CryptoStatus.UNKNOWN, changed_at=None),
+        _consecutive_decrypt_failures=None,
+        _last_decrypt_error=None,
+    )
+    sensor = _build_sensor(coordinator)
+    assert sensor.extra_state_attributes is None
+
+
+# --------------------------------------------------------------------------- #
+# T10 rename non-breaking: identity is independent of the translated name
+# --------------------------------------------------------------------------- #
+
+
+def test_t10_connectivity_identity_independent_of_translated_name() -> None:
+    """AP-9 changes only the translated name; the entity identity is untouched.
+
+    ``entity_id``/``unique_id`` derive from ``key``/``translation_key`` and the
+    unique-id suffix, never from the (now FCM-qualified) display name -- so the
+    rename cannot duplicate registry entries or break existing automations.
+    """
+
+    assert CONNECTIVITY_DESC.key == "connectivity"
+    assert CONNECTIVITY_DESC.translation_key == "connectivity"
+
+    en = json.loads((_TRANSLATIONS_DIR / "en.json").read_text(encoding="utf-8"))
+    assert (
+        en["entity"]["binary_sensor"]["connectivity"]["name"]
+        == "FCM Connection Status"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# T11 translation completeness across every shipped locale + strings.json
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "path", _all_translation_files(), ids=lambda p: p.name
+)
+def test_t11_encryption_key_status_present_and_complete(path: Path) -> None:
+    """Every translation file defines the sensor name and all four states."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    sensor = data["entity"]["sensor"]
+    assert "encryption_key_status" in sensor, f"{path.name} misses the sensor"
+
+    block = sensor["encryption_key_status"]
+    name = block.get("name")
+    assert isinstance(name, str) and name.strip(), f"{path.name} empty name"
+
+    states = set(block.get("state", {}).keys())
+    assert states == _REQUIRED_STATES, f"{path.name}: {states} != {_REQUIRED_STATES}"
+    for key, value in block["state"].items():
+        assert isinstance(value, str) and value.strip(), f"{path.name} {key} empty"
+
+
+@pytest.mark.parametrize(
+    "path", _all_translation_files(), ids=lambda p: p.name
+)
+def test_t11_connectivity_rename_present(path: Path) -> None:
+    """Every translation file carries the FCM-qualified connectivity name."""
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    name = data["entity"]["binary_sensor"]["connectivity"]["name"]
+    assert "FCM" in name, f"{path.name} connectivity name {name!r} lacks FCM"

--- a/tests/test_sensor_subentry_setup.py
+++ b/tests/test_sensor_subentry_setup.py
@@ -108,6 +108,7 @@ async def test_setup_iterates_sensor_subentries(stub_coordinator_factory: Any) -
     assert configs == {service_subentry.subentry_id, tracker_subentry.subentry_id}
     assert {entity.unique_id for entity, _ in added} == {
         f"{DOMAIN}_{entry.entry_id}_{service_subentry.subentry_id}_semantic_labels",
+        f"{DOMAIN}_{entry.entry_id}_{service_subentry.subentry_id}_encryption_key_status",
         f"{DOMAIN}_{entry.entry_id}_{service_subentry.subentry_id}_background_updates",
         f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_device-1_last_seen",
     }
@@ -169,8 +170,10 @@ async def test_dispatcher_adds_new_tracker_subentries(
     configs = [config for _, config in added]
     assert configs.count(tracker_subentry.subentry_id) == 1
     assert configs.count(new_subentry.subentry_id) == 1
-    assert configs.count(service_subentry.subentry_id) == 2
-    assert len({entity.unique_id for entity, _ in added}) == 4
+    # Service scope now emits three diagnostic sensors: semantic_labels,
+    # encryption_key_status (AP-10) and the background_updates stat.
+    assert configs.count(service_subentry.subentry_id) == 3
+    assert len({entity.unique_id for entity, _ in added}) == 5
     assert entry._unload_callbacks, "dispatcher listener should be cleaned up on unload"
 
 
@@ -222,7 +225,9 @@ async def test_dispatcher_deduplicates_existing_subentry_signals(
     async_dispatcher_send(hass, signal, service_subentry.subentry_id)
     await asyncio.gather(*pending)
 
-    assert len(added) == initial_count == 3
+    # Four entities: service semantic_labels + encryption_key_status (AP-10) +
+    # background_updates stat, plus the tracker last_seen sensor.
+    assert len(added) == initial_count == 4
     assert {config for _, config in added} == {
         service_subentry.subentry_id,
         tracker_subentry.subentry_id,
@@ -273,6 +278,7 @@ async def test_hidden_tracker_sensors_skip_invisible_devices(
         f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_visible-device_last_seen",
         f"{DOMAIN}_{entry.entry_id}_service_background_updates",
         f"{DOMAIN}_{entry.entry_id}_service_semantic_labels",
+        f"{DOMAIN}_{entry.entry_id}_service_encryption_key_status",
     }
     config_by_unique_id = {entity.unique_id: config for entity, config in added}
     assert (


### PR DESCRIPTION
## Summary

Adds a third diagnostic status axis for **end-to-end decryption (E2EE) health**, alongside the existing Nova auth and FCM connection sensors, and renames the FCM connection status sensor for clarity. This builds on the reauth/decryption work merged in #1112.

## What changed

### New encryption-key diagnostic sensor (AP-10)
- New `CryptoStatus` status group in `coordinator/helpers/stats.py` (string constants, mirroring the existing `ApiStatus`/`FcmStatus` design, not an `enum.Enum`), re-exported via `coordinator/__init__.py`.
- `polling.py` tracks `_crypto_status_state` from a **single source** (D6): `note_decrypt_failure` maps `DecryptionError` subtypes to `tracker_key_outdated` / `shared_key_missing` / `shared_key_invalid`. The same source that drives the reauth escalation drives the sensor, so they never drift apart.
- New `GoogleFindMyEncryptionKeyStatusSensor` (`ENUM`, `DIAGNOSTIC`) on the per-entry **service device**, respecting the HA enum invariant (`native_value` always in `options`; initial `unknown` -> `None`).

### Precise OK semantics
`crypto_status` is set to `OK` only after a poll cycle that had **at least one successful decrypt** and **no stale-key device** (`cycle_had_successful_decrypt` + `cycle_had_stale_key`). "No decrypt error" alone (e.g. a timeout-only cycle) does not flip the sensor to OK, and a healthy device cannot overwrite another tracker's `tracker_key_outdated` state within the same cycle.

### Non-breaking connectivity rename (AP-9)
- The `connectivity` binary sensor display name becomes **"FCM Connection Status"** via translations only. `key`, `translation_key` and `unique_id` are unchanged, so existing entity ids and unique ids stay stable (non-breaking).

### Translations + icons (AP-6)
- All 11 translation files (10 languages + `strings.json`) and `icons.json` updated for the renamed connection status and the new sensor (name + four enum states).

## Testing
- New `tests/test_encryption_key_status_sensor.py`: enum-state mapping (state in `options`), non-breaking-rename stability (entity_id/unique_id), translation completeness across all 11 files.
- Poll-cycle integration tests in `test_coordinator_semantic_mappings.py` assert `crypto_status` after real cycles, including a mixed stale+success cycle. Both OK-gate flags are mutation-checked (flipping each makes a test fail).
- Changed-code coverage 100% on `polling.py` / `sensor.py` / `stats.py` (measured, git-diff ∩ missing empty).
- Full CI-equivalent sequential run: `rc=0`, 0 failed, coverage 70.10% (>= 69%). `ruff` + `mypy` clean.
