### PR TITLE
fix(fcm): clear legacy receiver alias when per-entry store empties (#183)

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -2900,18 +2900,39 @@ def _sync_legacy_fcm_receiver_alias(bucket: GoogleFindMyDomainData) -> None:
 
     receiver_cls = _resolve_fcm_receiver_class()
     receivers_obj = bucket.get("fcm_receivers")
-    if isinstance(receivers_obj, dict) and receivers_obj:
+    if isinstance(receivers_obj, dict):
+        # ``fcm_receivers`` is the single source of truth once it exists.
+        # Mirror a valid receiver into the legacy ``fcm_receiver`` alias, or
+        # drop the alias when no active receiver remains (e.g. after the
+        # refcount->0 release path empties the dict on reload). Keeping a
+        # healthy alias here while the per-entry dict is empty is exactly the
+        # issue #183 desync: ``is_push_ready()`` resolves the (empty) per-entry
+        # store and reports False, while diagnostics read the surviving
+        # singleton and still report the receiver as healthy/connected.
         default_entry_id = bucket.get("default_fcm_entry_id")
         preferred = (
             receivers_obj.get(default_entry_id)
             if isinstance(default_entry_id, str)
             else None
         )
-        receiver = preferred or next(iter(receivers_obj.values()))
-        if isinstance(receiver, receiver_cls):
+        if not isinstance(preferred, receiver_cls):
+            preferred = None
+        receiver = preferred or next(
+            (
+                candidate
+                for candidate in receivers_obj.values()
+                if isinstance(candidate, receiver_cls)
+            ),
+            None,
+        )
+        if receiver is not None:
             bucket["fcm_receiver"] = receiver
-            return
+        else:
+            bucket.pop("fcm_receiver", None)
+        return
 
+    # ``fcm_receivers`` is absent entirely: preserve the legacy migration path
+    # that ``_get_fcm_receivers`` relies on, only dropping a wrong-type alias.
     legacy_receiver = bucket.get("fcm_receiver")
     if legacy_receiver is not None and not isinstance(legacy_receiver, receiver_cls):
         bucket.pop("fcm_receiver", None)

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -876,3 +876,50 @@ def test_push_updated_excludes_ignored_devices_from_merge(
     assert ids == {"dev-new"}, (
         f"merged snapshot must contain only the non-ignored push target; got {ids}"
     )
+
+
+def test_issue_183_status_stuck_on_false_readiness_then_recovers(
+    coordinator: GoogleFindMyCoordinator,
+    dummy_api: _DummyAPI,
+) -> None:
+    """Issue #183: a false-negative readiness pins fcm_status, a true one heals.
+
+    Discriminates the candidate root causes at the coordinator-status layer:
+
+    * H2 (false readiness): while ``api.is_push_ready()`` returns ``False`` the
+      poll-top recovery never promotes the status, so it stays non-CONNECTED
+      across cycles even though the receiver is healthy -- the "Disconnected
+      until restart" symptom.
+    * H1 (frozen cache) refuted: the moment readiness returns ``True`` a single
+      poll cycle restores CONNECTED, so the status is re-evaluated, not frozen.
+    * H3 (receiver down) refuted: only the readiness signal is toggled here; the
+      coordinator recovers without any change to the receiver itself.
+    """
+
+    loop = coordinator.hass.loop
+    coordinator._async_build_device_snapshot_with_fallbacks.return_value = []
+    # A real device lets the poll cycle complete (avoids the cold-start guard);
+    # the assertions below only inspect the status set by the recovery block.
+    dummy_api.device_list = [{"id": "dev-1", "name": "Device"}]
+    coordinator._enabled_poll_device_ids = {"dev-1"}
+
+    # Use the real soft-check so it consults ``api.is_push_ready`` (the desync
+    # victim in issue #183), instead of the fixture's hard-wired ``True``.
+    coordinator._is_fcm_ready_soft = type(coordinator)._is_fcm_ready_soft.__get__(
+        coordinator
+    )
+
+    # Reload start state: a healthy receiver, but readiness reports False.
+    dummy_api.is_push_ready = lambda: False
+
+    loop.run_until_complete(coordinator._async_update_data())
+    assert coordinator.fcm_status.state != FcmStatus.CONNECTED
+
+    # A second cycle keeps it stuck (does not self-heal while readiness is False).
+    loop.run_until_complete(coordinator._async_update_data())
+    assert coordinator.fcm_status.state != FcmStatus.CONNECTED
+
+    # Readiness becomes correct again -> the very next cycle recovers.
+    dummy_api.is_push_ready = lambda: True
+    loop.run_until_complete(coordinator._async_update_data())
+    assert coordinator.fcm_status.state == FcmStatus.CONNECTED

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -1263,3 +1263,63 @@ async def test_classify_registration_exception_forwards_generation(
     )
 
     assert seen == [7]
+
+
+@pytest.mark.asyncio
+async def test_reload_reacquire_repopulates_receiver_store() -> None:
+    """Issue #183: a reload re-acquire must repopulate the per-entry store.
+
+    Reproduces the full settings-change reload cycle on the real acquire/release
+    path: acquire -> release down to refcount 0 (empties ``fcm_receivers`` and
+    unregisters providers) -> re-acquire. The re-acquire must register a fresh
+    receiver back into the per-entry store and re-register providers, so the
+    provider (and therefore ``is_push_ready``) can resolve it again without a
+    full Home Assistant restart.
+
+    Before the fix the refcount->0 release stranded a healthy receiver in the
+    legacy ``fcm_receiver`` alias while emptying the per-entry dict; the
+    re-acquire then reused that stale singleton and skipped the store/provider
+    (re)registration, leaving ``fcm_receivers`` empty so the connection sensor
+    stayed "Disconnected" until a restart.
+    """
+
+    hass = SimpleNamespace(data={DOMAIN: {}})
+    entry = make_config_entry(entry_id="entry-reload")
+    creds = {"fcm": {"registration": {"token": "token-reload"}}}
+    cache = _DummyCache(entry.entry_id, creds)
+
+    receiver = await _async_acquire_shared_fcm(
+        hass,
+        entry=entry,
+        cache=cache,
+        entry_resolver=lambda: entry.entry_id,
+    )
+    bucket = hass.data[DOMAIN]
+    assert _get_fcm_receivers(bucket).get(entry.entry_id) is receiver
+    assert bucket.get("fcm_receiver") is receiver
+    assert bucket.get("providers_registered") is True
+
+    # Reload: release down to refcount 0 (settings-change unload).
+    await _async_release(receiver, hass, entry)
+    assert _get_fcm_receivers(bucket) == {}
+    # The legacy alias must not survive an empty per-entry dict (root fix).
+    assert bucket.get("fcm_receiver") is None
+    assert bucket.get("providers_registered") is False
+
+    # Re-acquire (reload setup): must rebuild the per-entry store and providers.
+    receiver_2 = await _async_acquire_shared_fcm(
+        hass,
+        entry=entry,
+        cache=cache,
+        entry_resolver=lambda: entry.entry_id,
+    )
+    assert receiver_2 is not receiver
+    receivers = _get_fcm_receivers(bucket)
+    assert receivers.get(entry.entry_id) is receiver_2
+    assert bucket.get("fcm_receiver") is receiver_2
+    assert bucket.get("providers_registered") is True
+    # The provider resolves the freshly registered receiver -> readiness input
+    # is restored without a Home Assistant restart.
+    assert _domain_fcm_provider(hass, entry.entry_id) is receiver_2
+
+    await _async_release(receiver_2, hass, entry)

--- a/tests/test_issue_183_reload_fcm_desync.py
+++ b/tests/test_issue_183_reload_fcm_desync.py
@@ -1,0 +1,234 @@
+# tests/test_issue_183_reload_fcm_desync.py
+"""Regression tests for issue #183 (reload left FCM stuck "Disconnected").
+
+The user reported that changing settings (which reloads the config entry)
+flipped the FCM connection status to "Disconnected" and it never recovered
+until Home Assistant was fully restarted. The submitted diagnostics were
+self-contradictory: the live receiver snapshot was ``healthy: true`` (STARTED,
+client_ready) while ``coordinator.fcm_status`` was ``degraded`` with reason
+``"Push transport not ready; continuing with cached data"``.
+
+The empirical reproduction that preceded the fix discriminated three candidate
+root causes and confirmed **H2** (false-negative readiness via store desync):
+the refcount->0 release path (``_pop_fcm_receiver``) emptied the per-entry
+provider dict ``fcm_receivers``, but ``_sync_legacy_fcm_receiver_alias`` only
+dropped the legacy ``fcm_receiver`` alias when it held the *wrong type*, so a
+healthy receiver of the right type survived there. ``is_push_ready()`` resolves
+the (now empty) per-entry store and returned ``False`` (rendered as
+"Disconnected"), while diagnostics read the surviving singleton and still
+reported the receiver as healthy/connected -- exactly the contradiction in the
+issue. H1 (frozen cache) and H3 (receiver genuinely dead) were refuted.
+
+The fix makes ``fcm_receivers`` the single source of truth: when the per-entry
+dict holds no valid receiver, the legacy alias is dropped as well. These tests
+now assert that fixed behaviour (the alias is cleared, and readiness and
+diagnostics stay consistent), and that a runtime re-sync heals readiness
+without a restart. The end-to-end reload re-acquire repopulation is covered by
+``test_fcm_receiver.test_reload_reacquire_repopulates_receiver_store``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import custom_components.googlefindmy as init_module
+from custom_components.googlefindmy.api import GoogleFindMyAPI
+from custom_components.googlefindmy.diagnostics import _fcm_receiver_state
+from tests.helpers.api_stub import StubCache
+
+ENTRY_ID = "entry-183"
+
+
+class _StubReceiver:
+    """Healthy FCM receiver double used to exercise the reload store handling.
+
+    Exposes only the surface consumed by the production code under test:
+    ``is_ready`` (read by the provider getter and ``is_push_ready``),
+    ``get_health_snapshots`` (read by the diagnostics summary), and
+    ``set_default_entry_id`` (called by ``_sync_receiver_default_entry``).
+    """
+
+    def __init__(self, entry_id: str) -> None:
+        self._entry_id = entry_id
+        self.is_ready = True
+        self.start_count = 5
+        self.default_entry_id: str | None = None
+
+    def set_default_entry_id(self, entry_id: str) -> None:
+        """Record the default entry id propagated by the provider."""
+
+        self.default_entry_id = entry_id
+
+    def get_health_snapshots(self) -> dict[str, dict[str, Any]]:
+        """Return a single healthy entry snapshot, mirroring the issue data."""
+
+        return {
+            self._entry_id: {
+                "healthy": True,
+                "run_state": "STARTED",
+                "seconds_since_last_activity": 1.0,
+                "activity_stale": False,
+                "supervisor_running": True,
+                "client_ready": True,
+                "do_listen": True,
+                "last_activity_monotonic": 123.0,
+            }
+        }
+
+
+@pytest.fixture
+def receiver_cls(monkeypatch: pytest.MonkeyPatch) -> type[_StubReceiver]:
+    """Make the store treat ``_StubReceiver`` as the canonical receiver type."""
+
+    monkeypatch.setattr(init_module, "_FCM_RECEIVER_CLASS", _StubReceiver)
+    return _StubReceiver
+
+
+def _make_hass() -> SimpleNamespace:
+    """Return a minimal hass stub exposing only the ``data`` mapping."""
+
+    return SimpleNamespace(data={})
+
+
+def test_release_path_clears_legacy_singleton_when_dict_empties(
+    receiver_cls: type[_StubReceiver],
+) -> None:
+    """Issue #183 root fix: the release path no longer strands the singleton.
+
+    After ``_set_fcm_receiver`` both the per-entry dict and the legacy alias see
+    the receiver. After ``_pop_fcm_receiver`` (the operative call inside the
+    refcount->0 release path) the per-entry dict is empty *and* the legacy
+    singleton is cleared, because ``fcm_receivers`` is the single source of
+    truth. Before the fix the healthy singleton survived here, which is what the
+    contradictory diagnostics exposed.
+    """
+
+    hass = _make_hass()
+    bucket = init_module._domain_data(hass)
+    receiver = receiver_cls(ENTRY_ID)
+
+    init_module._set_fcm_receiver(bucket, ENTRY_ID, receiver)
+    assert init_module._get_fcm_receivers(bucket) == {ENTRY_ID: receiver}
+    assert bucket["fcm_receiver"] is receiver
+
+    popped = init_module._pop_fcm_receiver(bucket, ENTRY_ID)
+    assert popped is receiver
+
+    # The provider dict is now empty...
+    assert init_module._get_fcm_receivers(bucket) == {}
+    # ...and the legacy singleton must NOT survive an empty per-entry dict.
+    assert bucket.get("fcm_receiver") is None
+
+
+def test_release_keeps_readiness_and_diagnostics_consistent(
+    receiver_cls: type[_StubReceiver],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #183: readiness and diagnostics agree after a release.
+
+    With the per-entry dict emptied (reload release) the production
+    ``is_push_ready()`` resolves nothing and returns ``False``. Because the
+    legacy singleton is cleared as well, the production diagnostics summary no
+    longer reports a stale healthy receiver -- both views consistently report
+    "not connected" instead of the contradictory state from the issue. The
+    receiver object itself is untouched (it is the *store* that was desynced).
+    """
+
+    hass = _make_hass()
+    bucket = init_module._domain_data(hass)
+    receiver = receiver_cls(ENTRY_ID)
+
+    # Register the production provider getter exactly as setup does.
+    def _provider(entry_id: str | None = None) -> Any:
+        return init_module._domain_fcm_provider(hass, entry_id)
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.api._FCM_ReceiverGetter", _provider
+    )
+
+    api = GoogleFindMyAPI(cache=StubCache(entry_id=ENTRY_ID))
+
+    # Baseline: a properly registered receiver makes readiness True and the
+    # diagnostics report it as connected.
+    init_module._set_fcm_receiver(bucket, ENTRY_ID, receiver)
+    assert api.is_push_ready() is True
+    state = _fcm_receiver_state(hass)
+    assert state is not None
+    assert state["connected_entries"] == [ENTRY_ID]
+
+    # Reload release path: per-entry dict empties, singleton is cleared too.
+    init_module._pop_fcm_receiver(bucket, ENTRY_ID)
+
+    # Readiness is False AND diagnostics report nothing -> consistent, not the
+    # contradictory "healthy receiver vs. degraded status" from the issue.
+    assert api.is_push_ready() is False
+    assert _fcm_receiver_state(hass) is None
+    # The receiver instance never stopped being ready; only the store changed.
+    assert receiver.is_ready is True
+
+
+def test_store_resync_restores_push_ready_without_restart(
+    receiver_cls: type[_StubReceiver],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """H1 refuted: a runtime store re-sync heals readiness, no restart needed.
+
+    Re-registering the receiver in the per-entry dict (what a correct reload
+    re-acquire does) flips ``is_push_ready()`` back to ``True`` in the same
+    process. The recovery signal is therefore honoured immediately once the
+    readiness input is correct; the stuck state was the broken store, not a
+    frozen cache.
+    """
+
+    hass = _make_hass()
+    bucket = init_module._domain_data(hass)
+    receiver = receiver_cls(ENTRY_ID)
+
+    def _provider(entry_id: str | None = None) -> Any:
+        return init_module._domain_fcm_provider(hass, entry_id)
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.api._FCM_ReceiverGetter", _provider
+    )
+
+    api = GoogleFindMyAPI(cache=StubCache(entry_id=ENTRY_ID))
+
+    init_module._set_fcm_receiver(bucket, ENTRY_ID, receiver)
+    init_module._pop_fcm_receiver(bucket, ENTRY_ID)
+    assert api.is_push_ready() is False
+
+    # Runtime re-sync (no HA restart): readiness recovers immediately.
+    init_module._set_fcm_receiver(bucket, ENTRY_ID, receiver)
+    assert api.is_push_ready() is True
+
+
+def test_absent_per_entry_dict_preserves_legacy_migration(
+    receiver_cls: type[_StubReceiver],
+) -> None:
+    """The legacy-migration path is untouched when ``fcm_receivers`` is absent.
+
+    When the per-entry dict has never been created (legacy upgrade), the alias
+    sync must only drop a *wrong-type* legacy receiver and preserve a valid one
+    so ``_get_fcm_receivers`` can migrate it into the per-entry store. This
+    guards the single-source-of-truth change from over-reaching into the
+    migration path.
+    """
+
+    hass = _make_hass()
+    bucket = init_module._domain_data(hass)
+
+    # Absent per-entry dict + wrong-type alias -> alias is dropped.
+    bucket.pop("fcm_receivers", None)
+    bucket["fcm_receiver"] = object()
+    init_module._sync_legacy_fcm_receiver_alias(bucket)
+    assert bucket.get("fcm_receiver") is None
+
+    # Absent per-entry dict + valid alias -> preserved for migration.
+    bucket.pop("fcm_receivers", None)
+    receiver = receiver_cls(ENTRY_ID)
+    bucket["fcm_receiver"] = receiver
+    init_module._sync_legacy_fcm_receiver_alias(bucket)
+    assert bucket.get("fcm_receiver") is receiver


### PR DESCRIPTION
## Summary

Fixes the BSkando issue #183 class: after changing settings (which reloads the config entry), the FCM connection status stuck on **"Disconnected"** and never recovered until a full Home Assistant restart. Reloading the integration did not help; only a restart did.

The submitted diagnostics were self-contradictory: the live receiver snapshot was `healthy: true` (STARTED, client_ready) while `coordinator.fcm_status` was `degraded` with reason `"Push transport not ready; continuing with cached data"`.

## Root cause (empirically reproduced — hypothesis H2)

Two receiver stores diverge across a `refcount -> 0` release (which happens on reload):

- `fcm_receivers` (the per-entry dict) is what `is_push_ready()` resolves through the provider getter — and therefore what the connectivity sensor reflects.
- `fcm_receiver` (the legacy singleton alias) is what the diagnostics summary reads.

`_pop_fcm_receiver` empties the per-entry dict, but `_sync_legacy_fcm_receiver_alias` only dropped the legacy singleton when it held the *wrong type*. A healthy, right-type receiver therefore survived as the singleton while the per-entry store was empty:

- `is_push_ready()` resolved nothing -> returned `False` -> sensor "Disconnected".
- diagnostics read the surviving singleton -> still reported the receiver as healthy/connected.

That mismatch is exactly the contradictory diagnostics in the issue. H1 (frozen cache) and H3 (receiver genuinely dead) were refuted: a runtime store re-sync flips readiness back to `True` in-process, and the receiver reported `is_ready` throughout.

## Fix

Treat `fcm_receivers` as the single source of truth whenever it exists. When the per-entry dict holds no valid receiver (e.g. after the release path empties it on reload), drop the legacy alias as well. The legacy migration path (dict absent entirely, used by `_get_fcm_receivers`) is preserved unchanged.

This also makes the reload **re-acquire** reliably repopulate the store: with no stale singleton to reuse, `_async_acquire_shared_fcm` falls through to creating a fresh receiver that re-registers the per-entry store and the providers, so `is_push_ready` recovers without a restart.

Single-file production change: `_sync_legacy_fcm_receiver_alias`.

## Tests

- `tests/test_issue_183_reload_fcm_desync.py` (new): the alias is cleared when the dict empties; readiness and diagnostics stay consistent (both "not connected" instead of contradictory); a runtime re-sync heals readiness without a restart; the absent-dict migration path is preserved.
- `tests/test_fcm_receiver.py::test_reload_reacquire_repopulates_receiver_store` (new): full `acquire -> release@refcount0 -> re-acquire` cycle on the real code paths, asserting the per-entry store and providers are rebuilt.
- `tests/test_coordinator_status.py`: status stays non-CONNECTED while readiness is false and recovers on the next poll cycle once it is true.

## Verification

- `ruff` 0.14.14 + `ruff format --check` + `mypy --strict`: clean.
- Full test suite: green, total coverage 70.27% (gate 69%).
- Changed production lines fully covered; mutation cross-check confirms the new tests fail when the fix is reverted.
- Independent diff review: PASS, no S1-S3 findings.

Once merged this flows into the BSkando PR (#182) via `1.7.2`.
