### PR TITLE
fix(coordinator): heal encryption-key sensor from a proven background push

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3002,15 +3002,21 @@ class FcmReceiverHA:
         clean poll cycle does. Without this, push-only accounts whose scheduled
         polls stay idle could accumulate a couple of *non-consecutive* background
         decrypt failures up to the reauth threshold even though real locations
-        keep arriving and decrypting -- a spurious reauth prompt. Swallowed to
-        debug so it never breaks the push path.
+        keep arriving and decrypting -- a spurious reauth prompt. The same idle
+        push-only condition would also strand the diagnostic encryption-key
+        sensor on a stale ``shared_key_invalid`` / ``shared_key_missing`` status,
+        so this proven decrypt heals the account-wide sensor state too via
+        :meth:`note_background_decrypt_success`. Swallowed to debug so it never
+        breaks the push path.
         """
         for coordinator in self._coordinators_for_entries({entry_id}):
             try:
-                coordinator.note_decrypt_success()
+                coordinator.note_background_decrypt_success()
             except Exception as err:  # noqa: BLE001 - never break the push path
                 _LOGGER.debug(
-                    "note_decrypt_success failed for entry %s: %s", entry_id, err
+                    "note_background_decrypt_success failed for entry %s: %s",
+                    entry_id,
+                    err,
                 )
 
     async def _decode_background_location_async(  # noqa: PLR0911

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -178,6 +178,9 @@ class _MixinBase:
     def note_decrypt_success(self) -> None:
         raise NotImplementedError
 
+    def note_background_decrypt_success(self) -> None:
+        raise NotImplementedError
+
     def _short_error_message(self, exc: Exception | str) -> str:
         raise NotImplementedError
 

--- a/custom_components/googlefindmy/coordinator/helpers/stats.py
+++ b/custom_components/googlefindmy/coordinator/helpers/stats.py
@@ -48,12 +48,15 @@ class CryptoStatus:
     These mirror the diagnostic enum sensor's ``options`` exactly (one Home
     Assistant enum state per constant). The values are driven from a single
     source -- the coordinator's ``note_decrypt_failure`` hook (failure states)
-    and the poll cycle's decrypt-clean outcome (``OK``) -- so the sensor never
-    drifts from the reauth escalation behaviour it visualizes.
+    and the decrypt-clean outcomes (``OK``: a poll cycle, or a proven
+    background-push decrypt that refutes an account-wide failure) -- so the
+    sensor never drifts from the reauth escalation behaviour it visualizes.
 
     States:
         UNKNOWN: No decryption has been attempted yet (initial state).
-        OK: The most recent poll cycle decrypted without an account-wide failure.
+        OK: The most recent poll cycle decrypted without an account-wide failure,
+            or a background push proved the account-wide shared key still works
+            and cleared a prior ``SHARED_KEY_INVALID`` / ``SHARED_KEY_MISSING``.
         SHARED_KEY_INVALID: The shared key no longer matches the server-side
             owner key (``SharedKeyMismatchError`` / ``InvalidTag``); account-wide
             reauthentication is required.

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -223,7 +223,9 @@ class PollingOperations(_MixinBase):
         Mirrors ``_set_fcm_status`` exactly. This is the single writer for the
         diagnostic encryption-key sensor: failure states come from
         ``note_decrypt_failure`` (one mapping for poll, push and manual locate),
-        the ``OK`` state from a decrypt-clean poll cycle. Keeping one writer
+        the ``OK`` state from a decrypt-clean poll cycle or a proven
+        background-push decrypt (``note_background_decrypt_success``, account-wide
+        states only). Keeping one writer
         guarantees the sensor never diverges from the reauth escalation.
         """
         if status == self._crypto_status_state and reason == self._crypto_status_reason:
@@ -432,9 +434,10 @@ class PollingOperations(_MixinBase):
         sensor while deliberately leaving this counter at zero, so clearing that
         field here would erase a still-relevant diagnostic on the very cycle a
         sibling tracker decrypts. A single background decode likewise has no
-        cross-tracker cycle view, so it only clears the account-wide reauth budget
-        here and leaves the sensor (status and error class together) to the poll
-        loop.
+        cross-tracker cycle view, so this shared entry point only clears the
+        account-wide reauth budget and leaves the per-tracker sensor surface to
+        the poll loop. The push path heals the *account-wide* failure states via
+        :meth:`note_background_decrypt_success`, which wraps this method.
         """
         if self._consecutive_decrypt_failures > 0:
             _LOGGER.info(
@@ -442,6 +445,38 @@ class PollingOperations(_MixinBase):
                 self._consecutive_decrypt_failures,
             )
             self._consecutive_decrypt_failures = 0
+
+    def note_background_decrypt_success(self) -> None:
+        """Clear the reauth budget and heal the account-wide sensor from a push.
+
+        Called only from the FCM background-push decode on positive proof of an
+        authenticated coordinate (see ``_note_decrypt_success_for_entry``). It
+        first clears the shared reauth budget via :meth:`note_decrypt_success`,
+        then lifts the diagnostic encryption-key sensor out of the *account-wide*
+        failure states (``SHARED_KEY_INVALID`` / ``SHARED_KEY_MISSING``) that the
+        proof refutes: a successful decrypt with the account owner key proves the
+        shared key works regardless of any single cycle's cross-tracker view, so
+        push-only setups whose scheduled polls stay idle no longer leave the
+        sensor stuck on a stale-key status the account has already recovered from.
+
+        It deliberately does NOT touch ``TRACKER_KEY_OUTDATED``: a single
+        background decode cannot prove a per-tracker outdated owner key has been
+        re-paired (no cross-tracker view), so that per-tracker state -- and its
+        error class -- stays owned by the poll cycle, which alone observes the
+        absence of a stale key across all trackers. ``UNKNOWN`` is left untouched
+        too: there is no failure to heal and the OK semantics stay anchored to
+        observed account-wide proof, not fabricated before the first real signal.
+        Routes through the single ``_set_crypto_status`` writer, so the sensor
+        never diverges from the reauth escalation it visualizes.
+        """
+        self.note_decrypt_success()
+        if self._crypto_status_state in (
+            CryptoStatus.SHARED_KEY_INVALID,
+            CryptoStatus.SHARED_KEY_MISSING,
+        ):
+            # Move status and error class together: they are one sensor surface.
+            self._set_crypto_status(CryptoStatus.OK)
+            self._last_decrypt_error = None
 
     def _is_on_hass_loop(self) -> bool:
         """Return True if currently executing on the HA event loop thread."""

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.googlefindmy.coordinator import polling as polling_mod
+from custom_components.googlefindmy.coordinator.helpers.stats import CryptoStatus
 from custom_components.googlefindmy.coordinator.polling import (
     _MAX_DECRYPT_FAILURES,
 )
@@ -214,3 +215,67 @@ def test_note_decrypt_success_is_idempotent_when_no_failures(
     assert stub._consecutive_decrypt_failures == 0
     assert stub._last_decrypt_error is None
     assert "clearing" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "account_wide_failure",
+    [CryptoStatus.SHARED_KEY_INVALID, CryptoStatus.SHARED_KEY_MISSING],
+)
+def test_note_background_decrypt_success_heals_account_wide_failure(
+    account_wide_failure: str,
+) -> None:
+    """A proven background push heals the sensor out of an account-wide failure.
+
+    On push-only setups whose scheduled polls stay idle, the diagnostic
+    encryption-key sensor would otherwise stick on a stale ``shared_key_invalid``
+    / ``shared_key_missing`` status even though real pushes keep decrypting. The
+    background success entry point lifts the account-wide failure to ``OK`` and
+    moves the error class with it (one sensor surface), and still clears the
+    shared reauth budget.
+    """
+    stub = _make_stub()
+    stub._crypto_status_state = account_wide_failure
+    stub._last_decrypt_error = "SharedKeyMismatchError: stale"
+    stub._consecutive_decrypt_failures = 2
+
+    stub.note_background_decrypt_success()
+
+    assert stub._crypto_status_state == CryptoStatus.OK
+    assert stub._last_decrypt_error is None
+    assert stub._consecutive_decrypt_failures == 0
+
+
+def test_note_background_decrypt_success_preserves_tracker_key_outdated() -> None:
+    """A single background decode must NOT wipe a per-tracker stale-key diagnostic.
+
+    A push proves the account-wide shared key, not that a per-tracker outdated
+    owner key has been re-paired (it has no cross-tracker view). So when the
+    sensor reports ``tracker_key_outdated`` the heal must leave both the status
+    and its error class untouched, while still clearing the account-wide budget.
+    This is the anti-widening guard for the round-5 diagnostic invariant.
+    """
+    stub = _make_stub()
+    stub._crypto_status_state = CryptoStatus.TRACKER_KEY_OUTDATED
+    stub._last_decrypt_error = "StaleOwnerKeyError: tracker v1 < v2"
+    stub._consecutive_decrypt_failures = 0
+
+    stub.note_background_decrypt_success()
+
+    assert stub._crypto_status_state == CryptoStatus.TRACKER_KEY_OUTDATED
+    assert stub._last_decrypt_error == "StaleOwnerKeyError: tracker v1 < v2"
+
+
+def test_note_background_decrypt_success_leaves_unknown_untouched() -> None:
+    """With no failure to heal, the push success does not fabricate an ``OK``.
+
+    ``UNKNOWN`` is the initial state before any decrypt signal; the OK semantics
+    stay anchored to an observed account-wide failure being refuted, so a push
+    must not flip a never-failed sensor to OK ahead of the first real proof.
+    """
+    stub = _make_stub()
+    assert stub._crypto_status_state == CryptoStatus.UNKNOWN
+
+    stub.note_background_decrypt_success()
+
+    assert stub._crypto_status_state == CryptoStatus.UNKNOWN
+    assert stub._last_decrypt_error is None

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -157,7 +157,7 @@ async def test_decode_background_location_clears_counter_on_success(
     result = await receiver._decode_background_location_async("entry-1", "deadbeef")
 
     assert result.get("last_seen") == 123.0
-    coordinator.note_decrypt_success.assert_called_once_with()
+    coordinator.note_background_decrypt_success.assert_called_once_with()
     coordinator.note_decrypt_failure.assert_not_called()
     entry.async_start_reauth.assert_not_called()
 
@@ -197,7 +197,7 @@ async def test_decode_background_location_metadata_only_does_not_clear_counter(
     # Metadata still flows downstream ...
     assert result.get("metadata_only") is True
     # ... but the budget is NOT cleared (no authenticated decrypt happened).
-    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_background_decrypt_success.assert_not_called()
     coordinator.note_decrypt_failure.assert_not_called()
     entry.async_start_reauth.assert_not_called()
 
@@ -245,7 +245,7 @@ async def test_decode_background_location_semantic_only_does_not_clear_counter(
     # Semantic data still flows downstream ...
     assert result.get("semantic_name") == "Home"
     # ... but the budget is NOT cleared (no authenticated decrypt happened).
-    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_background_decrypt_success.assert_not_called()
     coordinator.note_decrypt_failure.assert_not_called()
     entry.async_start_reauth.assert_not_called()
 
@@ -254,12 +254,12 @@ def test_note_decrypt_success_for_entry_swallows_coordinator_errors() -> None:
     """The push success path must never break: a misbehaving coordinator is
     swallowed exactly like the failure path."""
     receiver, coordinator, entry = _receiver_with_coordinator(escalate=False)
-    coordinator.note_decrypt_success = MagicMock(side_effect=RuntimeError("boom"))
+    coordinator.note_background_decrypt_success = MagicMock(side_effect=RuntimeError("boom"))
 
     # Must not raise.
     receiver._note_decrypt_success_for_entry("entry-1")
 
-    coordinator.note_decrypt_success.assert_called_once_with()
+    coordinator.note_background_decrypt_success.assert_called_once_with()
 
 
 def test_note_decrypt_success_for_entry_unknown_entry_is_noop() -> None:
@@ -268,4 +268,4 @@ def test_note_decrypt_success_for_entry_unknown_entry_is_noop() -> None:
 
     receiver._note_decrypt_success_for_entry("other-entry")
 
-    coordinator.note_decrypt_success.assert_not_called()
+    coordinator.note_background_decrypt_success.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to the Codex review on #182. The **Encryption Key Status** diagnostic sensor could stick on a stale `shared_key_invalid` / `shared_key_missing` status on **push-only setups** whose scheduled polls stay idle, even though successful FCM background pushes keep decrypting real locations. The `OK` transition was owned solely by the poll cycle, so a push healed the reauth budget but not the sensor.

## Change

- New push-specific coordinator entry point **`note_background_decrypt_success()`** (`coordinator/polling.py`). It clears the shared reauth budget via the unchanged `note_decrypt_success()`, then lifts the sensor out of the **account-wide** failure states (`SHARED_KEY_INVALID` / `SHARED_KEY_MISSING`) that a proven decrypt refutes, moving the error class with it through the single `_set_crypto_status` writer.
- The push path (`Auth/fcm_receiver_ha.py::_note_decrypt_success_for_entry`) now calls it, **gated as before** on `any_real_location_record` (no metadata-only / SEMANTIC heal).
- **Preserves the round-5 invariant:** `TRACKER_KEY_OUTDATED` and its error class are left intact (a single background decode has no cross-tracker view, so it cannot prove a per-tracker outdated owner key was re-paired). `UNKNOWN` is also left untouched, so `OK` is never fabricated before the first real signal.
- The shared `note_decrypt_success()` keeps its contract (account-wide counter only); the **poll path is unchanged**.

## Tests

- Parametrized heal of both account-wide failure states (`SHARED_KEY_INVALID` / `SHARED_KEY_MISSING` -> `OK`, error class cleared, budget cleared).
- Anti-widening guard: a background success on `TRACKER_KEY_OUTDATED` leaves status **and** error class intact.
- `UNKNOWN` no-op.
- fcm-receiver tests updated to the new push entry point.
- Mutation-checked: neutralizing the heal gate turns the two heal tests red.
- `ruff` + `mypy --strict` clean, full suite green.

After merge this flows into #182 automatically (PR #182 is `jleinenbach:1.7.2` -> `BSkando:1.7`).