### PR TITLE
fix: stop spurious reauth when one device fails to decrypt while siblings succeed

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -210,12 +210,7 @@ def _try_unwrap_aesgcm_envelope(
 def _extract_canonic_id(device_update_protobuf: Any) -> str | None:
     """Extract the first canonical ID from a DeviceUpdate protobuf."""
     try:
-        canonic_ids = (
-            device_update_protobuf.deviceMetadata
-            .identifierInformation
-            .canonicIds
-            .canonicId
-        )
+        canonic_ids = device_update_protobuf.deviceMetadata.identifierInformation.canonicIds.canonicId
         for cid in canonic_ids:
             val = getattr(cid, "id", None)
             if isinstance(val, str) and val:
@@ -268,6 +263,25 @@ class SharedKeyMissingError(DecryptionError):
 
     Account-wide: the secrets.json did not provide a usable shared key. A complete
     re-import / fresh secrets.json is required.
+    """
+
+
+class OwnReportIdentityMismatchError(DecryptionError):
+    """Raised when a device's OWN server reports all fail authentication.
+
+    Device-local condition: the account keys are healthy (the identity key was
+    derived and siblings decrypt), but THIS device's own reports on the server were
+    encrypted with an identity key the local cache no longer matches -- typically a
+    phone powered off for days whose server-side reports are stale, or a re-paired
+    device. A fresh secrets.json (account-wide re-auth) does NOT fix it, so when a
+    sibling proves the shared key is healthy the coordinator downgrades this to a
+    per-device warning instead of prompting for re-authentication.
+
+    Kept a DISTINCT subclass so the coordinator's sibling-success downgrade applies
+    ONLY here. Every OTHER ``DecryptionError`` -- identity-key derivation failures
+    (account-wide owner/shared key, e.g. "Identity key decryption failed.") and the
+    explicit shared-key subclasses -- stays on the account-wide reauth path, so a
+    new raise-site fails safe (escalates) rather than being silently suppressed.
     """
 
 
@@ -448,9 +462,7 @@ async def async_retrieve_identity_key(
             owner_key_info.version,
         )
         try:
-            owner_key_info = await async_get_owner_key(
-                cache=cache, force_refresh=True
-            )
+            owner_key_info = await async_get_owner_key(cache=cache, force_refresh=True)
         except (InvalidTag, RuntimeError) as exc:
             raise _classify_owner_key_failure(exc, context="forced refresh") from exc
 
@@ -475,9 +487,7 @@ async def async_retrieve_identity_key(
             flipped_blob = flip_bits(raw_encrypted_identity_key, do_flip)
 
             # --- EIK Cache Lookup (Performance Optimization) ---
-            eik_cache_key = _get_eik_cache_key(
-                flipped_blob, owner_key_version, do_flip
-            )
+            eik_cache_key = _get_eik_cache_key(flipped_blob, owner_key_version, do_flip)
             cached_eik = _eik_cache.get(eik_cache_key)
             if cached_eik is not None:
                 _eik_cache_stats["hits"] += 1
@@ -529,10 +539,7 @@ async def async_retrieve_identity_key(
                 envelope_result = _try_unwrap_aesgcm_envelope(
                     flipped_blob, wrapping_key, device_id=device_id
                 )
-                if (
-                    envelope_result is not None
-                    and len(envelope_result) == _EIK_LEN
-                ):
+                if envelope_result is not None and len(envelope_result) == _EIK_LEN:
                     key_bytes = bytes(envelope_result)
                     _eik_cache[eik_cache_key] = key_bytes
                     _LOGGER.info(
@@ -573,9 +580,7 @@ async def async_retrieve_identity_key(
         # timeout or SSL teardown) is swallowed and the regular decrypt
         # error path continues unaffected, so it must not surface as a
         # user-facing WARNING.
-        _LOGGER.debug(
-            "Failed to retrieve E2EE metadata for diagnostics: %s", meta_exc
-        )
+        _LOGGER.debug("Failed to retrieve E2EE metadata for diagnostics: %s", meta_exc)
 
     old_ver = getattr(encrypted_user_secrets, "ownerKeyVersion", None)
     last_exc = decrypt_errors[-1] if decrypt_errors else None
@@ -1325,7 +1330,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     # AES-EAX with different key derivation). Trying all candidates prevents
     # silent loss of all crowdsourced location data.
     all_identity_keys: list[bytes] = [
-        bytes(k) for k in (identity_key_candidates or [])
+        bytes(k)
+        for k in (identity_key_candidates or [])
         if k is not None and len(k) == _EIK_LEN
     ]
     # Track the active key; promote alternate candidates on success
@@ -1383,7 +1389,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     # guard. Intentionally a ValueError (config error, not an auth
                     # signal) so it is NOT counted as an own auth failure and does
                     # not trigger stale-key reauth escalation.
-                    raise ValueError("No identity key available for own-report decryption")
+                    raise ValueError(
+                        "No identity key available for own-report decryption"
+                    )
                 decrypted_location_raw = await _offload_decrypt_aes(
                     active_identity_key, encrypted_location
                 )
@@ -1399,7 +1407,8 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 decrypted_location_raw = None
                 _last_foreign_exc: Exception | None = None
                 for _candidate_idx, candidate_key in enumerate(
-                    all_identity_keys or ([active_identity_key] if active_identity_key else [])
+                    all_identity_keys
+                    or ([active_identity_key] if active_identity_key else [])
                 ):
                     try:
                         decrypted_location_raw = await _offload_decrypt_foreign(
@@ -1542,19 +1551,22 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
 
     # Diff-Review #1: When the device HAS its own encrypted reports and EVERY
     # one of them failed authentication (with not a single own-report success),
-    # the cached identity key no longer matches the server's reports. This is a
-    # genuine account-wide auth failure, distinct from the masked retrieve path
-    # above and from foreign/crowdsourced failures (which legitimately fail with
-    # other accounts' keys and must NOT escalate). Raise DecryptionError so the
-    # existing escalation machinery (coordinator poll/locate handlers and the FCM
-    # push handler, all gated by per-cycle counting + cooldown) can surface a
-    # reauth repair instead of silently returning empty every cycle.
+    # the cached identity key no longer matches THIS device's server reports --
+    # distinct from the masked retrieve path above and from foreign/crowdsourced
+    # failures (which legitimately fail with other accounts' keys and must NOT
+    # escalate). Raise the dedicated OwnReportIdentityMismatchError so the existing
+    # escalation machinery (coordinator poll/locate handlers and the FCM push
+    # handler, all gated by per-cycle counting + cooldown) surfaces a reauth repair
+    # instead of silently returning empty every cycle -- UNLESS a sibling device
+    # decrypts in the same poll cycle, which proves the account keys are healthy
+    # and lets the coordinator downgrade this device-local staleness to a warning
+    # (a fresh secrets.json cannot fix an offline/re-paired device anyway).
     if (
         _own_encrypted_report_count > 0
         and _own_auth_failures >= _own_encrypted_report_count
         and not _own_report_success
     ):
-        raise DecryptionError(
+        raise OwnReportIdentityMismatchError(
             "All own-report decryptions failed; the cached identity key no "
             "longer matches the server reports."
         )

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -368,9 +368,28 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                     SpotAuthPermanentError,
                     InvalidTag,
                 ) as err:
-                    _LOGGER.error(
-                        "Failed to process location data for %s: %s", name, err
-                    )
+                    # A per-device decryption/key failure (DecryptionError incl. its
+                    # StaleOwnerKeyError subclass, or InvalidTag) is NOT, on its own,
+                    # an account-wide crisis: a device powered off for days lands
+                    # here while sibling devices decrypt fine. Log those as warnings
+                    # -- the account-wide escalation is decided once per cycle by the
+                    # coordinator's positive-proof-gated verdict
+                    # (PollingOperations._resolve_cycle_decrypt_outcome), and its
+                    # ERROR is emitted there via note_decrypt_failure, not per device
+                    # here. Genuine session/auth failures
+                    # (SpotApiEmptyResponseError, SpotAuthPermanentError) keep ERROR
+                    # severity because they themselves drive reauth. ctx.error and
+                    # the propagation are unchanged in every case.
+                    if isinstance(
+                        err, (SpotApiEmptyResponseError, SpotAuthPermanentError)
+                    ):
+                        _LOGGER.error(
+                            "Failed to process location data for %s: %s", name, err
+                        )
+                    else:
+                        _LOGGER.warning(
+                            "Failed to process location data for %s: %s", name, err
+                        )
                     ctx.error = err
                     ctx.event.set()
                     return
@@ -609,9 +628,7 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
     # heavy import cycle, so the name is not available at module scope. It is used
     # below to surface an auth-fatal stale-key failure instead of swallowing it.
     decrypt_module = _import_decrypt_locations_module()
-    DecryptionError = cast(
-        type[Exception], getattr(decrypt_module, "DecryptionError")
-    )
+    DecryptionError = cast(type[Exception], getattr(decrypt_module, "DecryptionError"))
 
     try:
         # Generate request UUID

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -446,6 +446,34 @@ class PollingOperations(_MixinBase):
             return candidate
         return current
 
+    def _decrypt_failure_is_account_wide(
+        self,
+        cycle_decrypt_error: DecryptionError | None,
+        cycle_had_successful_decrypt: bool,
+    ) -> bool:
+        """Does a cycle's decrypt failure implicate the account-wide shared key?
+
+        Single source of truth shared by the escalation verdict
+        (:meth:`_resolve_cycle_decrypt_outcome`) and the cycle-failure
+        reconciliation (:meth:`_finalize_cycle_decrypt_state`) so the "escalate to
+        reauth" decision and the "mark the coordinator update failed" decision
+        cannot drift apart.
+
+        - No decrypt error at all -> not account-wide.
+        - Not a single device decrypted this cycle -> account-wide by the absence of
+          any positive proof the shared key still works.
+        - A sibling decrypted, so positive proof dominates: only the explicit
+          shared-key subclasses (:meth:`_is_account_wide_key_failure`) remain
+          account-wide -- a sibling decrypting from cached owner/EIK material cannot
+          refute them. A plain per-device own-report failure (e.g. a phone powered
+          off for days) is refuted as device-local.
+        """
+        if cycle_decrypt_error is None:
+            return False
+        if not cycle_had_successful_decrypt:
+            return True
+        return self._is_account_wide_key_failure(cycle_decrypt_error)
+
     def _resolve_cycle_decrypt_outcome(
         self,
         *,
@@ -481,11 +509,12 @@ class PollingOperations(_MixinBase):
         ``_MAX_DECRYPT_FAILURES`` and tripped a spurious reauth (removing the
         offline device silenced it -- the observed bug).
         """
-        account_wide_key_failure = self._is_account_wide_key_failure(
-            cycle_decrypt_error
-        )
-        if cycle_decrypt_error is not None and (
-            not cycle_had_successful_decrypt or account_wide_key_failure
+        # The explicit ``is not None`` narrows the type for the typed
+        # note_decrypt_failure(error=...) call; it is logically redundant with the
+        # predicate (which returns False for None) but keeps the predicate the
+        # single source of truth for the account-wide DECISION.
+        if cycle_decrypt_error is not None and self._decrypt_failure_is_account_wide(
+            cycle_decrypt_error, cycle_had_successful_decrypt
         ):
             # Account-wide stale/missing shared key: either NOT ONE device decrypted
             # this cycle, OR the failure is an explicit shared-key subclass that a
@@ -525,6 +554,60 @@ class PollingOperations(_MixinBase):
             # the poll path and the FCM background-push decode cannot drift apart.
             self.note_decrypt_success()
         return False
+
+    def _finalize_cycle_decrypt_state(
+        self,
+        *,
+        cycle_decrypt_error: DecryptionError | None,
+        cycle_had_successful_decrypt: bool,
+        cycle_had_stale_key: bool,
+        cycle_failed: bool,
+        last_exception: Exception | None,
+    ) -> tuple[bool, Exception | None, ConfigEntryAuthFailed | None]:
+        """Apply the cycle's decrypt verdict and reconcile the cycle-failure state.
+
+        Runs :meth:`_resolve_cycle_decrypt_outcome` (the counter/sensor side
+        effects) and then reconciles ``cycle_failed`` / ``last_exception`` with the
+        verdict in ONE place, returning ``(cycle_failed, last_exception,
+        reauth_exc)``. ``reauth_exc`` is non-``None`` iff the caller must escalate
+        (request reauth and abort the cycle).
+
+        The decrypt error must NOT contribute to the cycle-failure state at the
+        point it is caught: whether it fails the whole coordinator update depends on
+        the cross-device outcome resolved only after the loop. A per-device
+        own-report failure that a sibling success refutes is benign and leaves
+        ``cycle_failed`` / ``last_exception`` untouched, so a single offline/stale
+        device no longer marks every poll failed (the Codex finding). Only a
+        genuinely account-wide failure (see :meth:`_decrypt_failure_is_account_wide`)
+        surfaces on the coordinator update; at the consecutive-cycle threshold it
+        escalates to reauth. Failures from other device errors (timeouts, transient
+        auth) set ``cycle_failed`` / ``last_exception`` independently and are
+        preserved here untouched.
+        """
+        if self._resolve_cycle_decrypt_outcome(
+            cycle_decrypt_error=cycle_decrypt_error,
+            cycle_had_successful_decrypt=cycle_had_successful_decrypt,
+            cycle_had_stale_key=cycle_had_stale_key,
+        ):
+            reauth_exc = ConfigEntryAuthFailed(
+                "Location decryption keeps failing: the shared key "
+                "is stale; a fresh secrets.json (re-authentication) "
+                "is required"
+            )
+            return True, reauth_exc, reauth_exc
+        if self._decrypt_failure_is_account_wide(
+            cycle_decrypt_error, cycle_had_successful_decrypt
+        ):
+            # Genuine account-wide decrypt failure below the reauth threshold: the
+            # cycle failed to decrypt account data, so surface it on the coordinator
+            # update even though we do not yet force reauth.
+            cycle_failed = True
+            if last_exception is None:
+                last_exception = cycle_decrypt_error
+        # Otherwise: a clean cycle, or a per-device failure a sibling success
+        # refuted. The decrypt error (if any) is benign and must NOT mark the
+        # coordinator update failed.
+        return cycle_failed, last_exception, None
 
     def note_decrypt_success(self) -> None:
         """Record a proven location decryption and clear the reauth budget.
@@ -1997,25 +2080,25 @@ class PollingOperations(_MixinBase):
                             last_exception = stale_err
                         continue
                     except DecryptionError as dec_err:
-                        # Stale/missing shared key (account-wide) OR a per-device
-                        # own-report failure. Only FLAG the cycle here -- the
-                        # account-wide failure counter is advanced exactly once per
-                        # cycle after the device loop (see below). Counting per device
-                        # would let a multi-device account cross _MAX_DECRYPT_FAILURES
-                        # within a single cycle and escalate on the first poll,
-                        # defeating the documented "consecutive cycles" budget that
-                        # gives the in-decrypt self-heal a few cycles to recover an
-                        # owner-key bump. Keep the account-wide shared-key subclass as
-                        # the cycle's representative error over a co-occurring
-                        # per-device failure so the resolver's sibling-success
-                        # downgrade cannot mask a genuine shared-key problem.
+                        # Defer the cycle-failure bookkeeping (cycle_failed /
+                        # last_exception) to the post-loop verdict in
+                        # _finalize_cycle_decrypt_state. Whether this decrypt error
+                        # fails the whole coordinator update depends on the
+                        # cross-device outcome: a per-device own-report failure a
+                        # sibling success refutes is benign and must NOT mark the
+                        # cycle failed (otherwise a single offline device fails every
+                        # poll), while a genuinely account-wide failure does. Only
+                        # capture the representative error here -- the account-wide
+                        # shared-key subclass is kept over a co-occurring per-device
+                        # failure so the resolver's sibling-success downgrade cannot
+                        # mask a genuine shared-key problem. The account-wide failure
+                        # counter is still advanced exactly once after the loop, never
+                        # per device, preserving the documented consecutive-cycle
+                        # budget that gives the in-decrypt self-heal time to recover.
                         self._consecutive_timeouts = 0
-                        cycle_failed = True
                         cycle_decrypt_error = self._prefer_account_wide_decrypt_error(
                             cycle_decrypt_error, dec_err
                         )
-                        if last_exception is None:
-                            last_exception = dec_err
                         continue
                     except Exception as err:
                         _LOGGER.error(
@@ -2032,23 +2115,23 @@ class PollingOperations(_MixinBase):
                         await asyncio.sleep(self.device_poll_delay)
 
                 _LOGGER.debug("Completed polling cycle for %d devices", len(devices))
-                # Resolve the cycle's decrypt verdict in one place (positive proof
-                # dominates: a sibling success refutes a single device's failure as
-                # account-wide). Returns True only for a genuinely account-wide
-                # failure that crossed the consecutive-cycle reauth threshold.
-                if self._resolve_cycle_decrypt_outcome(
-                    cycle_decrypt_error=cycle_decrypt_error,
-                    cycle_had_successful_decrypt=cycle_had_successful_decrypt,
-                    cycle_had_stale_key=cycle_had_stale_key,
-                ):
-                    cycle_failed = True
-                    self._last_poll_result = "failed"
-                    reauth_exc = ConfigEntryAuthFailed(
-                        "Location decryption keeps failing: the shared key "
-                        "is stale; a fresh secrets.json (re-authentication) "
-                        "is required"
+                # Resolve the cycle's decrypt verdict AND reconcile the cycle's
+                # failure state with it in one place (positive proof dominates: a
+                # sibling success refutes a single device's failure as account-wide).
+                # A benign per-device downgrade neither escalates to reauth NOR marks
+                # the coordinator update failed; a genuinely account-wide failure
+                # surfaces and, at the consecutive-cycle threshold, escalates.
+                cycle_failed, last_exception, reauth_exc = (
+                    self._finalize_cycle_decrypt_state(
+                        cycle_decrypt_error=cycle_decrypt_error,
+                        cycle_had_successful_decrypt=cycle_had_successful_decrypt,
+                        cycle_had_stale_key=cycle_had_stale_key,
+                        cycle_failed=cycle_failed,
+                        last_exception=last_exception,
                     )
-                    last_exception = reauth_exc
+                )
+                if reauth_exc is not None:
+                    self._last_poll_result = "failed"
                     self._request_poll_reauth(reauth_exc)
                     return
             finally:

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -53,6 +53,7 @@ from ..const import (
 )
 from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    SharedKeyMismatchError,
     SharedKeyMissingError,
     StaleOwnerKeyError,
     is_real_location_record,
@@ -406,6 +407,45 @@ class PollingOperations(_MixinBase):
         )
         return True
 
+    @staticmethod
+    def _is_account_wide_key_failure(error: DecryptionError | None) -> bool:
+        """True for shared-key failures that need a fresh secrets.json (account-wide).
+
+        ``SharedKeyMissingError`` and ``SharedKeyMismatchError`` mean the bundle's
+        shared key itself is missing or incompatible, so EVERY device's owner-key
+        unwrap is doomed regardless of which device is polled. A sibling that still
+        decrypts from cached owner/EIK material does NOT prove the shared key is
+        healthy, so -- unlike a plain per-device own-report ``DecryptionError`` -- a
+        shared-key failure must stay on the account-wide reauth path even when a
+        sibling succeeds. Single discriminator for both the cycle-error capture
+        priority and the escalation gate so the two cannot drift apart.
+        """
+        return isinstance(error, (SharedKeyMissingError, SharedKeyMismatchError))
+
+    @classmethod
+    def _prefer_account_wide_decrypt_error(
+        cls,
+        current: DecryptionError | None,
+        candidate: DecryptionError,
+    ) -> DecryptionError:
+        """Pick the cycle's representative decrypt error, account-wide first.
+
+        A single cycle can mix a per-device own-report failure (a phone powered off
+        for days) with an account-wide shared-key failure on another device. The
+        verdict downgrades only the per-device case on sibling success, so the
+        representative error must be the account-wide one whenever present.
+        Otherwise an earlier-polled offline device would mask a genuine shared-key
+        failure and suppress the reauth the user actually needs. Keeps the first
+        error of equal severity (stable, order-independent for same-class errors).
+        """
+        if current is None:
+            return candidate
+        if cls._is_account_wide_key_failure(
+            candidate
+        ) and not cls._is_account_wide_key_failure(current):
+            return candidate
+        return current
+
     def _resolve_cycle_decrypt_outcome(
         self,
         *,
@@ -418,26 +458,40 @@ class PollingOperations(_MixinBase):
         Performs the post-loop crypto-sensor and reauth-budget side effects and
         returns ``True`` iff the caller must escalate to ``ConfigEntryAuthFailed``.
 
-        Positive proof dominates (D7): if ANY device produced an authenticated
-        coordinate this cycle (``cycle_had_successful_decrypt``), the account-wide
-        shared key is provably healthy, so a sibling device's ``DecryptionError``
+        Positive proof dominates (D7), but ONLY for a plain per-device own-report
+        failure: if ANY device produced an authenticated coordinate this cycle
+        (``cycle_had_successful_decrypt``), a sibling's plain ``DecryptionError``
         -- e.g. a phone powered off for days whose own server reports no longer
         decrypt -- is a per-device condition that must NOT advance the account-wide
         reauth budget and must NOT trigger reauth. This mirrors the per-tracker
         ``StaleOwnerKeyError`` (``stale=True``) treatment ("other devices are
-        unaffected"). Only a decrypt failure with NOT A SINGLE successful sibling
-        is account-wide and counted toward the consecutive-cycle reauth budget.
+        unaffected").
 
-        Before this gate the account-wide counter was advanced whenever a decrypt
-        error was seen, regardless of sibling success, so a single offline device
-        dragged a healthy multi-device account across ``_MAX_DECRYPT_FAILURES`` and
-        tripped a spurious reauth (removing the offline device silenced it -- the
-        observed bug).
+        Explicit shared-key subclasses are the exception (see
+        ``_is_account_wide_key_failure``): ``SharedKeyMissingError`` and
+        ``SharedKeyMismatchError`` mean the bundle's shared key itself cannot unwrap
+        the owner key, so a sibling decrypting from cached owner/EIK material does
+        NOT prove the key is healthy. Such failures stay on the account-wide reauth
+        path even with sibling success -- otherwise a mixed cycle would strand the
+        broken device without ever prompting for fresh secrets.
+
+        Before the positive-proof gate the account-wide counter was advanced
+        whenever a decrypt error was seen, regardless of sibling success, so a
+        single offline device dragged a healthy multi-device account across
+        ``_MAX_DECRYPT_FAILURES`` and tripped a spurious reauth (removing the
+        offline device silenced it -- the observed bug).
         """
-        if cycle_decrypt_error is not None and not cycle_had_successful_decrypt:
-            # Account-wide stale/missing shared key: a decrypt failure persisted AND
-            # not one device decrypted this cycle. Advance the consecutive-cycle
-            # counter exactly once; let it escalate (cooldown-gated) on threshold.
+        account_wide_key_failure = self._is_account_wide_key_failure(
+            cycle_decrypt_error
+        )
+        if cycle_decrypt_error is not None and (
+            not cycle_had_successful_decrypt or account_wide_key_failure
+        ):
+            # Account-wide stale/missing shared key: either NOT ONE device decrypted
+            # this cycle, OR the failure is an explicit shared-key subclass that a
+            # sibling's cached-material success cannot refute. Advance the
+            # consecutive-cycle counter exactly once; escalate (cooldown-gated) on
+            # threshold.
             return self.note_decrypt_failure(
                 stale=False, error=cycle_decrypt_error, device=None
             )
@@ -1943,18 +1997,23 @@ class PollingOperations(_MixinBase):
                             last_exception = stale_err
                         continue
                     except DecryptionError as dec_err:
-                        # Account-wide stale/missing shared key. Only FLAG the cycle
-                        # here -- the account-wide failure counter is advanced exactly
-                        # once per cycle after the device loop (see below). Counting
-                        # per device would let a multi-device account cross
-                        # _MAX_DECRYPT_FAILURES within a single cycle and escalate on
-                        # the first poll, defeating the documented "consecutive
-                        # cycles" budget that gives the in-decrypt self-heal a few
-                        # cycles to recover an owner-key bump.
+                        # Stale/missing shared key (account-wide) OR a per-device
+                        # own-report failure. Only FLAG the cycle here -- the
+                        # account-wide failure counter is advanced exactly once per
+                        # cycle after the device loop (see below). Counting per device
+                        # would let a multi-device account cross _MAX_DECRYPT_FAILURES
+                        # within a single cycle and escalate on the first poll,
+                        # defeating the documented "consecutive cycles" budget that
+                        # gives the in-decrypt self-heal a few cycles to recover an
+                        # owner-key bump. Keep the account-wide shared-key subclass as
+                        # the cycle's representative error over a co-occurring
+                        # per-device failure so the resolver's sibling-success
+                        # downgrade cannot mask a genuine shared-key problem.
                         self._consecutive_timeouts = 0
                         cycle_failed = True
-                        if cycle_decrypt_error is None:
-                            cycle_decrypt_error = dec_err
+                        cycle_decrypt_error = self._prefer_account_wide_decrypt_error(
+                            cycle_decrypt_error, dec_err
+                        )
                         if last_exception is None:
                             last_exception = dec_err
                         continue

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -183,9 +183,7 @@ class PollingOperations(_MixinBase):
     _is_polling: bool
     _startup_complete: bool
 
-    def _set_api_status(
-        self, status: str, *, reason: str | None = None
-    ) -> None:
+    def _set_api_status(self, status: str, *, reason: str | None = None) -> None:
         """Update the API polling status and notify listeners if it changed."""
         if status == self._api_status_state and reason == self._api_status_reason:
             return
@@ -200,9 +198,7 @@ class PollingOperations(_MixinBase):
             # Fallback for very early startup when listeners are not ready yet.
             pass
 
-    def _set_fcm_status(
-        self, status: str, *, reason: str | None = None
-    ) -> None:
+    def _set_fcm_status(self, status: str, *, reason: str | None = None) -> None:
         """Update the push transport status while avoiding noisy churn."""
         if status == self._fcm_status_state and reason == self._fcm_status_reason:
             return
@@ -216,9 +212,7 @@ class PollingOperations(_MixinBase):
         except Exception:
             pass
 
-    def _set_crypto_status(
-        self, status: str, *, reason: str | None = None
-    ) -> None:
+    def _set_crypto_status(self, status: str, *, reason: str | None = None) -> None:
         """Update the location-decryption status while avoiding noisy churn.
 
         Mirrors ``_set_fcm_status`` exactly. This is the single writer for the
@@ -412,6 +406,72 @@ class PollingOperations(_MixinBase):
         )
         return True
 
+    def _resolve_cycle_decrypt_outcome(
+        self,
+        *,
+        cycle_decrypt_error: DecryptionError | None,
+        cycle_had_successful_decrypt: bool,
+        cycle_had_stale_key: bool,
+    ) -> bool:
+        """Resolve a poll cycle's decrypt verdict and return whether to escalate.
+
+        Performs the post-loop crypto-sensor and reauth-budget side effects and
+        returns ``True`` iff the caller must escalate to ``ConfigEntryAuthFailed``.
+
+        Positive proof dominates (D7): if ANY device produced an authenticated
+        coordinate this cycle (``cycle_had_successful_decrypt``), the account-wide
+        shared key is provably healthy, so a sibling device's ``DecryptionError``
+        -- e.g. a phone powered off for days whose own server reports no longer
+        decrypt -- is a per-device condition that must NOT advance the account-wide
+        reauth budget and must NOT trigger reauth. This mirrors the per-tracker
+        ``StaleOwnerKeyError`` (``stale=True``) treatment ("other devices are
+        unaffected"). Only a decrypt failure with NOT A SINGLE successful sibling
+        is account-wide and counted toward the consecutive-cycle reauth budget.
+
+        Before this gate the account-wide counter was advanced whenever a decrypt
+        error was seen, regardless of sibling success, so a single offline device
+        dragged a healthy multi-device account across ``_MAX_DECRYPT_FAILURES`` and
+        tripped a spurious reauth (removing the offline device silenced it -- the
+        observed bug).
+        """
+        if cycle_decrypt_error is not None and not cycle_had_successful_decrypt:
+            # Account-wide stale/missing shared key: a decrypt failure persisted AND
+            # not one device decrypted this cycle. Advance the consecutive-cycle
+            # counter exactly once; let it escalate (cooldown-gated) on threshold.
+            return self.note_decrypt_failure(
+                stale=False, error=cycle_decrypt_error, device=None
+            )
+
+        # Either a clean cycle, or a per-device decrypt failure that a sibling
+        # success refutes as account-wide. Never escalate to reauth from here.
+        if cycle_decrypt_error is not None:
+            # cycle_had_successful_decrypt is True here (guard above): a sibling
+            # proved the shared key works, so this failure is device-local. Log it
+            # as a warning -- the account-wide escalation ERROR is reserved for the
+            # genuinely account-wide path -- and leave the reauth budget untouched.
+            _LOGGER.warning(
+                "Location decryption failed for a device this cycle while other "
+                "devices decrypted successfully; the account shared key is "
+                "healthy, so no re-authentication is required. The affected "
+                "device may be powered off or its own server reports may be "
+                "stale: %s",
+                cycle_decrypt_error,
+            )
+        if cycle_had_successful_decrypt and not cycle_had_stale_key:
+            # Positive proof and no per-tracker stale key: heal the diagnostic
+            # sensor (D6 OK source, single writer) and clear the error class with
+            # it. Gating on ``not cycle_had_stale_key`` keeps a per-tracker
+            # StaleOwnerKeyError's error class intact while its tracker_key_outdated
+            # status persists.
+            self._set_crypto_status(CryptoStatus.OK)
+            self._last_decrypt_error = None
+        if cycle_had_successful_decrypt:
+            # Clear the consecutive-decrypt counter only on POSITIVE proof the
+            # account-wide shared key works, via the shared success entry point so
+            # the poll path and the FCM background-push decode cannot drift apart.
+            self.note_decrypt_success()
+        return False
+
     def note_decrypt_success(self) -> None:
         """Record a proven location decryption and clear the reauth budget.
 
@@ -530,9 +590,7 @@ class PollingOperations(_MixinBase):
         else:
             self._run_on_hass_loop(_invoke)
 
-    def _schedule_short_retry(
-        self, delay_s: float = 5.0
-    ) -> None:
+    def _schedule_short_retry(self, delay_s: float = 5.0) -> None:
         """Schedule a short, coalesced refresh instead of shifting the poll baseline.
 
         Rationale:
@@ -584,9 +642,7 @@ class PollingOperations(_MixinBase):
             log_context="device registry event",
         )
 
-    def _compute_type_cooldown_seconds(
-        self, report_hint: str | None
-    ) -> int:
+    def _compute_type_cooldown_seconds(self, report_hint: str | None) -> int:
         """Return a server-aware cooldown duration in seconds for a crowdsourced report type.
 
         Derived from POPETS'25 observations:
@@ -807,9 +863,7 @@ class PollingOperations(_MixinBase):
         return min(predictions)
 
     # -------------------- Push transport error handling --------------------
-    def _note_push_transport_problem(
-        self, cooldown_s: int = 90
-    ) -> None:
+    def _note_push_transport_problem(self, cooldown_s: int = 90) -> None:
         """Enter a temporary cooldown after a push transport failure to avoid spamming.
 
         Args:
@@ -1360,9 +1414,7 @@ class PollingOperations(_MixinBase):
         """
         entry = getattr(self, "config_entry", None)
         if entry is None:
-            _LOGGER.debug(
-                "Cannot start reauth from poll cycle: no config entry bound."
-            )
+            _LOGGER.debug("Cannot start reauth from poll cycle: no config entry bound.")
             return
         try:
             # ``ConfigEntry.async_start_reauth`` is a synchronous @callback that
@@ -1370,13 +1422,9 @@ class PollingOperations(_MixinBase):
             # TypeError. Call it without await (mirrors locate.py and
             # fcm_receiver_ha.py).
             entry.async_start_reauth(self.hass)
-            _LOGGER.warning(
-                "Poll cycle triggered re-authentication: %s", reauth_exc
-            )
+            _LOGGER.warning("Poll cycle triggered re-authentication: %s", reauth_exc)
         except Exception as reauth_err:  # pragma: no cover - defensive
-            _LOGGER.debug(
-                "Failed to start reauth flow from poll cycle: %s", reauth_err
-            )
+            _LOGGER.debug("Failed to start reauth flow from poll cycle: %s", reauth_err)
 
     # ---------------------------- Polling Cycle -----------------------------
     async def _async_start_poll_cycle(
@@ -1499,9 +1547,7 @@ class PollingOperations(_MixinBase):
                             # inner FCM wait returns an empty result rather than
                             # raising. This is a healthy idle outcome, not a fault
                             # (kept at INFO, symmetric with the timeout branch).
-                            _LOGGER.info(
-                                "No location data returned for %s", dev_name
-                            )
+                            _LOGGER.info("No location data returned for %s", dev_name)
                             self._log_idle_poll_diagnostics(
                                 dev_id, dev_name, source="empty-result"
                             )
@@ -1927,73 +1973,25 @@ class PollingOperations(_MixinBase):
                         await asyncio.sleep(self.device_poll_delay)
 
                 _LOGGER.debug("Completed polling cycle for %d devices", len(devices))
-                if cycle_decrypt_error is not None:
-                    # Account-wide decrypt failure persisted this cycle: advance the
-                    # consecutive-cycle counter exactly ONCE (not once per device)
-                    # and escalate to a reauth flow when it crosses the threshold
-                    # (with cooldown). Counting once per cycle keeps a multi-device
-                    # account on the same "N consecutive cycles" budget as a
-                    # single-device account. Raised here (still inside the outer
-                    # try, before its finally) so it propagates exactly like the
-                    # former in-loop raise.
-                    if self.note_decrypt_failure(
-                        stale=False, error=cycle_decrypt_error, device=None
-                    ):
-                        cycle_failed = True
-                        self._last_poll_result = "failed"
-                        reauth_exc = ConfigEntryAuthFailed(
-                            "Location decryption keeps failing: the shared key "
-                            "is stale; a fresh secrets.json (re-authentication) "
-                            "is required"
-                        )
-                        last_exception = reauth_exc
-                        self._request_poll_reauth(reauth_exc)
-                        return
-                else:
-                    # Whole cycle finished without an account-wide decrypt failure.
-                    if cycle_had_successful_decrypt and not cycle_had_stale_key:
-                        # At least one device actually decrypted location data this
-                        # cycle (positive proof, not just the absence of an error)
-                        # and no per-tracker stale key was seen: the account-wide
-                        # shared key is healthy. Reflect that into the diagnostic
-                        # sensor (D6 OK source, single writer). A cycle of pure
-                        # timeouts/transient errors leaves the prior state intact
-                        # rather than flickering a stale key to OK.
-                        self._set_crypto_status(CryptoStatus.OK)
-                        # Clear the diagnostic error class together with the OK
-                        # status: both are the same sensor surface and must move
-                        # as one. Gating it on the same ``not cycle_had_stale_key``
-                        # condition keeps a per-tracker StaleOwnerKeyError's error
-                        # class intact while its tracker_key_outdated status
-                        # persists -- note_decrypt_success() no longer wipes this
-                        # field blindly from the shared (poll + push) entry point.
-                        self._last_decrypt_error = None
-                    if cycle_had_successful_decrypt:
-                        # Clear the consecutive-decrypt counter only on POSITIVE
-                        # proof that the account-wide shared key works (at least one
-                        # device decrypted this cycle), mirroring the CryptoStatus.OK
-                        # gate above. An idle cycle that only saw empty/no-reporter
-                        # results (cycle_had_successful_decrypt == False) must NOT
-                        # reset the counter: intermittently reporting BLE trackers
-                        # would otherwise let idle cycles between two failing decrypt
-                        # cycles perpetually clear the budget, so the reauth threshold
-                        # could never be reached and the user would stay stuck with a
-                        # stale key and no reauth prompt.
-                        #
-                        # Unlike the OK gate this intentionally does NOT also require
-                        # ``not cycle_had_stale_key``: this counter tracks the
-                        # account-wide shared key, while a per-tracker outdated owner
-                        # key (cycle_had_stale_key) is a separate, device-local
-                        # concern that never advances this counter (see
-                        # note_decrypt_failure(stale=True)). Proof that the account
-                        # key works must be allowed to clear it even when one tracker
-                        # still carries an outdated key.
-                        #
-                        # Clear via the shared success entry point so this poll path
-                        # and the FCM background-push decode cannot drift apart again:
-                        # both sources feed the counter, both must be able to clear it
-                        # (the asymmetry that previously stranded a healthy account).
-                        self.note_decrypt_success()
+                # Resolve the cycle's decrypt verdict in one place (positive proof
+                # dominates: a sibling success refutes a single device's failure as
+                # account-wide). Returns True only for a genuinely account-wide
+                # failure that crossed the consecutive-cycle reauth threshold.
+                if self._resolve_cycle_decrypt_outcome(
+                    cycle_decrypt_error=cycle_decrypt_error,
+                    cycle_had_successful_decrypt=cycle_had_successful_decrypt,
+                    cycle_had_stale_key=cycle_had_stale_key,
+                ):
+                    cycle_failed = True
+                    self._last_poll_result = "failed"
+                    reauth_exc = ConfigEntryAuthFailed(
+                        "Location decryption keeps failing: the shared key "
+                        "is stale; a fresh secrets.json (re-authentication) "
+                        "is required"
+                    )
+                    last_exception = reauth_exc
+                    self._request_poll_reauth(reauth_exc)
+                    return
             finally:
                 # Update scheduling baseline and clear flag, then push end snapshot.
                 # Always advance the poll baseline to prevent high-frequency

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -53,7 +53,7 @@ from ..const import (
 )
 from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
-    SharedKeyMismatchError,
+    OwnReportIdentityMismatchError,
     SharedKeyMissingError,
     StaleOwnerKeyError,
     is_real_location_record,
@@ -408,19 +408,27 @@ class PollingOperations(_MixinBase):
         return True
 
     @staticmethod
-    def _is_account_wide_key_failure(error: DecryptionError | None) -> bool:
-        """True for shared-key failures that need a fresh secrets.json (account-wide).
+    def _is_device_local_decrypt_failure(error: DecryptionError | None) -> bool:
+        """True ONLY for the one provably device-local class: own-report staleness.
 
-        ``SharedKeyMissingError`` and ``SharedKeyMismatchError`` mean the bundle's
-        shared key itself is missing or incompatible, so EVERY device's owner-key
-        unwrap is doomed regardless of which device is polled. A sibling that still
-        decrypts from cached owner/EIK material does NOT prove the shared key is
-        healthy, so -- unlike a plain per-device own-report ``DecryptionError`` -- a
-        shared-key failure must stay on the account-wide reauth path even when a
-        sibling succeeds. Single discriminator for both the cycle-error capture
-        priority and the escalation gate so the two cannot drift apart.
+        Fail-SAFE discriminator: a sibling decrypting proves the account keys are
+        healthy, so a device whose OWN server reports all fail authentication
+        (``OwnReportIdentityMismatchError`` -- e.g. a phone powered off for days, or
+        a re-paired device) is device-local and a fresh secrets.json cannot fix it.
+
+        EVERY other ``DecryptionError`` defaults to the account-wide reauth path:
+        the explicit shared-key subclasses (``SharedKeyMissingError`` /
+        ``SharedKeyMismatchError``) AND a plain ``DecryptionError`` from the
+        identity-key derivation path ("Identity key decryption failed.") -- the
+        owner/shared key feeding that derivation is account-wide, and a sibling
+        decrypting from cached owner/EIK material cannot refute it. Defaulting an
+        unrecognised failure to "account-wide / escalate" rather than "device-local
+        / suppress" means a NEW raise-site fails safe instead of stranding a broken
+        device without a reauth prompt (the Codex finding class). Single
+        discriminator for both the cycle-error capture priority and the escalation
+        gate so the two cannot drift apart.
         """
-        return isinstance(error, (SharedKeyMissingError, SharedKeyMismatchError))
+        return isinstance(error, OwnReportIdentityMismatchError)
 
     @classmethod
     def _prefer_account_wide_decrypt_error(
@@ -430,19 +438,20 @@ class PollingOperations(_MixinBase):
     ) -> DecryptionError:
         """Pick the cycle's representative decrypt error, account-wide first.
 
-        A single cycle can mix a per-device own-report failure (a phone powered off
-        for days) with an account-wide shared-key failure on another device. The
-        verdict downgrades only the per-device case on sibling success, so the
+        A single cycle can mix a device-local own-report failure (a phone powered
+        off for days) with an account-wide failure on another device (a shared-key
+        subclass, or a plain identity-key derivation failure). The verdict
+        downgrades only the device-local case on sibling success, so the
         representative error must be the account-wide one whenever present.
-        Otherwise an earlier-polled offline device would mask a genuine shared-key
+        Otherwise an earlier-polled offline device would mask a genuine account-wide
         failure and suppress the reauth the user actually needs. Keeps the first
         error of equal severity (stable, order-independent for same-class errors).
         """
         if current is None:
             return candidate
-        if cls._is_account_wide_key_failure(
-            candidate
-        ) and not cls._is_account_wide_key_failure(current):
+        if cls._is_device_local_decrypt_failure(
+            current
+        ) and not cls._is_device_local_decrypt_failure(candidate):
             return candidate
         return current
 
@@ -462,17 +471,18 @@ class PollingOperations(_MixinBase):
         - No decrypt error at all -> not account-wide.
         - Not a single device decrypted this cycle -> account-wide by the absence of
           any positive proof the shared key still works.
-        - A sibling decrypted, so positive proof dominates: only the explicit
-          shared-key subclasses (:meth:`_is_account_wide_key_failure`) remain
+        - A sibling decrypted, so positive proof dominates, but it refutes ONLY the
+          device-local own-report class (:meth:`_is_device_local_decrypt_failure`):
+          ``OwnReportIdentityMismatchError`` (e.g. a phone powered off for days). The
+          shared-key subclasses AND a plain identity-key derivation failure remain
           account-wide -- a sibling decrypting from cached owner/EIK material cannot
-          refute them. A plain per-device own-report failure (e.g. a phone powered
-          off for days) is refuted as device-local.
+          refute them, so they keep their reauth prompt (the Codex finding class).
         """
         if cycle_decrypt_error is None:
             return False
         if not cycle_had_successful_decrypt:
             return True
-        return self._is_account_wide_key_failure(cycle_decrypt_error)
+        return not self._is_device_local_decrypt_failure(cycle_decrypt_error)
 
     def _resolve_cycle_decrypt_outcome(
         self,
@@ -486,22 +496,24 @@ class PollingOperations(_MixinBase):
         Performs the post-loop crypto-sensor and reauth-budget side effects and
         returns ``True`` iff the caller must escalate to ``ConfigEntryAuthFailed``.
 
-        Positive proof dominates (D7), but ONLY for a plain per-device own-report
-        failure: if ANY device produced an authenticated coordinate this cycle
-        (``cycle_had_successful_decrypt``), a sibling's plain ``DecryptionError``
-        -- e.g. a phone powered off for days whose own server reports no longer
-        decrypt -- is a per-device condition that must NOT advance the account-wide
-        reauth budget and must NOT trigger reauth. This mirrors the per-tracker
-        ``StaleOwnerKeyError`` (``stale=True``) treatment ("other devices are
-        unaffected").
+        Positive proof dominates (D7), but ONLY for the device-local own-report
+        class: if ANY device produced an authenticated coordinate this cycle
+        (``cycle_had_successful_decrypt``), a sibling's
+        ``OwnReportIdentityMismatchError`` -- e.g. a phone powered off for days whose
+        own server reports no longer decrypt -- is a per-device condition that must
+        NOT advance the account-wide reauth budget and must NOT trigger reauth. This
+        mirrors the per-tracker ``StaleOwnerKeyError`` (``stale=True``) treatment
+        ("other devices are unaffected").
 
-        Explicit shared-key subclasses are the exception (see
-        ``_is_account_wide_key_failure``): ``SharedKeyMissingError`` and
-        ``SharedKeyMismatchError`` mean the bundle's shared key itself cannot unwrap
-        the owner key, so a sibling decrypting from cached owner/EIK material does
-        NOT prove the key is healthy. Such failures stay on the account-wide reauth
-        path even with sibling success -- otherwise a mixed cycle would strand the
-        broken device without ever prompting for fresh secrets.
+        Every OTHER ``DecryptionError`` is the exception (see
+        ``_is_device_local_decrypt_failure``): the shared-key subclasses
+        (``SharedKeyMissingError`` / ``SharedKeyMismatchError``) AND a plain
+        identity-key derivation failure ("Identity key decryption failed.") all rest
+        on the account-wide owner/shared key, so a sibling decrypting from cached
+        owner/EIK material does NOT prove the key is healthy. Such failures stay on
+        the account-wide reauth path even with sibling success -- otherwise a mixed
+        cycle would strand the broken device without ever prompting for fresh
+        secrets (the Codex finding class).
 
         Before the positive-proof gate the account-wide counter was advanced
         whenever a decrypt error was seen, regardless of sibling success, so a
@@ -516,8 +528,9 @@ class PollingOperations(_MixinBase):
         if cycle_decrypt_error is not None and self._decrypt_failure_is_account_wide(
             cycle_decrypt_error, cycle_had_successful_decrypt
         ):
-            # Account-wide stale/missing shared key: either NOT ONE device decrypted
-            # this cycle, OR the failure is an explicit shared-key subclass that a
+            # Account-wide failure: either NOT ONE device decrypted this cycle, OR
+            # the failure is anything other than the device-local own-report class (a
+            # shared-key subclass or a plain identity-key derivation failure) that a
             # sibling's cached-material success cannot refute. Advance the
             # consecutive-cycle counter exactly once; escalate (cooldown-gated) on
             # threshold.
@@ -2084,17 +2097,19 @@ class PollingOperations(_MixinBase):
                         # last_exception) to the post-loop verdict in
                         # _finalize_cycle_decrypt_state. Whether this decrypt error
                         # fails the whole coordinator update depends on the
-                        # cross-device outcome: a per-device own-report failure a
+                        # cross-device outcome: a device-local own-report failure a
                         # sibling success refutes is benign and must NOT mark the
                         # cycle failed (otherwise a single offline device fails every
                         # poll), while a genuinely account-wide failure does. Only
-                        # capture the representative error here -- the account-wide
-                        # shared-key subclass is kept over a co-occurring per-device
-                        # failure so the resolver's sibling-success downgrade cannot
-                        # mask a genuine shared-key problem. The account-wide failure
-                        # counter is still advanced exactly once after the loop, never
-                        # per device, preserving the documented consecutive-cycle
-                        # budget that gives the in-decrypt self-heal time to recover.
+                        # capture the representative error here -- a non-device-local
+                        # failure (shared-key subclass or plain identity-key
+                        # derivation failure) is kept over a co-occurring device-local
+                        # own-report failure so the resolver's sibling-success
+                        # downgrade cannot mask a genuine account-wide problem. The
+                        # account-wide failure counter is still advanced exactly once
+                        # after the loop, never per device, preserving the documented
+                        # consecutive-cycle budget that gives the in-decrypt self-heal
+                        # time to recover.
                         self._consecutive_timeouts = 0
                         cycle_decrypt_error = self._prefer_account_wide_decrypt_error(
                             cycle_decrypt_error, dec_err

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -412,3 +412,98 @@ def test_resolve_per_device_failure_with_stale_key_keeps_sensor() -> None:
     # OK gate is suppressed by the stale-key flag: sensor stays as-is.
     assert stub._crypto_status_state == CryptoStatus.TRACKER_KEY_OUTDATED
     assert stub._last_decrypt_error is None
+
+
+@pytest.mark.parametrize(
+    ("error_factory", "expected_status"),
+    [
+        pytest.param(
+            lambda: SharedKeyMissingError("missing"),
+            CryptoStatus.SHARED_KEY_MISSING,
+            id="missing",
+        ),
+        pytest.param(
+            lambda: SharedKeyMismatchError("mismatch"),
+            CryptoStatus.SHARED_KEY_INVALID,
+            id="mismatch",
+        ),
+    ],
+)
+def test_resolve_account_wide_key_failure_escalates_despite_sibling(
+    error_factory: Callable[[], DecryptionError],
+    expected_status: CryptoStatus,
+) -> None:
+    """A shared-key failure stays account-wide even when a sibling decrypts.
+
+    ``SharedKeyMissingError`` / ``SharedKeyMismatchError`` mean the bundle's shared
+    key itself cannot unwrap the owner key, so a sibling decrypting from cached
+    owner/EIK material does NOT prove the key healthy. Unlike a plain per-device
+    ``DecryptionError``, positive proof must NOT downgrade it: the verdict has to
+    advance the budget every cycle and escalate at the threshold, otherwise the
+    broken device is stranded without a reauth prompt (the Codex finding).
+
+    Mutation gate: the pre-fix gate (``not cycle_had_successful_decrypt`` only)
+    returned False and cleared the budget here, so asserting an advancing counter
+    and a threshold escalation turns red if the shared-key carve-out is removed.
+    """
+    stub = _make_stub()
+
+    # Below threshold: account-wide failure counts up despite sibling success.
+    for attempt in range(1, _MAX_DECRYPT_FAILURES):
+        assert (
+            stub._resolve_cycle_decrypt_outcome(
+                cycle_decrypt_error=error_factory(),
+                cycle_had_successful_decrypt=True,
+                cycle_had_stale_key=False,
+            )
+            is False
+        )
+        assert stub._consecutive_decrypt_failures == attempt
+    stub._set_auth_state.assert_not_called()
+    # Sibling success must NOT heal the sensor while the shared key is broken; the
+    # concrete subclass maps to its diagnostic status (note_decrypt_failure).
+    assert stub._crypto_status_state == expected_status
+
+    # Threshold reached -> escalate to reauth.
+    assert (
+        stub._resolve_cycle_decrypt_outcome(
+            cycle_decrypt_error=error_factory(),
+            cycle_had_successful_decrypt=True,
+            cycle_had_stale_key=False,
+        )
+        is True
+    )
+    stub._set_auth_state.assert_called_once()
+
+
+def test_prefer_account_wide_decrypt_error_upgrades_per_device_to_shared_key() -> None:
+    """Capture priority: a shared-key failure wins over a per-device one.
+
+    A mixed cycle can poll an offline device (plain ``DecryptionError``) before the
+    device whose shared-key unwrap fails. First-capture-wins would let the resolver
+    see only the per-device error and wrongly downgrade on sibling success, so the
+    capture must upgrade to the account-wide subclass regardless of poll order.
+    """
+    per_device = DecryptionError("own reports failed")
+    shared_key = SharedKeyMismatchError("stale shared key")
+
+    # None seed -> take the first error, whatever its class.
+    assert (
+        PollingStub._prefer_account_wide_decrypt_error(None, per_device) is per_device
+    )
+    # Per-device captured first, shared-key seen later -> upgrade.
+    assert (
+        PollingStub._prefer_account_wide_decrypt_error(per_device, shared_key)
+        is shared_key
+    )
+    # Shared-key captured first, per-device seen later -> keep the account-wide one.
+    assert (
+        PollingStub._prefer_account_wide_decrypt_error(shared_key, per_device)
+        is shared_key
+    )
+    # Two account-wide errors -> stable, keep the first (order-independent).
+    other_shared = SharedKeyMissingError("missing")
+    assert (
+        PollingStub._prefer_account_wide_decrypt_error(shared_key, other_shared)
+        is shared_key
+    )

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -32,6 +32,7 @@ from custom_components.googlefindmy.coordinator.polling import (
 )
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    OwnReportIdentityMismatchError,
     SharedKeyMismatchError,
     SharedKeyMissingError,
     StaleOwnerKeyError,
@@ -307,7 +308,11 @@ def test_resolve_mixed_cycle_sibling_success_blocks_spurious_reauth(
     """
     stub = _make_stub()
     stub._consecutive_decrypt_failures = _MAX_DECRYPT_FAILURES - 1
-    err = DecryptionError(
+    # The user's exact error: a powered-off device whose OWN server reports all
+    # fail authentication. decrypt_locations raises the dedicated device-local
+    # subclass here (NOT a plain DecryptionError), which is the only class the
+    # sibling-success downgrade applies to.
+    err = OwnReportIdentityMismatchError(
         "All own-report decryptions failed; the cached identity key no longer "
         "matches the server reports."
     )
@@ -400,7 +405,7 @@ def test_resolve_per_device_failure_with_stale_key_keeps_sensor() -> None:
     stub = _make_stub()
     stub._consecutive_decrypt_failures = 2
     stub._crypto_status_state = CryptoStatus.TRACKER_KEY_OUTDATED
-    err = DecryptionError("own reports failed")
+    err = OwnReportIdentityMismatchError("own reports failed")
 
     result = stub._resolve_cycle_decrypt_outcome(
         cycle_decrypt_error=err,
@@ -477,35 +482,49 @@ def test_resolve_account_wide_key_failure_escalates_despite_sibling(
     stub._set_auth_state.assert_called_once()
 
 
-def test_prefer_account_wide_decrypt_error_upgrades_per_device_to_shared_key() -> None:
-    """Capture priority: a shared-key failure wins over a per-device one.
+def test_prefer_account_wide_decrypt_error_upgrades_device_local_to_account_wide() -> (
+    None
+):
+    """Capture priority: an account-wide failure wins over a device-local one.
 
-    A mixed cycle can poll an offline device (plain ``DecryptionError``) before the
-    device whose shared-key unwrap fails. First-capture-wins would let the resolver
-    see only the per-device error and wrongly downgrade on sibling success, so the
-    capture must upgrade to the account-wide subclass regardless of poll order.
+    A mixed cycle can poll an offline device (``OwnReportIdentityMismatchError``)
+    before the device whose owner/shared-key unwrap fails. First-capture-wins would
+    let the resolver see only the device-local error and wrongly downgrade on
+    sibling success, so the capture must upgrade to the account-wide error
+    regardless of poll order. Every non-device-local ``DecryptionError`` qualifies:
+    the shared-key subclasses AND a plain identity-key derivation failure.
     """
-    per_device = DecryptionError("own reports failed")
+    device_local = OwnReportIdentityMismatchError("own reports failed")
     shared_key = SharedKeyMismatchError("stale shared key")
+    # A plain identity-key derivation failure (decrypt_locations: "Identity key
+    # decryption failed.") is account-wide too and must win over a device-local one
+    # -- the Codex finding: a plain DecryptionError must NOT be treated as benign.
+    identity_key = DecryptionError("Identity key decryption failed.")
 
     # None seed -> take the first error, whatever its class.
     assert (
-        PollingStub._prefer_account_wide_decrypt_error(None, per_device) is per_device
+        PollingStub._prefer_account_wide_decrypt_error(None, device_local)
+        is device_local
     )
-    # Per-device captured first, shared-key seen later -> upgrade.
+    # Device-local captured first, shared-key seen later -> upgrade.
     assert (
-        PollingStub._prefer_account_wide_decrypt_error(per_device, shared_key)
+        PollingStub._prefer_account_wide_decrypt_error(device_local, shared_key)
         is shared_key
     )
-    # Shared-key captured first, per-device seen later -> keep the account-wide one.
+    # Device-local captured first, plain identity-key failure later -> upgrade.
     assert (
-        PollingStub._prefer_account_wide_decrypt_error(shared_key, per_device)
+        PollingStub._prefer_account_wide_decrypt_error(device_local, identity_key)
+        is identity_key
+    )
+    # Account-wide captured first, device-local seen later -> keep the account-wide.
+    assert (
+        PollingStub._prefer_account_wide_decrypt_error(shared_key, device_local)
         is shared_key
     )
     # Two account-wide errors -> stable, keep the first (order-independent).
-    other_shared = SharedKeyMissingError("missing")
+    other_account_wide = SharedKeyMissingError("missing")
     assert (
-        PollingStub._prefer_account_wide_decrypt_error(shared_key, other_shared)
+        PollingStub._prefer_account_wide_decrypt_error(shared_key, other_account_wide)
         is shared_key
     )
 
@@ -532,11 +551,44 @@ def test_account_wide_predicate_without_sibling_is_account_wide() -> None:
     )
 
 
-def test_account_wide_predicate_per_device_with_sibling_is_local() -> None:
-    """A plain per-device failure that a sibling success refutes is device-local."""
+def test_account_wide_predicate_own_report_with_sibling_is_local() -> None:
+    """The device-local own-report class, refuted by a sibling, is NOT account-wide.
+
+    ``OwnReportIdentityMismatchError`` (a phone powered off for days) is the ONLY
+    class the sibling-success downgrade applies to: the account keys are proven
+    healthy and a fresh secrets.json cannot fix an offline/re-paired device.
+    """
     stub = _make_stub()
     assert (
-        stub._decrypt_failure_is_account_wide(DecryptionError("offline"), True) is False
+        stub._decrypt_failure_is_account_wide(
+            OwnReportIdentityMismatchError("offline"), True
+        )
+        is False
+    )
+
+
+def test_account_wide_predicate_plain_decryption_error_with_sibling_escalates() -> None:
+    """The Codex finding: a PLAIN DecryptionError stays account-wide despite a sibling.
+
+    The decryptor raises a plain ``DecryptionError("Identity key decryption
+    failed.")`` from the identity-key unwrap path after exhausting the account-wide
+    owner/shared-key candidates. A sibling decrypting from cached owner/EIK material
+    does NOT refute that, so the broken device must keep its reauth prompt. The fix
+    inverts the gate to fail-safe: ONLY the explicit device-local subclass is
+    downgraded; every other ``DecryptionError`` -- plain or shared-key subclass --
+    stays account-wide.
+
+    Mutation gate: the pre-fix gate downgraded ANY non-shared-key DecryptionError on
+    sibling success (returned False here), so asserting True turns red if the
+    discriminator regresses to keying off the shared-key subclasses instead of the
+    device-local own-report class.
+    """
+    stub = _make_stub()
+    assert (
+        stub._decrypt_failure_is_account_wide(
+            DecryptionError("Identity key decryption failed."), True
+        )
+        is True
     )
 
 
@@ -581,7 +633,7 @@ def test_finalize_downgraded_per_device_failure_does_not_fail_cycle() -> None:
     """
     stub = _make_stub()
     stub._consecutive_decrypt_failures = _MAX_DECRYPT_FAILURES - 1
-    err = DecryptionError("All own-report decryptions failed")
+    err = OwnReportIdentityMismatchError("All own-report decryptions failed")
 
     cycle_failed, last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
         cycle_decrypt_error=err,
@@ -609,7 +661,7 @@ def test_finalize_downgrade_preserves_independent_failure() -> None:
     other_failure = TimeoutError("device timed out")
 
     cycle_failed, last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
-        cycle_decrypt_error=DecryptionError("offline"),
+        cycle_decrypt_error=OwnReportIdentityMismatchError("offline"),
         cycle_had_successful_decrypt=True,
         cycle_had_stale_key=False,
         cycle_failed=True,

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -278,4 +278,137 @@ def test_note_background_decrypt_success_leaves_unknown_untouched() -> None:
     stub.note_background_decrypt_success()
 
     assert stub._crypto_status_state == CryptoStatus.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# _resolve_cycle_decrypt_outcome: the per-cycle verdict that decides escalation.
+# Regression suite for the "offline device drags a healthy account into a
+# spurious reauth" bug: positive proof (a sibling decrypt) must dominate a single
+# device's DecryptionError so the account-wide reauth budget is neither advanced
+# nor tripped.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_mixed_cycle_sibling_success_blocks_spurious_reauth(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The bug: a powered-off device fails to decrypt while siblings succeed.
+
+    With the account-wide budget one step below the threshold, a mixed cycle
+    (``cycle_decrypt_error`` set AND ``cycle_had_successful_decrypt`` True) must
+    NOT escalate: the sibling success proves the shared key is healthy. The budget
+    is cleared (not advanced), the diagnostic sensor heals to OK, a warning (not
+    the account-wide ERROR escalation) is logged, and no auth state is set.
+
+    Mutation gate: the pre-fix code advanced the counter here (2 -> 3) and
+    returned True, so asserting ``result is False`` with a cleared counter and an
+    untouched auth state turns red if the positive-proof guard is removed.
+    """
+    stub = _make_stub()
+    stub._consecutive_decrypt_failures = _MAX_DECRYPT_FAILURES - 1
+    err = DecryptionError(
+        "All own-report decryptions failed; the cached identity key no longer "
+        "matches the server reports."
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = stub._resolve_cycle_decrypt_outcome(
+            cycle_decrypt_error=err,
+            cycle_had_successful_decrypt=True,
+            cycle_had_stale_key=False,
+        )
+
+    assert result is False
+    assert stub._consecutive_decrypt_failures == 0
+    assert stub._crypto_status_state == CryptoStatus.OK
+    assert stub._last_decrypt_error is None
+    stub._set_auth_state.assert_not_called()
+    assert any(
+        rec.levelno == logging.WARNING
+        and "no re-authentication is required" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_resolve_account_wide_failure_without_sibling_escalates() -> None:
+    """A decrypt failure with NOT A SINGLE sibling success stays account-wide.
+
+    The verdict must still advance the consecutive-cycle budget and, at the
+    threshold, escalate to reauth -- the genuine stale-shared-key path that the
+    fix must preserve (the counterpart to the mixed-cycle suppression above).
+    """
+    stub = _make_stub()
+    err = SharedKeyMismatchError("stale shared key")
+
+    # Failures 1..N-1: account-wide, below threshold -> count up, no escalation.
+    for attempt in range(1, _MAX_DECRYPT_FAILURES):
+        assert (
+            stub._resolve_cycle_decrypt_outcome(
+                cycle_decrypt_error=err,
+                cycle_had_successful_decrypt=False,
+                cycle_had_stale_key=False,
+            )
+            is False
+        )
+        assert stub._consecutive_decrypt_failures == attempt
+    stub._set_auth_state.assert_not_called()
+
+    # Threshold reached -> escalate.
+    assert (
+        stub._resolve_cycle_decrypt_outcome(
+            cycle_decrypt_error=err,
+            cycle_had_successful_decrypt=False,
+            cycle_had_stale_key=False,
+        )
+        is True
+    )
+    stub._set_auth_state.assert_called_once()
+
+
+def test_resolve_clean_success_cycle_heals_without_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A cycle with a success and no decrypt error heals the sensor silently.
+
+    No ``cycle_decrypt_error`` means no per-device warning; positive proof still
+    sets the OK status and clears any partial budget.
+    """
+    stub = _make_stub()
+    stub._consecutive_decrypt_failures = 2
+
+    with caplog.at_level(logging.WARNING):
+        result = stub._resolve_cycle_decrypt_outcome(
+            cycle_decrypt_error=None,
+            cycle_had_successful_decrypt=True,
+            cycle_had_stale_key=False,
+        )
+
+    assert result is False
+    assert stub._crypto_status_state == CryptoStatus.OK
+    assert stub._consecutive_decrypt_failures == 0
+    assert not any(rec.levelno == logging.WARNING for rec in caplog.records)
+
+
+def test_resolve_per_device_failure_with_stale_key_keeps_sensor() -> None:
+    """A per-device decrypt failure plus a stale tracker key, with sibling success.
+
+    Sibling proof clears the account-wide budget, but the ``not
+    cycle_had_stale_key`` gate keeps the diagnostic sensor from flipping to OK so
+    a still-outstanding per-tracker stale key is not masked. No escalation.
+    """
+    stub = _make_stub()
+    stub._consecutive_decrypt_failures = 2
+    stub._crypto_status_state = CryptoStatus.TRACKER_KEY_OUTDATED
+    err = DecryptionError("own reports failed")
+
+    result = stub._resolve_cycle_decrypt_outcome(
+        cycle_decrypt_error=err,
+        cycle_had_successful_decrypt=True,
+        cycle_had_stale_key=True,
+    )
+
+    assert result is False
+    assert stub._consecutive_decrypt_failures == 0
+    # OK gate is suppressed by the stale-key flag: sensor stays as-is.
+    assert stub._crypto_status_state == CryptoStatus.TRACKER_KEY_OUTDATED
     assert stub._last_decrypt_error is None

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -23,6 +23,7 @@ from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.config_entries import ConfigEntryAuthFailed
 
 from custom_components.googlefindmy.coordinator import polling as polling_mod
 from custom_components.googlefindmy.coordinator.helpers.stats import CryptoStatus
@@ -507,3 +508,205 @@ def test_prefer_account_wide_decrypt_error_upgrades_per_device_to_shared_key() -
         PollingStub._prefer_account_wide_decrypt_error(shared_key, other_shared)
         is shared_key
     )
+
+
+# ---------------------------------------------------------------------------
+# _decrypt_failure_is_account_wide: the single discriminator shared by the
+# escalation verdict and the cycle-failure reconciliation. Pure predicate.
+# ---------------------------------------------------------------------------
+
+
+def test_account_wide_predicate_none_is_not_account_wide() -> None:
+    """No decrypt error this cycle is never an account-wide failure."""
+    stub = _make_stub()
+    assert stub._decrypt_failure_is_account_wide(None, True) is False
+    assert stub._decrypt_failure_is_account_wide(None, False) is False
+
+
+def test_account_wide_predicate_without_sibling_is_account_wide() -> None:
+    """Not a single device decrypted: the failure is account-wide by absence of
+    any positive proof, whatever the concrete error class."""
+    stub = _make_stub()
+    assert (
+        stub._decrypt_failure_is_account_wide(DecryptionError("offline"), False) is True
+    )
+
+
+def test_account_wide_predicate_per_device_with_sibling_is_local() -> None:
+    """A plain per-device failure that a sibling success refutes is device-local."""
+    stub = _make_stub()
+    assert (
+        stub._decrypt_failure_is_account_wide(DecryptionError("offline"), True) is False
+    )
+
+
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        pytest.param(lambda: SharedKeyMissingError("missing"), id="missing"),
+        pytest.param(lambda: SharedKeyMismatchError("mismatch"), id="mismatch"),
+    ],
+)
+def test_account_wide_predicate_shared_key_survives_sibling(
+    error_factory: Callable[[], DecryptionError],
+) -> None:
+    """A shared-key subclass stays account-wide even with sibling success: a
+    sibling decrypting from cached material cannot refute a broken shared key."""
+    stub = _make_stub()
+    assert stub._decrypt_failure_is_account_wide(error_factory(), True) is True
+
+
+# ---------------------------------------------------------------------------
+# _finalize_cycle_decrypt_state: resolve the verdict AND reconcile the cycle's
+# failure state with it. Regression suite for the Codex finding that a
+# downgraded per-device decrypt error still marked the whole coordinator update
+# failed every cycle (the eager except-block bookkeeping was never reconciled
+# with the sibling-success downgrade).
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_downgraded_per_device_failure_does_not_fail_cycle() -> None:
+    """THE Codex finding: a per-device failure refuted by a sibling success must
+    neither escalate NOR mark the coordinator update failed.
+
+    Below the reauth threshold, a mixed cycle (offline device + sibling success)
+    must leave ``cycle_failed`` False and ``last_exception`` None, so the finally
+    block records ``last_poll_result='success'`` and never calls
+    ``async_set_update_error``.
+
+    Mutation gate: restoring the eager ``cycle_failed = True`` /
+    ``last_exception = dec_err`` in the except block (or widening the account-wide
+    guard to always-True) makes this return ``(True, <err>, ...)`` -- the assert
+    turns red.
+    """
+    stub = _make_stub()
+    stub._consecutive_decrypt_failures = _MAX_DECRYPT_FAILURES - 1
+    err = DecryptionError("All own-report decryptions failed")
+
+    cycle_failed, last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
+        cycle_decrypt_error=err,
+        cycle_had_successful_decrypt=True,
+        cycle_had_stale_key=False,
+        cycle_failed=False,
+        last_exception=None,
+    )
+
+    assert cycle_failed is False
+    assert last_exception is None
+    assert reauth_exc is None
+    # Sibling proof cleared the budget rather than advancing it.
+    assert stub._consecutive_decrypt_failures == 0
+
+
+def test_finalize_downgrade_preserves_independent_failure() -> None:
+    """A co-occurring non-decrypt failure (e.g. a timeout) survives the downgrade.
+
+    The benign decrypt path must leave an already-set ``cycle_failed`` /
+    ``last_exception`` untouched -- it may only refrain from ADDING a failure, never
+    clear a real one a sibling success does not refute.
+    """
+    stub = _make_stub()
+    other_failure = TimeoutError("device timed out")
+
+    cycle_failed, last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
+        cycle_decrypt_error=DecryptionError("offline"),
+        cycle_had_successful_decrypt=True,
+        cycle_had_stale_key=False,
+        cycle_failed=True,
+        last_exception=other_failure,
+    )
+
+    assert cycle_failed is True
+    assert last_exception is other_failure
+    assert reauth_exc is None
+
+
+def test_finalize_account_wide_below_threshold_fails_without_reauth() -> None:
+    """A genuine account-wide failure below the threshold fails the cycle and
+    surfaces the decrypt error, but does not yet escalate to reauth."""
+    stub = _make_stub()
+    err = DecryptionError("no device decrypted this cycle")
+
+    cycle_failed, last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
+        cycle_decrypt_error=err,
+        cycle_had_successful_decrypt=False,
+        cycle_had_stale_key=False,
+        cycle_failed=False,
+        last_exception=None,
+    )
+
+    assert cycle_failed is True
+    assert last_exception is err
+    assert reauth_exc is None
+    assert stub._consecutive_decrypt_failures == 1
+
+
+def test_finalize_account_wide_preserves_prior_independent_failure() -> None:
+    """An account-wide failure below the threshold must not clobber a prior error.
+
+    When another device already failed this cycle (e.g. a timeout on device A) and
+    a shared-key failure surfaces on device B, the account-wide branch surfaces the
+    cycle as failed but keeps the FIRST captured ``last_exception`` (the ``if
+    last_exception is None`` guard). Mutation gate for that guard: dropping it makes
+    ``last_exception`` the shared-key error and turns the assert red.
+    """
+    stub = _make_stub()
+    other_failure = TimeoutError("device A timed out")
+    err = SharedKeyMismatchError("device B: stale shared key")
+
+    cycle_failed, last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
+        cycle_decrypt_error=err,
+        cycle_had_successful_decrypt=True,
+        cycle_had_stale_key=False,
+        cycle_failed=True,
+        last_exception=other_failure,
+    )
+
+    assert cycle_failed is True
+    assert last_exception is other_failure
+    assert reauth_exc is None
+    # Account-wide failure still advanced the consecutive-cycle budget.
+    assert stub._consecutive_decrypt_failures == 1
+
+
+def test_finalize_escalates_at_threshold_with_reauth_exc() -> None:
+    """At the consecutive-cycle threshold the verdict escalates: finalize returns a
+    ``ConfigEntryAuthFailed`` as both ``last_exception`` and the reauth signal, even
+    when a sibling decrypted (shared-key subclass cannot be refuted)."""
+    stub = _make_stub()
+    stub._consecutive_decrypt_failures = _MAX_DECRYPT_FAILURES - 1
+    err = SharedKeyMismatchError("stale shared key")
+
+    cycle_failed, last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
+        cycle_decrypt_error=err,
+        cycle_had_successful_decrypt=True,
+        cycle_had_stale_key=False,
+        cycle_failed=False,
+        last_exception=None,
+    )
+
+    assert cycle_failed is True
+    assert isinstance(reauth_exc, ConfigEntryAuthFailed)
+    assert last_exception is reauth_exc
+    stub._set_auth_state.assert_called_once()
+
+
+def test_finalize_clean_cycle_stays_success() -> None:
+    """A clean cycle (no decrypt error, sibling success) stays success and heals the
+    diagnostic sensor without failing the coordinator update."""
+    stub = _make_stub()
+    stub._consecutive_decrypt_failures = 2
+
+    cycle_failed, last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
+        cycle_decrypt_error=None,
+        cycle_had_successful_decrypt=True,
+        cycle_had_stale_key=False,
+        cycle_failed=False,
+        last_exception=None,
+    )
+
+    assert cycle_failed is False
+    assert last_exception is None
+    assert reauth_exc is None
+    assert stub._consecutive_decrypt_failures == 0
+    assert stub._crypto_status_state == CryptoStatus.OK

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -425,9 +425,7 @@ def _add_report(
 ) -> None:
     """Append one encrypted report; empty public_key_random marks an own report."""
 
-    reports = (
-        update.deviceMetadata.information.locationInformation.reports.recentLocationAndNetworkLocations
-    )
+    reports = update.deviceMetadata.information.locationInformation.reports.recentLocationAndNetworkLocations
     network_location = reports.networkLocations.add()
     network_location.status = Common_pb2.Status.LAST_KNOWN
     network_location.geoLocation.accuracy = ACCURACY_METERS
@@ -443,11 +441,15 @@ def _add_report(
 async def test_all_own_reports_failing_auth_raises_decryption_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """T-D1: every own report fails authentication → escalate via DecryptionError.
+    """T-D1: every own report fails authentication → OwnReportIdentityMismatchError.
 
-    This is the account-wide stale-key signal: the cached identity key no longer
-    matches the server's own reports, so the function must raise instead of
-    silently returning empty (which the coordinator would never escalate).
+    Device-local signal: the cached identity key no longer matches THIS device's own
+    server reports (e.g. a phone powered off for days), so the function must raise
+    the dedicated subclass instead of silently returning empty (which the
+    coordinator would never surface). The coordinator downgrades it to a warning
+    only when a sibling proves the account keys healthy; on its own it still
+    escalates. Asserting the concrete subclass locks in the contract the
+    coordinator's sibling-success gate keys off.
     """
 
     base_now = 1_700_000_000.0
@@ -474,7 +476,7 @@ async def test_all_own_reports_failing_auth_raises_decryption_error(
         base_now=base_now,
     )
 
-    with pytest.raises(decrypt_locations.DecryptionError):
+    with pytest.raises(decrypt_locations.OwnReportIdentityMismatchError):
         await decrypt_locations.async_decrypt_location_response_locations(
             update, cache=object()
         )

--- a/tests/test_guard_async_test_marker.py
+++ b/tests/test_guard_async_test_marker.py
@@ -1,0 +1,126 @@
+# tests/test_guard_async_test_marker.py
+"""Guard requiring an explicit asyncio marker on every async test.
+
+``tests/AGENTS.md`` (Async tests) mandates that coroutine tests carry
+``@pytest.mark.asyncio`` (or a module-level ``pytestmark = pytest.mark.asyncio``).
+The repository runs ``asyncio_mode = "auto"``, which still *collects* unmarked
+``async def test_*`` functions, so the omission passes silently today and only
+surfaces in review. This guard fails loudly instead, mirroring the sibling
+``test_no_asyncio_run_in_tests`` guard: the legacy files below are frozen as a
+documented backlog, and no new violations may be added outside the allowlist.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# Pre-existing files whose async tests rely solely on ``asyncio_mode = "auto"``
+# without an explicit marker. Do not add new entries; mark new async tests
+# instead. Shrinking this list (by adding markers) is always welcome.
+LEGACY_ALLOWLIST: set[str] = {
+    "tests/test_aas_token_retrieval.py",
+    "tests/test_api_location_selection.py",
+    "tests/test_cli_entry_selection.py",
+    "tests/test_coordinator_locate_basics.py",
+    "tests/test_coordinator_polling_basics.py",
+    "tests/test_coordinator_polling_branches.py",
+    "tests/test_coordinator_snapshot.py",
+    "tests/test_device_tracker.py",
+    "tests/test_fcmpushclient_close_log_level.py",
+    "tests/test_get_owner_key.py",
+    "tests/test_last_seen_sensor_no_map_attributes.py",
+    "tests/test_map_view_unique_id_resolution.py",
+    "tests/test_nova_request.py",
+    "tests/test_restart_required_issue.py",
+    "tests/test_sensor_coverage_supplement.py",
+    "tests/test_shared_key_retrieval.py",
+}
+
+
+def _references_asyncio_marker(node: ast.AST) -> bool:
+    """Whether an expression refers to ``pytest.mark.asyncio``.
+
+    Matches the precise ``.mark.asyncio`` attribute chain (covering the bare
+    decorator, its call form, and list-valued ``pytestmark``) rather than any
+    attribute named ``asyncio``, so an unrelated ``.asyncio`` symbol inside,
+    say, a ``parametrize`` argument cannot mask an unmarked test.
+    """
+
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Attribute)
+            and sub.attr == "asyncio"
+            and isinstance(sub.value, ast.Attribute)
+            and sub.value.attr == "mark"
+        ):
+            return True
+    return False
+
+
+def _has_module_asyncio_pytestmark(tree: ast.Module) -> bool:
+    for stmt in tree.body:
+        if not isinstance(stmt, ast.Assign):
+            continue
+        if any(
+            isinstance(target, ast.Name) and target.id == "pytestmark"
+            for target in stmt.targets
+        ) and _references_asyncio_marker(stmt.value):
+            return True
+    return False
+
+
+def _unmarked_async_tests(path: Path) -> list[tuple[int, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    if _has_module_asyncio_pytestmark(tree):
+        return []
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        if not node.name.startswith("test_"):
+            continue
+        if any(_references_asyncio_marker(deco) for deco in node.decorator_list):
+            continue
+        offenders.append((node.lineno, node.name))
+    return offenders
+
+
+def test_async_tests_declare_asyncio_marker() -> None:
+    """Fail loudly if an async test lacks an explicit asyncio marker."""
+
+    offenses: list[tuple[str, int, str]] = []
+    tests_root = Path(__file__).parent
+    # Anchor relative paths at the known ``tests/`` root instead of the volatile
+    # process cwd, so the allowlist matches regardless of where pytest runs.
+    repo_root = tests_root.parent
+    for path in tests_root.rglob("*.py"):
+        if path.name == Path(__file__).name:
+            continue
+        rel_path = path.relative_to(repo_root).as_posix()
+        if rel_path in LEGACY_ALLOWLIST:
+            continue
+        for lineno, name in _unmarked_async_tests(path):
+            offenses.append((rel_path, lineno, name))
+
+    if offenses:
+        lines = [
+            f"File: {file}\nLine: {lineno}\nTest: {name}\n"
+            for file, lineno, name in offenses
+        ]
+        message = (
+            "ASYNC TEST CONTRACT VIOLATION DETECTED!\n"
+            "------------------------------------------------------------\n"
+            + "\n".join(lines)
+            + "WHY THIS IS WRONG:\n"
+            "tests/AGENTS.md requires every coroutine test to carry an explicit\n"
+            "asyncio marker. asyncio_mode='auto' still collects unmarked tests, so\n"
+            "the omission passes silently and only surfaces in review.\n\n"
+            "HOW TO FIX:\n"
+            "1. Add '@pytest.mark.asyncio' above the async test, or\n"
+            "2. Add 'pytestmark = pytest.mark.asyncio' at module scope.\n"
+            "------------------------------------------------------------\n"
+        )
+        pytest.fail(message)

--- a/tests/test_location_request_decrypt_log_severity.py
+++ b/tests/test_location_request_decrypt_log_severity.py
@@ -1,0 +1,121 @@
+# tests/test_location_request_decrypt_log_severity.py
+"""Per-device decrypt-failure log severity in the FCM location callback.
+
+A single device whose own server reports no longer decrypt -- e.g. a phone
+powered off for days -- must be logged as a WARNING, not an ERROR: the callback
+has no cross-device view, so the account-wide escalation decision (and its ERROR)
+belongs to the coordinator's positive-proof-gated verdict
+(``PollingOperations._resolve_cycle_decrypt_outcome``). Genuine session/auth
+failures (``SpotApiEmptyResponseError``, ``SpotAuthPermanentError``) keep ERROR
+severity because they themselves drive reauth. In every case ``ctx.error`` and the
+propagation to the awaiting requester are unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    location_request,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    StaleOwnerKeyError,
+)
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
+    SpotApiEmptyResponseError,
+)
+from custom_components.googlefindmy.SpotApi.spot_request import SpotAuthPermanentError
+
+_CANONIC = "device-canonic-id"
+
+
+def _patch_callback_imports(
+    monkeypatch: pytest.MonkeyPatch, *, decrypt_exc: Exception
+) -> None:
+    """Stub the callback's lazy module imports so the decrypt step raises.
+
+    The protobuf parse is reduced to an identity sentinel and the decrypt call is
+    forced to raise ``decrypt_exc``; the real exception classes are wired in so the
+    production ``except`` tuple and the severity ``isinstance`` check match.
+    """
+
+    async def _raise_decrypt(*_: Any, **__: Any) -> list[dict[str, Any]]:
+        raise decrypt_exc
+
+    decoder_module = SimpleNamespace(parse_device_update_protobuf=lambda _hex: object())
+    decrypt_module = SimpleNamespace(
+        async_decrypt_location_response_locations=_raise_decrypt,
+        DecryptionError=DecryptionError,
+        StaleOwnerKeyError=StaleOwnerKeyError,
+    )
+    eid_module = SimpleNamespace(SpotApiEmptyResponseError=SpotApiEmptyResponseError)
+
+    monkeypatch.setattr(
+        location_request, "_import_decoder_module", lambda: decoder_module
+    )
+    monkeypatch.setattr(
+        location_request, "_import_decrypt_locations_module", lambda: decrypt_module
+    )
+    monkeypatch.setattr(location_request, "_import_eid_info_module", lambda: eid_module)
+
+
+@pytest.mark.parametrize(
+    ("decrypt_exc", "expected_level"),
+    [
+        # Per-device decrypt/key failure -> warning (the offline-phone case).
+        (
+            DecryptionError(
+                "All own-report decryptions failed; the cached identity key no "
+                "longer matches the server reports."
+            ),
+            logging.WARNING,
+        ),
+        # StaleOwnerKeyError is a DecryptionError subclass -> also warning.
+        (StaleOwnerKeyError("tracker v1 < v2"), logging.WARNING),
+        # Genuine session/auth failures keep ERROR severity (they drive reauth).
+        (SpotApiEmptyResponseError("empty"), logging.ERROR),
+        (SpotAuthPermanentError("invalid session"), logging.ERROR),
+    ],
+)
+async def test_callback_decrypt_failure_log_severity(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    decrypt_exc: Exception,
+    expected_level: int,
+) -> None:
+    """The callback logs per-device decrypt failures at the type-aware severity.
+
+    Decrypt/key failures are warnings; session/auth failures stay errors. In all
+    cases the error is surfaced via ``ctx.error`` so the requester still sees it.
+    """
+    _patch_callback_imports(monkeypatch, decrypt_exc=decrypt_exc)
+    ctx = location_request._CallbackContext()
+    callback = location_request._make_location_callback(
+        name="Old Phone",
+        canonic_device_id=_CANONIC,
+        ctx=ctx,
+        loop=asyncio.get_running_loop(),
+        cache=MagicMock(),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        callback(_CANONIC, "00")
+        await asyncio.wait_for(ctx.event.wait(), timeout=2.0)
+
+    # The decrypt error is surfaced to the awaiting requester unchanged.
+    assert ctx.error is decrypt_exc
+
+    severity_records = [
+        rec
+        for rec in caplog.records
+        if "Failed to process location data" in rec.message
+    ]
+    assert len(severity_records) == 1
+    assert severity_records[0].levelno == expected_level

--- a/tests/test_location_request_decrypt_log_severity.py
+++ b/tests/test_location_request_decrypt_log_severity.py
@@ -66,6 +66,7 @@ def _patch_callback_imports(
     monkeypatch.setattr(location_request, "_import_eid_info_module", lambda: eid_module)
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("decrypt_exc", "expected_level"),
     [


### PR DESCRIPTION
## Problem

A device powered off for several days (e.g. an old phone) fails its own-report decryption with

```
ERROR ... LocateTracker.location_request] Failed to process location data for <device>:
All own-report decryption failed; the cached identity key no longer matches the server reports.
```

while every other device in the same account decrypts fine. The integration then **falsely** prompts a re-authentication (new `secrets.json`), even though the account keys are healthy. Removing the offline device from the integration silences the prompt, confirming the trigger is that single device, not the account key.

## Root cause (scientific debugging)

In `coordinator/polling.py` the post-loop verdict had two **mutually exclusive** branches:

- `if cycle_decrypt_error is not None:` advanced the account-wide reauth budget (`_consecutive_decrypt_failures`, threshold `_MAX_DECRYPT_FAILURES`),
- `else:` cleared the budget via `note_decrypt_success()` on positive proof.

In a **mixed cycle** (one device fails, siblings succeed) the failure branch always won, so the budget climbed 1→2→3 despite siblings proving the shared key is healthy, and the third cycle tripped a spurious `ConfigEntryAuthFailed`. Removing the offline device eliminated `cycle_decrypt_error`, so the `else` branch ran and cleared the budget — exactly the reported behaviour.

## Fix

1. **Positive proof dominates.** Extract the verdict into `PollingOperations._resolve_cycle_decrypt_outcome(...)`: if any device decrypted an authenticated coordinate this cycle, a sibling `DecryptionError` is per-device — it neither advances the reauth budget nor triggers reauth, and is logged as a **warning**. This mirrors the existing per-tracker `StaleOwnerKeyError` (`stale=True`) treatment ("other devices are unaffected"). Only a decrypt failure with **no** sibling success stays account-wide and counts toward the consecutive-cycle reauth budget. The genuine account-wide escalation (threshold + cooldown) is unchanged.
2. **Log severity.** In the FCM location callback the per-device decrypt/key failure (`DecryptionError`/`InvalidTag`) is downgraded from ERROR to **WARNING** — the callback has no cross-device view to judge account-wide severity. Genuine session/auth failures (`SpotApiEmptyResponseError`, `SpotAuthPermanentError`) keep ERROR severity because they themselves drive reauth. `ctx.error` and propagation are unchanged.

## Tests

- `test_resolve_mixed_cycle_sibling_success_blocks_spurious_reauth` — the regression (RED→GREEN, mutation-checked: removing the positive-proof guard re-introduces the spurious escalation).
- `test_resolve_account_wide_failure_without_sibling_escalates` — genuine account-wide path preserved (count-up + escalate at threshold).
- `test_resolve_clean_success_cycle_heals_without_warning`, `test_resolve_per_device_failure_with_stale_key_keeps_sensor` — verdict branch coverage.
- `test_callback_decrypt_failure_log_severity` — parametrized severity split (decrypt/key → WARNING, session/auth → ERROR).

Full suite: **4116 passed, 20 skipped**, coverage **70.58%** (≥ 70% gate). Independent diff review: PASS.