### PR TITLE
fix(chrome_driver): reuse detected Chrome version instead of escalating to latest stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,36 @@ The integration provides a couple of Home Assistant Actions for use with automat
 - Check if devices have moved recently (Find My devices may not update GPS when stationary)
 - Check battery levels (low battery may disable GPS reporting)
 
+### Chrome/ChromeDriver version mismatch (standalone auth scripts)
+When you run the standalone helper scripts (`get_oauth_token.py`,
+`Auth/auth_flow.py`, `KeyBackup/shared_key_flow.py`) from the command line,
+`undetected_chromedriver` downloads a driver for your installed Chrome version.
+If the Chrome-for-Testing **stable** channel has moved ahead of the Chrome build
+offered to your desktop (for example the driver targets Chrome 150 while only
+149 is installed), startup can abort with `only supports Chrome version 150`.
+
+The integration auto-detects the installed version and passes it through, so
+this usually resolves itself. If detection fails, or you need to pin a specific
+version, use the layered override (priority: **CLI flag > environment variable >
+auto-detection**):
+
+| Override | CLI flag | Environment variable |
+| --- | --- | --- |
+| Chrome binary path | `--chrome-path /path/to/chrome` | `GOOGLEFINDMY_CHROME_PATH` |
+| Chrome major version | `--chrome-version 149` | `GOOGLEFINDMY_CHROME_VERSION` |
+
+```bash
+# Pin the major version on the command line
+python custom_components/googlefindmy/get_oauth_token.py --chrome-version 149
+
+# Or via environment variables. These also cover the Home Assistant runtime
+# path, which has no command line of its own.
+export GOOGLEFINDMY_CHROME_VERSION=149
+export GOOGLEFINDMY_CHROME_PATH=/usr/bin/google-chrome
+```
+
+Run any of the scripts with `--help` to list the available options.
+
 ### Location updates stopped after an upgrade
 Location data is fetched **outbound** from Home Assistant to Google (FCM push plus Nova/SPOT polling); it does **not** depend on your Home Assistant internal or external URL configuration. If updates stop after upgrading the integration:
 1. **Reload the integration** (Settings → Devices & Services → Google Find My Device → ⋮ → Reload) or restart Home Assistant. This re-establishes the FCM connection and refreshes tokens, which resolves most post-upgrade stalls.

--- a/custom_components/googlefindmy/Auth/auth_flow.py
+++ b/custom_components/googlefindmy/Auth/auth_flow.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
 from typing import TYPE_CHECKING, Any, cast
 
@@ -17,8 +18,34 @@ if TYPE_CHECKING:
     from selenium.webdriver.remote.webdriver import WebDriver
 
 
+def _parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the standalone auth flow helper."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the Google account OAuth login flow via Chrome."
+    )
+    parser.add_argument(
+        "--chrome-path",
+        default=None,
+        help="Path to the Chrome/Chromium binary (overrides auto-detection).",
+    )
+    parser.add_argument(
+        "--chrome-version",
+        type=int,
+        default=None,
+        help=(
+            "Chrome major version to pin (e.g. 149). Overrides auto-detection; "
+            "useful when the stable channel is ahead of your installed Chrome."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
 def request_oauth_account_token_flow(
     headless: bool = False,
+    *,
+    chrome_path: str | None = None,
+    chrome_version: int | None = None,
 ) -> tuple[str, str | None]:
     """Open Chrome for Google login and return ``(oauth_token, email)``.
 
@@ -42,7 +69,9 @@ def request_oauth_account_token_flow(
     if not is_home_assistant:
         print("[AuthFlow] Installing ChromeDriver...")
 
-    driver: WebDriver = create_driver(headless=headless)
+    driver: WebDriver = create_driver(
+        chrome_path=chrome_path, chrome_version=chrome_version, headless=headless
+    )
 
     try:
         # Open the browser and navigate to the URL
@@ -119,4 +148,7 @@ def _extract_email_from_session(driver: WebDriver) -> str | None:
 
 
 if __name__ == "__main__":
-    request_oauth_account_token_flow()
+    _args = _parse_cli_args()
+    request_oauth_account_token_flow(
+        chrome_path=_args.chrome_path, chrome_version=_args.chrome_version
+    )

--- a/custom_components/googlefindmy/Auth/auth_flow.py
+++ b/custom_components/googlefindmy/Auth/auth_flow.py
@@ -14,7 +14,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 from custom_components.googlefindmy.chrome_driver import create_driver, safe_quit_driver
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover - import-time typing block
     from selenium.webdriver.remote.webdriver import WebDriver
 
 

--- a/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
+++ b/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
@@ -23,7 +23,7 @@ from custom_components.googlefindmy.KeyBackup.shared_key_request import (
     get_security_domain_request_url,
 )
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover - import-time typing block
     from selenium.webdriver.remote.webdriver import WebDriver
 
 

--- a/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
+++ b/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 from typing import TYPE_CHECKING
@@ -29,12 +30,37 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def request_shared_key_flow() -> str | None:
+def _parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the standalone shared key helper."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the manual shared key retrieval flow via Chrome."
+    )
+    parser.add_argument(
+        "--chrome-path",
+        default=None,
+        help="Path to the Chrome/Chromium binary (overrides auto-detection).",
+    )
+    parser.add_argument(
+        "--chrome-version",
+        type=int,
+        default=None,
+        help=(
+            "Chrome major version to pin (e.g. 149). Overrides auto-detection; "
+            "useful when the stable channel is ahead of your installed Chrome."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def request_shared_key_flow(
+    *, chrome_path: str | None = None, chrome_version: int | None = None
+) -> str | None:
     """Execute the manual shared key retrieval flow via Selenium."""
 
     driver: WebDriver | None = None
     try:
-        driver = create_driver()
+        driver = create_driver(chrome_path=chrome_path, chrome_version=chrome_version)
     except Exception:  # pragma: no cover - relies on runtime Selenium setup
         LOGGER.exception("Failed to initialize ChromeDriver for shared key flow")
         return None
@@ -106,4 +132,7 @@ def request_shared_key_flow() -> str | None:
 
 
 if __name__ == "__main__":
-    request_shared_key_flow()
+    _args = _parse_cli_args()
+    request_shared_key_flow(
+        chrome_path=_args.chrome_path, chrome_version=_args.chrome_version
+    )

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -19,7 +19,7 @@ from selenium.webdriver.remote.webdriver import WebDriver as RemoteWebDriver
 
 # Platform-specific import for Windows registry access
 _winreg: ModuleType | None = None
-if sys.platform == "win32":
+if sys.platform == "win32":  # pragma: no cover - Windows-only import
     import winreg as _winreg
 
 # Optional imports for webdriver-manager fallback
@@ -483,7 +483,7 @@ def create_driver(
             time.sleep(3)
 
     # Should not reach here, but satisfy type checker
-    return _create_driver_inner(
+    return _create_driver_inner(  # pragma: no cover - loop always returns or raises
         chrome_path=chrome_path, chrome_version=chrome_version, headless=headless
     )
 

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -44,6 +44,11 @@ except ImportError:
 
 LOGGER = logging.getLogger(__name__)
 
+# Environment variable overrides for the layered resolution chain
+# (priority: CLI argument > environment variable > auto-detection).
+_ENV_CHROME_PATH = "GOOGLEFINDMY_CHROME_PATH"
+_ENV_CHROME_VERSION = "GOOGLEFINDMY_CHROME_VERSION"
+
 
 def _load_uc() -> Any:
     """Import undetected-chromedriver with a stub fallback.
@@ -305,13 +310,20 @@ def get_options(*, headless: bool = False) -> ChromeOptions:
     return chrome_options
 
 
-def get_driver(chrome_path: str | None, *, headless: bool = False) -> WebDriver:
+def get_driver(
+    chrome_path: str | None,
+    *,
+    chrome_version: int | None = None,
+    headless: bool = False,
+) -> WebDriver:
     """Initialize and return an undetected Chrome driver.
 
     Parameters
     ----------
-    chrome_path: str
+    chrome_path: str | None
         Path to the Chrome executable.
+    chrome_version: int | None
+        Optional explicit Chrome major version override (highest priority).
     headless: bool
         Whether to run the browser in headless mode.
 
@@ -325,7 +337,19 @@ def get_driver(chrome_path: str | None, *, headless: bool = False) -> WebDriver:
     if chrome_path:
         options.binary_location = chrome_path
 
-    return cast(WebDriver, _get_uc_module().Chrome(options=options, version_main=None))
+    # Apply the same resolution invariant as the main path: never escalate to
+    # version_main=None while a version is known (explicit/env/detected).
+    detected = get_chrome_version(chrome_path) if chrome_path else None
+    resolved_version, _source = _resolve_chrome_version(
+        explicit=chrome_version,
+        env_raw=os.environ.get(_ENV_CHROME_VERSION),
+        detected=detected,
+    )
+
+    return cast(
+        WebDriver,
+        _get_uc_module().Chrome(options=options, version_main=resolved_version),
+    )
 
 
 def _try_webdriver_manager_fallback() -> WebDriver | None:
@@ -407,7 +431,10 @@ def _quit_driver(driver: WebDriver | None) -> None:
 
 
 def create_driver(
-    chrome_path: str | None = None, *, headless: bool = False
+    chrome_path: str | None = None,
+    *,
+    chrome_version: int | None = None,
+    headless: bool = False,
 ) -> WebDriver:
     """Backward-compatible wrapper for driver creation with multiple fallbacks.
 
@@ -426,7 +453,11 @@ def create_driver(
     max_retries = 3
     for attempt in range(max_retries):
         try:
-            return _create_driver_inner(chrome_path=chrome_path, headless=headless)
+            return _create_driver_inner(
+                chrome_path=chrome_path,
+                chrome_version=chrome_version,
+                headless=headless,
+            )
         except (PermissionError, OSError) as err:
             # WinError 32 (file in use) or WinError 183 (file already exists)
             err_str = str(err)
@@ -452,13 +483,79 @@ def create_driver(
             time.sleep(3)
 
     # Should not reach here, but satisfy type checker
-    return _create_driver_inner(chrome_path=chrome_path, headless=headless)
+    return _create_driver_inner(
+        chrome_path=chrome_path, chrome_version=chrome_version, headless=headless
+    )
 
 
 def _is_file_lock_error(err: BaseException) -> bool:
     """Check if an exception is a Windows file lock error (WinError 32/183)."""
     msg = str(err)
     return "WinError 32" in msg or "WinError 183" in msg
+
+
+def _parse_env_version(env_raw: str | None) -> int | None:
+    """Parse a ``GOOGLEFINDMY_CHROME_VERSION`` value into a major version int.
+
+    An unset, empty or whitespace-only value yields ``None``. A non-integer
+    value is ignored with a warning (so resolution falls through to the next
+    lower-priority source) rather than raising.
+    """
+    if env_raw is None:
+        return None
+    stripped = env_raw.strip()
+    if not stripped:
+        return None
+    try:
+        return int(stripped)
+    except ValueError:
+        LOGGER.warning(
+            "Ignoring invalid %s=%r (not an integer); "
+            "falling back to lower-priority source",
+            _ENV_CHROME_VERSION,
+            env_raw,
+        )
+        return None
+
+
+def _resolve_chrome_version(
+    *, explicit: int | None, env_raw: str | None, detected: int | None
+) -> tuple[int | None, str]:
+    """Resolve the effective Chrome major version and its provenance.
+
+    Priority: ``explicit`` (CLI) > environment variable > ``detected`` (auto).
+    Returns ``(version, source)`` where ``source`` is one of ``"cli"``,
+    ``"env"``, ``"auto"`` or ``"none"``. An invalid/empty env value is skipped
+    (see :func:`_parse_env_version`).
+    """
+    if explicit is not None:
+        return explicit, "cli"
+    parsed_env = _parse_env_version(env_raw)
+    if parsed_env is not None:
+        return parsed_env, "env"
+    if detected is not None:
+        return detected, "auto"
+    return None, "none"
+
+
+def _resolve_chrome_path(
+    *, explicit: str | None, env_raw: str | None, detected: str | None
+) -> tuple[str | None, str]:
+    """Resolve the effective Chrome binary path and its provenance.
+
+    Priority: ``explicit`` (CLI) > environment variable > ``detected`` (auto).
+    An empty/whitespace-only env value is treated as unset. The three sources
+    are kept separate on purpose: collapsing ``explicit or detected`` before
+    consulting the env var would make the env unreachable between CLI and auto.
+    Returns ``(path, source)``.
+    """
+    if explicit:
+        return explicit, "cli"
+    if env_raw and env_raw.strip():
+        return env_raw.strip(), "env"
+    if detected:
+        return detected, "auto"
+    return None, "none"
 
 
 def _try_strategy_default(
@@ -563,43 +660,79 @@ def _try_strategy_headless(
 
 
 def _create_driver_inner(
-    chrome_path: str | None = None, *, headless: bool = False
+    chrome_path: str | None = None,
+    *,
+    chrome_version: int | None = None,
+    headless: bool = False,
 ) -> WebDriver:
-    """Internal driver creation, orchestrating the strategy fallbacks."""
+    """Internal driver creation, orchestrating the strategy fallbacks.
+
+    Resolution follows the layered chain CLI argument > environment variable >
+    auto-detection for both the Chrome path and the Chrome version. The version
+    is resolved independently of the path so an explicit version override still
+    applies when no binary path can be located.
+    """
     # Kill any existing Chrome processes to avoid conflicts
     _kill_existing_chrome_processes()
 
-    resolved_path = chrome_path or find_chrome()
-    version_main = get_chrome_version(resolved_path) if resolved_path else None
-    if version_main:
-        LOGGER.debug("Detected Chrome version: %d", version_main)
+    # Resolve path and version from their three independent sources. The sources
+    # are kept separate (no chrome_path-or-find_chrome collapse) so the env var
+    # can take effect between an explicit argument and auto-detection.
+    resolved_path, _path_source = _resolve_chrome_path(
+        explicit=chrome_path,
+        env_raw=os.environ.get(_ENV_CHROME_PATH),
+        detected=find_chrome(),
+    )
+    detected_version = get_chrome_version(resolved_path) if resolved_path else None
+    if detected_version:
+        LOGGER.debug("Detected Chrome version: %d", detected_version)
+    resolved_version, version_source = _resolve_chrome_version(
+        explicit=chrome_version,
+        env_raw=os.environ.get(_ENV_CHROME_VERSION),
+        detected=detected_version,
+    )
+    if resolved_version is not None and resolved_path is None:
+        LOGGER.warning(
+            "Chrome version override is set (version=%s, source=%s) but no Chrome "
+            "binary path could be resolved; undetected-chromedriver must locate "
+            "Chrome on its own (binary_location/browser_executable_path unset).",
+            resolved_version,
+            version_source,
+        )
 
     # Build the ordered list of strategy attempts. Strategy 2 only applies when
-    # a path is resolved; strategy 4 (headless retry) only when not already
-    # headless. Each attempt returns (driver, saw_non_file_lock_error).
+    # a path is resolved; strategy 3 (let uc pick the version) only when no
+    # version could be resolved -- with a known version it would duplicate
+    # strategy 1 and, in the old code, escalate to the latest stable driver;
+    # strategy 4 (headless retry) only when not already headless. Every strategy
+    # uses resolved_version so we never escalate to None while a version is
+    # known. Each attempt returns (driver, saw_non_file_lock_error).
     attempts: list[Callable[[], tuple[WebDriver | None, bool]]] = [
         lambda: _try_strategy_default(
-            resolved_path=resolved_path, version_main=version_main, headless=headless
+            resolved_path=resolved_path,
+            version_main=resolved_version,
+            headless=headless,
         )
     ]
     if resolved_path:
         attempts.append(
             lambda: _try_strategy_explicit_path(
                 resolved_path=resolved_path,
-                version_main=version_main,
+                version_main=resolved_version,
                 headless=headless,
             )
         )
-    attempts.append(
-        lambda: _try_strategy_no_version(
-            resolved_path=resolved_path, headless=headless
+    if resolved_version is None:
+        attempts.append(
+            lambda: _try_strategy_no_version(
+                resolved_path=resolved_path, headless=headless
+            )
         )
-    )
     if not headless:
         LOGGER.info("Trying headless mode...")
         attempts.append(
             lambda: _try_strategy_headless(
-                resolved_path=resolved_path, version_main=version_main
+                resolved_path=resolved_path, version_main=resolved_version
             )
         )
 
@@ -625,13 +758,15 @@ def _create_driver_inner(
             "A previous ChromeDriver process may still be running."
         )
 
-    # All strategies failed
+    # All strategies failed -- report detected vs. used version and its source
+    # so the failure is diagnosable instead of just echoing Selenium's raw line.
     raise RuntimeError(
         "Failed to start ChromeDriver after all attempts.\n"
         "Possible solutions:\n"
         "1. Make sure Google Chrome is installed and up-to-date\n"
         "2. Try: pip install --upgrade undetected-chromedriver selenium webdriver-manager\n"
         f"3. Current detected path: {resolved_path or 'None'}\n"
-        f"4. Current detected version: {version_main or 'Unknown'}\n"
+        f"4. detected: {detected_version or 'Unknown'}; "
+        f"requested/used: {resolved_version or 'Unknown'}; source: {version_source}\n"
         "5. Check if Chrome is blocked by antivirus or firewall"
     )

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -494,6 +494,41 @@ def _is_file_lock_error(err: BaseException) -> bool:
     return "WinError 32" in msg or "WinError 183" in msg
 
 
+def _is_version_mismatch_error(err: BaseException) -> bool:
+    """Check if an exception looks like a Chrome/driver version mismatch.
+
+    undetected-chromedriver surfaces Selenium's "only supports Chrome version N"
+    message when the driver and the installed browser disagree on the version.
+    """
+    return "only supports Chrome version" in str(err)
+
+
+def _log_version_mismatch_hint(
+    error: BaseException | None,
+    *,
+    detected_version: int | None,
+    resolved_version: int | None,
+    version_source: str,
+) -> None:
+    """Log an actionable hint when the last failure was a version mismatch.
+
+    Replaces Selenium's bare "only supports Chrome version" line with the
+    detected/used versions, the override source and how to pin a version.
+    """
+    if error is None or not _is_version_mismatch_error(error):
+        return
+    LOGGER.error(
+        "Chrome/driver version mismatch (detected: %s, requested/used: %s, "
+        "source: %s). Pin a matching major version via --chrome-version or the "
+        "%s environment variable (set it to your installed Chrome major "
+        "version).",
+        detected_version or "Unknown",
+        resolved_version or "Unknown",
+        version_source,
+        _ENV_CHROME_VERSION,
+    )
+
+
 def _parse_env_version(env_raw: str | None) -> int | None:
     """Parse a ``GOOGLEFINDMY_CHROME_VERSION`` value into a major version int.
 
@@ -560,12 +595,12 @@ def _resolve_chrome_path(
 
 def _try_strategy_default(
     *, resolved_path: str | None, version_main: int | None, headless: bool
-) -> tuple[WebDriver | None, bool]:
+) -> tuple[WebDriver | None, BaseException | None]:
     """Strategy 1: default creation, passing ``version_main`` if detected.
 
-    Returns ``(driver, saw_non_file_lock_error)``. ``driver`` is ``None`` on
-    failure; the boolean reports whether the failure was something other than a
-    Windows file lock (so the caller can track ``_all_file_lock``).
+    Returns ``(driver, error)``. ``driver`` is ``None`` on failure and ``error``
+    is the caught exception (``None`` on success), letting the caller track
+    ``all_file_lock`` and surface a version-mismatch hint on total failure.
     """
     driver: WebDriver | None = None
     try:
@@ -577,16 +612,16 @@ def _try_strategy_default(
             _get_uc_module().Chrome(options=options, version_main=version_main),
         )
         LOGGER.debug("ChromeDriver started successfully.")
-        return driver, False
+        return driver, None
     except Exception as err:  # noqa: BLE001
         _quit_driver(driver)
         LOGGER.warning("Strategy 1 (default) failed: %s", err)
-        return None, not _is_file_lock_error(err)
+        return None, err
 
 
 def _try_strategy_explicit_path(
     *, resolved_path: str, version_main: int | None, headless: bool
-) -> tuple[WebDriver | None, bool]:
+) -> tuple[WebDriver | None, BaseException | None]:
     """Strategy 2: pass ``browser_executable_path`` explicitly.
 
     See :func:`_try_strategy_default` for the return contract.
@@ -603,16 +638,16 @@ def _try_strategy_explicit_path(
             ),
         )
         LOGGER.debug("ChromeDriver started with browser_executable_path.")
-        return driver, False
+        return driver, None
     except Exception as err:  # noqa: BLE001
         _quit_driver(driver)
         LOGGER.warning("Strategy 2 (explicit path) failed: %s", err)
-        return None, not _is_file_lock_error(err)
+        return None, err
 
 
 def _try_strategy_no_version(
     *, resolved_path: str | None, headless: bool
-) -> tuple[WebDriver | None, bool]:
+) -> tuple[WebDriver | None, BaseException | None]:
     """Strategy 3: attempt creation without specifying a version.
 
     See :func:`_try_strategy_default` for the return contract.
@@ -626,16 +661,16 @@ def _try_strategy_no_version(
             WebDriver, _get_uc_module().Chrome(options=options, version_main=None)
         )
         LOGGER.debug("ChromeDriver started without explicit version.")
-        return driver, False
+        return driver, None
     except Exception as err:  # noqa: BLE001
         _quit_driver(driver)
         LOGGER.warning("Strategy 3 (no version) failed: %s", err)
-        return None, not _is_file_lock_error(err)
+        return None, err
 
 
 def _try_strategy_headless(
     *, resolved_path: str | None, version_main: int | None
-) -> tuple[WebDriver | None, bool]:
+) -> tuple[WebDriver | None, BaseException | None]:
     """Strategy 4: retry in headless mode.
 
     See :func:`_try_strategy_default` for the return contract.
@@ -652,11 +687,11 @@ def _try_strategy_headless(
             ),
         )
         LOGGER.debug("ChromeDriver started in headless mode.")
-        return driver, False
+        return driver, None
     except Exception as err:  # noqa: BLE001
         _quit_driver(driver)
         LOGGER.warning("Strategy 4 (headless) failed: %s", err)
-        return None, not _is_file_lock_error(err)
+        return None, err
 
 
 def _create_driver_inner(
@@ -707,7 +742,7 @@ def _create_driver_inner(
     # strategy 4 (headless retry) only when not already headless. Every strategy
     # uses resolved_version so we never escalate to None while a version is
     # known. Each attempt returns (driver, saw_non_file_lock_error).
-    attempts: list[Callable[[], tuple[WebDriver | None, bool]]] = [
+    attempts: list[Callable[[], tuple[WebDriver | None, BaseException | None]]] = [
         lambda: _try_strategy_default(
             resolved_path=resolved_path,
             version_main=resolved_version,
@@ -736,14 +771,18 @@ def _create_driver_inner(
             )
         )
 
-    # Track whether all failures are file-lock related (Windows)
+    # Track whether all failures are file-lock related (Windows) and keep the
+    # last error so we can surface a targeted version-mismatch hint.
     all_file_lock = True
+    last_error: BaseException | None = None
     for attempt in attempts:
-        driver, saw_non_file_lock = attempt()
+        driver, error = attempt()
         if driver is not None:
             return driver
-        if saw_non_file_lock:
-            all_file_lock = False
+        if error is not None:
+            last_error = error
+            if not _is_file_lock_error(error):
+                all_file_lock = False
 
     # Strategy 5: webdriver-manager fallback
     fallback_driver = _try_webdriver_manager_fallback()
@@ -760,6 +799,12 @@ def _create_driver_inner(
 
     # All strategies failed -- report detected vs. used version and its source
     # so the failure is diagnosable instead of just echoing Selenium's raw line.
+    _log_version_mismatch_hint(
+        last_error,
+        detected_version=detected_version,
+        resolved_version=resolved_version,
+        version_source=version_source,
+    )
     raise RuntimeError(
         "Failed to start ChromeDriver after all attempts.\n"
         "Possible solutions:\n"

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -109,13 +109,19 @@ def _reset_uc_cache(module: Any | None = None) -> None:
 type ChromeOptions = Any
 
 
-def get_chrome_version(chrome_path: str) -> int | None:
+def get_chrome_version(chrome_path: str, *, prefer_binary: bool = False) -> int | None:
     """Get Chrome version from executable.
 
     Parameters
     ----------
     chrome_path: str
         Path to the Chrome executable.
+    prefer_binary: bool
+        When ``True``, skip the Windows registry lookup and query the given
+        binary directly via ``--version``. Set this for an explicit/env path
+        override: the registry reports the registered default Chrome, which may
+        differ from the overridden binary. Auto-detection leaves this ``False``
+        so the registry-first fast path is preserved (no behavior change).
 
     Returns
     -------
@@ -124,8 +130,10 @@ def get_chrome_version(chrome_path: str) -> int | None:
     """
     try:
         if platform.system() == "Windows":
-            # Try to get version from registry first
-            if _winreg is not None:
+            # Try the registry first only for auto-detected Chrome. For an
+            # explicit/env override the registry may report a different
+            # binary's version, so query the selected binary directly instead.
+            if _winreg is not None and not prefer_binary:
                 try:
                     key = _winreg.OpenKey(
                         _winreg.HKEY_CURRENT_USER, r"Software\Google\Chrome\BLBeacon"
@@ -339,7 +347,11 @@ def get_driver(
 
     # Apply the same resolution invariant as the main path: never escalate to
     # version_main=None while a version is known (explicit/env/detected).
-    detected = get_chrome_version(chrome_path) if chrome_path else None
+    # chrome_path here is always an explicit override, so query the binary
+    # directly (prefer_binary) instead of trusting the Windows registry.
+    detected = (
+        get_chrome_version(chrome_path, prefer_binary=True) if chrome_path else None
+    )
     resolved_version, _source = _resolve_chrome_version(
         explicit=chrome_version,
         env_raw=os.environ.get(_ENV_CHROME_VERSION),
@@ -713,12 +725,19 @@ def _create_driver_inner(
     # Resolve path and version from their three independent sources. The sources
     # are kept separate (no chrome_path-or-find_chrome collapse) so the env var
     # can take effect between an explicit argument and auto-detection.
-    resolved_path, _path_source = _resolve_chrome_path(
+    resolved_path, path_source = _resolve_chrome_path(
         explicit=chrome_path,
         env_raw=os.environ.get(_ENV_CHROME_PATH),
         detected=find_chrome(),
     )
-    detected_version = get_chrome_version(resolved_path) if resolved_path else None
+    # For an explicit/env path override, bypass the Windows registry so the
+    # overridden binary's own version is detected (the registry reports the
+    # registered default Chrome). Auto-detection keeps the registry-first path.
+    detected_version = (
+        get_chrome_version(resolved_path, prefer_binary=path_source != "auto")
+        if resolved_path
+        else None
+    )
     if detected_version:
         LOGGER.debug("Detected Chrome version: %d", detected_version)
     resolved_version, version_source = _resolve_chrome_version(

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 
@@ -460,25 +461,15 @@ def _is_file_lock_error(err: BaseException) -> bool:
     return "WinError 32" in msg or "WinError 183" in msg
 
 
-def _create_driver_inner(  # noqa: PLR0912, PLR0915
-    chrome_path: str | None = None, *, headless: bool = False
-) -> WebDriver:
-    """Internal driver creation with multiple strategy fallbacks."""
-    # Kill any existing Chrome processes to avoid conflicts
-    _kill_existing_chrome_processes()
+def _try_strategy_default(
+    *, resolved_path: str | None, version_main: int | None, headless: bool
+) -> tuple[WebDriver | None, bool]:
+    """Strategy 1: default creation, passing ``version_main`` if detected.
 
-    resolved_path = chrome_path or find_chrome()
-    version_main: int | None = None
-
-    if resolved_path:
-        version_main = get_chrome_version(resolved_path)
-        if version_main:
-            LOGGER.debug("Detected Chrome version: %d", version_main)
-
-    # Track whether all failures are file-lock related (Windows)
-    _all_file_lock = True
-
-    # Strategy 1: Default with version_main if detected
+    Returns ``(driver, saw_non_file_lock_error)``. ``driver`` is ``None`` on
+    failure; the boolean reports whether the failure was something other than a
+    Windows file lock (so the caller can track ``_all_file_lock``).
+    """
     driver: WebDriver | None = None
     try:
         options = get_options(headless=headless)
@@ -489,34 +480,47 @@ def _create_driver_inner(  # noqa: PLR0912, PLR0915
             _get_uc_module().Chrome(options=options, version_main=version_main),
         )
         LOGGER.debug("ChromeDriver started successfully.")
-        return driver
+        return driver, False
     except Exception as err:  # noqa: BLE001
         _quit_driver(driver)
-        if not _is_file_lock_error(err):
-            _all_file_lock = False
         LOGGER.warning("Strategy 1 (default) failed: %s", err)
+        return None, not _is_file_lock_error(err)
 
-    # Strategy 2: Use browser_executable_path parameter (if supported)
-    if resolved_path:
-        try:
-            options = get_options(headless=headless)
-            driver = cast(
-                WebDriver,
-                _get_uc_module().Chrome(
-                    options=options,
-                    version_main=version_main,
-                    browser_executable_path=resolved_path,
-                ),
-            )
-            LOGGER.debug("ChromeDriver started with browser_executable_path.")
-            return driver
-        except Exception as err:  # noqa: BLE001
-            _quit_driver(driver)
-            if not _is_file_lock_error(err):
-                _all_file_lock = False
-            LOGGER.warning("Strategy 2 (explicit path) failed: %s", err)
 
-    # Strategy 3: Try without specifying version
+def _try_strategy_explicit_path(
+    *, resolved_path: str, version_main: int | None, headless: bool
+) -> tuple[WebDriver | None, bool]:
+    """Strategy 2: pass ``browser_executable_path`` explicitly.
+
+    See :func:`_try_strategy_default` for the return contract.
+    """
+    driver: WebDriver | None = None
+    try:
+        options = get_options(headless=headless)
+        driver = cast(
+            WebDriver,
+            _get_uc_module().Chrome(
+                options=options,
+                version_main=version_main,
+                browser_executable_path=resolved_path,
+            ),
+        )
+        LOGGER.debug("ChromeDriver started with browser_executable_path.")
+        return driver, False
+    except Exception as err:  # noqa: BLE001
+        _quit_driver(driver)
+        LOGGER.warning("Strategy 2 (explicit path) failed: %s", err)
+        return None, not _is_file_lock_error(err)
+
+
+def _try_strategy_no_version(
+    *, resolved_path: str | None, headless: bool
+) -> tuple[WebDriver | None, bool]:
+    """Strategy 3: attempt creation without specifying a version.
+
+    See :func:`_try_strategy_default` for the return contract.
+    """
+    driver: WebDriver | None = None
     try:
         options = get_options(headless=headless)
         if resolved_path:
@@ -525,33 +529,88 @@ def _create_driver_inner(  # noqa: PLR0912, PLR0915
             WebDriver, _get_uc_module().Chrome(options=options, version_main=None)
         )
         LOGGER.debug("ChromeDriver started without explicit version.")
-        return driver
+        return driver, False
     except Exception as err:  # noqa: BLE001
         _quit_driver(driver)
-        if not _is_file_lock_error(err):
-            _all_file_lock = False
         LOGGER.warning("Strategy 3 (no version) failed: %s", err)
+        return None, not _is_file_lock_error(err)
 
-    # Strategy 4: Try headless mode
+
+def _try_strategy_headless(
+    *, resolved_path: str | None, version_main: int | None
+) -> tuple[WebDriver | None, bool]:
+    """Strategy 4: retry in headless mode.
+
+    See :func:`_try_strategy_default` for the return contract.
+    """
+    driver: WebDriver | None = None
+    try:
+        headless_options = get_options(headless=True)
+        if resolved_path:
+            headless_options.binary_location = resolved_path
+        driver = cast(
+            WebDriver,
+            _get_uc_module().Chrome(
+                options=headless_options, version_main=version_main
+            ),
+        )
+        LOGGER.debug("ChromeDriver started in headless mode.")
+        return driver, False
+    except Exception as err:  # noqa: BLE001
+        _quit_driver(driver)
+        LOGGER.warning("Strategy 4 (headless) failed: %s", err)
+        return None, not _is_file_lock_error(err)
+
+
+def _create_driver_inner(
+    chrome_path: str | None = None, *, headless: bool = False
+) -> WebDriver:
+    """Internal driver creation, orchestrating the strategy fallbacks."""
+    # Kill any existing Chrome processes to avoid conflicts
+    _kill_existing_chrome_processes()
+
+    resolved_path = chrome_path or find_chrome()
+    version_main = get_chrome_version(resolved_path) if resolved_path else None
+    if version_main:
+        LOGGER.debug("Detected Chrome version: %d", version_main)
+
+    # Build the ordered list of strategy attempts. Strategy 2 only applies when
+    # a path is resolved; strategy 4 (headless retry) only when not already
+    # headless. Each attempt returns (driver, saw_non_file_lock_error).
+    attempts: list[Callable[[], tuple[WebDriver | None, bool]]] = [
+        lambda: _try_strategy_default(
+            resolved_path=resolved_path, version_main=version_main, headless=headless
+        )
+    ]
+    if resolved_path:
+        attempts.append(
+            lambda: _try_strategy_explicit_path(
+                resolved_path=resolved_path,
+                version_main=version_main,
+                headless=headless,
+            )
+        )
+    attempts.append(
+        lambda: _try_strategy_no_version(
+            resolved_path=resolved_path, headless=headless
+        )
+    )
     if not headless:
         LOGGER.info("Trying headless mode...")
-        try:
-            headless_options = get_options(headless=True)
-            if resolved_path:
-                headless_options.binary_location = resolved_path
-            driver = cast(
-                WebDriver,
-                _get_uc_module().Chrome(
-                    options=headless_options, version_main=version_main
-                ),
+        attempts.append(
+            lambda: _try_strategy_headless(
+                resolved_path=resolved_path, version_main=version_main
             )
-            LOGGER.debug("ChromeDriver started in headless mode.")
+        )
+
+    # Track whether all failures are file-lock related (Windows)
+    all_file_lock = True
+    for attempt in attempts:
+        driver, saw_non_file_lock = attempt()
+        if driver is not None:
             return driver
-        except Exception as err:  # noqa: BLE001
-            _quit_driver(driver)
-            if not _is_file_lock_error(err):
-                _all_file_lock = False
-            LOGGER.warning("Strategy 4 (headless) failed: %s", err)
+        if saw_non_file_lock:
+            all_file_lock = False
 
     # Strategy 5: webdriver-manager fallback
     fallback_driver = _try_webdriver_manager_fallback()
@@ -560,7 +619,7 @@ def _create_driver_inner(  # noqa: PLR0912, PLR0915
 
     # If all failures were file-lock related, raise PermissionError so the
     # outer retry loop in create_driver() can wait and retry.
-    if _all_file_lock and platform.system() == "Windows":
+    if all_file_lock and platform.system() == "Windows":
         raise PermissionError(
             "All ChromeDriver strategies failed due to file lock (WinError 32/183). "
             "A previous ChromeDriver process may still be running."

--- a/custom_components/googlefindmy/get_oauth_token.py
+++ b/custom_components/googlefindmy/get_oauth_token.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from collections.abc import Mapping
@@ -37,7 +38,32 @@ def _cookie_value(cookie: Mapping[str, Any] | None) -> str | None:
     return cast(str | None, value)
 
 
-def main() -> None:
+def _parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the standalone OAuth token helper."""
+
+    parser = argparse.ArgumentParser(
+        description="Obtain an OAuth token for the Google Find My integration."
+    )
+    parser.add_argument(
+        "--chrome-path",
+        default=None,
+        help="Path to the Chrome/Chromium binary (overrides auto-detection).",
+    )
+    parser.add_argument(
+        "--chrome-version",
+        type=int,
+        default=None,
+        help=(
+            "Chrome major version to pin (e.g. 149). Overrides auto-detection; "
+            "useful when the stable channel is ahead of your installed Chrome."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(
+    *, chrome_path: str | None = None, chrome_version: int | None = None
+) -> None:
     """Get OAuth token for Google Find My Device."""
 
     print("=" * 60)
@@ -57,7 +83,9 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        driver: WebDriver = create_driver(headless=False)
+        driver: WebDriver = create_driver(
+            chrome_path=chrome_path, chrome_version=chrome_version, headless=False
+        )
     except Exception as err:
         print(f"Error: {err}")
         print()
@@ -107,4 +135,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    _args = _parse_cli_args()
+    main(chrome_path=_args.chrome_path, chrome_version=_args.chrome_version)

--- a/custom_components/googlefindmy/get_oauth_token.py
+++ b/custom_components/googlefindmy/get_oauth_token.py
@@ -10,7 +10,7 @@ import sys
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, cast
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover - import-time typing block
     from selenium.webdriver.remote.webdriver import WebDriver
 
 
@@ -20,7 +20,7 @@ sys.path.insert(0, current_dir)
 
 # Also add parent directories to handle custom_components structure
 parent_dir = os.path.dirname(current_dir)
-if "custom_components" in current_dir:
+if "custom_components" in current_dir:  # pragma: no cover - import-time path setup
     # If we're inside custom_components, add the parent of custom_components
     sys.path.insert(0, os.path.dirname(parent_dir))
 

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -96,7 +96,7 @@ def _apply_flow_patches(
     monkeypatch: pytest.MonkeyPatch, driver: FakeDriver
 ) -> ImmediateWaitFactory:
     wait_factory = ImmediateWaitFactory()
-    monkeypatch.setattr(auth_flow, "create_driver", lambda headless: driver)
+    monkeypatch.setattr(auth_flow, "create_driver", lambda **kwargs: driver)
     monkeypatch.setattr(auth_flow, "WebDriverWait", wait_factory)
     return wait_factory
 

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -1,4 +1,5 @@
 # tests/test_auth_flow.py
+import sys
 from collections.abc import Callable
 from typing import Any
 
@@ -129,6 +130,239 @@ def test_request_oauth_account_token_flow_missing_cookie(
 
     assert driver.quit_calls == 1
     assert wait_factory.instances and wait_factory.instances[0].until_calls == 1
+
+
+def test_request_oauth_flow_forwards_chrome_path_and_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The flow must pass ``chrome_path``/``chrome_version`` to ``create_driver``."""
+
+    driver = FakeDriver(cookie_after_wait={"value": "tok"})
+    captured: dict[str, Any] = {}
+
+    def fake_create_driver(**kwargs: Any) -> FakeDriver:
+        captured.update(kwargs)
+        return driver
+
+    monkeypatch.setattr(auth_flow, "create_driver", fake_create_driver)
+    monkeypatch.setattr(auth_flow, "WebDriverWait", ImmediateWaitFactory())
+
+    request_oauth_account_token_flow(
+        headless=True, chrome_path="/opt/chrome", chrome_version=149
+    )
+
+    assert captured == {
+        "chrome_path": "/opt/chrome",
+        "chrome_version": 149,
+        "headless": True,
+    }
+
+
+def test_request_oauth_flow_non_string_cookie_value_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cookie whose ``value`` is not a string is rejected."""
+
+    driver = FakeDriver(cookie_after_wait={"value": 12345})  # type: ignore[dict-item]
+    _apply_flow_patches(monkeypatch, driver)
+
+    with pytest.raises(RuntimeError, match="not a string"):
+        request_oauth_account_token_flow(headless=True)
+
+    assert driver.quit_calls == 1
+
+
+def test_request_oauth_flow_prints_when_not_home_assistant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-headless, non-HA mode walks the interactive print/input branches."""
+
+    driver = FakeDriver(cookie_after_wait={"value": "tok"})
+    monkeypatch.setattr(auth_flow, "create_driver", lambda **kwargs: driver)
+    monkeypatch.setattr(auth_flow, "WebDriverWait", ImmediateWaitFactory())
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+    # Ensure the HA detection path is False so the print branches execute.
+    monkeypatch.delitem(sys.modules, "homeassistant", raising=False)
+    # Make email extraction succeed so the "Detected account" branch runs too.
+    monkeypatch.setattr(
+        auth_flow, "_extract_email_from_session", lambda _: "user@example.com"
+    )
+
+    token, email = request_oauth_account_token_flow(headless=False)
+
+    assert token == "tok"
+    assert email == "user@example.com"
+
+
+def test_request_oauth_flow_non_ha_without_email_skips_account_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-HA mode with no detected email skips the 'Detected account' print."""
+
+    driver = FakeDriver(cookie_after_wait={"value": "tok"})
+    monkeypatch.setattr(auth_flow, "create_driver", lambda **kwargs: driver)
+    monkeypatch.setattr(auth_flow, "WebDriverWait", ImmediateWaitFactory())
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+    monkeypatch.delitem(sys.modules, "homeassistant", raising=False)
+    monkeypatch.setattr(auth_flow, "_extract_email_from_session", lambda _: None)
+
+    token, email = request_oauth_account_token_flow(headless=False)
+
+    assert token == "tok"
+    assert email is None
+
+
+def test_request_oauth_flow_home_assistant_context_skips_prompts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``homeassistant`` is imported, prompts and prints are skipped."""
+
+    driver = FakeDriver(cookie_after_wait={"value": "tok"})
+    monkeypatch.setattr(auth_flow, "create_driver", lambda **kwargs: driver)
+    monkeypatch.setattr(auth_flow, "WebDriverWait", ImmediateWaitFactory())
+    # Force the HA detection branch.
+    monkeypatch.setitem(sys.modules, "homeassistant", object())
+
+    token, _email = request_oauth_account_token_flow(headless=False)
+
+    assert token == "tok"
+
+
+# ---------------------------------------------------------------------------
+# _parse_cli_args
+# ---------------------------------------------------------------------------
+
+
+def test_parse_cli_args_defaults() -> None:
+    args = auth_flow._parse_cli_args([])
+    assert args.chrome_path is None
+    assert args.chrome_version is None
+
+
+def test_parse_cli_args_values() -> None:
+    args = auth_flow._parse_cli_args(
+        ["--chrome-path", "/opt/chrome", "--chrome-version", "149"]
+    )
+    assert args.chrome_path == "/opt/chrome"
+    assert args.chrome_version == 149
+
+
+def test_parse_cli_args_help_exits_zero() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        auth_flow._parse_cli_args(["--help"])
+    assert excinfo.value.code == 0
+
+
+def test_parse_cli_args_invalid_version_exits_two() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        auth_flow._parse_cli_args(["--chrome-version", "x"])
+    assert excinfo.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# _extract_email_from_session
+# ---------------------------------------------------------------------------
+
+
+class _ScriptDriver:
+    """Driver double whose ``execute_script``/``get_cookies`` are configurable."""
+
+    def __init__(
+        self,
+        *,
+        script_results: list[Any] | None = None,
+        cookies: list[dict[str, Any]] | None = None,
+        script_raises: bool = False,
+        cookies_raises: bool = False,
+    ) -> None:
+        self._script_results = list(script_results or [])
+        self._cookies = cookies or []
+        self._script_raises = script_raises
+        self._cookies_raises = cookies_raises
+
+    def execute_script(self, _script: str) -> Any:
+        if self._script_raises:
+            raise RuntimeError("script boom")
+        if self._script_results:
+            return self._script_results.pop(0)
+        return None
+
+    def get_cookies(self) -> list[dict[str, Any]]:
+        if self._cookies_raises:
+            raise RuntimeError("cookies boom")
+        return self._cookies
+
+
+def test_extract_email_from_data_email_attribute() -> None:
+    driver = _ScriptDriver(script_results=["user@example.com"])
+    assert (
+        auth_flow._extract_email_from_session(driver)  # type: ignore[arg-type]
+        == "user@example.com"
+    )
+
+
+def test_extract_email_from_cookie_scan() -> None:
+    """Both DOM selectors miss, but a cookie value looks like an email."""
+
+    driver = _ScriptDriver(
+        script_results=[None, "no-at-sign"],
+        cookies=[
+            {"value": 123},
+            {"value": "plain"},
+            {"value": "found@example.com"},
+        ],
+    )
+    assert (
+        auth_flow._extract_email_from_session(driver)  # type: ignore[arg-type]
+        == "found@example.com"
+    )
+
+
+def test_extract_email_returns_none_when_nothing_matches() -> None:
+    driver = _ScriptDriver(
+        script_results=[None, None],
+        cookies=[{"value": "nope"}],
+    )
+    assert auth_flow._extract_email_from_session(driver) is None  # type: ignore[arg-type]
+
+
+def test_extract_email_swallows_script_and_cookie_errors() -> None:
+    """Exceptions in both strategies are swallowed and yield ``None``."""
+
+    driver = _ScriptDriver(script_raises=True, cookies_raises=True)
+    assert auth_flow._extract_email_from_session(driver) is None  # type: ignore[arg-type]
+
+
+def test_module_entrypoint_invokes_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the ``__main__`` guard by running the module as a script.
+
+    The freshly executed copy rebinds ``create_driver`` via ``from ... import``,
+    so patching the source ``chrome_driver.create_driver`` to raise keeps the
+    real browser out of the test while still covering the entry-point lines.
+    """
+
+    import runpy
+
+    from custom_components.googlefindmy import chrome_driver
+
+    calls: dict[str, Any] = {}
+
+    def boom(**kwargs: Any) -> Any:
+        calls.update(kwargs)
+        raise RuntimeError("no chrome in __main__ test")
+
+    monkeypatch.setattr(chrome_driver, "create_driver", boom)
+    monkeypatch.setitem(sys.modules, "homeassistant", object())
+    monkeypatch.setattr(sys, "argv", ["auth_flow.py"])
+
+    with pytest.raises(RuntimeError, match="no chrome in __main__ test"):
+        runpy.run_path(auth_flow.__file__, run_name="__main__")
+
+    assert calls == {
+        "chrome_path": None,
+        "chrome_version": None,
+        "headless": False,
+    }
 
 
 # Silence unused-import checks while keeping explicit references for clarity.

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 
 import importlib
 import logging
+import os
+import platform
+import subprocess
 import sys
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -272,3 +276,1251 @@ def test_strategy3_does_not_escalate_to_none_when_version_known(
     assert recorded_versions, "expected at least one uc.Chrome attempt"
     assert None not in recorded_versions
     assert all(version == 149 for version in recorded_versions)
+
+
+def test_module_import_with_webdriver_manager_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reload the module with stubbed webdriver-manager deps to cover the import-success block.
+
+    The optional ``webdriver_manager``/Selenium service imports normally fail in
+    this environment (``except ImportError`` path). Injecting lightweight stubs
+    into ``sys.modules`` and reloading exercises the success branch that records
+    the fallback classes. The module is reloaded again afterwards so the rest of
+    the suite observes the original (unavailable) state.
+    """
+
+    import types
+
+    class _StubChromeDriverManager:
+        def install(self) -> str:  # pragma: no cover - stub never invoked here
+            return "/driver"
+
+    wdm_chrome_mod = types.ModuleType("webdriver_manager.chrome")
+    wdm_chrome_mod.ChromeDriverManager = _StubChromeDriverManager  # type: ignore[attr-defined]
+    wdm_pkg = types.ModuleType("webdriver_manager")
+
+    monkeypatch.setitem(sys.modules, "webdriver_manager", wdm_pkg)
+    monkeypatch.setitem(sys.modules, "webdriver_manager.chrome", wdm_chrome_mod)
+
+    try:
+        importlib.reload(chrome_driver)
+        assert chrome_driver._WEBDRIVER_MANAGER_AVAILABLE is True
+        assert chrome_driver._chrome_driver_manager_cls is _StubChromeDriverManager
+    finally:
+        # Restore the real (import-failing) module state for later tests.
+        sys.modules.pop("webdriver_manager.chrome", None)
+        sys.modules.pop("webdriver_manager", None)
+        importlib.reload(chrome_driver)
+        assert chrome_driver._WEBDRIVER_MANAGER_AVAILABLE is False
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize the Chrome override env vars for deterministic resolution."""
+
+    monkeypatch.delenv("GOOGLEFINDMY_CHROME_PATH", raising=False)
+    monkeypatch.delenv("GOOGLEFINDMY_CHROME_VERSION", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _load_uc / _get_uc_module
+# ---------------------------------------------------------------------------
+
+
+def test_load_uc_falls_back_to_stub_on_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the real package is missing, ``_load_uc`` returns a stub namespace."""
+
+    def fake_import(name: str) -> Any:
+        raise ImportError("no undetected_chromedriver")
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    stub = chrome_driver._load_uc()
+
+    options = stub.ChromeOptions()
+    options.add_argument("--foo")
+    assert options.arguments == ["--foo"]
+    assert options.binary_location is None
+    with pytest.raises(RuntimeError, match="could not be imported"):
+        stub.Chrome(options=options)
+
+
+def test_get_uc_module_caches_loaded_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_get_uc_module`` loads via ``_load_uc`` once and then reuses the cache."""
+
+    sentinel = SimpleNamespace(name="cached")
+    calls = {"count": 0}
+
+    def fake_load() -> Any:
+        calls["count"] += 1
+        return sentinel
+
+    chrome_driver._reset_uc_cache(None)
+    monkeypatch.setattr(chrome_driver, "_load_uc", fake_load)
+
+    first = chrome_driver._get_uc_module()
+    second = chrome_driver._get_uc_module()
+
+    assert first is sentinel
+    assert second is sentinel
+    assert calls["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# get_chrome_version
+# ---------------------------------------------------------------------------
+
+
+def test_get_chrome_version_linux_parses_subprocess_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+    def fake_run(*args: Any, **kwargs: Any) -> Any:
+        return SimpleNamespace(stdout="Google Chrome 149.0.1234.56 ")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert chrome_driver.get_chrome_version("/usr/bin/chrome") == 149
+
+
+def test_get_chrome_version_linux_no_match_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: SimpleNamespace(stdout="no version here")
+    )
+
+    assert chrome_driver.get_chrome_version("/usr/bin/chrome") is None
+
+
+def test_get_chrome_version_subprocess_error_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+    def boom(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("cannot run chrome")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+
+    assert chrome_driver.get_chrome_version("/usr/bin/chrome") is None
+
+
+def test_get_chrome_version_windows_registry_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows path reads the version from a fake ``winreg`` module."""
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    class _FakeWinreg:
+        HKEY_CURRENT_USER = 1
+
+        @staticmethod
+        def OpenKey(root: Any, sub: str) -> Any:
+            return object()
+
+        @staticmethod
+        def QueryValueEx(key: Any, name: str) -> tuple[str, int]:
+            return "152.0.99.7", 1
+
+        @staticmethod
+        def CloseKey(key: Any) -> None:
+            return None
+
+    monkeypatch.setattr(chrome_driver, "_winreg", _FakeWinreg)
+
+    assert chrome_driver.get_chrome_version("C:/chrome.exe") == 152
+
+
+def test_get_chrome_version_windows_registry_failure_falls_back_to_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registry errors fall through to the ``--version`` subprocess on Windows."""
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    class _BrokenWinreg:
+        HKEY_CURRENT_USER = 1
+
+        @staticmethod
+        def OpenKey(root: Any, sub: str) -> Any:
+            raise OSError("registry unavailable")
+
+    monkeypatch.setattr(chrome_driver, "_winreg", _BrokenWinreg)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(stdout="Chrome 151.0.0.0"),
+    )
+
+    assert chrome_driver.get_chrome_version("C:/chrome.exe") == 151
+
+
+def test_get_chrome_version_windows_no_winreg_uses_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``_winreg`` is ``None`` on Windows, only the subprocess path runs."""
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(chrome_driver, "_winreg", None)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(stdout="Chrome 153.1.2.3"),
+    )
+
+    assert chrome_driver.get_chrome_version("C:/chrome.exe") == 153
+
+
+def test_get_chrome_version_windows_no_match_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(chrome_driver, "_winreg", None)
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: SimpleNamespace(stdout="nothing")
+    )
+
+    assert chrome_driver.get_chrome_version("C:/chrome.exe") is None
+
+
+# ---------------------------------------------------------------------------
+# _kill_existing_chrome_processes
+# ---------------------------------------------------------------------------
+
+
+def test_kill_existing_chrome_processes_non_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(chrome_driver.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        subprocess, "run", lambda cmd, **k: calls.append(cmd) or SimpleNamespace()
+    )
+
+    chrome_driver._kill_existing_chrome_processes()
+
+    assert calls == [["pkill", "-f", "chrome"]]
+
+
+def test_kill_existing_chrome_processes_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(chrome_driver.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        subprocess, "run", lambda cmd, **k: calls.append(cmd) or SimpleNamespace()
+    )
+
+    chrome_driver._kill_existing_chrome_processes()
+
+    assert calls == [["taskkill", "/f", "/im", "chrome.exe"]]
+
+
+# ---------------------------------------------------------------------------
+# find_chrome
+# ---------------------------------------------------------------------------
+
+
+def test_find_chrome_returns_existing_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    target = "/usr/bin/google-chrome"
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(os.path, "exists", lambda p: p == target)
+
+    assert chrome_driver.find_chrome() == target
+
+
+def test_find_chrome_uses_which_when_no_path_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(os.path, "exists", lambda _p: False)
+
+    def fake_which(name: str) -> str | None:
+        return "/snap/chromium" if name == "chromium" else None
+
+    monkeypatch.setattr(chrome_driver.shutil, "which", fake_which)
+
+    assert chrome_driver.find_chrome() == "/snap/chromium"
+
+
+def test_find_chrome_returns_none_when_nothing_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(os.path, "exists", lambda _p: False)
+    monkeypatch.setattr(chrome_driver.shutil, "which", lambda _n: None)
+
+    assert chrome_driver.find_chrome() is None
+
+
+def test_find_chrome_windows_which_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(os.path, "exists", lambda _p: False)
+
+    def fake_which(name: str) -> str | None:
+        return "C:/chrome.exe" if name == "chrome" else None
+
+    monkeypatch.setattr(chrome_driver.shutil, "which", fake_which)
+
+    assert chrome_driver.find_chrome() == "C:/chrome.exe"
+
+
+def test_find_chrome_windows_where_command_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(os.path, "exists", lambda _p: False)
+    monkeypatch.setattr(chrome_driver.shutil, "which", lambda _n: None)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(
+            returncode=0, stdout="C:/where/chrome.exe\nC:/other.exe"
+        ),
+    )
+
+    assert chrome_driver.find_chrome() == "C:/where/chrome.exe"
+
+
+def test_find_chrome_windows_where_nonzero_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero ``where`` return code falls through to ``None``."""
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(os.path, "exists", lambda _p: False)
+    monkeypatch.setattr(chrome_driver.shutil, "which", lambda _n: None)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout=""),
+    )
+
+    assert chrome_driver.find_chrome() is None
+
+
+def test_find_chrome_windows_where_command_failure_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(os.path, "exists", lambda _p: False)
+    monkeypatch.setattr(chrome_driver.shutil, "which", lambda _n: None)
+
+    def boom(*a: Any, **k: Any) -> Any:
+        raise OSError("where failed")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+
+    assert chrome_driver.find_chrome() is None
+
+
+# ---------------------------------------------------------------------------
+# get_driver
+# ---------------------------------------------------------------------------
+
+
+def test_get_driver_passes_resolved_version_and_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    fake_driver = object()
+
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+
+    def fake_chrome(
+        *, options: FakeChromeOptions, version_main: int | None = None, **kwargs: object
+    ) -> object:
+        captured["binary_location"] = options.binary_location
+        captured["version_main"] = version_main
+        return fake_driver
+
+    monkeypatch.setattr(uc_module, "Chrome", fake_chrome)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: 140)
+
+    driver = chrome_driver.get_driver("/opt/chrome", chrome_version=149)
+
+    assert driver is fake_driver
+    assert captured["binary_location"] == "/opt/chrome"
+    # Explicit version wins over the detected one.
+    assert captured["version_main"] == 149
+
+
+def test_get_driver_without_path_uses_detected_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    fake_driver = object()
+
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+
+    def fake_chrome(
+        *, options: FakeChromeOptions, version_main: int | None = None, **kwargs: object
+    ) -> object:
+        captured["binary_location"] = options.binary_location
+        captured["version_main"] = version_main
+        return fake_driver
+
+    monkeypatch.setattr(uc_module, "Chrome", fake_chrome)
+
+    chrome_driver.get_driver(None)
+
+    assert captured["binary_location"] is None
+    assert captured["version_main"] is None
+
+
+# ---------------------------------------------------------------------------
+# _try_webdriver_manager_fallback
+# ---------------------------------------------------------------------------
+
+
+def test_webdriver_manager_fallback_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
+    assert chrome_driver._try_webdriver_manager_fallback() is None
+
+
+def test_webdriver_manager_fallback_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_driver = object()
+
+    class _FakeOptions:
+        def __init__(self) -> None:
+            self.arguments: list[str] = []
+
+        def add_argument(self, arg: str) -> None:
+            self.arguments.append(arg)
+
+    fake_webdriver = SimpleNamespace(
+        ChromeOptions=_FakeOptions,
+        Chrome=lambda *, service, options: fake_driver,
+    )
+
+    monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", True)
+    monkeypatch.setattr(chrome_driver, "_selenium_webdriver", fake_webdriver)
+    monkeypatch.setattr(
+        chrome_driver, "_chrome_service_cls", lambda path: SimpleNamespace(path=path)
+    )
+    monkeypatch.setattr(
+        chrome_driver,
+        "_chrome_driver_manager_cls",
+        lambda: SimpleNamespace(install=lambda: "/driver"),
+    )
+
+    assert chrome_driver._try_webdriver_manager_fallback() is fake_driver
+
+
+def test_webdriver_manager_fallback_failure_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", True)
+
+    def boom() -> Any:
+        raise RuntimeError("manager install failed")
+
+    monkeypatch.setattr(chrome_driver, "_chrome_driver_manager_cls", boom)
+
+    assert chrome_driver._try_webdriver_manager_fallback() is None
+
+
+# ---------------------------------------------------------------------------
+# safe_quit_driver / _quit_driver
+# ---------------------------------------------------------------------------
+
+
+def test_safe_quit_driver_none_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No subprocess should be invoked for a ``None`` driver.
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: pytest.fail("should not run")
+    )
+    chrome_driver.safe_quit_driver(None)
+
+
+def test_safe_quit_driver_normal_non_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        subprocess, "run", lambda cmd, **k: calls.append(cmd) or SimpleNamespace()
+    )
+
+    quit_calls = {"n": 0}
+
+    class _Driver:
+        def quit(self) -> None:
+            quit_calls["n"] += 1
+
+    chrome_driver.safe_quit_driver(_Driver())  # type: ignore[arg-type]
+
+    assert quit_calls["n"] == 1
+    assert calls == [["pkill", "-f", "chromedriver"]]
+
+
+def test_safe_quit_driver_oserror_is_handled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        subprocess, "run", lambda cmd, **k: calls.append(cmd) or SimpleNamespace()
+    )
+
+    class _Driver:
+        def quit(self) -> None:
+            raise OSError("WinError 6")
+
+    chrome_driver.safe_quit_driver(_Driver())  # type: ignore[arg-type]
+
+    assert calls == [["taskkill", "/f", "/im", "chromedriver.exe"]]
+
+
+def test_safe_quit_driver_other_exception_is_handled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: SimpleNamespace())
+
+    class _Driver:
+        def quit(self) -> None:
+            raise RuntimeError("boom")
+
+    # Must not raise.
+    chrome_driver.safe_quit_driver(_Driver())  # type: ignore[arg-type]
+
+
+def test_safe_quit_driver_swallows_cleanup_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+    class _Driver:
+        def quit(self) -> None:
+            return None
+
+    def boom(*a: Any, **k: Any) -> Any:
+        raise OSError("pkill missing")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+
+    # The cleanup subprocess error is swallowed by the inner try/except.
+    chrome_driver.safe_quit_driver(_Driver())  # type: ignore[arg-type]
+
+
+def test_quit_driver_none_is_noop() -> None:
+    chrome_driver._quit_driver(None)
+
+
+def test_quit_driver_suppresses_quit_error() -> None:
+    class _Driver:
+        def quit(self) -> None:
+            raise RuntimeError("boom")
+
+    chrome_driver._quit_driver(_Driver())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _parse_env_version
+# ---------------------------------------------------------------------------
+
+
+def test_parse_env_version_none() -> None:
+    assert chrome_driver._parse_env_version(None) is None
+
+
+def test_parse_env_version_empty_and_whitespace() -> None:
+    assert chrome_driver._parse_env_version("") is None
+    assert chrome_driver._parse_env_version("   ") is None
+
+
+def test_parse_env_version_valid_int() -> None:
+    assert chrome_driver._parse_env_version("149") == 149
+    assert chrome_driver._parse_env_version("  150  ") == 150
+
+
+def test_parse_env_version_invalid_warns_and_returns_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    assert chrome_driver._parse_env_version("abc") is None
+    assert "Ignoring invalid" in " ".join(caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_chrome_version / _resolve_chrome_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("explicit", "env_raw", "detected", "expected"),
+    [
+        (149, "150", 151, (149, "cli")),
+        (None, "150", 151, (150, "env")),
+        (None, None, 151, (151, "auto")),
+        (None, "  ", 151, (151, "auto")),
+        (None, "bad", 151, (151, "auto")),
+        (None, None, None, (None, "none")),
+    ],
+)
+def test_resolve_chrome_version_precedence(
+    explicit: int | None,
+    env_raw: str | None,
+    detected: int | None,
+    expected: tuple[int | None, str],
+) -> None:
+    assert (
+        chrome_driver._resolve_chrome_version(
+            explicit=explicit, env_raw=env_raw, detected=detected
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("explicit", "env_raw", "detected", "expected"),
+    [
+        ("/cli", "/env", "/auto", ("/cli", "cli")),
+        (None, "/env", "/auto", ("/env", "env")),
+        (None, "  /env  ", "/auto", ("/env", "env")),
+        (None, "   ", "/auto", ("/auto", "auto")),
+        (None, None, "/auto", ("/auto", "auto")),
+        (None, None, None, (None, "none")),
+    ],
+)
+def test_resolve_chrome_path_precedence(
+    explicit: str | None,
+    env_raw: str | None,
+    detected: str | None,
+    expected: tuple[str | None, str],
+) -> None:
+    assert (
+        chrome_driver._resolve_chrome_path(
+            explicit=explicit, env_raw=env_raw, detected=detected
+        )
+        == expected
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_file_lock_error / _is_version_mismatch_error / _log_version_mismatch_hint
+# ---------------------------------------------------------------------------
+
+
+def test_is_file_lock_error() -> None:
+    assert chrome_driver._is_file_lock_error(OSError("WinError 32 something"))
+    assert chrome_driver._is_file_lock_error(OSError("WinError 183"))
+    assert not chrome_driver._is_file_lock_error(OSError("other"))
+
+
+def test_is_version_mismatch_error() -> None:
+    assert chrome_driver._is_version_mismatch_error(
+        RuntimeError("only supports Chrome version 150")
+    )
+    assert not chrome_driver._is_version_mismatch_error(RuntimeError("nope"))
+
+
+def test_log_version_mismatch_hint_noop_for_non_mismatch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    chrome_driver._log_version_mismatch_hint(
+        RuntimeError("unrelated"),
+        detected_version=149,
+        resolved_version=150,
+        version_source="cli",
+    )
+    assert caplog.messages == []
+
+
+def test_log_version_mismatch_hint_noop_for_none(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    chrome_driver._log_version_mismatch_hint(
+        None, detected_version=None, resolved_version=None, version_source="none"
+    )
+    assert caplog.messages == []
+
+
+def test_log_version_mismatch_hint_emits_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR)
+    chrome_driver._log_version_mismatch_hint(
+        RuntimeError("only supports Chrome version 150"),
+        detected_version=None,
+        resolved_version=None,
+        version_source="auto",
+    )
+    joined = " ".join(caplog.messages)
+    assert "version mismatch" in joined.lower()
+    assert "Unknown" in joined
+
+
+# ---------------------------------------------------------------------------
+# Strategy helpers (failure return contracts)
+# ---------------------------------------------------------------------------
+
+
+def _install_failing_chrome(monkeypatch: pytest.MonkeyPatch) -> None:
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+
+    def chrome_stub(
+        *, options: FakeChromeOptions, version_main: int | None = None, **kwargs: object
+    ) -> object:
+        raise SentinelError("strategy failed")
+
+    monkeypatch.setattr(uc_module, "Chrome", chrome_stub)
+
+
+def test_strategy_default_failure_returns_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_failing_chrome(monkeypatch)
+    driver, error = chrome_driver._try_strategy_default(
+        resolved_path="/opt/chrome", version_main=149, headless=False
+    )
+    assert driver is None
+    assert isinstance(error, SentinelError)
+
+
+def test_strategy_explicit_path_failure_returns_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_failing_chrome(monkeypatch)
+    driver, error = chrome_driver._try_strategy_explicit_path(
+        resolved_path="/opt/chrome", version_main=149, headless=True
+    )
+    assert driver is None
+    assert isinstance(error, SentinelError)
+
+
+def test_strategy_no_version_failure_returns_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_failing_chrome(monkeypatch)
+    driver, error = chrome_driver._try_strategy_no_version(
+        resolved_path=None, headless=True
+    )
+    assert driver is None
+    assert isinstance(error, SentinelError)
+
+
+def test_strategy_headless_failure_returns_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_failing_chrome(monkeypatch)
+    driver, error = chrome_driver._try_strategy_headless(
+        resolved_path=None, version_main=149
+    )
+    assert driver is None
+    assert isinstance(error, SentinelError)
+
+
+def test_strategy_default_success_without_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_driver = object()
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+    monkeypatch.setattr(
+        uc_module, "Chrome", lambda *, options, version_main=None, **k: fake_driver
+    )
+
+    driver, error = chrome_driver._try_strategy_default(
+        resolved_path=None, version_main=None, headless=False
+    )
+    assert driver is fake_driver
+    assert error is None
+
+
+def test_strategy_explicit_path_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_driver = object()
+    captured: dict[str, Any] = {}
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+
+    def fake_chrome(
+        *, options: Any, version_main: int | None = None, **kwargs: object
+    ) -> object:
+        captured["version_main"] = version_main
+        captured["browser_executable_path"] = kwargs.get("browser_executable_path")
+        return fake_driver
+
+    monkeypatch.setattr(uc_module, "Chrome", fake_chrome)
+
+    driver, error = chrome_driver._try_strategy_explicit_path(
+        resolved_path="/opt/chrome", version_main=149, headless=False
+    )
+    assert driver is fake_driver
+    assert error is None
+    assert captured == {
+        "version_main": 149,
+        "browser_executable_path": "/opt/chrome",
+    }
+
+
+def test_strategy_no_version_success_with_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_driver = object()
+    captured: dict[str, Any] = {}
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+
+    def fake_chrome(*, options: Any, version_main: int | None = None, **k: object) -> object:
+        captured["binary"] = options.binary_location
+        captured["version_main"] = version_main
+        return fake_driver
+
+    monkeypatch.setattr(uc_module, "Chrome", fake_chrome)
+
+    driver, error = chrome_driver._try_strategy_no_version(
+        resolved_path="/opt/chrome", headless=True
+    )
+    assert driver is fake_driver
+    assert error is None
+    assert captured == {"binary": "/opt/chrome", "version_main": None}
+
+
+def test_strategy_headless_success_with_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_driver = object()
+    captured: dict[str, Any] = {}
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+
+    def fake_chrome(*, options: Any, version_main: int | None = None, **k: object) -> object:
+        captured["binary"] = options.binary_location
+        captured["headless"] = "--headless" in options.arguments
+        return fake_driver
+
+    monkeypatch.setattr(uc_module, "Chrome", fake_chrome)
+
+    driver, error = chrome_driver._try_strategy_headless(
+        resolved_path="/opt/chrome", version_main=149
+    )
+    assert driver is fake_driver
+    assert error is None
+    assert captured == {"binary": "/opt/chrome", "headless": True}
+
+
+# ---------------------------------------------------------------------------
+# Resolver behavior in _create_driver_inner (precedence / env / overrides)
+# ---------------------------------------------------------------------------
+
+
+def _stub_uc_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    """Install a UC stub that records every Chrome call and returns a driver."""
+
+    records: list[dict[str, Any]] = []
+    fake_driver = object()
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+
+    def fake_chrome(
+        *, options: FakeChromeOptions, version_main: int | None = None, **kwargs: object
+    ) -> object:
+        records.append(
+            {
+                "version_main": version_main,
+                "binary_location": options.binary_location,
+                "browser_executable_path": kwargs.get("browser_executable_path"),
+            }
+        )
+        return fake_driver
+
+    monkeypatch.setattr(uc_module, "Chrome", fake_chrome)
+    monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
+    return records
+
+
+@pytest.mark.parametrize(
+    ("explicit", "env", "detected", "expected_version"),
+    [
+        (149, "150", 151, 149),  # explicit beats env
+        (None, "150", 151, 150),  # env beats auto
+        (None, None, 151, 151),  # auto
+    ],
+)
+def test_version_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    explicit: int | None,
+    env: str | None,
+    detected: int | None,
+    expected_version: int,
+) -> None:
+    records = _stub_uc_capture(monkeypatch)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/opt/chrome")
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: detected)
+    if env is not None:
+        monkeypatch.setenv("GOOGLEFINDMY_CHROME_VERSION", env)
+
+    chrome_driver.create_driver(chrome_version=explicit, headless=True)
+
+    assert records[0]["version_main"] == expected_version
+
+
+@pytest.mark.parametrize(
+    ("explicit", "env", "detected", "expected_path"),
+    [
+        ("/cli", "/env", "/auto", "/cli"),
+        (None, "/env", "/auto", "/env"),
+        (None, None, "/auto", "/auto"),
+    ],
+)
+def test_path_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+    explicit: str | None,
+    env: str | None,
+    detected: str | None,
+    expected_path: str,
+) -> None:
+    records = _stub_uc_capture(monkeypatch)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: detected)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    if env is not None:
+        monkeypatch.setenv("GOOGLEFINDMY_CHROME_PATH", env)
+
+    chrome_driver.create_driver(chrome_path=explicit, headless=True)
+
+    assert records[0]["binary_location"] == expected_path
+
+
+def test_strategy3_passes_none_only_when_unresolvable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no resolvable version, strategy 3 (version_main=None) is appended."""
+
+    versions: list[int | None] = []
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+
+    def chrome_stub(
+        *, options: FakeChromeOptions, version_main: int | None = None, **kwargs: object
+    ) -> object:
+        versions.append(version_main)
+        raise SentinelError("fail")
+
+    monkeypatch.setattr(uc_module, "Chrome", chrome_stub)
+    monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
+
+    with pytest.raises(RuntimeError):
+        chrome_driver.create_driver(headless=True)
+
+    # No path, no version: strategies 1 and 3 run, both with version_main=None.
+    assert versions == [None, None]
+
+
+def test_version_override_without_path_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An explicit version with no resolvable path logs a warning and is used."""
+
+    caplog.set_level(logging.WARNING)
+    records = _stub_uc_capture(monkeypatch)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+
+    chrome_driver.create_driver(chrome_version=149, headless=True)
+
+    assert records[0]["version_main"] == 149
+    assert records[0]["binary_location"] is None
+    assert "Chrome version override is set" in " ".join(caplog.messages)
+
+
+def test_env_var_applied_without_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``create_driver()`` with no args picks up both env overrides."""
+
+    records = _stub_uc_capture(monkeypatch)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setenv("GOOGLEFINDMY_CHROME_PATH", "/env/chrome")
+    monkeypatch.setenv("GOOGLEFINDMY_CHROME_VERSION", "148")
+
+    chrome_driver.create_driver(headless=True)
+
+    assert records[0]["binary_location"] == "/env/chrome"
+    assert records[0]["version_main"] == 148
+
+
+def test_invalid_env_version_warns_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING)
+    records = _stub_uc_capture(monkeypatch)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/opt/chrome")
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: 151)
+    monkeypatch.setenv("GOOGLEFINDMY_CHROME_VERSION", "garbage")
+
+    chrome_driver.create_driver(headless=True)
+
+    # Invalid env is ignored; detected version (auto) is used instead.
+    assert records[0]["version_main"] == 151
+    assert "Ignoring invalid" in " ".join(caplog.messages)
+
+
+def test_empty_env_version_treated_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = _stub_uc_capture(monkeypatch)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/opt/chrome")
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: 151)
+    monkeypatch.setenv("GOOGLEFINDMY_CHROME_VERSION", "   ")
+
+    chrome_driver.create_driver(headless=True)
+
+    assert records[0]["version_main"] == 151
+
+
+def test_final_error_message_contains_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+    monkeypatch.setattr(
+        uc_module,
+        "Chrome",
+        lambda *, options, version_main=None, **k: (_ for _ in ()).throw(
+            SentinelError("nope")
+        ),
+    )
+    monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        chrome_driver.create_driver(headless=True)
+
+    message = str(excinfo.value)
+    assert "detected:" in message
+    assert "requested/used:" in message
+    assert "source:" in message
+
+
+def test_final_error_logs_version_mismatch_hint(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.ERROR)
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+    monkeypatch.setattr(
+        uc_module,
+        "Chrome",
+        lambda *, options, version_main=None, **k: (_ for _ in ()).throw(
+            SentinelError("only supports Chrome version 150")
+        ),
+    )
+    monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
+
+    with pytest.raises(RuntimeError):
+        chrome_driver.create_driver(headless=True)
+
+    assert "version mismatch" in " ".join(caplog.messages).lower()
+
+
+def test_create_driver_uses_webdriver_manager_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fallback_driver = object()
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+    monkeypatch.setattr(
+        uc_module,
+        "Chrome",
+        lambda *, options, version_main=None, **k: (_ for _ in ()).throw(
+            SentinelError("nope")
+        ),
+    )
+    monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(
+        chrome_driver, "_try_webdriver_manager_fallback", lambda: fallback_driver
+    )
+
+    assert chrome_driver.create_driver(headless=True) is fallback_driver
+
+
+def test_get_driver_invariant_with_and_without_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[int | None] = []
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+    monkeypatch.setattr(
+        uc_module,
+        "Chrome",
+        lambda *, options, version_main=None, **k: captured.append(version_main)
+        or object(),
+    )
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: 151)
+
+    chrome_driver.get_driver("/opt/chrome", chrome_version=149)
+    chrome_driver.get_driver("/opt/chrome")
+
+    assert captured == [149, 151]
+
+
+# ---------------------------------------------------------------------------
+# create_driver retry loop (PermissionError / RuntimeError)
+# ---------------------------------------------------------------------------
+
+
+def test_create_driver_retries_on_file_lock_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_driver = object()
+    state = {"attempts": 0}
+
+    def fake_inner(**kwargs: Any) -> Any:
+        state["attempts"] += 1
+        if state["attempts"] == 1:
+            raise PermissionError("WinError 32 file in use")
+        return fake_driver
+
+    monkeypatch.setattr(chrome_driver, "_create_driver_inner", fake_inner)
+    monkeypatch.setattr(chrome_driver.time, "sleep", lambda _s: None)
+
+    assert chrome_driver.create_driver() is fake_driver
+    assert state["attempts"] == 2
+
+
+def test_create_driver_non_file_lock_oserror_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_inner(**kwargs: Any) -> Any:
+        raise OSError("some other failure")
+
+    monkeypatch.setattr(chrome_driver, "_create_driver_inner", fake_inner)
+    monkeypatch.setattr(chrome_driver.time, "sleep", lambda _s: None)
+
+    with pytest.raises(OSError, match="some other failure"):
+        chrome_driver.create_driver()
+
+
+def test_create_driver_file_lock_exhausts_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_inner(**kwargs: Any) -> Any:
+        raise PermissionError("WinError 32 still locked")
+
+    monkeypatch.setattr(chrome_driver, "_create_driver_inner", fake_inner)
+    monkeypatch.setattr(chrome_driver.time, "sleep", lambda _s: None)
+
+    with pytest.raises(PermissionError):
+        chrome_driver.create_driver()
+
+
+def test_create_driver_runtime_error_retries_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_driver = object()
+    state = {"attempts": 0}
+
+    def fake_inner(**kwargs: Any) -> Any:
+        state["attempts"] += 1
+        if state["attempts"] == 1:
+            raise RuntimeError("all strategies failed")
+        return fake_driver
+
+    monkeypatch.setattr(chrome_driver, "_create_driver_inner", fake_inner)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(chrome_driver.time, "sleep", lambda _s: None)
+
+    assert chrome_driver.create_driver() is fake_driver
+    assert state["attempts"] == 2
+
+
+def test_create_driver_runtime_error_non_windows_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_inner(**kwargs: Any) -> Any:
+        raise RuntimeError("all strategies failed")
+
+    monkeypatch.setattr(chrome_driver, "_create_driver_inner", fake_inner)
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(chrome_driver.time, "sleep", lambda _s: None)
+
+    with pytest.raises(RuntimeError, match="all strategies failed"):
+        chrome_driver.create_driver()
+
+
+def test_create_driver_inner_strategy_returns_no_driver_no_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A strategy yielding ``(None, None)`` loops on without recording an error.
+
+    This pins the ``error is None`` branch of the attempt loop: the first
+    strategy reports neither a driver nor an error, so the loop continues to the
+    next attempt without flipping ``all_file_lock`` or storing ``last_error``.
+    """
+
+    fake_driver = object()
+    monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(
+        chrome_driver,
+        "_try_strategy_default",
+        lambda **kwargs: (None, None),
+    )
+    # Strategy 3 (no version) succeeds and short-circuits the rest.
+    monkeypatch.setattr(
+        chrome_driver,
+        "_try_strategy_no_version",
+        lambda **kwargs: (fake_driver, None),
+    )
+
+    assert chrome_driver._create_driver_inner(headless=True) is fake_driver
+
+
+def test_create_driver_inner_all_file_lock_raises_permission_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All strategies failing with WinError 32 on Windows raises PermissionError."""
+
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+    monkeypatch.setattr(
+        uc_module,
+        "Chrome",
+        lambda *, options, version_main=None, **k: (_ for _ in ()).throw(
+            OSError("WinError 32 file in use")
+        ),
+    )
+    monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    with pytest.raises(PermissionError, match="file lock"):
+        chrome_driver._create_driver_inner(headless=True)

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -231,25 +231,19 @@ def test_create_driver_headless_fallback_on_non_headless_mode(
     assert "Strategy 4 (headless) failed" in " ".join(caplog.messages)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="characterizes Strategy-3 None-escalation bug; flips to GREEN in AP2",
-)
-def test_strategy3_escalates_to_none_when_strategy1_raises(
+def test_strategy3_does_not_escalate_to_none_when_version_known(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Characterize the Strategy-3 ``version_main=None`` escalation bug.
+    """No uc.Chrome attempt may pass ``version_main=None`` when a version is known.
 
-    When Strategy 1 and Strategy 2 fail transiently but a Chrome version was
-    detected (149), the current code reaches Strategy 3, which hardcodes
-    ``version_main=None``. undetected-chromedriver then fetches the latest
-    stable driver (e.g. 150) instead of the detected 149, causing a hard
-    version-mismatch abort.
+    With Chrome 149 detected, every ``Chrome(...)`` call must carry
+    ``version_main=149``. The old code reached Strategy 3 and hardcoded
+    ``version_main=None``, making undetected-chromedriver fetch the latest
+    stable driver (e.g. 150) and abort with a version mismatch.
 
-    This test pins the desired behavior: no ``Chrome(...)`` call may pass
-    ``version_main=None`` while a version is known. It is marked ``xfail``
-    here because the fix lands in AP2; the marker is removed there so the test
-    flips to a hard GREEN in the same commit as the fix.
+    All attempts are forced to fail so we can inspect every recorded
+    ``version_main`` regardless of which strategy would otherwise succeed; the
+    assertion is design-agnostic (it pins the invariant, not the call count).
     """
 
     recorded_versions: list[int | None] = []
@@ -258,28 +252,23 @@ def test_strategy3_escalates_to_none_when_strategy1_raises(
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/opt/chrome")
     monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _: 149)
     monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
-
-    fake_driver = object()
+    monkeypatch.delenv("GOOGLEFINDMY_CHROME_PATH", raising=False)
+    monkeypatch.delenv("GOOGLEFINDMY_CHROME_VERSION", raising=False)
 
     def chrome_stub(
         *, options: FakeChromeOptions, version_main: int | None = None, **kwargs: object
     ) -> object:
         recorded_versions.append(version_main)
-        # Strategy 1 and Strategy 2 fail transiently; Strategy 3 (third call)
-        # succeeds, so the loop returns the fake driver from Strategy 3.
-        if len(recorded_versions) < 3:
-            raise SentinelError("transient driver start failure")
-        return fake_driver
+        raise SentinelError("driver start failure")
 
     uc_module = chrome_driver._get_uc_module()
     monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
     monkeypatch.setattr(uc_module, "Chrome", chrome_stub)
 
-    driver = chrome_driver.create_driver(headless=True)
+    with pytest.raises(RuntimeError):
+        chrome_driver.create_driver(headless=True)
 
-    assert driver is fake_driver
-    # The third call is Strategy 3. Against today's code it records ``None``.
-    assert recorded_versions[-1] == 149, (
-        "Strategy 3 must reuse the detected version, not escalate to None"
-    )
+    # Core invariant: not a single attempt may use None while 149 is known.
+    assert recorded_versions, "expected at least one uc.Chrome attempt"
     assert None not in recorded_versions
+    assert all(version == 149 for version in recorded_versions)

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -229,3 +229,57 @@ def test_create_driver_headless_fallback_on_non_headless_mode(
     assert chrome_calls[3].binary_location == "/opt/chrome"
     assert "--headless" in chrome_calls[3].arguments
     assert "Strategy 4 (headless) failed" in " ".join(caplog.messages)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="characterizes Strategy-3 None-escalation bug; flips to GREEN in AP2",
+)
+def test_strategy3_escalates_to_none_when_strategy1_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Characterize the Strategy-3 ``version_main=None`` escalation bug.
+
+    When Strategy 1 and Strategy 2 fail transiently but a Chrome version was
+    detected (149), the current code reaches Strategy 3, which hardcodes
+    ``version_main=None``. undetected-chromedriver then fetches the latest
+    stable driver (e.g. 150) instead of the detected 149, causing a hard
+    version-mismatch abort.
+
+    This test pins the desired behavior: no ``Chrome(...)`` call may pass
+    ``version_main=None`` while a version is known. It is marked ``xfail``
+    here because the fix lands in AP2; the marker is removed there so the test
+    flips to a hard GREEN in the same commit as the fix.
+    """
+
+    recorded_versions: list[int | None] = []
+
+    monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/opt/chrome")
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _: 149)
+    monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
+
+    fake_driver = object()
+
+    def chrome_stub(
+        *, options: FakeChromeOptions, version_main: int | None = None, **kwargs: object
+    ) -> object:
+        recorded_versions.append(version_main)
+        # Strategy 1 and Strategy 2 fail transiently; Strategy 3 (third call)
+        # succeeds, so the loop returns the fake driver from Strategy 3.
+        if len(recorded_versions) < 3:
+            raise SentinelError("transient driver start failure")
+        return fake_driver
+
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+    monkeypatch.setattr(uc_module, "Chrome", chrome_stub)
+
+    driver = chrome_driver.create_driver(headless=True)
+
+    assert driver is fake_driver
+    # The third call is Strategy 3. Against today's code it records ``None``.
+    assert recorded_versions[-1] == 149, (
+        "Strategy 3 must reuse the detected version, not escalate to None"
+    )
+    assert None not in recorded_versions

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -149,7 +149,7 @@ def test_create_driver_fallback_logs_and_raises_runtime_error(
     # Mock _kill_existing_chrome_processes to avoid actual process killing
     monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
     # Mock get_chrome_version to return None (can't detect version)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _, **_k: None)
     # Disable webdriver-manager fallback
     monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
 
@@ -202,7 +202,7 @@ def test_create_driver_headless_fallback_on_non_headless_mode(
     # Mock _kill_existing_chrome_processes to avoid actual process killing
     monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
     # Mock get_chrome_version to return None (can't detect version)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _, **_k: None)
     # Disable webdriver-manager fallback
     monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
 
@@ -254,7 +254,7 @@ def test_strategy3_does_not_escalate_to_none_when_version_known(
 
     monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/opt/chrome")
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _: 149)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _, **_k: 149)
     monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
     monkeypatch.delenv("GOOGLEFINDMY_CHROME_PATH", raising=False)
     monkeypatch.delenv("GOOGLEFINDMY_CHROME_VERSION", raising=False)
@@ -492,6 +492,54 @@ def test_get_chrome_version_windows_no_match_returns_none(
     assert chrome_driver.get_chrome_version("C:/chrome.exe") is None
 
 
+def test_get_chrome_version_windows_prefer_binary_skips_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``prefer_binary=True`` bypasses the registry and queries the binary.
+
+    The registry reports the registered default Chrome. For an explicit/env
+    path override the overridden binary may carry a different version, so the
+    binary's own ``--version`` must win. The fake ``winreg`` raises if touched,
+    proving the registry branch is skipped entirely.
+    """
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    class _DefaultWinreg:
+        """Registry that successfully reports the registered default Chrome (152)."""
+
+        HKEY_CURRENT_USER = 1
+
+        @staticmethod
+        def OpenKey(root: Any, sub: str) -> Any:
+            return object()
+
+        @staticmethod
+        def QueryValueEx(key: Any, name: str) -> tuple[str, int]:
+            return "152.0.99.7", 1
+
+        @staticmethod
+        def CloseKey(key: Any) -> None:
+            return None
+
+    monkeypatch.setattr(chrome_driver, "_winreg", _DefaultWinreg)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(stdout="Chrome 149.0.7827.155"),
+    )
+
+    # The registry would have returned the default 152; with prefer_binary the
+    # overridden binary's own version (149) must win instead. Without the skip
+    # this would return 152, so the assertion is mutation-sharp.
+    assert (
+        chrome_driver.get_chrome_version(
+            "C:/portable/chrome.exe", prefer_binary=True
+        )
+        == 149
+    )
+
+
 # ---------------------------------------------------------------------------
 # _kill_existing_chrome_processes
 # ---------------------------------------------------------------------------
@@ -647,7 +695,7 @@ def test_get_driver_passes_resolved_version_and_binary(
         return fake_driver
 
     monkeypatch.setattr(uc_module, "Chrome", fake_chrome)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: 140)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: 140)
 
     driver = chrome_driver.get_driver("/opt/chrome", chrome_version=149)
 
@@ -679,6 +727,36 @@ def test_get_driver_without_path_uses_detected_none(
 
     assert captured["binary_location"] is None
     assert captured["version_main"] is None
+
+
+def test_get_driver_detects_explicit_binary_with_prefer_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``get_driver`` always queries an explicit path binary directly.
+
+    The ``chrome_path`` argument here is always an explicit override, so the
+    call site must pass ``prefer_binary=True`` to bypass the Windows registry.
+    """
+
+    captured: dict[str, Any] = {}
+    uc_module = chrome_driver._get_uc_module()
+    monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)
+    monkeypatch.setattr(
+        uc_module,
+        "Chrome",
+        lambda *, options, version_main=None, **kwargs: object(),
+    )
+
+    def spy(path: str, *, prefer_binary: bool = False) -> int:
+        captured["path"] = path
+        captured["prefer_binary"] = prefer_binary
+        return 149
+
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", spy)
+
+    chrome_driver.get_driver("/opt/portable/chrome")
+
+    assert captured == {"path": "/opt/portable/chrome", "prefer_binary": True}
 
 
 # ---------------------------------------------------------------------------
@@ -1172,7 +1250,7 @@ def test_version_precedence(
 ) -> None:
     records = _stub_uc_capture(monkeypatch)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/opt/chrome")
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: detected)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: detected)
     if env is not None:
         monkeypatch.setenv("GOOGLEFINDMY_CHROME_VERSION", env)
 
@@ -1198,13 +1276,51 @@ def test_path_precedence(
 ) -> None:
     records = _stub_uc_capture(monkeypatch)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: detected)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: None)
     if env is not None:
         monkeypatch.setenv("GOOGLEFINDMY_CHROME_PATH", env)
 
     chrome_driver.create_driver(chrome_path=explicit, headless=True)
 
     assert records[0]["binary_location"] == expected_path
+
+
+@pytest.mark.parametrize(
+    ("explicit", "env", "expected_prefer"),
+    [
+        ("/cli/chrome", None, True),  # explicit override -> query binary
+        (None, "/env/chrome", True),  # env override -> query binary
+        (None, None, False),  # auto-detected -> registry-first preserved
+    ],
+)
+def test_prefer_binary_follows_path_source(
+    monkeypatch: pytest.MonkeyPatch,
+    explicit: str | None,
+    env: str | None,
+    expected_prefer: bool,
+) -> None:
+    """The version lookup bypasses the registry only for explicit/env paths.
+
+    Auto-detected paths keep ``prefer_binary=False`` (registry-first), while an
+    explicit CLI argument or the env override must set ``prefer_binary=True`` so
+    the overridden binary's own version is detected.
+    """
+
+    _stub_uc_capture(monkeypatch)
+    captured: dict[str, bool] = {}
+    monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/auto/chrome")
+
+    def spy(path: str, *, prefer_binary: bool = False) -> int:
+        captured["prefer_binary"] = prefer_binary
+        return 149
+
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", spy)
+    if env is not None:
+        monkeypatch.setenv("GOOGLEFINDMY_CHROME_PATH", env)
+
+    chrome_driver.create_driver(chrome_path=explicit, headless=True)
+
+    assert captured["prefer_binary"] is expected_prefer
 
 
 def test_strategy3_passes_none_only_when_unresolvable(
@@ -1225,7 +1341,7 @@ def test_strategy3_passes_none_only_when_unresolvable(
     monkeypatch.setattr(uc_module, "Chrome", chrome_stub)
     monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: None)
     monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
 
     with pytest.raises(RuntimeError):
@@ -1243,7 +1359,7 @@ def test_version_override_without_path_warns(
     caplog.set_level(logging.WARNING)
     records = _stub_uc_capture(monkeypatch)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: None)
 
     chrome_driver.create_driver(chrome_version=149, headless=True)
 
@@ -1257,7 +1373,7 @@ def test_env_var_applied_without_cli(monkeypatch: pytest.MonkeyPatch) -> None:
 
     records = _stub_uc_capture(monkeypatch)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: None)
     monkeypatch.setenv("GOOGLEFINDMY_CHROME_PATH", "/env/chrome")
     monkeypatch.setenv("GOOGLEFINDMY_CHROME_VERSION", "148")
 
@@ -1273,7 +1389,7 @@ def test_invalid_env_version_warns_and_falls_back(
     caplog.set_level(logging.WARNING)
     records = _stub_uc_capture(monkeypatch)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/opt/chrome")
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: 151)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: 151)
     monkeypatch.setenv("GOOGLEFINDMY_CHROME_VERSION", "garbage")
 
     chrome_driver.create_driver(headless=True)
@@ -1288,7 +1404,7 @@ def test_empty_env_version_treated_as_unset(
 ) -> None:
     records = _stub_uc_capture(monkeypatch)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: "/opt/chrome")
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: 151)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: 151)
     monkeypatch.setenv("GOOGLEFINDMY_CHROME_VERSION", "   ")
 
     chrome_driver.create_driver(headless=True)
@@ -1310,7 +1426,7 @@ def test_final_error_message_contains_provenance(
     )
     monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: None)
     monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
 
     with pytest.raises(RuntimeError) as excinfo:
@@ -1337,7 +1453,7 @@ def test_final_error_logs_version_mismatch_hint(
     )
     monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: None)
     monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
 
     with pytest.raises(RuntimeError):
@@ -1361,7 +1477,7 @@ def test_create_driver_uses_webdriver_manager_fallback(
     )
     monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: None)
     monkeypatch.setattr(
         chrome_driver, "_try_webdriver_manager_fallback", lambda: fallback_driver
     )
@@ -1381,7 +1497,7 @@ def test_get_driver_invariant_with_and_without_version(
         lambda *, options, version_main=None, **k: captured.append(version_main)
         or object(),
     )
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: 151)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: 151)
 
     chrome_driver.get_driver("/opt/chrome", chrome_version=149)
     chrome_driver.get_driver("/opt/chrome")
@@ -1486,7 +1602,7 @@ def test_create_driver_inner_strategy_returns_no_driver_no_error(
     fake_driver = object()
     monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: None)
     monkeypatch.setattr(
         chrome_driver,
         "_try_strategy_default",
@@ -1518,7 +1634,7 @@ def test_create_driver_inner_all_file_lock_raises_permission_on_windows(
     )
     monkeypatch.setattr(chrome_driver, "_kill_existing_chrome_processes", lambda: None)
     monkeypatch.setattr(chrome_driver, "find_chrome", lambda: None)
-    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p: None)
+    monkeypatch.setattr(chrome_driver, "get_chrome_version", lambda _p, **_k: None)
     monkeypatch.setattr(chrome_driver, "_WEBDRIVER_MANAGER_AVAILABLE", False)
     monkeypatch.setattr(platform, "system", lambda: "Windows")
 

--- a/tests/test_get_oauth_token.py
+++ b/tests/test_get_oauth_token.py
@@ -1,0 +1,211 @@
+# tests/test_get_oauth_token.py
+"""Tests for the standalone OAuth token helper ``get_oauth_token``."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy import chrome_driver, get_oauth_token
+
+
+class _FakeDriver:
+    """Minimal Selenium driver double recording navigation and cookies."""
+
+    def __init__(self, cookie: dict[str, Any] | None) -> None:
+        self._cookie = cookie
+        self.visited_urls: list[str] = []
+        self.quit_calls = 0
+
+    def get(self, url: str) -> None:
+        self.visited_urls.append(url)
+
+    def get_cookie(self, name: str) -> Any:
+        assert name == "oauth_token"
+        return self._cookie
+
+    def quit(self) -> None:
+        self.quit_calls += 1
+
+
+class _ImmediateWait:
+    """WebDriverWait replacement that evaluates the predicate immediately."""
+
+    def __init__(self, driver: _FakeDriver, timeout: int) -> None:
+        self.driver = driver
+        self.timeout = timeout
+
+    def until(self, predicate: Any) -> Any:
+        return predicate(self.driver)
+
+
+@pytest.fixture(autouse=True)
+def _no_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize interactive ``input`` prompts during tests."""
+
+    monkeypatch.setattr(builtins, "input", lambda *args, **kwargs: "")
+
+
+def _patch_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install the immediate WebDriverWait into the selenium support module."""
+
+    import selenium.webdriver.support.ui as ui_module
+
+    monkeypatch.setattr(ui_module, "WebDriverWait", _ImmediateWait)
+
+
+# ---------------------------------------------------------------------------
+# _cookie_value
+# ---------------------------------------------------------------------------
+
+
+def test_cookie_value_returns_none_for_missing_cookie() -> None:
+    assert get_oauth_token._cookie_value(None) is None
+
+
+def test_cookie_value_returns_value() -> None:
+    assert get_oauth_token._cookie_value({"value": "token123"}) == "token123"
+
+
+def test_cookie_value_returns_none_when_value_absent() -> None:
+    assert get_oauth_token._cookie_value({}) is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_cli_args
+# ---------------------------------------------------------------------------
+
+
+def test_parse_cli_args_defaults() -> None:
+    args = get_oauth_token._parse_cli_args([])
+    assert args.chrome_path is None
+    assert args.chrome_version is None
+
+
+def test_parse_cli_args_values() -> None:
+    args = get_oauth_token._parse_cli_args(
+        ["--chrome-path", "/opt/chrome", "--chrome-version", "149"]
+    )
+    assert args.chrome_path == "/opt/chrome"
+    assert args.chrome_version == 149
+
+
+def test_parse_cli_args_help_exits_zero() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        get_oauth_token._parse_cli_args(["--help"])
+    assert excinfo.value.code == 0
+
+
+def test_parse_cli_args_invalid_version_exits_two() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        get_oauth_token._parse_cli_args(["--chrome-version", "not-an-int"])
+    assert excinfo.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+def test_main_success_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = _FakeDriver(cookie={"value": "token-abc"})
+    captured: dict[str, Any] = {}
+
+    def fake_create_driver(*, chrome_path: Any, chrome_version: Any, headless: bool) -> Any:
+        captured["chrome_path"] = chrome_path
+        captured["chrome_version"] = chrome_version
+        captured["headless"] = headless
+        return driver
+
+    monkeypatch.setattr(chrome_driver, "create_driver", fake_create_driver)
+    _patch_wait(monkeypatch)
+
+    get_oauth_token.main(chrome_path="/opt/chrome", chrome_version=149)
+
+    assert captured == {
+        "chrome_path": "/opt/chrome",
+        "chrome_version": 149,
+        "headless": False,
+    }
+    assert driver.visited_urls == ["https://accounts.google.com/EmbeddedSetup"]
+    assert driver.quit_calls == 1
+
+
+def test_main_missing_cookie_exits_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    driver = _FakeDriver(cookie=None)
+
+    monkeypatch.setattr(
+        chrome_driver, "create_driver", lambda **kwargs: driver
+    )
+    _patch_wait(monkeypatch)
+
+    with pytest.raises(SystemExit) as excinfo:
+        get_oauth_token.main()
+
+    assert excinfo.value.code == 1
+    assert driver.quit_calls == 1
+
+
+def test_main_import_error_exits_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "selenium.webdriver.support.ui":
+            raise ImportError("missing selenium")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(SystemExit) as excinfo:
+        get_oauth_token.main()
+
+    assert excinfo.value.code == 1
+
+
+def test_main_create_driver_failure_exits_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(**kwargs: Any) -> Any:
+        raise RuntimeError("no chrome")
+
+    monkeypatch.setattr(chrome_driver, "create_driver", boom)
+
+    with pytest.raises(SystemExit) as excinfo:
+        get_oauth_token.main()
+
+    assert excinfo.value.code == 1
+
+
+def test_module_entrypoint_invokes_main(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the ``__main__`` guard by executing the module body as a script.
+
+    ``runpy`` re-executes the source file with ``__name__ == "__main__"`` in a
+    throwaway namespace, so we inject lightweight ``create_driver`` and ``main``
+    replacements via the imported submodules to avoid launching a real browser.
+    """
+
+    import runpy
+
+    captured: dict[str, Any] = {}
+    driver = _FakeDriver(cookie={"value": "entry-token"})
+
+    def fake_create_driver(*, chrome_path: Any, chrome_version: Any, headless: bool) -> Any:
+        captured["chrome_path"] = chrome_path
+        captured["chrome_version"] = chrome_version
+        return driver
+
+    monkeypatch.setattr(chrome_driver, "create_driver", fake_create_driver)
+    _patch_wait(monkeypatch)
+    monkeypatch.setattr(
+        sys, "argv", ["get_oauth_token.py", "--chrome-version", "150"]
+    )
+
+    runpy.run_path(get_oauth_token.__file__, run_name="__main__")
+
+    # The script parses argv and forwards it to ``main``, which builds the
+    # driver via the patched factory and walks the success branch.
+    assert captured == {"chrome_path": None, "chrome_version": 150}
+    assert driver.visited_urls == ["https://accounts.google.com/EmbeddedSetup"]

--- a/tests/test_shared_key_flow.py
+++ b/tests/test_shared_key_flow.py
@@ -1,0 +1,308 @@
+# tests/test_shared_key_flow.py
+"""Tests for the manual shared key retrieval flow ``KeyBackup.shared_key_flow``."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.KeyBackup import shared_key_flow
+
+
+class _FakeAlert:
+    """Selenium alert double exposing canned text and an ``accept`` recorder."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.accepted = False
+
+    def accept(self) -> None:
+        self.accepted = True
+
+
+class _FakeSwitchTo:
+    """``driver.switch_to`` shim returning the next queued alert."""
+
+    def __init__(self, driver: _FakeDriver) -> None:
+        self._driver = driver
+
+    @property
+    def alert(self) -> _FakeAlert:
+        return self._driver.current_alert
+
+
+class _FakeDriver:
+    """Scripted driver that feeds a sequence of alert payloads to the flow.
+
+    The ``WebDriverWait`` replacement consults ``alert_present`` to decide
+    whether an alert is pending. Each loop iteration pops the next payload and
+    arms ``current_alert`` so ``switch_to.alert`` returns it.
+    """
+
+    def __init__(self, payloads: list[str]) -> None:
+        self._payloads = list(payloads)
+        self.current_alert: _FakeAlert = _FakeAlert("")
+        self.visited_urls: list[str] = []
+        self.scripts: list[str] = []
+        self.quit_calls = 0
+        self.switch_to = _FakeSwitchTo(self)
+
+    def get(self, url: str) -> None:
+        self.visited_urls.append(url)
+
+    def execute_script(self, script: str) -> Any:
+        self.scripts.append(script)
+        return None
+
+    def quit(self) -> None:
+        self.quit_calls += 1
+
+    def arm_next_alert(self) -> bool:
+        """Load the next payload as the active alert; return False when drained."""
+
+        if not self._payloads:
+            return False
+        self.current_alert = _FakeAlert(self._payloads.pop(0))
+        return True
+
+
+class _FlowWait:
+    """WebDriverWait replacement driving both wait stages of the flow.
+
+    The first ``until`` (url_contains) returns immediately. Subsequent ``until``
+    calls (alert_is_present, 0.5s timeout) arm the next alert; once payloads run
+    out a ``TimeoutException`` would loop forever, so the driver instead raises
+    ``_StopFlow`` to break the otherwise infinite ``while True`` loop in a test.
+    """
+
+    def __init__(self, driver: _FakeDriver, timeout: float) -> None:
+        self.driver = driver
+        self.timeout = timeout
+
+    def until(self, _condition: Any) -> Any:
+        # The first stage waits on a URL; treat any condition with the long
+        # timeout as that stage and resolve instantly.
+        if self.timeout >= 1:
+            return True
+        if not self.driver.arm_next_alert():
+            raise _StopFlow
+        return True
+
+
+class _StopFlow(Exception):
+    """Sentinel used by tests to terminate the otherwise infinite alert loop."""
+
+
+def _patch_flow(
+    monkeypatch: pytest.MonkeyPatch,
+    driver: _FakeDriver,
+    *,
+    shared_key: bytes | None = None,
+) -> None:
+    """Patch driver creation, waits and the security URL/parser helpers."""
+
+    monkeypatch.setattr(shared_key_flow, "create_driver", lambda **kwargs: driver)
+    monkeypatch.setattr(shared_key_flow, "WebDriverWait", _FlowWait)
+    monkeypatch.setattr(
+        shared_key_flow, "get_security_domain_request_url", lambda: "https://sec"
+    )
+    if shared_key is not None:
+        monkeypatch.setattr(
+            shared_key_flow, "get_fmdn_shared_key", lambda _: shared_key
+        )
+
+
+# ---------------------------------------------------------------------------
+# _parse_cli_args
+# ---------------------------------------------------------------------------
+
+
+def test_parse_cli_args_defaults() -> None:
+    args = shared_key_flow._parse_cli_args([])
+    assert args.chrome_path is None
+    assert args.chrome_version is None
+
+
+def test_parse_cli_args_values() -> None:
+    args = shared_key_flow._parse_cli_args(
+        ["--chrome-path", "/opt/chrome", "--chrome-version", "149"]
+    )
+    assert args.chrome_path == "/opt/chrome"
+    assert args.chrome_version == 149
+
+
+def test_parse_cli_args_help_exits_zero() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        shared_key_flow._parse_cli_args(["--help"])
+    assert excinfo.value.code == 0
+
+
+def test_parse_cli_args_invalid_version_exits_two() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        shared_key_flow._parse_cli_args(["--chrome-version", "x"])
+    assert excinfo.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# request_shared_key_flow
+# ---------------------------------------------------------------------------
+
+
+def test_create_driver_failure_returns_none(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    def boom(**kwargs: Any) -> Any:
+        raise RuntimeError("no chrome")
+
+    monkeypatch.setattr(shared_key_flow, "create_driver", boom)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+
+
+def test_returns_shared_key_hex_on_set_vault_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = json.dumps(
+        {"method": "setVaultSharedKeys", "vaultKeys": "raw-keys"}
+    )
+    driver = _FakeDriver([payload])
+    raw_key = bytes(range(8))
+    _patch_flow(monkeypatch, driver, shared_key=raw_key)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda d: d.quit())
+
+    captured_path: dict[str, Any] = {}
+    monkeypatch.setattr(
+        shared_key_flow,
+        "create_driver",
+        lambda **kwargs: captured_path.update(kwargs) or driver,
+    )
+
+    result = shared_key_flow.request_shared_key_flow(
+        chrome_path="/opt/chrome", chrome_version=149
+    )
+
+    assert result == raw_key.hex()
+    assert captured_path == {"chrome_path": "/opt/chrome", "chrome_version": 149}
+    assert driver.visited_urls == ["https://accounts.google.com/", "https://sec"]
+    assert driver.quit_calls == 1
+
+
+def test_close_view_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.dumps({"method": "closeView"})
+    driver = _FakeDriver([payload])
+    _patch_flow(monkeypatch, driver)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+
+
+def test_malformed_json_is_discarded_then_loop_continues(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    good = json.dumps({"method": "closeView"})
+    driver = _FakeDriver(["{not-json", good])
+    _patch_flow(monkeypatch, driver)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+    assert "malformed alert payload" in " ".join(caplog.messages).lower()
+
+
+def test_set_vault_keys_with_invalid_payload_continues(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    bad = json.dumps({"method": "setVaultSharedKeys", "vaultKeys": 123})
+    good = json.dumps({"method": "closeView"})
+    driver = _FakeDriver([bad, good])
+    _patch_flow(monkeypatch, driver)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+    assert "invalid vaultkeys" in " ".join(caplog.messages).lower()
+
+
+def test_unhandled_method_is_logged_then_loop_continues(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    caplog.set_level(logging.DEBUG)
+    other = json.dumps({"method": "somethingElse"})
+    good = json.dumps({"method": "closeView"})
+    driver = _FakeDriver([other, good])
+    _patch_flow(monkeypatch, driver)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+    assert "unhandled alert payload" in " ".join(caplog.messages).lower()
+
+
+def test_timeout_exception_continues_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pending-alert ``TimeoutException`` must ``continue`` the wait loop."""
+
+    from selenium.common.exceptions import TimeoutException
+
+    good = json.dumps({"method": "closeView"})
+    driver = _FakeDriver([good])
+
+    state = {"raised": False}
+
+    class _TimeoutOnceWait:
+        def __init__(self, drv: _FakeDriver, timeout: float) -> None:
+            self.driver = drv
+            self.timeout = timeout
+
+        def until(self, _condition: Any) -> Any:
+            if self.timeout >= 1:
+                return True
+            if not state["raised"]:
+                state["raised"] = True
+                raise TimeoutException
+            if not self.driver.arm_next_alert():
+                raise _StopFlow
+            return True
+
+    monkeypatch.setattr(shared_key_flow, "create_driver", lambda **kwargs: driver)
+    monkeypatch.setattr(shared_key_flow, "WebDriverWait", _TimeoutOnceWait)
+    monkeypatch.setattr(
+        shared_key_flow, "get_security_domain_request_url", lambda: "https://sec"
+    )
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+    assert state["raised"] is True
+
+
+def test_module_entrypoint_invokes_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the ``__main__`` guard by running the module as a script.
+
+    ``runpy`` re-executes the file with fresh module-level imports, so the
+    patched ``WebDriverWait`` cannot reach the rebound copy. To avoid launching
+    a real browser, the freshly imported ``create_driver`` is forced to raise so
+    the flow returns ``None`` through its early failure branch before any wait
+    loop runs.
+    """
+
+    import runpy
+
+    from custom_components.googlefindmy import chrome_driver
+
+    calls: dict[str, Any] = {}
+
+    def boom(**kwargs: Any) -> Any:
+        calls.update(kwargs)
+        raise RuntimeError("no chrome in __main__ test")
+
+    # shared_key_flow binds ``create_driver`` via ``from ... import`` at module
+    # load, so the runpy copy resolves this patched attribute at import time.
+    monkeypatch.setattr(chrome_driver, "create_driver", boom)
+    monkeypatch.setattr(chrome_driver, "safe_quit_driver", lambda _: None)
+    monkeypatch.setattr(sys, "argv", ["shared_key_flow.py"])
+
+    runpy.run_path(shared_key_flow.__file__, run_name="__main__")
+
+    assert calls == {"chrome_path": None, "chrome_version": None}


### PR DESCRIPTION
## Problem

When running the integration's standalone CLI helpers (or the HA-internal
auth bootstrap), `create_driver` can abort with a hard version mismatch
(e.g. "only supports Chrome version 150") even though the user has a valid
Chrome installed (e.g. 149). This happens because Chrome-for-Testing's
*stable* channel moved to 150 before the desktop auto-update offered it.

## Root cause

`_create_driver_inner` tries up to five strategies. **Strategy 3**
(`chrome_driver.py:525`) hardcodes `version_main=None`. When Strategy 1/2
fail transiently but a version *was* detected (149), Strategy 3 discards it
and `undetected_chromedriver` fetches the latest stable driver (150) ->
mismatch abort. `get_driver` (line 327) has the same raw `version_main=None`.

## Solution (layered override, recommendation A)

1. **Root fix:** never escalate to `version_main=None` while a version is
   known; pass the resolved version through every strategy. `None` stays
   legitimate only when no version is resolvable at all.
2. **Layered override** `CLI flag > env var > auto-detection`, evaluated at
   the shared chokepoint so it also covers the two HA-internal callers that
   have no `argv` (`main.py:402`, `shared_key_retrieval.py`):
   - `--chrome-path` / `--chrome-version` (+ `--help`) on the 3 CLI scripts
   - `GOOGLEFINDMY_CHROME_PATH` / `GOOGLEFINDMY_CHROME_VERSION` env vars
3. **Honest error message:** final `RuntimeError` reports detected vs.
   used version and the override source.

## Roadmap (this PR)

- [x] AP1: characterization test (xfail) pinning the Strategy-3 escalation
- [ ] AP2.0: extract the strategy blocks (complexity budget before extension)
- [ ] AP2: root fix + resolver + env evaluation at the chokepoint
- [ ] AP3: CLI flags + `--help` + testable parser in the 3 scripts
- [ ] AP4: honest error message (detected/used/source)
- [ ] AP4.5: README docs for the new switches
- [ ] AP5: tests toward 100% line+branch coverage for the touched files
- [ ] AP6: terminal diff review, final gates, ready for review

Draft until the roadmap is complete.