### PR TITLE
fix(coordinator): require an authenticated location before clearing decrypt budget

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -88,8 +88,8 @@ from custom_components.googlefindmy.exceptions import FatalRegistrationError
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
     StaleOwnerKeyError,
+    any_real_location_record,
     async_decrypt_location_response_locations,
-    is_real_location_record,
 )
 from custom_components.googlefindmy.NovaApi.nova_request import (
     _CACHE_PROVIDER,
@@ -3093,7 +3093,7 @@ class FcmReceiverHA:
             # same account-wide owner_key, so the source success already proves
             # their key; clearing the routed target set instead would break the
             # source entry's own reset invariant.
-            if any(is_real_location_record(record) for record in locations):
+            if any_real_location_record(locations):
                 self._note_decrypt_success_for_entry(entry_id)
 
             best_record: Mapping[str, Any] | None = None

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -89,6 +89,7 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_
     DecryptionError,
     StaleOwnerKeyError,
     async_decrypt_location_response_locations,
+    is_real_location_record,
 )
 from custom_components.googlefindmy.NovaApi.nova_request import (
     _CACHE_PROVIDER,
@@ -3076,18 +3077,23 @@ class FcmReceiverHA:
             if not locations:
                 return {}
 
-            # Usable decrypted records: positive proof the account-wide shared key
-            # still works (mirrors the poll cycle's cycle_had_successful_decrypt
-            # gate). Clear the shared reauth budget so non-consecutive background
-            # failures interleaved with successful pushes cannot strand a healthy
-            # account at the reauth threshold.
+            # Clear the shared reauth budget only on positive proof: at least one
+            # *authenticated* location report. A metadata_only sentinel row is
+            # non-empty but carries only secrets-bundle key material (no successful
+            # decrypt), so it must NOT clear the budget -- otherwise report-less
+            # pushes interleaved with failures could keep a stale key below the
+            # reauth threshold. This mirrors the poll cycle's
+            # cycle_had_successful_decrypt gate, which excludes the same sentinel,
+            # and lets non-consecutive background failures interleaved with genuine
+            # pushes avoid stranding a healthy account at the reauth threshold.
             # Keyed on the source entry_id -- the cache that actually performed
             # this decrypt -- and symmetric with the failure paths above. Routed
             # fan-out targets share the source's FCM registration token, hence the
             # same account-wide owner_key, so the source success already proves
             # their key; clearing the routed target set instead would break the
             # source entry's own reset invariant.
-            self._note_decrypt_success_for_entry(entry_id)
+            if any(is_real_location_record(record) for record in locations):
+                self._note_decrypt_success_for_entry(entry_id)
 
             best_record: Mapping[str, Any] | None = None
             best_key: tuple[float, int, int] | None = None

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3078,12 +3078,13 @@ class FcmReceiverHA:
                 return {}
 
             # Clear the shared reauth budget only on positive proof: at least one
-            # *authenticated* location report. A metadata_only sentinel row is
-            # non-empty but carries only secrets-bundle key material (no successful
-            # decrypt), so it must NOT clear the budget -- otherwise report-less
-            # pushes interleaved with failures could keep a stale key below the
-            # reauth threshold. This mirrors the poll cycle's
-            # cycle_had_successful_decrypt gate, which excludes the same sentinel,
+            # *authenticated* coordinate report. Truthy-but-unauthenticated rows --
+            # a metadata_only sentinel (only secrets-bundle key material) or a
+            # SEMANTIC row (no decrypted coordinates) -- are non-empty but carry no
+            # successful decrypt, so they must NOT clear the budget -- otherwise
+            # report-less pushes interleaved with failures could keep a stale key
+            # below the reauth threshold. This mirrors the poll cycle's
+            # cycle_had_successful_decrypt gate, which excludes the same shapes,
             # and lets non-consecutive background failures interleaved with genuine
             # pushes avoid stranding a healthy account at the reauth threshold.
             # Keyed on the source entry_id -- the cache that actually performed

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -880,22 +880,30 @@ def _infer_report_hint(status_value: Any) -> str | None:
 
 
 def is_real_location_record(record: dict[str, Any] | None) -> bool:
-    """Return True if a decoded record authenticates the account-wide shared key.
+    """Return True only for an authenticated, decrypted *coordinate* report.
 
-    ``async_decrypt_location_response_locations`` returns a single ``metadata_only``
-    sentinel row (``metadata_only=True``, produced below when no encrypted report
-    decrypts but the secrets bundle still yields key material, e.g. a phone without
-    a fresh fix) so such devices still surface their key metadata downstream. That
-    row carries key *material* parsed from the bundle, not the result of a
-    successful E2EE decrypt, so it must never be treated as positive proof that the
-    shared key still works. Only a non-sentinel record counts as a real,
-    authenticated location report and may clear the shared decrypt-failure (reauth)
-    budget. ``metadata_only=True`` is set in exactly one place (the no-decrypt
-    branch), so this flag is the authoritative discriminator.
+    Clearing the shared decrypt-failure (reauth) budget requires positive proof
+    that the account-wide shared key still decrypts. Decrypted coordinates are
+    that proof: they are produced exclusively by the authenticated crypto path
+    (own/foreign AES-GCM decrypt, then lat/lon validation below). Requiring a real
+    coordinate pair is therefore an allowlist for genuine reports and rejects every
+    truthy-but-unauthenticated record shape, including:
+
+    - ``metadata_only=True`` sentinel rows -- only secrets-bundle key *material*,
+      emitted when no encrypted report decrypts (e.g. a phone without a fresh fix).
+    - ``SEMANTIC`` rows -- appended with ``decrypted_location=b""`` and ``continue``d
+      before the crypto path, so they carry a server-provided ``semantic_name`` and
+      a ``last_seen`` timestamp but ``latitude``/``longitude`` are ``None``.
+
+    Neither shape carries coordinates, so neither may clear the budget; a denylist
+    on a single known sentinel (``metadata_only``) would miss the others. ``is not
+    None`` (not truthiness) preserves legitimate ``0.0`` coordinates. The metadata
+    merges below only ever write key-material/date keys, never ``latitude``/
+    ``longitude``, so they cannot make a sentinel/SEMANTIC row look authenticated.
     """
     if not record:
         return False
-    return record.get("metadata_only") is not True
+    return record.get("latitude") is not None and record.get("longitude") is not None
 
 
 # ----------------------------- Main decryptor ---------------------------------

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -879,6 +879,25 @@ def _infer_report_hint(status_value: Any) -> str | None:
     return None
 
 
+def is_real_location_record(record: dict[str, Any] | None) -> bool:
+    """Return True if a decoded record authenticates the account-wide shared key.
+
+    ``async_decrypt_location_response_locations`` returns a single ``metadata_only``
+    sentinel row (``metadata_only=True``, produced below when no encrypted report
+    decrypts but the secrets bundle still yields key material, e.g. a phone without
+    a fresh fix) so such devices still surface their key metadata downstream. That
+    row carries key *material* parsed from the bundle, not the result of a
+    successful E2EE decrypt, so it must never be treated as positive proof that the
+    shared key still works. Only a non-sentinel record counts as a real,
+    authenticated location report and may clear the shared decrypt-failure (reauth)
+    budget. ``metadata_only=True`` is set in exactly one place (the no-decrypt
+    branch), so this flag is the authoritative discriminator.
+    """
+    if not record:
+        return False
+    return record.get("metadata_only") is not True
+
+
 # ----------------------------- Main decryptor ---------------------------------
 async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     device_update_protobuf: DeviceUpdateProto, *, cache: TokenCache

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -906,6 +906,25 @@ def is_real_location_record(record: dict[str, Any] | None) -> bool:
     return record.get("latitude") is not None and record.get("longitude") is not None
 
 
+def any_real_location_record(records: list[dict[str, Any]] | None) -> bool:
+    """Return True if ANY record in a response authenticates a coordinate report.
+
+    The decrypt proof -- positive evidence that the account-wide shared key still
+    decrypts -- is a property of the WHOLE response, not of any single record. A
+    display selector that ranks by newest ``last_seen`` (see
+    ``api._select_best_location``) can hand back a report-less SEMANTIC/metadata
+    row even when a sibling coordinate report decrypted successfully in the same
+    response. Evaluating only that collapsed record would discard the proof and
+    let a later transient failure trip a spurious reauth. Both automatic paths
+    (poll and background push) must therefore run the FULL candidate list through
+    this one predicate so a hidden success is never lost. See
+    ``is_real_location_record`` for the per-record allowlist.
+    """
+    if not records:
+        return False
+    return any(is_real_location_record(record) for record in records)
+
+
 # ----------------------------- Main decryptor ---------------------------------
 async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     device_update_protobuf: DeviceUpdateProto, *, cache: TokenCache

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -44,7 +44,10 @@ from .const import (
     DEFAULT_CONTRIBUTOR_MODE,
 )
 from .NovaApi import nova_request
-from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import DecryptionError
+from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    any_real_location_record,
+)
 from .NovaApi.ExecuteAction.LocateTracker.location_request import (
     get_location_data_for_device,
 )
@@ -1240,6 +1243,13 @@ class GoogleFindMyAPI:
                     device_name,
                     len(records),
                 )
+                # _select_best_location ranks by newest last_seen and may return a
+                # report-less SEMANTIC/metadata row, hiding a sibling coordinate
+                # report that decrypted successfully. Carry the FULL-list decrypt
+                # proof as an internal hint so the poll loop's reauth-budget gate
+                # is not fooled by the collapsed view (consumers pop it before
+                # caching, like _report_hint). See any_real_location_record.
+                best["_decrypt_proven"] = any_real_location_record(records)
                 return best
             _LOGGER.debug("API v3.0 Async: No location data for %s", device_name)
             return {}

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -323,6 +323,13 @@ class LocateOperations(_MixinBase):
                 if not location_data:
                     return {}
 
+                # Manual locate is upward-only for the reauth budget and never
+                # consumes the poll-only decrypt-proof hint; drop it here (after the
+                # empty guard, so location_data is a non-empty dict) so it cannot
+                # leak into the cached payload or the returned dict (mirrors the
+                # _report_hint stripping discipline).
+                location_data.pop("_decrypt_proven", None)
+
                 self._record_semantic_label(location_data, device_id=device_id)
 
                 cached_loc = self._device_location_data.get(device_id)

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1471,13 +1471,14 @@ class PollingOperations(_MixinBase):
                             )
                             continue
 
-                        # A device returned usable location data without raising a
-                        # DecryptionError: positive proof the account-wide shared
-                        # key still decrypts. Gate the crypto OK state on this.
-                        # A metadata_only sentinel row (key material from the secrets
-                        # bundle, no authenticated decrypt) is truthy but proves
-                        # nothing, so one report-less device must not mask another
-                        # device's stale key for the whole cycle.
+                        # A device returned an authenticated coordinate report
+                        # without raising a DecryptionError: positive proof the
+                        # account-wide shared key still decrypts. Gate the crypto OK
+                        # state on this. Truthy-but-unauthenticated rows -- a
+                        # metadata_only sentinel (secrets-bundle key material) or a
+                        # SEMANTIC row (no decrypted coordinates) -- prove nothing, so
+                        # one report-less device must not mask another device's stale
+                        # key for the whole cycle.
                         if is_real_location_record(location):
                             cycle_had_successful_decrypt = True
 

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1479,7 +1479,19 @@ class PollingOperations(_MixinBase):
                         # SEMANTIC row (no decrypted coordinates) -- prove nothing, so
                         # one report-less device must not mask another device's stale
                         # key for the whole cycle.
-                        if is_real_location_record(location):
+                        #
+                        # The proof is a property of the WHOLE response, but
+                        # api.async_get_device_location collapses it to a single
+                        # display record (newest last_seen) that can be a report-less
+                        # SEMANTIC row even when a sibling coordinate report decrypted.
+                        # It therefore carries the full-list verdict in the internal
+                        # _decrypt_proven hint; pop it here (leak-safe, like
+                        # _report_hint) and prefer it. Fall back to the collapsed
+                        # record only when the hint is absent (legacy/mocked stubs).
+                        decrypt_proven = location.pop("_decrypt_proven", None)
+                        if decrypt_proven is None:
+                            decrypt_proven = is_real_location_record(location)
+                        if decrypt_proven:
                             cycle_had_successful_decrypt = True
 
                         self._record_semantic_label(location, device_id=dev_id)

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -55,6 +55,7 @@ from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
     SharedKeyMissingError,
     StaleOwnerKeyError,
+    is_real_location_record,
 )
 from ..NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
 from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
@@ -1473,7 +1474,12 @@ class PollingOperations(_MixinBase):
                         # A device returned usable location data without raising a
                         # DecryptionError: positive proof the account-wide shared
                         # key still decrypts. Gate the crypto OK state on this.
-                        cycle_had_successful_decrypt = True
+                        # A metadata_only sentinel row (key material from the secrets
+                        # bundle, no authenticated decrypt) is truthy but proves
+                        # nothing, so one report-less device must not mask another
+                        # device's stale key for the whole cycle.
+                        if is_real_location_record(location):
+                            cycle_had_successful_decrypt = True
 
                         self._record_semantic_label(location, device_id=dev_id)
                         raw_semantic_name = (

--- a/tests/test_api_fcm_token_scoping.py
+++ b/tests/test_api_fcm_token_scoping.py
@@ -266,8 +266,20 @@ def test_async_get_device_location_uses_scoped_cache(
         loc1 = await api_entry_1.async_get_device_location("device-1", "Device 1")
         loc2 = await api_entry_2.async_get_device_location("device-2", "Device 2")
 
-        assert loc1 == {"canonic_id": "device-1", "latitude": 1}
-        assert loc2 == {"canonic_id": "device-2", "latitude": 1}
+        # async_get_device_location annotates the returned record with the
+        # internal full-list decrypt-proof hint (False here: latitude only, no
+        # longitude, so no authenticated coordinate report). Consumers pop it
+        # before caching, like _report_hint.
+        assert loc1 == {
+            "canonic_id": "device-1",
+            "latitude": 1,
+            "_decrypt_proven": False,
+        }
+        assert loc2 == {
+            "canonic_id": "device-2",
+            "latitude": 1,
+            "_decrypt_proven": False,
+        }
 
     asyncio.run(_exercise())
 

--- a/tests/test_api_location_selection.py
+++ b/tests/test_api_location_selection.py
@@ -285,3 +285,74 @@ def test_api_forwards_contributor_mode(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert captured["mode"] == "high_traffic"
     assert captured["switch"] == 1_700_000_000
+
+
+def test_async_get_device_location_marks_decrypt_proof_hidden_by_semantic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A coordinate fix hidden behind a newer SEMANTIC row still proves the key.
+
+    ``_select_best_location`` ranks by newest ``last_seen``, so a report-less
+    SEMANTIC row outranks an older coordinate report and becomes the returned
+    record. The full-list decrypt proof must survive that collapse via the internal
+    ``_decrypt_proven`` hint, otherwise the poll loop would miss the successful
+    decrypt and let a later transient failure trip a spurious reauth.
+    """
+
+    async def fake_get_location_data_for_device(
+        device_id: str,
+        device_name: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        return [
+            # Older coordinate report: a genuine decrypted fix.
+            {"last_seen": 100.0, "latitude": 1.0, "longitude": 2.0},
+            # Newer SEMANTIC row: outranks the fix in the selector, no coordinates.
+            {"last_seen": 200.0, "semantic_name": "Home", "latitude": None},
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.api.get_location_data_for_device",
+        fake_get_location_data_for_device,
+    )
+
+    async def _run() -> dict[str, Any]:
+        api = GoogleFindMyAPI(cache=_StubCache())
+        return await api.async_get_device_location("dev-1", "Tracker")
+
+    best = asyncio.run(_run())
+
+    # The display selector returned the newer, report-less SEMANTIC row...
+    assert best.get("semantic_name") == "Home"
+    assert best.get("latitude") is None
+    # ...but the full-list proof was carried, so the budget can still be cleared.
+    assert best.get("_decrypt_proven") is True
+
+
+def test_async_get_device_location_marks_no_proof_for_reportless_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A response without any coordinate report carries a False decrypt proof."""
+
+    async def fake_get_location_data_for_device(
+        device_id: str,
+        device_name: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        return [
+            {"last_seen": 100.0, "metadata_only": True, "owner_key_version": 7},
+            {"last_seen": 200.0, "semantic_name": "Home", "latitude": None},
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.api.get_location_data_for_device",
+        fake_get_location_data_for_device,
+    )
+
+    async def _run() -> dict[str, Any]:
+        api = GoogleFindMyAPI(cache=_StubCache())
+        return await api.async_get_device_location("dev-1", "Tracker")
+
+    best = asyncio.run(_run())
+
+    assert best.get("_decrypt_proven") is False

--- a/tests/test_api_location_selection.py
+++ b/tests/test_api_location_selection.py
@@ -160,18 +160,18 @@ def test_sync_wrappers_execute_without_running_loop() -> None:
     ]
 
 
-def test_sync_wrappers_guard_when_loop_running() -> None:
+async def test_sync_wrappers_guard_when_loop_running() -> None:
     """Sync helpers refuse to run when an event loop is already active."""
 
     api = _SyncHarness()
 
-    async def _runner() -> None:
-        assert api.get_basic_device_list() == []
-        assert api.get_device_location("dev-1", "Device 1") == {}
-        assert api.play_sound("dev-2") is False
-        assert api.stop_sound("dev-3") is False
+    # Running inside pytest-asyncio's managed loop is exactly the guarded
+    # condition: the sync wrappers must detect the active loop and refuse.
+    assert api.get_basic_device_list() == []
+    assert api.get_device_location("dev-1", "Device 1") == {}
+    assert api.play_sound("dev-2") is False
+    assert api.stop_sound("dev-3") is False
 
-    asyncio.run(_runner())
     assert api.calls == []
 
 
@@ -247,7 +247,7 @@ def test_process_device_list_response_deduplicates_canonic_ids(
     ]
 
 
-def test_api_forwards_contributor_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_api_forwards_contributor_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     """Contributor mode settings are passed to the location request helper."""
 
     captured: dict[str, Any] = {}
@@ -272,22 +272,19 @@ def test_api_forwards_contributor_mode(monkeypatch: pytest.MonkeyPatch) -> None:
         fake_get_location_data_for_device,
     )
 
-    async def _run() -> None:
-        api = GoogleFindMyAPI(
-            cache=_StubCache(),
-            contributor_mode="high_traffic",
-            contributor_mode_switch_epoch=1_700_000_000,
-        )
+    api = GoogleFindMyAPI(
+        cache=_StubCache(),
+        contributor_mode="high_traffic",
+        contributor_mode_switch_epoch=1_700_000_000,
+    )
 
-        await api.async_get_device_location("dev-1", "Tracker")
-
-    asyncio.run(_run())
+    await api.async_get_device_location("dev-1", "Tracker")
 
     assert captured["mode"] == "high_traffic"
     assert captured["switch"] == 1_700_000_000
 
 
-def test_async_get_device_location_marks_decrypt_proof_hidden_by_semantic(
+async def test_async_get_device_location_marks_decrypt_proof_hidden_by_semantic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A coordinate fix hidden behind a newer SEMANTIC row still proves the key.
@@ -316,11 +313,8 @@ def test_async_get_device_location_marks_decrypt_proof_hidden_by_semantic(
         fake_get_location_data_for_device,
     )
 
-    async def _run() -> dict[str, Any]:
-        api = GoogleFindMyAPI(cache=_StubCache())
-        return await api.async_get_device_location("dev-1", "Tracker")
-
-    best = asyncio.run(_run())
+    api = GoogleFindMyAPI(cache=_StubCache())
+    best = await api.async_get_device_location("dev-1", "Tracker")
 
     # The display selector returned the newer, report-less SEMANTIC row...
     assert best.get("semantic_name") == "Home"
@@ -329,7 +323,7 @@ def test_async_get_device_location_marks_decrypt_proof_hidden_by_semantic(
     assert best.get("_decrypt_proven") is True
 
 
-def test_async_get_device_location_marks_no_proof_for_reportless_only(
+async def test_async_get_device_location_marks_no_proof_for_reportless_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A response without any coordinate report carries a False decrypt proof."""
@@ -349,10 +343,7 @@ def test_async_get_device_location_marks_no_proof_for_reportless_only(
         fake_get_location_data_for_device,
     )
 
-    async def _run() -> dict[str, Any]:
-        api = GoogleFindMyAPI(cache=_StubCache())
-        return await api.async_get_device_location("dev-1", "Tracker")
-
-    best = asyncio.run(_run())
+    api = GoogleFindMyAPI(cache=_StubCache())
+    best = await api.async_get_device_location("dev-1", "Tracker")
 
     assert best.get("_decrypt_proven") is False

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -574,6 +574,67 @@ async def test_poll_cycle_semantic_only_does_not_reset_decrypt_counter() -> None
     assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
 
 
+class _DecryptThenHiddenProofAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then returns a
+    SEMANTIC-shaped record that still carries the full-list decrypt proof.
+
+    Models the Codex round-8 finding: the same Nova response decrypted a real
+    coordinate report, but ``api._select_best_location`` ranked a newer report-less
+    SEMANTIC row first and returned it. ``async_get_device_location`` preserves the
+    full-list verdict in the internal ``_decrypt_proven`` hint, so even though the
+    visible record has no coordinates the cycle DID prove the shared key and the
+    accumulated decrypt-failure counter must reset.
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        # Display-selected SEMANTIC row (newest last_seen, no coordinates) but the
+        # response decrypted a sibling coordinate fix -> hint records the proof.
+        return {
+            "last_seen": 200.0,
+            "semantic_name": "Home",
+            "status": "semantic",
+            "latitude": None,
+            "longitude": None,
+            "_decrypt_proven": True,
+        }
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_hidden_decrypt_proof_resets_counter() -> None:
+    """A real decrypt hidden behind a newer SEMANTIC row still clears the budget.
+
+    The display selector collapses the response to a report-less SEMANTIC record,
+    but the full-list ``_decrypt_proven`` hint shows a coordinate report decrypted.
+    The cycle must therefore reset the consecutive-decrypt-failure counter; without
+    carrying the full-list proof the success would be lost and a later transient
+    failure could trip a spurious reauth (Codex finding on PR #182)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenHiddenProofAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles accumulate the counter without escalating.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # The hidden-proof cycle resets the counter back to zero.
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == 0
+    # The internal hint must not leak into the cached payload.
+    cached = coordinator._device_location_data.get("dev-1")
+    if isinstance(cached, dict):
+        assert "_decrypt_proven" not in cached
+
+
 class _PerDeviceDecryptAPI:
     """Raises a decryption error for one device id, succeeds (empty) for others."""
 

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -520,6 +520,60 @@ async def test_poll_cycle_metadata_only_does_not_reset_decrypt_counter() -> None
     assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
 
 
+class _DecryptThenSemanticAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then returns a
+    SEMANTIC-shaped record (no coordinates).
+
+    Models a device whose server response is a semantic location ("Home") rather
+    than an encrypted fix. The decode layer appends SEMANTIC rows with
+    ``decrypted_location=b""`` and skips the crypto path, so the record carries a
+    ``semantic_name`` and ``last_seen`` but ``latitude``/``longitude`` are ``None``
+    and no ``metadata_only`` flag. It is truthy yet authenticates nothing, so such a
+    cycle must NOT clear the accumulated decrypt-failure counter (Codex finding on
+    PR #182): a denylist on ``metadata_only`` alone would let it through.
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        return {
+            "last_seen": 123.0,
+            "semantic_name": "Home",
+            "status": "semantic",
+            "latitude": None,
+            "longitude": None,
+        }
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_semantic_only_does_not_reset_decrypt_counter() -> None:
+    """A SEMANTIC-only cycle must NOT clear accumulated decrypt failures: the row
+    skips the crypto path (``decrypted_location=b""``) and carries no coordinates,
+    so it is no proof the stale shared key recovered. It also lacks the
+    ``metadata_only`` flag, so the previous denylist predicate would have wrongly
+    reset the counter and could strand a stale key below the reauth threshold
+    (Codex finding on PR #182)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenSemanticAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles accumulate the counter without escalating.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # A SEMANTIC-only cycle in between must leave the counter intact (not reset).
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+
 class _PerDeviceDecryptAPI:
     """Raises a decryption error for one device id, succeeds (empty) for others."""
 

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -473,6 +473,53 @@ async def test_poll_cycle_idle_does_not_reset_decrypt_counter() -> None:
     assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
 
 
+class _DecryptThenMetadataOnlyAPI:
+    """Raises a decryption error for the first ``fail_times`` calls, then returns a
+    ``metadata_only`` sentinel row.
+
+    Models a device whose secrets bundle still yields key *material* (so a
+    metadata_only row is emitted) while no encrypted report decrypts. The sentinel
+    is truthy but proves nothing about the shared key, so such a cycle must NOT
+    clear the accumulated decrypt-failure counter (Codex finding on PR #182).
+    """
+
+    def __init__(self, exc: Exception, fail_times: int) -> None:
+        self._exc = exc
+        self._fail = fail_times
+        self.calls = 0
+
+    async def async_get_device_location(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        self.calls += 1
+        if self.calls <= self._fail:
+            raise self._exc
+        # metadata_only sentinel: key material from the secrets bundle, no decrypt.
+        return {"metadata_only": True, "owner_key_version": 7}
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_metadata_only_does_not_reset_decrypt_counter() -> None:
+    """A metadata_only cycle must NOT clear accumulated decrypt failures: the
+    sentinel row carries key material from the secrets bundle, not an authenticated
+    decrypt, so it is no proof the stale shared key recovered. Otherwise a
+    report-less device emitting metadata_only could let such cycles perpetually
+    reset the counter, the reauth threshold is never reached, and the user stays
+    stuck with no location updates and no reauth prompt (Codex finding on PR
+    #182)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptThenMetadataOnlyAPI(
+        SharedKeyMismatchError("transient stale"), fail_times=_MAX_DECRYPT_FAILURES - 1
+    )
+
+    # Below-threshold failing cycles accumulate the counter without escalating.
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+    # A metadata_only cycle in between must leave the counter intact (not reset).
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    assert coordinator._consecutive_decrypt_failures == _MAX_DECRYPT_FAILURES - 1
+
+
 class _PerDeviceDecryptAPI:
     """Raises a decryption error for one device id, succeeds (empty) for others."""
 

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -671,3 +671,24 @@ async def test_own_report_mac_valueerror_counts_as_own_failure(
         await decrypt_locations.async_decrypt_location_response_locations(
             update, cache=object()
         )
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        ({"last_seen": 123.0, "latitude": 1.0, "longitude": 2.0}, True),
+        ({"last_seen": 123.0, "metadata_only": False}, True),
+        ({"last_seen": 123.0, "metadata_only": None}, True),
+        ({"metadata_only": True, "owner_key_version": 7}, False),
+        ({}, False),
+        (None, False),
+    ],
+)
+async def test_is_real_location_record(record: object, expected: bool) -> None:
+    """Only a non-sentinel record proves the shared key.
+
+    ``metadata_only=True`` rows carry secrets-bundle key material, not a successful
+    decrypt, so they must not be treated as positive proof (which would let them
+    clear the shared decrypt-failure budget and mask a stale key).
+    """
+    assert decrypt_locations.is_real_location_record(record) is expected

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -712,3 +712,39 @@ async def test_is_real_location_record(record: object, expected: bool) -> None:
     they would clear the shared decrypt-failure budget and mask a stale key.
     """
     assert decrypt_locations.is_real_location_record(record) is expected
+
+
+@pytest.mark.parametrize(
+    ("records", "expected"),
+    [
+        # Empty / falsy inputs -> no proof.
+        (None, False),
+        ([], False),
+        # Only report-less rows -> no record authenticates a coordinate report.
+        (
+            [
+                {"metadata_only": True, "owner_key_version": 7},
+                {"last_seen": 9.0, "semantic_name": "Home", "latitude": None},
+            ],
+            False,
+        ),
+        # A real coordinate report anywhere in the list proves the shared key,
+        # even when a report-less SEMANTIC row would outrank it in the selector.
+        (
+            [
+                {"last_seen": 5.0, "latitude": 1.0, "longitude": 2.0},
+                {"last_seen": 9.0, "semantic_name": "Home", "latitude": None},
+            ],
+            True,
+        ),
+    ],
+)
+async def test_any_real_location_record(records: object, expected: bool) -> None:
+    """The decrypt proof is a full-list property, not a single-record property.
+
+    ``any_real_location_record`` must return True when ANY record authenticates a
+    coordinate report, so a successfully decrypted fix hidden behind a newer
+    report-less SEMANTIC/metadata row is never lost. Empty inputs and lists of only
+    report-less rows must return False so they cannot clear the reauth budget.
+    """
+    assert decrypt_locations.any_real_location_record(records) is expected

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -676,19 +676,39 @@ async def test_own_report_mac_valueerror_counts_as_own_failure(
 @pytest.mark.parametrize(
     ("record", "expected"),
     [
+        # Authenticated coordinate report -> positive proof of the shared key.
         ({"last_seen": 123.0, "latitude": 1.0, "longitude": 2.0}, True),
-        ({"last_seen": 123.0, "metadata_only": False}, True),
-        ({"last_seen": 123.0, "metadata_only": None}, True),
+        # Coordinates win regardless of an explicit metadata_only=False flag.
+        ({"latitude": 1.0, "longitude": 2.0, "metadata_only": False}, True),
+        # 0.0 coordinates are valid (is-None check, not truthiness).
+        ({"latitude": 0.0, "longitude": 0.0}, True),
+        # SEMANTIC-shaped row: last_seen + semantic_name but no coordinates and no
+        # metadata_only flag -> skipped the crypto path, so it proves nothing.
+        (
+            {
+                "last_seen": 123.0,
+                "semantic_name": "Home",
+                "status": "semantic",
+                "latitude": None,
+                "longitude": None,
+            },
+            False,
+        ),
+        # Partial coordinates (only one axis) -> not an authenticated fix.
+        ({"latitude": 1.0, "longitude": None}, False),
+        # metadata_only sentinel -> secrets-bundle key material, no decrypt.
         ({"metadata_only": True, "owner_key_version": 7}, False),
         ({}, False),
         (None, False),
     ],
 )
 async def test_is_real_location_record(record: object, expected: bool) -> None:
-    """Only a non-sentinel record proves the shared key.
+    """Only an authenticated coordinate report proves the shared key.
 
-    ``metadata_only=True`` rows carry secrets-bundle key material, not a successful
-    decrypt, so they must not be treated as positive proof (which would let them
-    clear the shared decrypt-failure budget and mask a stale key).
+    Decrypted coordinates are produced solely by the authenticated crypto path, so
+    requiring a real ``latitude``/``longitude`` pair is an allowlist for genuine
+    reports. Truthy-but-unauthenticated shapes -- ``metadata_only=True`` sentinels
+    and SEMANTIC rows (no coordinates, crypto path skipped) -- must return False, or
+    they would clear the shared decrypt-failure budget and mask a stale key.
     """
     assert decrypt_locations.is_real_location_record(record) is expected

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -162,6 +162,46 @@ async def test_decode_background_location_clears_counter_on_success(
     entry.async_start_reauth.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_decode_background_location_metadata_only_does_not_clear_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A metadata_only decode result must NOT clear the shared reauth budget.
+
+    The decode layer returns a single ``metadata_only`` sentinel row (key material
+    from the secrets bundle, no authenticated decrypt) when no encrypted report
+    decrypts. That row is non-empty, but it is no positive proof the shared key
+    works, so report-less pushes interleaved with real failures must not keep a
+    stale key below the reauth threshold (Codex finding on PR #182). The metadata
+    must still pass through downstream.
+    """
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+    receiver._entry_caches["entry-1"] = MagicMock()
+
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    # Decrypt yields only a metadata_only sentinel (no usable location report).
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(
+            return_value=[{"metadata_only": True, "owner_key_version": 7}]
+        ),
+    )
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    # Metadata still flows downstream ...
+    assert result.get("metadata_only") is True
+    # ... but the budget is NOT cleared (no authenticated decrypt happened).
+    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_decrypt_failure.assert_not_called()
+    entry.async_start_reauth.assert_not_called()
+
+
 def test_note_decrypt_success_for_entry_swallows_coordinator_errors() -> None:
     """The push success path must never break: a misbehaving coordinator is
     swallowed exactly like the failure path."""

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -202,6 +202,54 @@ async def test_decode_background_location_metadata_only_does_not_clear_counter(
     entry.async_start_reauth.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_decode_background_location_semantic_only_does_not_clear_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SEMANTIC-only decode result must NOT clear the shared reauth budget.
+
+    SEMANTIC rows are appended with ``decrypted_location=b""`` and skip the crypto
+    path, so the record carries a ``semantic_name`` and ``last_seen`` but no
+    coordinates and no ``metadata_only`` flag. It is non-empty yet authenticates
+    nothing, so a background push of a semantic location must not clear the budget
+    and let a stale key stay below the reauth threshold (Codex finding on PR #182).
+    A denylist on ``metadata_only`` alone would miss this shape.
+    """
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
+    receiver._entry_caches["entry-1"] = MagicMock()
+
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    # Decrypt yields only a SEMANTIC row (no authenticated coordinates).
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(
+            return_value=[
+                {
+                    "last_seen": 123.0,
+                    "semantic_name": "Home",
+                    "status": "semantic",
+                    "latitude": None,
+                    "longitude": None,
+                }
+            ]
+        ),
+    )
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    # Semantic data still flows downstream ...
+    assert result.get("semantic_name") == "Home"
+    # ... but the budget is NOT cleared (no authenticated decrypt happened).
+    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_decrypt_failure.assert_not_called()
+    entry.async_start_reauth.assert_not_called()
+
+
 def test_note_decrypt_success_for_entry_swallows_coordinator_errors() -> None:
     """The push success path must never break: a misbehaving coordinator is
     swallowed exactly like the failure path."""

--- a/tests/test_guard_asyncio_run_antipattern.py
+++ b/tests/test_guard_asyncio_run_antipattern.py
@@ -13,7 +13,6 @@ import pytest
 LEGACY_ALLOWLIST: set[str] = {
     "tests/test_adm_token_retrieval.py",
     "tests/test_api_fcm_token_scoping.py",
-    "tests/test_api_location_selection.py",
     "tests/test_cli_entry_selection.py",
     "tests/test_cli_sound_request_entry_selection.py",
     "tests/test_config_flow_discovery.py",


### PR DESCRIPTION
## Summary

Addresses the Codex review on PR #182 (commit `5f83158b`): the shared
consecutive-decrypt-failure budget that gates re-authentication was cleared on
any non-empty decode result, including a `metadata_only` sentinel row that
proves no successful decrypt.

## The bug

`async_decrypt_location_response_locations` returns a single **`metadata_only`
sentinel row** when no encrypted report decrypts but the secrets bundle still
yields key material (e.g. a phone without a fresh fix). That row is non-empty
but carries only key *material*, not the result of an authenticated E2EE
decrypt. Two automatic paths treated its non-emptiness as positive proof of the
account-wide key:

- **background push** (`Auth/fcm_receiver_ha.py`): `_note_decrypt_success_for_entry`
  fired after the `if not locations` guard.
- **poll cycle** (`coordinator/polling.py`): `cycle_had_successful_decrypt` was
  set for any truthy `location` (a metadata_only row reaches it via the
  `_select_best_location` fallback).

Report-less `metadata_only` pushes/polls interleaved with real decrypt failures
could keep a stale E2EE key **below the reauth threshold**, leaving the account
stuck with no location updates and no reauth prompt. Codex flagged the
background path; the poll path had the same defect (breadth sweep).

## The fix

A shared predicate **`is_real_location_record()`** in `decrypt_locations.py`
(the sentinel's producer, the single source of truth for the `metadata_only`
contract; `metadata_only=True` is set in exactly one place). Both success
signals are now gated on it:

- background: `if any(is_real_location_record(r) for r in locations): _note_decrypt_success_for_entry(...)`
- poll: `if is_real_location_record(location): cycle_had_successful_decrypt = True`

A genuine decrypted record still clears the budget; the metadata still flows
downstream unchanged. **Manual locate** stays upward-only (only ever increments,
never resets — unchanged).

## Tests

- New: a metadata_only result does **not** clear the budget on the background
  path (and the metadata still passes through).
- New: a metadata_only poll cycle does **not** reset the decrypt-failure counter
  (modelled on the existing idle-cycle test).
- New: parametrized unit test for `is_real_location_record` (real / `False` /
  `None` flag / sentinel / empty / `None`).
- Mutation-checked: reverting either gate, or the predicate, turns the matching
  test red.
- `ruff check` + `mypy --strict` (sources + tests) green; broader regression
  green; changed lines covered.

## Why a separate PR

Codex reviewed PR #182 (the `1.7.2` → upstream PR). This fix branches from
`jleinenbach:1.7.2` and targets `1.7.2`, so after merge it flows into #182
automatically.


---

### Review note (Codex round 7)

Codex flagged that the round‑6 predicate `is_real_location_record()` used a
denylist on a single sentinel (`metadata_only is not True`). `SEMANTIC` rows
skip the crypto path (`decrypted_location=b""`, `continue` before
authentication) and carry no `metadata_only` flag, so they passed the predicate
without proving a decrypt. The predicate is now an **allowlist on positive
proof**: a record clears the reauth budget only if it carries authenticated
coordinates (`latitude` and `longitude` both not `None`) — the sole output of
the crypto path. This rejects `metadata_only` sentinels, `SEMANTIC` rows, and
any future report‑less shape across both consumer paths (poll cycle and
background push), without changing own/foreign coordinate‑report handling, and
keeps `manual locate` upward‑only. Added a predicate unit matrix (SEMANTIC,
partial‑coordinate, `0.0`) and poll/background regression tests; mutation‑checked
(reverting to the denylist and dropping one coordinate axis both fail the new
tests).

---

### Review note (Codex round 8)

Codex flagged that the poll path derived the decrypt proof from the single
display-selected record returned by `async_get_device_location`. That selector
ranks by newest `last_seen`, so a newer report-less SEMANTIC/metadata row can
hide a sibling coordinate report that decrypted in the same response, leaving
`cycle_had_successful_decrypt` false and risking a spurious reauth.

Fix: the decrypt proof is now computed over the **full** response via a shared
`any_real_location_record(records)` predicate (single source of truth in
`decrypt_locations.py`). `async_get_device_location` carries the full-list
verdict to the poll loop through an internal `_decrypt_proven` hint (popped
before caching, like `_report_hint`); the gate prefers the hint and falls back
to the single record only when it is absent. The background push path now uses
the same shared helper instead of an inline `any(...)`, so both automatic paths
share one full-list contract. Manual locate stays upward-only and strips the
hint at the source. New mutation-sharp tests cover the helper, the API hint, and
the poll reset; full suite green (4010 passed).

---

**Review note round 9 (test hygiene, Codex commit `74dd6640`):** Codex flagged `asyncio.run()` in the newly added `test_api_location_selection.py` tests, which `tests/AGENTS.md` forbids (HA manages the event loop; `asyncio_mode = auto`). Converted all four `asyncio.run()` call sites in that file to `async def` + `await` (the two new decrypt-proof tests plus two pre-existing same-file tests) and removed the file from `LEGACY_ALLOWLIST` in `test_guard_asyncio_run_antipattern.py`, so the guard now enforces the rule there. `test_sync_wrappers_guard_when_loop_running` keeps its semantics (it now runs inside the managed loop, exactly its guarded condition). The deliberate `asyncio.new_event_loop()` loop-capture test is intentionally left as-is. No production code changed; guard + affected suites green, ruff + mypy --strict clean.