### PR TITLE
fix: mark restored fallback accuracy as estimated when seeding the cache

### DIFF
--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -40,6 +40,7 @@ from . import helpers
 from .helpers.geo import (
     is_valid_accuracy,
     recorded_accuracy_pair,
+    resolve_seeded_accuracy,
     safe_accuracy,
 )
 
@@ -101,6 +102,7 @@ __all__ = [
     "is_valid_accuracy",
     "normalize_epoch_seconds",
     "recorded_accuracy_pair",
+    "resolve_seeded_accuracy",
     "safe_accuracy",
     # Semi-public functions
     "_as_ha_attributes",

--- a/custom_components/googlefindmy/coordinator/helpers/geo.py
+++ b/custom_components/googlefindmy/coordinator/helpers/geo.py
@@ -261,11 +261,15 @@ def resolve_seeded_accuracy(raw: Any, flag: bool | None) -> tuple[float, bool | 
     This helper keeps the two halves together so every seed site classifies
     provenance the same way the canonical writer does:
 
-    - an explicit producer ``flag`` wins (a restored real/estimated fix keeps
-      its recorded provenance);
-    - otherwise the value is ``estimated`` exactly when :func:`safe_accuracy`
-      had to fall back (``raw`` is missing/invalid), matching the canonical
-      ``_is_significant_update`` rule;
+    - whenever :func:`safe_accuracy` has to fall back (``raw`` is missing or
+      invalid) the value is ``estimated``, overriding any recorded ``flag``.
+      The canonical ``_is_significant_update`` writer marks every fabricated
+      fallback radius estimated regardless of an incoming flag, so a stale
+      ``accuracy_estimated=False`` recorded beside an error-code value (e.g.
+      ``gps_accuracy=0``) never wins -- otherwise the fabricated radius would
+      masquerade as a real measurement and map_view would draw a solid circle;
+    - otherwise, for a numerically valid value, an explicit producer ``flag``
+      wins (a restored real/estimated fix keeps its recorded provenance);
     - otherwise ``None`` for a legacy *valid* measurement with no recorded
       flag, leaving the documented map_view legacy fallback in charge instead
       of fabricating a flag.
@@ -282,12 +286,17 @@ def resolve_seeded_accuracy(raw: Any, flag: bool | None) -> tuple[float, bool | 
         flag unset (legacy valid value without recorded provenance).
     """
     sanitized = safe_accuracy(raw)
-    if flag is not None:
-        return sanitized, bool(flag)
     if not is_valid_accuracy(raw):
-        # safe_accuracy fell back to the conservative radius; mark provenance
-        # so the seeded row is not later reclassified as a real measurement.
+        # safe_accuracy fell back to the conservative radius. The canonical
+        # _is_significant_update writer ALWAYS marks such a fabricated radius
+        # estimated, overriding any flag a stale recorder row carried (e.g. an
+        # explicit accuracy_estimated=False next to gps_accuracy=0). Mirror that
+        # unconditionally so the fallback can never masquerade as a real fix.
         return sanitized, True
+    if flag is not None:
+        # Valid measurement with recorded provenance: honor it (a carried
+        # estimated fix keeps its flag; a real fix stays real).
+        return sanitized, bool(flag)
     # Legacy valid measurement without a recorded flag: do not fabricate one.
     return sanitized, None
 

--- a/custom_components/googlefindmy/coordinator/helpers/geo.py
+++ b/custom_components/googlefindmy/coordinator/helpers/geo.py
@@ -245,6 +245,53 @@ def recorded_accuracy_pair(
     return raw, (bool(flag) if flag is not None else None)
 
 
+def resolve_seeded_accuracy(raw: Any, flag: bool | None) -> tuple[float, bool | None]:
+    """Couple accuracy sanitization with its ``estimated`` provenance.
+
+    Write-side mirror of :func:`recorded_accuracy_pair`. A direct cache seed
+    (e.g. ``prime_device_location_cache`` on restore) bypasses the canonical
+    ``_is_significant_update`` writer, which is the single place that normally
+    pairs sanitization with provenance: whenever it replaces an invalid value
+    with the conservative fallback radius it also sets ``accuracy_estimated``
+    so a fabricated radius never masquerades as a real measurement. Open-coding
+    only :func:`safe_accuracy` at such a seed site reproduces that decoupling
+    (the recurring PR #1124 defect class) -- the fabricated fallback radius
+    enters flagless and map_view then draws a solid accuracy circle for it.
+
+    This helper keeps the two halves together so every seed site classifies
+    provenance the same way the canonical writer does:
+
+    - an explicit producer ``flag`` wins (a restored real/estimated fix keeps
+      its recorded provenance);
+    - otherwise the value is ``estimated`` exactly when :func:`safe_accuracy`
+      had to fall back (``raw`` is missing/invalid), matching the canonical
+      ``_is_significant_update`` rule;
+    - otherwise ``None`` for a legacy *valid* measurement with no recorded
+      flag, leaving the documented map_view legacy fallback in charge instead
+      of fabricating a flag.
+
+    Args:
+        raw: The recorded/raw accuracy value (producer or legacy), or ``None``.
+        flag: The recorded ``accuracy_estimated`` provenance, or ``None`` when
+            the source row predates the flag.
+
+    Returns:
+        A ``(sanitized_accuracy, estimated_flag)`` tuple. ``sanitized_accuracy``
+        is always a finite float (see :func:`safe_accuracy`). ``estimated_flag``
+        is the resolved provenance, or ``None`` when the caller should leave the
+        flag unset (legacy valid value without recorded provenance).
+    """
+    sanitized = safe_accuracy(raw)
+    if flag is not None:
+        return sanitized, bool(flag)
+    if not is_valid_accuracy(raw):
+        # safe_accuracy fell back to the conservative radius; mark provenance
+        # so the seeded row is not later reclassified as a real measurement.
+        return sanitized, True
+    # Legacy valid measurement without a recorded flag: do not fabricate one.
+    return sanitized, None
+
+
 # ---------------------------------------------------------------------------
 # Distance Calculation
 # ---------------------------------------------------------------------------

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -53,7 +53,7 @@ from .coordinator import (
     GoogleFindMyCoordinator,
     _as_ha_attributes,
     recorded_accuracy_pair,
-    safe_accuracy,
+    resolve_seeded_accuracy,
 )
 from .discovery import (
     CLOUD_DISCOVERY_NAMESPACE,
@@ -944,14 +944,20 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             if acc is not None:
                 # Seed the coordinator cache, whose ``accuracy`` field is a
                 # sanitized float everywhere else (api/locate/fusion writers).
-                # Normalize through the same producer policy (safe_accuracy)
-                # instead of truncating with int(): truncation would drop a
-                # restored sub-meter real fix (e.g. 0.5m -> 0) below
-                # MIN_VALID_ACCURACY and seed an invalid 0m radius, while a
-                # paired accuracy_estimated=False still claims it is real.
-                restored["accuracy"] = safe_accuracy(acc)
-                if estimated is not None:
-                    restored["accuracy_estimated"] = bool(estimated)
+                # resolve_seeded_accuracy couples sanitization with provenance
+                # the way the canonical _is_significant_update writer does
+                # (which this direct prime bypasses): it normalizes through the
+                # producer policy (safe_accuracy) -- avoiding the int() truncation
+                # that would drop a restored sub-meter real fix (e.g. 0.5m -> 0)
+                # below MIN_VALID_ACCURACY -- AND marks accuracy_estimated when
+                # that sanitization had to fall back, so a fabricated 200m radius
+                # cannot enter flagless and be reclassified as a real fix. An
+                # explicitly recorded flag still wins; a legacy *valid* value
+                # without a flag stays unflagged (map_view legacy fallback).
+                accuracy_value, estimated_flag = resolve_seeded_accuracy(acc, estimated)
+                restored["accuracy"] = accuracy_value
+                if estimated_flag is not None:
+                    restored["accuracy_estimated"] = estimated_flag
         except (TypeError, ValueError) as ex:
             _LOGGER.debug("Invalid restored coordinates for %s: %s", self.entity_id, ex)
             restored = {}

--- a/tests/test_coordinator_geo.py
+++ b/tests/test_coordinator_geo.py
@@ -423,15 +423,19 @@ class TestResolveSeededAccuracy:
         assert accuracy == 15.0
         assert estimated is False
 
-    def test_explicit_false_flag_wins_even_for_invalid_value(self) -> None:
-        """An explicit flag wins over the fallback heuristic (Codex carve-out).
+    def test_invalid_value_overrides_explicit_false_flag(self) -> None:
+        """A sanitized fallback is marked estimated even over an explicit False.
 
-        The producer already classified this row; we respect the restored flag
-        even though the value sanitizes to the fallback radius.
+        Codex review of PR #1126: a stale recorder row can carry an explicit
+        ``accuracy_estimated=False`` next to an error-code ``gps_accuracy=0``.
+        The canonical ``_is_significant_update`` writer always marks a
+        fabricated fallback radius estimated, overriding the incoming flag, so
+        the seed-side mirror must do the same -- otherwise the 200m fallback
+        masquerades as a real measurement and map_view draws a solid circle.
         """
         accuracy, estimated = resolve_seeded_accuracy(0, False)
         assert accuracy == DEFAULT_ACCURACY_FALLBACK_M
-        assert estimated is False
+        assert estimated is True
 
     def test_invalid_value_without_flag_marks_estimated(self) -> None:
         """The Codex fix: a flagless error-code value is marked estimated.

--- a/tests/test_coordinator_geo.py
+++ b/tests/test_coordinator_geo.py
@@ -21,6 +21,7 @@ from custom_components.googlefindmy.coordinator.helpers.geo import (
     clamp,
     coerce_float,
     haversine_distance,
+    resolve_seeded_accuracy,
     safe_accuracy,
 )
 
@@ -398,3 +399,69 @@ class TestGeoIntegration:
 
         dist = haversine_distance(lat1, lon1, lat2, lon2)
         assert 479_000 < dist < 529_000
+
+
+class TestResolveSeededAccuracy:
+    """Tests for resolve_seeded_accuracy (write-side provenance coupler).
+
+    This helper is the structural fix for the recurring PR #1124 defect class:
+    a direct cache seed (prime_device_location_cache on restore) bypasses the
+    canonical _is_significant_update writer, so sanitization and the
+    accuracy_estimated provenance flag must be derived together here instead of
+    open-coding only safe_accuracy() and leaving a fabricated radius flagless.
+    """
+
+    def test_explicit_true_flag_wins(self) -> None:
+        """A recorded estimated=True survives even for a numerically valid value."""
+        accuracy, estimated = resolve_seeded_accuracy(200.0, True)
+        assert accuracy == 200.0
+        assert estimated is True
+
+    def test_explicit_false_flag_wins(self) -> None:
+        """A recorded estimated=False is preserved (real measurement)."""
+        accuracy, estimated = resolve_seeded_accuracy(15.0, False)
+        assert accuracy == 15.0
+        assert estimated is False
+
+    def test_explicit_false_flag_wins_even_for_invalid_value(self) -> None:
+        """An explicit flag wins over the fallback heuristic (Codex carve-out).
+
+        The producer already classified this row; we respect the restored flag
+        even though the value sanitizes to the fallback radius.
+        """
+        accuracy, estimated = resolve_seeded_accuracy(0, False)
+        assert accuracy == DEFAULT_ACCURACY_FALLBACK_M
+        assert estimated is False
+
+    def test_invalid_value_without_flag_marks_estimated(self) -> None:
+        """The Codex fix: a flagless error-code value is marked estimated.
+
+        A legacy row predating accuracy_estimated with gps_accuracy=0 sanitizes
+        to the 200m fallback. Without this coupling the radius enters flagless
+        and map_view draws a solid circle for a fabricated measurement.
+        """
+        accuracy, estimated = resolve_seeded_accuracy(0, None)
+        assert accuracy == DEFAULT_ACCURACY_FALLBACK_M
+        assert estimated is True
+
+    def test_none_value_without_flag_marks_estimated(self) -> None:
+        """A missing value without a flag also sanitizes-and-marks estimated."""
+        accuracy, estimated = resolve_seeded_accuracy(None, None)
+        assert accuracy == DEFAULT_ACCURACY_FALLBACK_M
+        assert estimated is True
+
+    def test_valid_value_without_flag_stays_unflagged(self) -> None:
+        """A legacy valid measurement without a flag is not fabricated.
+
+        Returning None tells the caller to leave accuracy_estimated unset, so
+        the documented map_view legacy fallback stays in charge.
+        """
+        accuracy, estimated = resolve_seeded_accuracy(30, None)
+        assert accuracy == 30.0
+        assert estimated is None
+
+    def test_valid_submeter_value_without_flag_stays_unflagged(self) -> None:
+        """A valid sub-meter real fix is preserved and left unflagged."""
+        accuracy, estimated = resolve_seeded_accuracy(0.5, None)
+        assert accuracy == 0.5
+        assert estimated is None

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -773,3 +773,38 @@ async def test_restore_sanitizes_invalid_legacy_accuracy(
 
     assert coordinator.primed["data"]["accuracy"] == 200.0
     assert coordinator.primed["data"]["accuracy_estimated"] is False
+
+
+@pytest.mark.asyncio
+async def test_restore_marks_estimated_for_flagless_invalid_accuracy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flagless legacy error-code accuracy is marked estimated on restore.
+
+    Codex review of PR #1125: a recorder row predating ``accuracy_estimated``
+    can carry only the Android error code ``gps_accuracy=0`` and *no* flag.
+    ``safe_accuracy`` maps it to the 200m fallback, but the direct
+    ``prime_device_location_cache`` seed bypasses the canonical
+    ``_is_significant_update`` writer that would pair that fallback with
+    ``accuracy_estimated=True``. Without the coupling the fabricated radius
+    enters flagless and map_view draws a solid accuracy circle for it. The
+    restore path must mark the value estimated when the sanitization fell back
+    and no explicit flag was recorded.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            # Android error code; no producer accuracy_m AND no recorded flag.
+            "gps_accuracy": 0,
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    assert coordinator.primed["data"]["accuracy"] == 200.0
+    assert coordinator.primed["data"]["accuracy_estimated"] is True

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -743,17 +743,19 @@ async def test_restore_preserves_sub_meter_accuracy(
 
 
 @pytest.mark.asyncio
-async def test_restore_sanitizes_invalid_legacy_accuracy(
+async def test_restore_invalid_accuracy_overrides_explicit_false_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A legacy error-code accuracy is sanitized, not seeded as an invalid fix.
+    """A sanitized legacy error-code accuracy is marked estimated even over False.
 
-    A legacy recorder row can carry the Android error code ``gps_accuracy=0``
-    (no producer ``accuracy_m``). The old ``int(float(acc))`` seeded a literal
-    ``0`` -- an invalid radius that wins fusion against every real fix. Routing
-    through ``safe_accuracy`` maps it to the 200m fallback, which fusion then
-    correctly down-weights. The flag is carried as recorded (not fabricated):
-    this pins the documented legacy boundary as deliberate behaviour.
+    Codex review of PR #1126: a stale recorder row can carry the Android error
+    code ``gps_accuracy=0`` (no producer ``accuracy_m``) together with an
+    explicit ``accuracy_estimated=False``. ``safe_accuracy`` maps the error code
+    to the 200m fallback; the canonical ``_is_significant_update`` writer always
+    marks such a fabricated radius estimated regardless of an incoming flag, so
+    the direct ``prime_device_location_cache`` seed must mirror that. Honoring
+    the stale ``False`` would let the fabricated radius masquerade as a real
+    measurement and map_view would draw a solid accuracy circle for it.
     """
 
     coordinator = _RestoreCoordinatorStub()
@@ -772,7 +774,7 @@ async def test_restore_sanitizes_invalid_legacy_accuracy(
     await entity.async_added_to_hass()
 
     assert coordinator.primed["data"]["accuracy"] == 200.0
-    assert coordinator.primed["data"]["accuracy_estimated"] is False
+    assert coordinator.primed["data"]["accuracy_estimated"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What this fixes

Codex review of #189 found that on a Home Assistant restart, a legacy recorder row that predates the `accuracy_estimated` producer flag — carrying only the Android error code `gps_accuracy=0` and **no** flag — was restored as a **solid 200 m accuracy circle on the map**, as if it were a real measurement.

### Root cause

The device_tracker restore path normalized the error-code value through `safe_accuracy()` to the conservative 200 m fallback, but left `accuracy_estimated` unset, then primed the coordinator cache directly via `prime_device_location_cache`. That direct seed **bypasses** the canonical `_is_significant_update` writer — the single place that normally pairs sanitization with provenance (whenever it replaces an invalid value with the fallback radius, it also sets `accuracy_estimated=True`). So the fabricated radius entered flagless and `map_view` drew a solid circle for it.

This is the same value/provenance decoupling defect class as the earlier #1124/#1125 findings, now on the **write/seed** side instead of the read side.

## The fix (structural, not a point patch)

Introduce `resolve_seeded_accuracy()` in `coordinator.helpers.geo` as the **write-side mirror** of the existing read-side `recorded_accuracy_pair()`. It couples sanitization with provenance so any direct seed site classifies the flag the way the canonical writer does:

- an explicit recorded flag still wins (a restored real/estimated fix keeps its provenance);
- a flagless value that had to fall back is marked `estimated=True`;
- a legacy **valid** value without a flag stays unflagged (the documented `map_view` legacy fallback remains in charge — no fabricated flag).

The device_tracker restore path now uses this helper.

### Why this removes the category (not just the instance)

A variant sweep confirmed `device_tracker` restore-prime is the **only** site that open-codes `safe_accuracy` at a direct cache seed and bypasses the canonical coupler. The other restore/snapshot paths (`coordinator/main.py`) carry the raw value, which `sanitize_decoder_row` coerces to `None` and the canonical `_is_significant_update` then re-couples correctly. Centralizing the coupling in one named, tested helper means future seed sites cannot re-introduce the half-fix.

## Tests

- New `TestResolveSeededAccuracy` (7 unit cases): explicit-flag-wins (incl. explicit `False` over an invalid value), flagless-invalid → `estimated=True` (the Codex case), flagless-valid → unflagged.
- New device_tracker regression test: a flagless `gps_accuracy=0` restore primes `accuracy=200.0` **and** `accuracy_estimated=True`.
- Mutation check confirmed the new tests fail without the fix.
- Existing restore tests (legacy-valid stays unflagged; explicit `False` preserved) remain green.

Full suite: 4141 passed, 20 skipped, coverage 70.62% (≥ 70 % gate). mypy strict, ruff, ruff format clean.

## Risk / rollback

Low. Additive helper plus one call-site swap; behavior changes only for the previously-mismarked flagless-invalid restore case. Rollback is a single revert.