### PR TITLE
fix(coordinator): keep decrypt-failure budget across idle polls; normalize GCM identity whitespace

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3081,6 +3081,12 @@ class FcmReceiverHA:
             # gate). Clear the shared reauth budget so non-consecutive background
             # failures interleaved with successful pushes cannot strand a healthy
             # account at the reauth threshold.
+            # Keyed on the source entry_id -- the cache that actually performed
+            # this decrypt -- and symmetric with the failure paths above. Routed
+            # fan-out targets share the source's FCM registration token, hence the
+            # same account-wide owner_key, so the source success already proves
+            # their key; clearing the routed target set instead would break the
+            # source entry's own reset invariant.
             self._note_decrypt_success_for_entry(entry_id)
 
             best_record: Mapping[str, Any] | None = None

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -2992,6 +2992,26 @@ class FcmReceiverHA:
                 if entry is not None:
                     entry.async_start_reauth(hass)
 
+    def _note_decrypt_success_for_entry(self, entry_id: str) -> None:
+        """Feed a background-path decryption success into the matching coordinator(s).
+
+        Symmetric counterpart of :meth:`_note_decrypt_failure_for_entry`. The
+        background decode shares the coordinator's account-wide decrypt-failure
+        counter, so a successful background decrypt must clear it just like a
+        clean poll cycle does. Without this, push-only accounts whose scheduled
+        polls stay idle could accumulate a couple of *non-consecutive* background
+        decrypt failures up to the reauth threshold even though real locations
+        keep arriving and decrypting -- a spurious reauth prompt. Swallowed to
+        debug so it never breaks the push path.
+        """
+        for coordinator in self._coordinators_for_entries({entry_id}):
+            try:
+                coordinator.note_decrypt_success()
+            except Exception as err:  # noqa: BLE001 - never break the push path
+                _LOGGER.debug(
+                    "note_decrypt_success failed for entry %s: %s", entry_id, err
+                )
+
     async def _decode_background_location_async(  # noqa: PLR0911
         self, entry_id: str, hex_string: str
     ) -> JSONDict:
@@ -3055,6 +3075,13 @@ class FcmReceiverHA:
             )
             if not locations:
                 return {}
+
+            # Usable decrypted records: positive proof the account-wide shared key
+            # still works (mirrors the poll cycle's cycle_had_successful_decrypt
+            # gate). Clear the shared reauth budget so non-consecutive background
+            # failures interleaved with successful pushes cannot strand a healthy
+            # account at the reauth threshold.
+            self._note_decrypt_success_for_entry(entry_id)
 
             best_record: Mapping[str, Any] | None = None
             best_key: tuple[float, int, int] | None = None

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -175,6 +175,9 @@ class _MixinBase:
     ) -> bool:
         raise NotImplementedError
 
+    def note_decrypt_success(self) -> None:
+        raise NotImplementedError
+
     def _short_error_message(self, exc: Exception | str) -> str:
         raise NotImplementedError
 

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -408,6 +408,35 @@ class PollingOperations(_MixinBase):
         )
         return True
 
+    def note_decrypt_success(self) -> None:
+        """Record a proven location decryption and clear the reauth budget.
+
+        Shared success entry point that mirrors :meth:`note_decrypt_failure`. The
+        account-wide ``_consecutive_decrypt_failures`` counter is *fed* from more
+        than one source -- the poll cycle and the FCM background-push decode both
+        increment it through ``note_decrypt_failure`` -- so the symmetric clear
+        must be reachable from every automatic source that can observe positive
+        proof the shared key still decrypts. A successful own/crowd location
+        decrypt is exactly that proof, so it resets the counter that drives
+        ``ConfigEntryAuthFailed`` escalation; otherwise non-consecutive failures
+        from one source accumulate to the threshold and trip a spurious reauth.
+        Idempotent and cheap when the counter is already zero.
+
+        Intentionally does NOT touch :class:`CryptoStatus`: that diagnostic state
+        is owned by the poll cycle, whose OK transition is additionally gated on
+        the absence of a per-tracker stale key so it never flickers
+        ``tracker_key_outdated`` away. A single background decode has no
+        cross-tracker cycle view, so it only clears the account-wide reauth
+        budget here and leaves the sensor to the poll loop.
+        """
+        if self._consecutive_decrypt_failures > 0:
+            _LOGGER.info(
+                "Location decryption succeeded; clearing %d decrypt failure(s).",
+                self._consecutive_decrypt_failures,
+            )
+            self._consecutive_decrypt_failures = 0
+        self._last_decrypt_error = None
+
     def _is_on_hass_loop(self) -> bool:
         """Return True if currently executing on the HA event loop thread."""
         loop = self.hass.loop
@@ -1865,7 +1894,7 @@ class PollingOperations(_MixinBase):
                         # timeouts/transient errors leaves the prior state intact
                         # rather than flickering a stale key to OK.
                         self._set_crypto_status(CryptoStatus.OK)
-                    if cycle_had_successful_decrypt and self._consecutive_decrypt_failures > 0:
+                    if cycle_had_successful_decrypt:
                         # Clear the consecutive-decrypt counter only on POSITIVE
                         # proof that the account-wide shared key works (at least one
                         # device decrypted this cycle), mirroring the CryptoStatus.OK
@@ -1885,13 +1914,12 @@ class PollingOperations(_MixinBase):
                         # note_decrypt_failure(stale=True)). Proof that the account
                         # key works must be allowed to clear it even when one tracker
                         # still carries an outdated key.
-                        _LOGGER.info(
-                            "Location decryption succeeded this cycle; clearing "
-                            "%d decrypt failure(s).",
-                            self._consecutive_decrypt_failures,
-                        )
-                        self._consecutive_decrypt_failures = 0
-                        self._last_decrypt_error = None
+                        #
+                        # Clear via the shared success entry point so this poll path
+                        # and the FCM background-push decode cannot drift apart again:
+                        # both sources feed the counter, both must be able to clear it
+                        # (the asymmetry that previously stranded a healthy account).
+                        self.note_decrypt_success()
             finally:
                 # Update scheduling baseline and clear flag, then push end snapshot.
                 # Always advance the poll baseline to prevent high-frequency

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1865,14 +1865,28 @@ class PollingOperations(_MixinBase):
                         # timeouts/transient errors leaves the prior state intact
                         # rather than flickering a stale key to OK.
                         self._set_crypto_status(CryptoStatus.OK)
-                    if self._consecutive_decrypt_failures > 0:
-                        # Clear the consecutive-decrypt counter so a recovered/
-                        # healthy shared key (or a successful self-heal) does not
-                        # later trip a spurious reauth. Gated on the entire cycle --
-                        # one healthy tracker must not mask a persistently stale
-                        # account-wide shared key on the others.
+                    if cycle_had_successful_decrypt and self._consecutive_decrypt_failures > 0:
+                        # Clear the consecutive-decrypt counter only on POSITIVE
+                        # proof that the account-wide shared key works (at least one
+                        # device decrypted this cycle), mirroring the CryptoStatus.OK
+                        # gate above. An idle cycle that only saw empty/no-reporter
+                        # results (cycle_had_successful_decrypt == False) must NOT
+                        # reset the counter: intermittently reporting BLE trackers
+                        # would otherwise let idle cycles between two failing decrypt
+                        # cycles perpetually clear the budget, so the reauth threshold
+                        # could never be reached and the user would stay stuck with a
+                        # stale key and no reauth prompt.
+                        #
+                        # Unlike the OK gate this intentionally does NOT also require
+                        # ``not cycle_had_stale_key``: this counter tracks the
+                        # account-wide shared key, while a per-tracker outdated owner
+                        # key (cycle_had_stale_key) is a separate, device-local
+                        # concern that never advances this counter (see
+                        # note_decrypt_failure(stale=True)). Proof that the account
+                        # key works must be allowed to clear it even when one tracker
+                        # still carries an outdated key.
                         _LOGGER.info(
-                            "Location decryption succeeded for all devices; clearing "
+                            "Location decryption succeeded this cycle; clearing "
                             "%d decrypt failure(s).",
                             self._consecutive_decrypt_failures,
                         )

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -422,12 +422,18 @@ class PollingOperations(_MixinBase):
         from one source accumulate to the threshold and trip a spurious reauth.
         Idempotent and cheap when the counter is already zero.
 
-        Intentionally does NOT touch :class:`CryptoStatus`: that diagnostic state
-        is owned by the poll cycle, whose OK transition is additionally gated on
+        Intentionally touches ONLY the account-wide counter, not the diagnostic
+        sensor surface (:class:`CryptoStatus` and ``_last_decrypt_error``): those
+        are owned by the poll cycle, whose OK transition is additionally gated on
         the absence of a per-tracker stale key so it never flickers
-        ``tracker_key_outdated`` away. A single background decode has no
-        cross-tracker cycle view, so it only clears the account-wide reauth
-        budget here and leaves the sensor to the poll loop.
+        ``tracker_key_outdated`` -- nor the error class behind it -- away. A
+        per-tracker ``StaleOwnerKeyError`` records ``_last_decrypt_error`` for the
+        sensor while deliberately leaving this counter at zero, so clearing that
+        field here would erase a still-relevant diagnostic on the very cycle a
+        sibling tracker decrypts. A single background decode likewise has no
+        cross-tracker cycle view, so it only clears the account-wide reauth budget
+        here and leaves the sensor (status and error class together) to the poll
+        loop.
         """
         if self._consecutive_decrypt_failures > 0:
             _LOGGER.info(
@@ -435,7 +441,6 @@ class PollingOperations(_MixinBase):
                 self._consecutive_decrypt_failures,
             )
             self._consecutive_decrypt_failures = 0
-        self._last_decrypt_error = None
 
     def _is_on_hass_loop(self) -> bool:
         """Return True if currently executing on the HA event loop thread."""
@@ -1894,6 +1899,14 @@ class PollingOperations(_MixinBase):
                         # timeouts/transient errors leaves the prior state intact
                         # rather than flickering a stale key to OK.
                         self._set_crypto_status(CryptoStatus.OK)
+                        # Clear the diagnostic error class together with the OK
+                        # status: both are the same sensor surface and must move
+                        # as one. Gating it on the same ``not cycle_had_stale_key``
+                        # condition keeps a per-tracker StaleOwnerKeyError's error
+                        # class intact while its tracker_key_outdated status
+                        # persists -- note_decrypt_success() no longer wipes this
+                        # field blindly from the shared (poll + push) entry point.
+                        self._last_decrypt_error = None
                     if cycle_had_successful_decrypt:
                         # Clear the consecutive-decrypt counter only on POSITIVE
                         # proof that the account-wide shared key works (at least one

--- a/custom_components/googlefindmy/shared_helpers.py
+++ b/custom_components/googlefindmy/shared_helpers.py
@@ -110,12 +110,14 @@ def safe_fcm_health_snapshots(receiver: Any) -> dict[str, dict[str, Any]]:
         return {}
 
 
-# Credential keys whose values are base64 / base64url / hex / JWT tokens.
-# Those alphabets never contain a legitimate space, so ALL whitespace (including
-# interior characters introduced by a line-wrapped copy/paste) is stripped from
-# their values. Every other key keeps interior whitespace and is only trimmed at
-# the edges, so values that may legitimately contain spaces (display names,
-# email addresses) are never corrupted.
+# Credential keys whose values are base64 / base64url / hex / JWT tokens, or the
+# numeric GCM identity material (``android_id`` / ``security_token``, both parsed
+# via ``int(...)`` on the FCM login path). Those alphabets never contain a
+# legitimate space, so ALL whitespace (including interior characters introduced
+# by a line-wrapped copy/paste) is stripped from their values. Every other key
+# keeps interior whitespace and is only trimmed at the edges, so values that may
+# legitimately contain spaces (display names, email addresses) are never
+# corrupted.
 _SECRET_WHITELIST_KEYS: frozenset[str] = frozenset(
     {
         "owner_key",
@@ -129,6 +131,11 @@ _SECRET_WHITELIST_KEYS: frozenset[str] = frozenset(
         "adm_token",
         "admToken",
         "Auth",
+        # GCM device identity under ``fcm_credentials.gcm`` -- numeric values fed
+        # to ``int(android_id)`` / ``int(security_token)`` during push
+        # registration; an interior space from a wrapped paste breaks login.
+        "android_id",
+        "security_token",
     }
 )
 

--- a/tests/test_config_flow_secrets_normalization.py
+++ b/tests/test_config_flow_secrets_normalization.py
@@ -71,6 +71,29 @@ def test_nested_fcm_token_normalized() -> None:
     assert result["fcm_credentials"]["fcm"]["registration"]["token"] == "registration"
 
 
+def test_nested_gcm_identity_normalized() -> None:
+    """The numeric GCM identity (android_id / security_token under
+    fcm_credentials.gcm) loses ALL whitespace: both are fed to int() on the FCM
+    login path, so an interior space from a wrapped paste would break push
+    registration (Codex finding on PR #182)."""
+    bundle = {
+        "fcm_credentials": {
+            "gcm": {
+                "android_id": "1234 5678 9012 3456",
+                "security_token": " 9876\n543210 ",
+                "app_id": "app-1",
+            }
+        }
+    }
+    result = normalize_secrets_bundle(bundle)
+    gcm = result["fcm_credentials"]["gcm"]
+    assert gcm["android_id"] == "1234567890123456"
+    assert gcm["security_token"] == "9876543210"
+    # app_id is a structured identifier (not numeric/token credential material)
+    # and is not in the whitelist: only edge-trimmed, interior preserved.
+    assert gcm["app_id"] == "app-1"
+
+
 def test_idempotent() -> None:
     """Applying the normalization twice yields the same result."""
     bundle = {

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -18,8 +18,11 @@ through CI: a 0.0 sentinel made the first escalation uptime-dependent).
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from unittest.mock import MagicMock
+
+import pytest
 
 from custom_components.googlefindmy.coordinator import polling as polling_mod
 from custom_components.googlefindmy.coordinator.polling import (
@@ -88,8 +91,9 @@ def test_t5_success_reset_prevents_premature_escalation() -> None:
     stub.note_decrypt_failure(stale=False, error=err)
     stub.note_decrypt_failure(stale=False, error=err)
     assert stub._consecutive_decrypt_failures == 2
-    stub._consecutive_decrypt_failures = 0  # success path reset
-    stub._last_decrypt_error = None
+    stub.note_decrypt_success()  # the real success path reset
+    assert stub._consecutive_decrypt_failures == 0
+    assert stub._last_decrypt_error is None
 
     # Two fresh failures must NOT escalate (threshold is 3, not 1).
     assert stub.note_decrypt_failure(stale=False, error=err) is False
@@ -163,3 +167,44 @@ def test_t9_first_escalation_is_independent_of_process_uptime() -> None:
     stub._set_auth_state.assert_called_once()
     # The escalation timestamp is now recorded (no longer the None sentinel).
     assert stub._last_decrypt_reauth_monotonic == fresh_boot_clock
+
+
+def test_note_decrypt_success_clears_accumulated_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The shared success entry point clears a partial decrypt-failure budget.
+
+    This is the symmetric counterpart of ``note_decrypt_failure`` that both the
+    poll cycle and the FCM background-push decode call on a proven decrypt. Two
+    non-escalating failures leave the counter at 2; a single success must reset
+    it to 0 (and drop the stale last-error), so a later failure starts the
+    threshold count fresh instead of escalating one step early.
+    """
+    stub = _make_stub()
+    err = DecryptionError("boom")
+    stub.note_decrypt_failure(stale=False, error=err)
+    stub.note_decrypt_failure(stale=False, error=err)
+    assert stub._consecutive_decrypt_failures == 2
+    assert stub._last_decrypt_error is not None
+
+    with caplog.at_level(logging.INFO, logger=polling_mod.__name__):
+        stub.note_decrypt_success()
+
+    assert stub._consecutive_decrypt_failures == 0
+    assert stub._last_decrypt_error is None
+    assert "clearing 2 decrypt failure(s)" in caplog.text
+
+
+def test_note_decrypt_success_is_idempotent_when_no_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With an empty budget the success entry point is a cheap no-op: it clears
+    nothing and stays silent (no misleading "clearing 0 failure(s)" log)."""
+    stub = _make_stub()
+
+    with caplog.at_level(logging.INFO, logger=polling_mod.__name__):
+        stub.note_decrypt_success()
+
+    assert stub._consecutive_decrypt_failures == 0
+    assert stub._last_decrypt_error is None
+    assert "clearing" not in caplog.text

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -93,7 +93,9 @@ def test_t5_success_reset_prevents_premature_escalation() -> None:
     assert stub._consecutive_decrypt_failures == 2
     stub.note_decrypt_success()  # the real success path reset
     assert stub._consecutive_decrypt_failures == 0
-    assert stub._last_decrypt_error is None
+    # The shared entry point clears only the account-wide counter; the diagnostic
+    # error class is owned by the poll loop's OK gate, so it survives this call.
+    assert stub._last_decrypt_error is not None
 
     # Two fresh failures must NOT escalate (threshold is 3, not 1).
     assert stub.note_decrypt_failure(stale=False, error=err) is False
@@ -177,8 +179,11 @@ def test_note_decrypt_success_clears_accumulated_failures(
     This is the symmetric counterpart of ``note_decrypt_failure`` that both the
     poll cycle and the FCM background-push decode call on a proven decrypt. Two
     non-escalating failures leave the counter at 2; a single success must reset
-    it to 0 (and drop the stale last-error), so a later failure starts the
-    threshold count fresh instead of escalating one step early.
+    it to 0, so a later failure starts the threshold count fresh instead of
+    escalating one step early. The diagnostic ``_last_decrypt_error`` is NOT
+    cleared here: it is part of the sensor surface owned by the poll loop's OK
+    gate (which alone knows whether a per-tracker stale key must keep it), so
+    this shared entry point leaves it intact.
     """
     stub = _make_stub()
     err = DecryptionError("boom")
@@ -191,7 +196,8 @@ def test_note_decrypt_success_clears_accumulated_failures(
         stub.note_decrypt_success()
 
     assert stub._consecutive_decrypt_failures == 0
-    assert stub._last_decrypt_error is None
+    # Counter cleared, diagnostic preserved (owned by the poll OK gate).
+    assert stub._last_decrypt_error is not None
     assert "clearing 2 decrypt failure(s)" in caplog.text
 
 

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -397,7 +397,11 @@ class _DecryptThenSucceedAPI:
         self.calls += 1
         if self.calls <= self._fail:
             raise self._exc
-        return {}  # success with no decryptable report (still clears the counter)
+        # A genuinely decryptable report: positive proof the account-wide shared
+        # key works again. Only such a real decrypt clears the counter -- an empty
+        # / no-reporter response (falsy) is an idle outcome and must NOT (see
+        # test_poll_cycle_idle_does_not_reset_decrypt_counter).
+        return {"latitude": 1.0, "longitude": 2.0, "accuracy": 5.0}
 
 
 @pytest.mark.asyncio
@@ -417,6 +421,51 @@ async def test_poll_cycle_decrypt_counter_resets_on_success() -> None:
     # A successful cycle resets the counter back to zero.
     await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
     assert coordinator._consecutive_decrypt_failures == 0
+
+
+class _DecryptThenIdleAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then returns
+    an empty (no-reporter) result.
+
+    Models an intermittently reporting BLE tracker: failing decrypt cycles are
+    interleaved with idle cycles that simply return no location data. Such idle
+    cycles carry no positive proof the shared key recovered and must therefore
+    NOT clear the accumulated decrypt-failure counter.
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        return []  # idle: no reporter in range, nothing decrypted this cycle
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_idle_does_not_reset_decrypt_counter() -> None:
+    """An idle cycle (empty/no-reporter result) must NOT clear accumulated decrypt
+    failures: without a real successful decrypt there is no proof the stale shared
+    key recovered. Otherwise an intermittently reporting BLE tracker would let idle
+    cycles perpetually reset the counter, so the reauth threshold is never reached
+    and the user stays stuck with no location updates and no reauth prompt
+    (Codex finding on PR #182)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenIdleAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles accumulate the counter without escalating.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # An idle cycle in between must leave the counter intact (not reset to zero).
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
 
 
 class _PerDeviceDecryptAPI:

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -421,6 +421,11 @@ async def test_poll_cycle_decrypt_counter_resets_on_success() -> None:
     # A successful cycle resets the counter back to zero.
     await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
     assert coordinator._consecutive_decrypt_failures == 0
+    # No per-tracker stale key was seen, so the OK gate also clears the diagnostic
+    # error class (status and error class move together). Mutation guard: dropping
+    # the OK-gate ``_last_decrypt_error = None`` leaves the stale class behind.
+    assert coordinator._last_decrypt_error is None
+    assert coordinator.crypto_status.state == CryptoStatus.OK
 
 
 class _DecryptThenIdleAPI:
@@ -728,3 +733,36 @@ async def test_poll_cycle_mixed_stale_and_success_keeps_tracker_outdated() -> No
     )
 
     assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_mixed_stale_and_success_keeps_last_decrypt_error() -> None:
+    """The stale-key diagnostic must survive a sibling's successful decrypt.
+
+    Same mixed cycle as above, but asserting the *error class* the encryption-key
+    status sensor exposes (``last_decrypt_error_class`` from ``_last_decrypt_error``).
+    The successful sibling clears the account-wide reauth budget via the shared
+    success entry point, yet the per-tracker StaleOwnerKeyError diagnostic must
+    stay so the sensor can still report which class is outdated.
+
+    Regression guard for the Codex finding: clearing ``_last_decrypt_error``
+    unconditionally in ``note_decrypt_success()`` (or gating it only on the
+    counter) wipes this on the very cycle a sibling decrypts and turns this red.
+    """
+
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _MixedDecryptAPI(
+        "dev-stale",
+        StaleOwnerKeyError("tracker v1 < v2"),
+        {"latitude": 1.0, "longitude": 2.0, "last_seen": 100},
+    )
+    coordinator._set_auth_state = lambda **_kwargs: None
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-stale", "name": "Old"}, {"id": "dev-ok", "name": "Hub"}]
+    )
+
+    # Status stays outdated AND the error class behind it survives for triage.
+    assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED
+    assert coordinator._last_decrypt_error is not None
+    assert coordinator._last_decrypt_error.split(":", 1)[0] == "StaleOwnerKeyError"

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -123,3 +123,61 @@ async def test_decode_background_location_feeds_counter_on_decrypt_error(
     assert result == {}
     coordinator.note_decrypt_failure.assert_called_once()
     assert entry.async_start_reauth.called is expect_reauth
+
+
+@pytest.mark.asyncio
+async def test_decode_background_location_clears_counter_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful background decrypt must clear the shared reauth budget.
+
+    The background path feeds decrypt *failures* into the coordinator's
+    account-wide counter, so a successful background decrypt has to clear it too
+    (symmetry with the poll cycle). Otherwise non-consecutive push failures
+    interleaved with healthy pushes could accumulate to the reauth threshold and
+    trip a spurious reauth for a perfectly healthy account.
+    """
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+    receiver._entry_caches["entry-1"] = MagicMock()
+
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    # Decrypt succeeds and yields one usable record (positive proof of the key).
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(
+            return_value=[{"last_seen": 123.0, "latitude": 1.0, "longitude": 2.0}]
+        ),
+    )
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    assert result.get("last_seen") == 123.0
+    coordinator.note_decrypt_success.assert_called_once_with()
+    coordinator.note_decrypt_failure.assert_not_called()
+    entry.async_start_reauth.assert_not_called()
+
+
+def test_note_decrypt_success_for_entry_swallows_coordinator_errors() -> None:
+    """The push success path must never break: a misbehaving coordinator is
+    swallowed exactly like the failure path."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+    coordinator.note_decrypt_success = MagicMock(side_effect=RuntimeError("boom"))
+
+    # Must not raise.
+    receiver._note_decrypt_success_for_entry("entry-1")
+
+    coordinator.note_decrypt_success.assert_called_once_with()
+
+
+def test_note_decrypt_success_for_entry_unknown_entry_is_noop() -> None:
+    """Unknown entry id: nothing to clear, no crash."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+
+    receiver._note_decrypt_success_for_entry("other-entry")
+
+    coordinator.note_decrypt_success.assert_not_called()


### PR DESCRIPTION
## Summary

Addresses two Codex review findings raised on the upstream PR #182. Both are fixed here on `1.7.2` so they flow into that PR automatically.

### Fixed
- **Stale key could leave a tracker stuck with no reauth prompt.** The consecutive-decrypt-failure counter was cleared on *any* poll cycle that ended without an account-wide decrypt error, including idle cycles that only returned empty / no-reporter responses. For intermittently reporting BLE trackers, an idle cycle between two failing decrypt cycles kept resetting the budget, so the re-authentication threshold was never reached: the user could stay stuck with no location updates and no reauth prompt. The counter is now cleared only on **positive proof** that the account-wide shared key works (at least one device actually decrypted location data this cycle). Idle cycles leave the accumulated count intact.
- **Push registration could fail after pasting `secrets.json`.** Whitespace normalization of pasted credential bundles did not cover the numeric GCM identity values `android_id` and `security_token`. Both are parsed with `int(...)` during FCM login, so a single interior space introduced by a line-wrapped copy/paste broke push registration even though other credential fields were already cleaned. These two values now have all whitespace removed like the other credential keys.

### Notes
- The decrypt-counter reset intentionally clears even when one tracker still reports an *outdated owner key*: that per-tracker condition is tracked separately and never drives the account-wide reauth budget, so proof the account key works should clear it.
- Structured, non-numeric identifiers (e.g. `app_id`) are deliberately left edge-trimmed only and are not affected.

### Testing
- New regression test proving an idle cycle no longer resets the decrypt-failure budget (mutation-verified: reverting the fix makes it fail).
- The existing "resets on success" test now exercises a genuinely decryptable location instead of an empty response.
- New normalization test covering `android_id` / `security_token` (interior space + newline) with a negative control on `app_id`.
- `ruff check`, `mypy --strict` (sources and tests), and the affected coordinator / config-flow suites all pass.

### Compatibility
No config-schema or storage migration. Behavior-only changes.

---

### Follow-up (second Codex round on this PR)

**Reset the shared decrypt-failure budget on background-push decrypt successes too.**

The previous commit gated the poll-cycle reset of the account-wide
`_consecutive_decrypt_failures` counter on a real decrypt. But that counter is
fed from more than one source: the poll cycle *and* the FCM background-push
decode both increment it (via `note_decrypt_failure`), while only the poll cycle
cleared it on success. For push-driven accounts whose scheduled polls stay idle,
a couple of *non-consecutive* background decrypt failures could therefore
accumulate to the reauth threshold and trip a spurious re-authentication even
though real locations keep arriving and decrypting.

#### Changed
- New shared `note_decrypt_success()` entry point on the coordinator that mirrors
  `note_decrypt_failure()`: it clears the counter (and the stale last-error) on
  proven decrypt success. The poll-cycle inline reset now calls it, so the poll
  and push paths can no longer drift apart.
- The FCM receiver gains `_note_decrypt_success_for_entry()`, invoked when a
  background decode yields usable locations (the push-side equivalent of the poll
  cycle's positive-proof gate).
- `note_decrypt_success()` deliberately does **not** touch `CryptoStatus`: that
  diagnostic state stays owned by the poll loop, whose OK transition is
  additionally gated on the absence of a per-tracker stale key.
- Manual locate is intentionally left as an upward-only (non-reset) evidence
  surface, matching its existing documented design.

#### Note
- `note_decrypt_success()` now also clears the diagnostic `last_decrypt_error`
  attribute on any proven-healthy cycle (previously only when the counter was
  non-zero). This is a benign diagnostic-only change: a stale error string no
  longer lingers on the sensor after the account recovers.

#### Testing
- New test proving a successful background decode clears the shared counter
  (mutation-verified: removing the call makes it fail).
- New direct tests for `note_decrypt_success()` (clears an accumulated budget;
  idempotent no-op when empty) plus swallow-on-error / unknown-entry guards for
  the receiver helper.
- The poll-cycle "resets on success" path now routes through the shared method;
  reverting the method's reset turns both the unit and the poll-cycle test red.
- `ruff check`, `mypy --strict` (sources and tests) and the affected
  coordinator / FCM-receiver suites pass.


#### Review note (Codex round 4)
- The suggestion to clear the routed `target_entries` on a successful background
  decrypt was reviewed and is intentionally not applied. The decrypt validates
  only the source entry's cache/`owner_key`, and the failure paths key on the
  same source, so the reset is symmetric (`{source}`). Routed targets share the
  source's FCM registration token (same account-wide `owner_key`), so the source
  success already proves their key; clearing the routed set instead would break
  the source entry's own reset and could mask a genuinely stale key. Added an
  inline clarification comment instead of changing the keying.

### Review note (Codex round 5)

Fixed a real diagnostic-consistency bug surfaced on commit `fce73df`: `note_decrypt_success()` (shared by the poll cycle and the FCM background-push decode) cleared `_last_decrypt_error` unconditionally. A per-tracker `StaleOwnerKeyError` records that field for the encryption-key status sensor while deliberately leaving the account-wide counter at zero and keeping `CryptoStatus` at `tracker_key_outdated`. On a mixed cycle (one stale tracker, one healthy sibling) the success path wiped the stale-key diagnostic while the coupled status intentionally stayed outdated, so the sensor exposed an outdated tracker without the `last_decrypt_error_class` needed to triage it.

The clearing of `_last_decrypt_error` now lives in the poll OK gate (gated on `cycle_had_successful_decrypt and not cycle_had_stale_key`), coupled to the `CryptoStatus.OK` transition so status and error class move as one sensor surface. `note_decrypt_success()` now touches only the account-wide counter (both poll and push reset it on proven decrypt). This also removes a pre-existing push-path divergence (status invalid + error class cleared). Added a mixed-cycle regression test (StaleOwnerKeyError class survives a sibling's success), extended the recovery test (OK gate clears the class when no stale key), and aligned the shared-entry-point tests; mutation-checked both ways.
