### PR TITLE
docs: anchor manifest.json/const.py version coupling

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -32,6 +32,16 @@ When reusing the shared grpclib transport (`SpotGrpcTransport`), keep SSL contex
 When adding new guidance, prefer creating another `agents/<topic>/AGENTS.md` file instead of expanding this index. This keeps
 updates like the subentry unload reminder easy to place without scrolling through unrelated instructions.
 
+### Version bump touches two files (manifest.json + const.py)
+
+The integration version lives in **two** places that MUST be bumped together on every release:
+`manifest.json` `"version"` and `const.py` `INTEGRATION_VERSION` (the latter feeds diagnostics,
+device `sw_version`, and logs). `manifest.json` is strict JSON validated by hassfest, so it cannot
+carry an inline cross-reference comment or an extra key; this note is the canonical anchor for the
+manifest side, while `const.py` carries the reverse reference in a code comment. A release that bumps
+only one file ships an inconsistent version string. Before tagging a release, grep both:
+`git grep -nE '"version"|INTEGRATION_VERSION' custom_components/googlefindmy/manifest.json custom_components/googlefindmy/const.py`.
+
 ### Quick-start reminder: avoid false-positive tracker discovery
 
 When restoring `device_tracker` entities on startup, confirm the cloud discovery trigger only fires for **truly new** tracker

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -20,7 +20,10 @@ DOMAIN: str = "googlefindmy"
 DATA_EID_RESOLVER: Final[Literal["eid_resolver"]] = "eid_resolver"
 # Latest config entry schema version handled by this integration.
 CONFIG_ENTRY_VERSION: int = 2
-# Keep the integration version aligned across the project (match manifest.json)
+# Integration version. MUST be bumped together with manifest.json "version" on every
+# release; the two are a coupled pair. manifest.json is strict JSON (hassfest-validated)
+# and cannot carry this cross-reference, so the manifest side is anchored in this
+# directory's AGENTS.md ("Version bump touches two files").
 INTEGRATION_VERSION: str = "1.7.3"
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
## What

Documents the coupling between the two files that carry the integration version, so a future release bump never updates just one of them.

- `const.py` `INTEGRATION_VERSION` and `manifest.json` `"version"` are a coupled pair; both must be bumped together on every release.
- `manifest.json` is strict JSON validated by hassfest, so it cannot carry an inline comment or an extra key. The manifest side of the cross-reference is therefore anchored in this directory's `AGENTS.md`, and `const.py` carries the reverse reference in its code comment.

## Why

During the 1.7.2 -> 1.7.3 bump the version turned out to live in **two** files; updating only `manifest.json` would ship an inconsistent version string (`const.py` feeds diagnostics, device `sw_version`, and logs). This PR makes the coupling discoverable from both sides plus a pre-release grep command.

## Scope

Docs/comment only. No logic, no behaviour change. `manifest.json` untouched and still valid JSON.