### PR TITLE
fix(map): keep safe_accuracy resolver compatible with map-view stubs

### DIFF
--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -32,6 +32,13 @@ from ..KeyBackup.cloud_key_decryptor import decrypt_eik
 # Re-export helpers subpackage
 from . import helpers
 
+# Re-export the canonical GPS accuracy normalizer. Exposing it as a direct
+# attribute of the coordinator package (mirroring GoogleFindMyCoordinator) lets
+# lightweight consumers such as map_view resolve it without reaching into the
+# nested .helpers.geo submodule, which keeps them tolerant of plain ModuleType
+# coordinator stubs in tests. geo is a pure, dependency-light module.
+from .helpers.geo import safe_accuracy
+
 # Re-export stats classes from helpers (commonly needed)
 from .helpers.stats import (
     ApiStatus,
@@ -88,6 +95,7 @@ __all__ = [
     "format_epoch_utc",
     "get_recorder",
     "normalize_epoch_seconds",
+    "safe_accuracy",
     # Semi-public functions
     "_as_ha_attributes",
     "_sync_get_last_gps_from_history",

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -55,11 +55,18 @@ def _resolve_safe_accuracy() -> Any:
     ``_resolve_coordinator_class``). Resolving and caching it on first use
     preserves the same import-time guarantees while letting the map reuse the
     integration-wide accuracy policy instead of duplicating it.
+
+    We import it as a direct attribute of ``.coordinator`` (re-exported there),
+    exactly like ``_resolve_coordinator_class`` resolves the coordinator class.
+    Reaching into the nested ``.coordinator.helpers.geo`` submodule instead would
+    require the coordinator to be a real package, which breaks lightweight test
+    loaders that install it as a plain ``ModuleType`` stub. Tests can also patch
+    the cached ``_SAFE_ACCURACY`` directly or expose ``safe_accuracy`` on the stub.
     """
 
     global _SAFE_ACCURACY
     if _SAFE_ACCURACY is None:
-        from .coordinator.helpers.geo import safe_accuracy as _safe_accuracy
+        from .coordinator import safe_accuracy as _safe_accuracy
 
         _SAFE_ACCURACY = _safe_accuracy
     return _SAFE_ACCURACY

--- a/tests/test_map_view_unique_id_resolution.py
+++ b/tests/test_map_view_unique_id_resolution.py
@@ -122,6 +122,32 @@ class _StubEntityRegistry:
         return self.entities.get(entity_id)
 
 
+def _load_real_safe_accuracy() -> Any:
+    """Load the canonical ``safe_accuracy`` from geo.py by file path.
+
+    Loading the module directly (rather than importing it through the package)
+    keeps this lightweight loader free of the heavy integration import chain
+    while still exercising the real accuracy policy that production re-exports as
+    ``coordinator.safe_accuracy``. geo.py imports only ``math``/``typing`` and has
+    no relative imports, so it loads in isolation.
+    """
+
+    geo_path = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "googlefindmy"
+        / "coordinator"
+        / "helpers"
+        / "geo.py"
+    )
+    spec = importlib.util.spec_from_file_location("googlefindmy_test_geo", geo_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to load geo module for testing")
+    geo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(geo)
+    return geo.safe_accuracy
+
+
 def _load_map_view_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     """Load the map_view module with stubbed Home Assistant dependencies."""
 
@@ -210,9 +236,24 @@ def _load_map_view_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
 
     coordinator_module = ModuleType("custom_components.googlefindmy.coordinator")
     coordinator_module.GoogleFindMyCoordinator = _StubCoordinator
+    # Expose safe_accuracy as a direct attribute, mirroring the production
+    # re-export in coordinator/__init__.py. map_view resolves it via
+    # ``from .coordinator import safe_accuracy``; without this attribute the
+    # plain ModuleType stub (no __path__) would make that import fail.
+    coordinator_module.safe_accuracy = _load_real_safe_accuracy()
     monkeypatch.setitem(
         sys.modules, "custom_components.googlefindmy.coordinator", coordinator_module
     )
+    # Force every coordinator lookup through the stub. If a previous test already
+    # imported the real ``coordinator.helpers.geo`` it would linger in sys.modules
+    # and let a nested ``from .coordinator.helpers.geo import ...`` resolve from
+    # that cache, masking the very import-order fragility this loader guards
+    # against. Dropping the cached submodules makes the stub the only source.
+    for cached in (
+        "custom_components.googlefindmy.coordinator.helpers.geo",
+        "custom_components.googlefindmy.coordinator.helpers",
+    ):
+        monkeypatch.delitem(sys.modules, cached, raising=False)
 
     module_name = "custom_components.googlefindmy.map_view"
     spec = importlib.util.spec_from_file_location(
@@ -463,3 +504,30 @@ def test_map_view_html_uses_iso_conversion(monkeypatch: pytest.MonkeyPatch) -> N
     assert "parsed.toISOString()" in html_empty
     assert "getFullYear()" in html_with_locations
     assert "getFullYear()" in html_empty
+
+
+def test_map_view_resolves_safe_accuracy_under_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The accuracy resolver must work under the lightweight coordinator stub.
+
+    Regression for the Codex #186 finding: ``_resolve_safe_accuracy`` previously
+    imported ``.coordinator.helpers.geo``, which requires the coordinator to be a
+    real package. Under the plain ModuleType stub installed by this loader the
+    nested import aborted with "coordinator is not a package", so any history
+    render exercising the accuracy filter would crash. Resolving the re-exported
+    ``coordinator.safe_accuracy`` keeps the map renderable under the stub.
+    """
+
+    map_view = _load_map_view_module(monkeypatch)
+
+    safe_accuracy = map_view._resolve_safe_accuracy()
+
+    # Canonical policy: valid measurements pass through unchanged, while the 0.0
+    # Android error code and missing values map to the conservative fallback.
+    assert safe_accuracy(50.0) == 50.0
+    assert safe_accuracy(0.0) == 200.0
+    assert safe_accuracy(None) == 200.0
+
+    # Second call must hit the cache instead of re-importing (same object).
+    assert map_view._resolve_safe_accuracy() is safe_accuracy


### PR DESCRIPTION
## Summary

Fixes a latent import-order fragility that Codex flagged on PR #186: the map view's lazy resolver for `safe_accuracy` could fail under lightweight, stubbed-coordinator test loaders.

## Background

PR #1121 added accuracy normalization to the map view via `safe_accuracy`, resolved lazily as:

```python
from .coordinator.helpers.geo import safe_accuracy
```

This reaches into a **sub-subpackage** (`.coordinator.helpers.geo`), which requires `.coordinator` to be a real package (have `__path__`). In isolated map-view tests, the coordinator is intentionally installed as a plain `ModuleType` exposing only `GoogleFindMyCoordinator`, so the nested import raises `'...coordinator' is not a package` whenever the resolver runs **before** `geo` was imported elsewhere. The bug is import-order dependent (masked by `sys.modules` caching in the full suite), which is exactly why the existing targeted tests stayed green.

The sibling resolver `_resolve_coordinator_class()` does **not** have this problem because it imports a **direct attribute** (`from .coordinator import GoogleFindMyCoordinator`), which tolerates the plain-`ModuleType` stub. The fix removes the asymmetry.

## Changes

- **`coordinator/__init__.py`**: re-export `safe_accuracy` (added to `__all__`), mirroring the existing "re-export commonly needed helpers" pattern (e.g. `GoogleFindMyCoordinator`, `helpers.stats`). `geo` is lightweight (only `math`/`typing`), so no import cost or cycle.
- **`map_view.py`**: switch the resolver to `from .coordinator import safe_accuracy` — same stub-tolerant mechanism as the coordinator-class resolver; the `_SAFE_ACCURACY` cache is preserved.
- **`tests/test_map_view_unique_id_resolution.py`**: the lightweight stub now exposes the real `safe_accuracy` (loaded by file path, without heavy parent imports), drops cached `coordinator.helpers*` entries for determinism, and adds a regression test that reproduces the exact failure.

## Tests

- Mutation proof: reverting the `map_view.py` import line turns the new regression test **red** with exactly `'...coordinator' is not a package`; the fix turns it **green**.
- Verified the real re-export: `coordinator.safe_accuracy is geo.safe_accuracy`, in `__all__`, no import cycle.
- `ruff` and `mypy --strict` clean; changed-line coverage 100%; full suite `rc=0`.

## Compatibility

No user-facing or behavioral change. Internal import/test-infrastructure hardening only.
