### PR TITLE
fix(secrets): enforce single-key (shared_key) validation across all import surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=70 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=71 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ The manifest classifies Google Find My Device as a **hub** integration. Home Ass
 >While going through the process in main.py to authenticate, you **MUST** go through **2 login processes!**  After the first login is successful, your available devices will be listed.  You must complete the next step to display location data for one of your devices.  You will then login again.  After you complete this step, you should see valid location data for your device, followed by several errors that are not important.  ONLY at this point are you ready to move on to the next step!
 3. Copy the entire contents of the secrets.json file.
     - Specifically, open the file in a text editor, select all, and copy.
+> [!IMPORTANT]
+> The encryption key (`shared_key`) is only retrieved during the **second** login, which happens when you actively **select a device to locate**. If you stop after the device list appears (skipping that step), the resulting `secrets.json` has no `shared_key` and Home Assistant will reject the import with a `keys_missing` error, because locations cannot be decrypted without it.
+> As an alternative to the external GoogleFindMyTools, the bundled CLI (`custom_components/googlefindmy/main.py`) fetches **both** keys automatically in a single run, without requiring you to select a device manually, so it is the more robust way to generate a complete `secrets.json`.
 
 ### <ins>Authentication Part 2 (Home Assistant Steps)</ins>
 4. Add the integration to your Home Assistant install.

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -7724,12 +7724,24 @@ async def _async_save_secrets_data(
     owner_key = secrets_data.get("owner_key")
     shared_key = secrets_data.get("shared_key")
     if not shared_key:
-        _LOGGER.warning(
-            "No 'shared_key' found in secrets bundle for %s. "
-            "FMDN network (crowdsourced) location reports will fail to decrypt. "
-            "Re-authenticate to obtain a current secrets.json that includes the shared_key.",
-            google_email or "(unknown)",
-        )
+        # The trigger is solely the missing shared_key; the locally present
+        # owner_key only selects how wide the outage is described.
+        if owner_key:
+            _LOGGER.warning(
+                "No 'shared_key' found in secrets bundle for %s. "
+                "Crowdsourced/FMDN locations cannot be decrypted now; "
+                "own-device locations will fail when the owner key rotates "
+                "(it can only be refreshed with the shared_key). "
+                "Re-import a complete secrets.json.",
+                google_email or "(unknown)",
+            )
+        else:
+            _LOGGER.warning(
+                "No 'shared_key' found in secrets bundle for %s. "
+                "No location can be decrypted. "
+                "Re-import a complete secrets.json.",
+                google_email or "(unknown)",
+            )
     if google_email:
         email_key = str(google_email)
         try:

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -1280,6 +1280,35 @@ def _secrets_key_status(parsed: dict[str, Any]) -> tuple[bool, bool]:
     return _present(parsed.get("shared_key")), _present(parsed.get("owner_key"))
 
 
+def _reject_if_shared_key_missing(
+    parsed: dict[str, Any], errors: dict[str, str], *, slot: str = "base"
+) -> bool:
+    """Apply the single-key import gate to ``parsed``; report blocked bundles.
+
+    The single-key rule (see :func:`_secrets_key_status`) must hold at *every*
+    import surface. This is the one named guard the reauth confirm flow uses at
+    both of its persist sub-paths so the rule has a single call form rather than
+    being re-inlined per branch. When the bundle has no usable ``shared_key`` the
+    guard writes ``keys_missing`` into ``errors[slot]`` and returns ``True`` so
+    the caller can fall through to re-show the form without persisting.
+
+    Args:
+        parsed: An already-normalized secrets bundle.
+        errors: The flow's error mapping, mutated in place when blocked.
+        slot: The error slot to populate (``"base"`` for surfaces without a
+            dedicated field, like reauth).
+
+    Returns:
+        ``True`` if the bundle was rejected (caller must not persist), else
+        ``False``.
+    """
+    has_shared, _has_owner = _secrets_key_status(parsed)
+    if has_shared:
+        return False
+    errors[slot] = "keys_missing"
+    return True
+
+
 # ---------------------------
 # API probing helpers (signature-robust)
 # ---------------------------
@@ -3586,7 +3615,16 @@ class ConfigFlow(
                         if not isinstance(payload, Mapping):
                             errors["base"] = "invalid_token"
                         else:
-                            parsed: dict[str, Any] = dict(payload)
+                            # Normalize locally so the gate, the email/token
+                            # extraction, and the persisted bundle all operate on
+                            # the same whitespace-normalized, scoped-key-promoted
+                            # bundle, instead of depending on an implicit
+                            # invariant established by an upstream caller.
+                            # ``normalize_secrets_bundle`` is idempotent, so this
+                            # is a no-op when ``payload`` was already normalized.
+                            parsed: dict[str, Any] = normalize_secrets_bundle(
+                                dict(payload)
+                            )
                             extracted_email = normalize_email(
                                 _extract_email_from_secrets(parsed)
                             )
@@ -3634,52 +3672,56 @@ class ConfigFlow(
                                             )
                                             if alt:
                                                 to_persist = alt
-                                        updated_data = {
-                                            **entry.data,
-                                            DATA_AUTH_METHOD: _AUTH_METHOD_SECRETS,
-                                            CONF_OAUTH_TOKEN: to_persist,
-                                            DATA_SECRET_BUNDLE: parsed,
-                                        }
-                                        fcm_credentials = (
-                                            _extract_fcm_credentials_from_secrets(
-                                                parsed
+                                        # Single-key rule: a shared_key-less bundle
+                                        # is a non-renewable dead end. Block the
+                                        # reauth persist and fall through to
+                                        # re-show the form, mirroring the
+                                        # initial/options/discovery gates instead
+                                        # of warning-then-persisting.
+                                        if not _reject_if_shared_key_missing(
+                                            parsed, errors
+                                        ):
+                                            updated_data = {
+                                                **entry.data,
+                                                DATA_AUTH_METHOD: _AUTH_METHOD_SECRETS,
+                                                CONF_OAUTH_TOKEN: to_persist,
+                                                DATA_SECRET_BUNDLE: parsed,
+                                            }
+                                            fcm_credentials = (
+                                                _extract_fcm_credentials_from_secrets(
+                                                    parsed
+                                                )
                                             )
-                                        )
-                                        if fcm_credentials is not None:
-                                            updated_data["fcm_credentials"] = (
-                                                fcm_credentials
+                                            if fcm_credentials is not None:
+                                                updated_data["fcm_credentials"] = (
+                                                    fcm_credentials
+                                                )
+                                            if isinstance(
+                                                to_persist, str
+                                            ) and to_persist.startswith("aas_et/"):
+                                                updated_data[DATA_AAS_TOKEN] = to_persist
+                                            elif DATA_AAS_TOKEN in updated_data:
+                                                updated_data.pop(DATA_AAS_TOKEN, None)
+                                            await self._async_clear_cached_aas_token(
+                                                entry
                                             )
-                                        if isinstance(
-                                            to_persist, str
-                                        ) and to_persist.startswith("aas_et/"):
-                                            updated_data[DATA_AAS_TOKEN] = to_persist
-                                        elif DATA_AAS_TOKEN in updated_data:
-                                            updated_data.pop(DATA_AAS_TOKEN, None)
-                                        await self._async_clear_cached_aas_token(entry)
-                                        _reauth_shared = parsed.get("shared_key")
-                                        if _reauth_shared:
+                                            # The single-key gate above guarantees a
+                                            # usable shared_key here; record it for
+                                            # operators without re-deriving the
+                                            # missing-key warning (now a hard block).
                                             _LOGGER.info(
                                                 "Reauth for %s: shared_key present in secrets bundle",
                                                 fixed_email,
                                             )
-                                        else:
-                                            _LOGGER.warning(
-                                                "Reauth for %s: no shared_key in secrets bundle. "
-                                                "Crowdsourced/FMDN locations cannot be decrypted now; "
-                                                "own-device locations will fail when the owner key rotates "
-                                                "(it can only be refreshed with the shared_key). "
-                                                "Re-import a complete secrets.json.",
-                                                fixed_email,
+                                            success_reason = self.context.get(
+                                                "reauth_success_reason_override",
+                                                "reauth_successful",
                                             )
-                                        success_reason = self.context.get(
-                                            "reauth_success_reason_override",
-                                            "reauth_successful",
-                                        )
-                                        return self.async_update_reload_and_abort(
-                                            entry=entry,
-                                            data=updated_data,
-                                            reason=success_reason,
-                                        )
+                                            return self.async_update_reload_and_abort(
+                                                entry=entry,
+                                                data=updated_data,
+                                                reason=success_reason,
+                                            )
                 except Exception as err2:  # noqa: BLE001
                     if _is_multi_entry_guard_error(err2):
                         # Defer: accept first candidate and reload
@@ -3701,11 +3743,14 @@ class ConfigFlow(
                                 data=updated_data,
                                 reason="reauth_successful",
                             )
-                        if method == "secrets":
-                            if not isinstance(payload, Mapping):
-                                errors["base"] = "invalid_token"
-                            else:
-                                parsed = dict(payload)
+                        if method == "secrets" and isinstance(payload, Mapping):
+                            # Normalize once and gate on the SAME object that is
+                            # persisted, so the single-key gate and the stored
+                            # bundle can never disagree. An entry-scope guard
+                            # error must not become a bypass for a shared_key-less
+                            # (or whitespace-corrupted) bundle.
+                            parsed = normalize_secrets_bundle(dict(payload))
+                            if not _reject_if_shared_key_missing(parsed, errors):
                                 cands = _extract_oauth_candidates_from_secrets(parsed)
                                 token_first = cands[0][1] if cands else ""
                                 updated_data = {
@@ -3731,7 +3776,14 @@ class ConfigFlow(
                                     data=updated_data,
                                     reason="reauth_successful",
                                 )
-                    errors["base"] = _map_api_exc_to_error_key(err2)
+                        elif method == "secrets":
+                            # payload is not a Mapping: malformed deferral input.
+                            errors["base"] = "invalid_token"
+                    # Fall back to the generic mapped error only when the
+                    # deferral branch above did not already classify the failure
+                    # (for example the single-key gate setting ``keys_missing``);
+                    # do not clobber a more specific error.
+                    errors.setdefault("base", _map_api_exc_to_error_key(err2))
 
         return self.async_show_form(
             step_id="reauth_confirm",

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -3637,7 +3637,18 @@ class ConfigFlow(
                                 if existing is not None:
                                     return self.async_abort(reason="already_configured")
                                 errors["base"] = "email_mismatch"
-                            else:
+                            # Single-key rule: a shared_key-less bundle is a
+                            # non-renewable dead end. Gate it BEFORE the token
+                            # probe, mirroring the initial/options/discovery
+                            # surfaces where the gate always dominates token
+                            # validation. This sits INSIDE the email-matches
+                            # branch so a foreign/already-configured bundle keeps
+                            # its email_mismatch/already_configured precedence
+                            # above. Hoisting the gate makes a shared_key-less
+                            # bundle with a dead token return the deterministic
+                            # ``keys_missing`` instead of masking it as
+                            # ``cannot_connect`` from a failed probe.
+                            elif not _reject_if_shared_key_missing(parsed, errors):
                                 try:
                                     chosen = await async_pick_working_token(
                                         self.hass,
@@ -3672,56 +3683,47 @@ class ConfigFlow(
                                             )
                                             if alt:
                                                 to_persist = alt
-                                        # Single-key rule: a shared_key-less bundle
-                                        # is a non-renewable dead end. Block the
-                                        # reauth persist and fall through to
-                                        # re-show the form, mirroring the
-                                        # initial/options/discovery gates instead
-                                        # of warning-then-persisting.
-                                        if not _reject_if_shared_key_missing(
-                                            parsed, errors
-                                        ):
-                                            updated_data = {
-                                                **entry.data,
-                                                DATA_AUTH_METHOD: _AUTH_METHOD_SECRETS,
-                                                CONF_OAUTH_TOKEN: to_persist,
-                                                DATA_SECRET_BUNDLE: parsed,
-                                            }
-                                            fcm_credentials = (
-                                                _extract_fcm_credentials_from_secrets(
-                                                    parsed
-                                                )
+                                        updated_data = {
+                                            **entry.data,
+                                            DATA_AUTH_METHOD: _AUTH_METHOD_SECRETS,
+                                            CONF_OAUTH_TOKEN: to_persist,
+                                            DATA_SECRET_BUNDLE: parsed,
+                                        }
+                                        fcm_credentials = (
+                                            _extract_fcm_credentials_from_secrets(
+                                                parsed
                                             )
-                                            if fcm_credentials is not None:
-                                                updated_data["fcm_credentials"] = (
-                                                    fcm_credentials
-                                                )
-                                            if isinstance(
-                                                to_persist, str
-                                            ) and to_persist.startswith("aas_et/"):
-                                                updated_data[DATA_AAS_TOKEN] = to_persist
-                                            elif DATA_AAS_TOKEN in updated_data:
-                                                updated_data.pop(DATA_AAS_TOKEN, None)
-                                            await self._async_clear_cached_aas_token(
-                                                entry
+                                        )
+                                        if fcm_credentials is not None:
+                                            updated_data["fcm_credentials"] = (
+                                                fcm_credentials
                                             )
-                                            # The single-key gate above guarantees a
-                                            # usable shared_key here; record it for
-                                            # operators without re-deriving the
-                                            # missing-key warning (now a hard block).
-                                            _LOGGER.info(
-                                                "Reauth for %s: shared_key present in secrets bundle",
-                                                fixed_email,
-                                            )
-                                            success_reason = self.context.get(
-                                                "reauth_success_reason_override",
-                                                "reauth_successful",
-                                            )
-                                            return self.async_update_reload_and_abort(
-                                                entry=entry,
-                                                data=updated_data,
-                                                reason=success_reason,
-                                            )
+                                        if isinstance(
+                                            to_persist, str
+                                        ) and to_persist.startswith("aas_et/"):
+                                            updated_data[DATA_AAS_TOKEN] = to_persist
+                                        elif DATA_AAS_TOKEN in updated_data:
+                                            updated_data.pop(DATA_AAS_TOKEN, None)
+                                        await self._async_clear_cached_aas_token(
+                                            entry
+                                        )
+                                        # The single-key gate above already
+                                        # guaranteed a usable shared_key, so the
+                                        # persist runs unconditionally here; record
+                                        # the key for operators.
+                                        _LOGGER.info(
+                                            "Reauth for %s: shared_key present in secrets bundle",
+                                            fixed_email,
+                                        )
+                                        success_reason = self.context.get(
+                                            "reauth_success_reason_override",
+                                            "reauth_successful",
+                                        )
+                                        return self.async_update_reload_and_abort(
+                                            entry=entry,
+                                            data=updated_data,
+                                            reason=success_reason,
+                                        )
                 except Exception as err2:  # noqa: BLE001
                     if _is_multi_entry_guard_error(err2):
                         # Defer: accept first candidate and reload

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -1252,6 +1252,34 @@ def _extract_fcm_credentials_from_secrets(
     return None
 
 
+def _secrets_key_status(parsed: dict[str, Any]) -> tuple[bool, bool]:
+    """Report which E2EE keys are present in a parsed secrets bundle.
+
+    The single-key rule: ``has_shared`` is the only gate that decides whether a
+    bundle is importable. A bundle without a ``shared_key`` is a non-renewable
+    dead end (the owner key can only be refreshed with the shared key), so it
+    must be blocked regardless of the owner key. ``has_owner`` does NOT gate the
+    validation; it only selects the wording of the D2 seeding warning (an
+    owner-only bundle decrypts own-device locations until the owner key rotates,
+    whereas a bundle with neither key decrypts nothing).
+
+    A value counts as present only when it is a non-empty string after stripping
+    surrounding whitespace; no further structural assumptions are made about the
+    bundle.
+
+    Args:
+        parsed: A parsed (and normally already whitespace-normalized) bundle.
+
+    Returns:
+        A ``(has_shared, has_owner)`` tuple of booleans.
+    """
+
+    def _present(value: Any) -> bool:
+        return isinstance(value, str) and bool(value.strip())
+
+    return _present(parsed.get("shared_key")), _present(parsed.get("owner_key"))
+
+
 # ---------------------------
 # API probing helpers (signature-robust)
 # ---------------------------
@@ -1421,6 +1449,13 @@ def _interpret_credentials_choice(
             parsed = normalize_secrets_bundle(parsed)
         except (json.JSONDecodeError, TypeError):
             return "secrets", None, None, "invalid_json"
+
+        has_shared, _has_owner = _secrets_key_status(parsed)
+        if not has_shared:
+            # Single-key rule: a bundle without a shared_key is a non-renewable
+            # dead end (the owner key can never be refreshed) and is blocked,
+            # regardless of whether an owner_key is present.
+            return "secrets", None, None, "keys_missing"
 
         email = _extract_email_from_secrets(parsed) or ""
         cands = _extract_oauth_candidates_from_secrets(parsed)
@@ -1691,6 +1726,12 @@ def _normalize_and_validate_discovery_payload(
         # cleanup. A stray space in owner_key/shared_key breaks AES-GCM
         # decryption. normalize_secrets_bundle is idempotent and copies its input.
         secrets_dict = dict(normalize_secrets_bundle(secrets_raw))
+        # Single-key rule (parity with the paste/options import surfaces): a
+        # discovered bundle without a shared_key is a non-renewable dead end and
+        # is rejected here instead of being accepted as a valid discovery.
+        has_shared, _has_owner = _secrets_key_status(secrets_dict)
+        if not has_shared:
+            raise DiscoveryFlowError("keys_missing")
         secrets_bundle = MappingProxyType(secrets_dict)
         email_from_secrets = _extract_email_from_secrets(secrets_dict)
         if email_from_secrets:
@@ -3623,9 +3664,11 @@ class ConfigFlow(
                                             )
                                         else:
                                             _LOGGER.warning(
-                                                "Reauth for %s: no shared_key in secrets bundle — "
-                                                "FMDN crowdsourced reports cannot be decrypted. "
-                                                "Re-run GoogleFindMyTools to obtain the shared_key first.",
+                                                "Reauth for %s: no shared_key in secrets bundle. "
+                                                "Crowdsourced/FMDN locations cannot be decrypted now; "
+                                                "own-device locations will fail when the owner key rotates "
+                                                "(it can only be refreshed with the shared_key). "
+                                                "Re-import a complete secrets.json.",
                                                 fixed_email,
                                             )
                                         success_reason = self.context.get(
@@ -5845,8 +5888,19 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
                             except Exception:
                                 errors["new_secrets_json"] = "invalid_json"
                             else:
-                                cands = _extract_oauth_candidates_from_secrets(parsed)
-                                if not cands:
+                                has_shared, _has_owner = _secrets_key_status(parsed)
+                                if not has_shared:
+                                    # Single-key rule: reject a shared_key-less
+                                    # bundle before any persist/reload. Field
+                                    # slot (like invalid_json) because it is a
+                                    # correctable paste, not a bundle/network
+                                    # state.
+                                    errors["new_secrets_json"] = "keys_missing"
+                                elif not (
+                                    cands := _extract_oauth_candidates_from_secrets(
+                                        parsed
+                                    )
+                                ):
                                     errors["base"] = "invalid_token"
                                 else:
                                     try:

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -210,6 +210,45 @@ else:
         sys.modules["homeassistant.exceptions"] = _ha_exceptions
 
 
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    """Atomically write ``data`` as JSON to ``path`` with 0600 permissions.
+
+    The standalone ``secrets.json`` carries OAuth/AAS tokens, so an interrupted
+    write (process abort, full disk) must never leave a truncated or empty file
+    behind. The data is first written to a temporary file in the *same*
+    directory (``os.replace`` is only atomic within a single filesystem), then
+    flushed and ``fsync``-ed, then renamed onto the target. On any failure the
+    temporary artifact is removed so no orphan ``*.tmp`` lingers next to the
+    real file. ``tempfile.mkstemp`` creates the temp file with 0600, which the
+    rename preserves; the explicit ``os.chmod`` keeps the mode correct even if
+    the target already existed with looser permissions.
+    """
+    import json  # noqa: PLC0415
+    import tempfile  # noqa: PLC0415
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, str(path))
+        os.chmod(path, 0o600)
+    except BaseException:
+        # Clean up the temp artifact on any failure (errors *and* interrupts);
+        # the rename either fully succeeded or never happened, so removing the
+        # leftover temp keeps the directory free of orphans without touching
+        # the existing target file.
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
 def _register_file_cache(entry_id: str = "") -> object:
     """Create a file-backed TokenCache and register it for standalone CLI use.
 
@@ -277,9 +316,7 @@ def _register_file_cache(entry_id: str = "") -> object:
             if self._load_failed and not self._data:
                 return  # Don't overwrite valid file with empty data
             self._load_failed = False
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._path, "w", encoding="utf-8") as fh:
-                json.dump(self._data, fh, indent=2)
+            _atomic_write_json(self._path, self._data)
 
         # --- async interface expected by nbe_list_devices / nova_request ---
 
@@ -434,9 +471,7 @@ def _ensure_authenticated() -> None:
     data.pop("aas_token", None)
 
     # 3) Persist to secrets.json
-    secrets_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(secrets_path, "w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
+    _atomic_write_json(secrets_path, data)
 
     print("\nCredentials saved. Continuing...\n")
 
@@ -513,6 +548,73 @@ async def _ensure_shared_key(cache: object) -> None:
         username=username if isinstance(username, str) else None,
     )
     print("Encryption key saved.\n")
+
+
+async def _ensure_owner_key(cache: object) -> None:
+    """Eagerly fetch the owner key so the generated bundle is complete.
+
+    Mirrors :func:`_ensure_shared_key`: called once during CLI startup after the
+    shared key is available. The owner-key fetch is non-interactive (a SPOT API
+    call plus a decrypt with the already-retrieved shared key, no browser), so
+    it is cheap to perform eagerly. Functionally the shared key alone suffices
+    for the HA integration (the owner key is derivable at runtime); fetching it
+    here is a robustness/completeness step so a single CLI run yields a bundle
+    that carries both keys.
+
+    Beyond the runtime-scoped ``owner_key_{username}`` cache entry (which
+    ``async_get_owner_key`` writes itself), this also stores the owner key as a
+    top-level ``owner_key`` hex string. That top-level field is the only form
+    the paste/seeding import reads (``__init__._async_save_secrets_data``), so
+    writing it keeps the generated ``secrets.json`` paste-compatible.
+    """
+    existing = await cache.get("owner_key")  # type: ignore[attr-defined]
+    if existing:
+        return
+    username = await cache.get("username")  # type: ignore[attr-defined]
+    if isinstance(username, str) and username:
+        scoped = await cache.get(f"owner_key_{username}")  # type: ignore[attr-defined]
+        if scoped:
+            return
+    print("Retrieving owner key...\n")
+    from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (  # noqa: PLC0415
+        async_get_owner_key,
+    )
+
+    info = await async_get_owner_key(cache=cache)  # type: ignore[arg-type]
+    # Persist the top-level paste-compatible hex form (bundle-inherently
+    # version-less, matching externally produced Google bundles).
+    await cache.set("owner_key", info.key.hex())  # type: ignore[attr-defined]
+    print("Owner key saved.\n")
+
+
+async def _ensure_vault_keys(cache: object) -> None:
+    """Eagerly obtain both vault keys, exiting cleanly on any vault failure.
+
+    Wraps the eager shared-key and owner-key retrieval at the CLI terminal
+    point. The vault/login step can fail in several ways (``RuntimeError`` from
+    ``shared_key_retrieval``, ``ValueError`` from hex/base64 decoding, or
+    ``ConfigEntryAuthFailed`` from the SPOT auth path); rather than surfacing a
+    raw traceback, this prints an actionable message and exits with status 1.
+    ``except Exception`` deliberately does *not* catch ``KeyboardInterrupt``
+    (a ``BaseException``), so a user-initiated abort still propagates.
+
+    No tokens are deleted on failure: the AAS/oauth tokens are durable by design
+    (``_FileCache._SOFT_INVALIDATE_KEYS``); removing them would force an
+    expensive full OAuth login on the next run.
+    """
+    try:
+        await _ensure_shared_key(cache)
+        await _ensure_owner_key(cache)
+    except Exception:  # noqa: BLE001
+        print(
+            "\nError: vault key retrieval failed.\n"
+            "Could not obtain the encryption keys from Google's vault.\n"
+            "\n"
+            "Please re-run the tool and complete the Google sign-in when the "
+            "browser opens.\n",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 async def _clear_stale_adm_token(cache: object) -> None:
@@ -717,7 +819,9 @@ if __name__ == "__main__":
             # cookie has a very short TTL and is invalidated once a new Chrome
             # session is opened, so the exchange must happen immediately.
             await _ensure_aas_token(_file_cache)
-            await _ensure_shared_key(_file_cache)
+            # Eagerly obtain both vault keys (shared + owner); a vault failure
+            # exits cleanly without deleting the durable AAS/oauth tokens.
+            await _ensure_vault_keys(_file_cache)
             await _clear_stale_adm_token(_file_cache)
             fcm = await _setup_fcm_receiver(_file_cache)
             try:

--- a/custom_components/googlefindmy/shared_helpers.py
+++ b/custom_components/googlefindmy/shared_helpers.py
@@ -152,31 +152,122 @@ def _normalize_secret_value(key: str, value: str) -> str:
     return value.strip()
 
 
-def normalize_secrets_bundle(data: Any) -> Any:
-    """Return a whitespace-normalized deep copy of a secrets.json bundle.
+_SCOPED_SHARED_KEY_PREFIX = "shared_key_"
 
-    Copy/paste of ``secrets.json`` into the config flow can inject stray
-    whitespace into credential values (a single space in ``owner_key`` breaks
-    AES-GCM decryption). This walks the bundle recursively and normalizes every
-    string value via :func:`_normalize_secret_value`, descending into nested
-    dicts (e.g. ``fcm_credentials``) and lists.
 
-    The function is idempotent and never mutates its input, so it is safe to
-    apply to ``MappingProxyType``-wrapped structures. Non-string scalars are
-    returned unchanged.
+def _normalize_whitespace(data: Any) -> Any:
+    """Return a whitespace-normalized deep copy of a secrets.json structure.
+
+    This is the recursive core of :func:`normalize_secrets_bundle`: it walks the
+    bundle, normalizes every string value via :func:`_normalize_secret_value`,
+    and descends into nested mappings (e.g. ``fcm_credentials``) and lists. It
+    performs *only* whitespace normalization; the top-level-only scoped-key
+    promotion lives in the public wrapper so recursion never triggers it.
     """
     if isinstance(data, Mapping):
         return {
             key: (
                 _normalize_secret_value(key, value)
                 if isinstance(value, str)
-                else normalize_secrets_bundle(value)
+                else _normalize_whitespace(value)
             )
             for key, value in data.items()
         }
     if isinstance(data, list):
-        return [normalize_secrets_bundle(item) for item in data]
+        return [_normalize_whitespace(item) for item in data]
     return data
+
+
+def _promote_scoped_shared_key(bundle: dict[str, Any]) -> dict[str, Any]:
+    """Promote an unambiguous scoped ``shared_key_<id>`` to the top level.
+
+    The single-key rule (``_secrets_key_status`` in ``config_flow``) decides
+    importability solely from the *top-level* ``shared_key``. Legacy and
+    CLI-produced ``secrets.json`` bundles, however, may carry only a *scoped*
+    ``shared_key_<username>`` entry: the CLI producer (``main.py::_ensure_shared_key``)
+    treats either form as present, and the runtime reader
+    (``shared_key_retrieval._get_or_generate_shared_key_hex``) can migrate a
+    scoped key into the canonical slot. Without this promotion the import gate
+    would reject such a bundle as ``keys_missing`` even though it is perfectly
+    usable -- a producer/consumer divergence over the *definition* of "has a
+    shared key".
+
+    This is the single canonical chokepoint for that reconciliation:
+    ``normalize_secrets_bundle`` runs at every import surface and on the runtime
+    save path, so promoting here makes the canonical top-level ``shared_key``
+    visible to the gate *and* to the runtime reader's top-level fast path,
+    instead of replicating the rule per surface or depending on the runtime's
+    fragile username-matched migration.
+
+    Promotion rules (top-level keys only):
+
+    * If a non-empty top-level ``shared_key`` already exists, nothing changes.
+    * Otherwise, collect every top-level ``shared_key_<suffix>`` entry (the
+      suffix must be non-empty, so the bare ``shared_key`` is never matched)
+      whose value is a non-empty string. If there is exactly one such value -- or
+      several that are all identical -- it becomes the top-level ``shared_key``
+      (the scoped entry is kept so the runtime save path stays consistent).
+    * If two or more *distinct* scoped values exist (an ambiguous multi-account
+      bundle), nothing is promoted. The import gate then rejects the bundle as
+      ``keys_missing``, which is the safe outcome: we will not guess which
+      account's key is canonical.
+
+    The caller already passes a freshly built dict (from
+    :func:`_normalize_whitespace`); this returns that dict with at most one added
+    key, so the public contract (idempotent, input never mutated) is preserved.
+    """
+    existing = bundle.get("shared_key")
+    if isinstance(existing, str) and existing.strip():
+        return bundle
+
+    # Normalize each scoped value as if it were the canonical ``shared_key`` so a
+    # wrapped-paste interior space cannot survive promotion (the scoped keys
+    # themselves are not whitelisted, so they were only edge-trimmed above). The
+    # ambiguity check then compares the *normalized* values, so two scoped
+    # entries differing only by whitespace count as the same key, not a conflict.
+    scoped_values = [
+        _normalize_secret_value("shared_key", value)
+        for key, value in bundle.items()
+        if isinstance(key, str)
+        and key.startswith(_SCOPED_SHARED_KEY_PREFIX)
+        and len(key) > len(_SCOPED_SHARED_KEY_PREFIX)
+        and isinstance(value, str)
+        and value.strip()
+    ]
+    if not scoped_values or len(set(scoped_values)) > 1:
+        return bundle
+
+    return {**bundle, "shared_key": scoped_values[0]}
+
+
+def normalize_secrets_bundle(data: Any) -> Any:
+    """Return a normalized deep copy of a secrets.json bundle.
+
+    Two normalizations are applied, in order:
+
+    1. **Whitespace** -- copy/paste of ``secrets.json`` into the config flow can
+       inject stray whitespace into credential values (a single space in
+       ``owner_key`` breaks AES-GCM decryption). Every string value is normalized
+       via :func:`_normalize_secret_value`, descending into nested dicts (e.g.
+       ``fcm_credentials``) and lists.
+    2. **Scoped-shared-key promotion** (top-level invocation only) -- an
+       unambiguous scoped ``shared_key_<id>`` is promoted to the canonical
+       top-level ``shared_key`` so the single-key import gate and the runtime
+       reader agree on one key definition. See
+       :func:`_promote_scoped_shared_key` for the exact rule (including the
+       ambiguous-multi-account case that is intentionally left unpromoted).
+
+    Promotion runs *only* at this top-level entry point, never during recursion,
+    so nested mappings are never given a synthesized top-level ``shared_key``.
+
+    The function is idempotent and never mutates its input, so it is safe to
+    apply to ``MappingProxyType``-wrapped structures. Non-string scalars are
+    returned unchanged.
+    """
+    normalized = _normalize_whitespace(data)
+    if isinstance(normalized, dict):
+        return _promote_scoped_shared_key(normalized)
+    return normalized
 
 
 def normalize_fcm_entry_snapshot(entry_id: str, snap: dict[str, Any]) -> dict[str, Any]:

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -84,6 +84,7 @@
       "cannot_connect": "Failed to connect to Google Find My Device.",
       "dependency_not_ready": "Google Find My Device dependencies are not installed. Install the requirements and try again.",
       "invalid_discovery_info": "The discovery payload was invalid. Check the credentials and try again.",
+      "keys_missing": "secrets.json has no encryption key (shared_key); locations cannot be decrypted. Re-generate it with full key retrieval: the bundled CLI (main.py) fetches both keys automatically, or in GoogleFindMyTools select a device to locate before exporting.",
       "reauth_successful": "Reauthentication successful.",
       "migration_successful": "Migration complete.",
       "migration_failed": "Migration failed. Please remove and re-add the integration.",

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Invalid authentication. Please provide a fresh token and/or sign in again.",
       "invalid_token": "Invalid token/email provided or required fields are missing.",
       "invalid_json": "Invalid JSON format in secrets.json content.",
+      "keys_missing": "secrets.json has no encryption key (shared_key); locations cannot be decrypted. Re-generate it with full key retrieval: the bundled CLI (main.py) fetches both keys automatically, or in GoogleFindMyTools select a device to locate before exporting.",
       "no_devices": "No devices found. Please ensure that Find My Device is enabled on your Google account.",
       "cannot_connect": "Failed to connect to the Google API. This may be temporary — please try again later.",
       "dependency_not_ready": "Required integration dependencies are missing. Install the Google Find My Device requirements and restart Home Assistant.",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Invalid JSON format in secrets.json content.",
+      "keys_missing": "secrets.json has no encryption key (shared_key); locations cannot be decrypted. Re-generate it with full key retrieval: the bundled CLI (main.py) fetches both keys automatically, or in GoogleFindMyTools select a device to locate before exporting.",
       "invalid": "Validation failed. Please check your input.",
       "invalid_auth": "Invalid authentication. Please provide a fresh token and/or sign in again.",
       "cannot_connect": "Failed to connect to the Google API.",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -84,6 +84,7 @@
       "cannot_connect": "Verbindung zu Google Find My Device fehlgeschlagen.",
       "dependency_not_ready": "Google Find My Device-Abhängigkeiten sind nicht installiert. Installiere die Anforderungen und versuche es erneut.",
       "invalid_discovery_info": "Die Discovery-Nutzlast war ungültig. Überprüfe die Anmeldedaten und versuche es erneut.",
+      "keys_missing": "secrets.json enthält keinen Verschlüsselungsschlüssel (shared_key); Standorte können nicht entschlüsselt werden. Erzeuge die Datei mit vollständigem Schlüsselabruf neu: Die mitgelieferte CLI (main.py) holt beide Schlüssel automatisch, oder wähle in GoogleFindMyTools vor dem Export ein Gerät zur Ortung aus.",
       "reauth_successful": "Erneute Authentifizierung erfolgreich.",
       "migration_successful": "Migration abgeschlossen.",
       "migration_failed": "Migration fehlgeschlagen. Entferne die Integration und füge sie erneut hinzu.",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Ungültige Authentifizierung. Bitte gib einen frischen Token ein und/oder melde dich erneut an.",
       "invalid_token": "Ungültige E-Mail/Token oder erforderliche Felder fehlen.",
       "invalid_json": "Ungültiges JSON-Format im Inhalt der secrets.json.",
+      "keys_missing": "secrets.json enthält keinen Verschlüsselungsschlüssel (shared_key); Standorte können nicht entschlüsselt werden. Erzeuge die Datei mit vollständigem Schlüsselabruf neu: Die mitgelieferte CLI (main.py) holt beide Schlüssel automatisch, oder wähle in GoogleFindMyTools vor dem Export ein Gerät zur Ortung aus.",
       "no_devices": "Keine Geräte gefunden. Bitte stelle sicher, dass „Mein Gerät finden“ in deinem Google-Konto aktiviert ist.",
       "cannot_connect": "Verbindung zur Google-API fehlgeschlagen. Dies ist möglicherweise ein vorübergehendes Problem – bitte versuche es später erneut.",
       "dependency_not_ready": "Erforderliche Integrationsabhängigkeiten fehlen. Installiere die Anforderungen von Google Find My Device und starte Home Assistant neu.",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Ungültiges JSON-Format im Inhalt der secrets.json.",
+      "keys_missing": "secrets.json enthält keinen Verschlüsselungsschlüssel (shared_key); Standorte können nicht entschlüsselt werden. Erzeuge die Datei mit vollständigem Schlüsselabruf neu: Die mitgelieferte CLI (main.py) holt beide Schlüssel automatisch, oder wähle in GoogleFindMyTools vor dem Export ein Gerät zur Ortung aus.",
       "invalid": "Validierung fehlgeschlagen. Bitte überprüfe deine Eingabe.",
       "invalid_auth": "Ungültige Authentifizierung. Bitte gib einen frischen Token ein und/oder melde dich erneut an.",
       "cannot_connect": "Verbindung zur Google-API fehlgeschlagen.",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -84,6 +84,7 @@
       "cannot_connect": "Failed to connect to Google Find My Device.",
       "dependency_not_ready": "Google Find My Device dependencies are not installed. Install the requirements and try again.",
       "invalid_discovery_info": "The discovery payload was invalid. Check the credentials and try again.",
+      "keys_missing": "secrets.json has no encryption key (shared_key); locations cannot be decrypted. Re-generate it with full key retrieval: the bundled CLI (main.py) fetches both keys automatically, or in GoogleFindMyTools select a device to locate before exporting.",
       "reauth_successful": "Reauthentication successful.",
       "migration_successful": "Migration complete.",
       "migration_failed": "Migration failed. Please remove and re-add the integration.",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Invalid authentication. Please provide a fresh token and/or sign in again.",
       "invalid_token": "Invalid token/email provided or required fields are missing.",
       "invalid_json": "Invalid JSON format in secrets.json content.",
+      "keys_missing": "secrets.json has no encryption key (shared_key); locations cannot be decrypted. Re-generate it with full key retrieval: the bundled CLI (main.py) fetches both keys automatically, or in GoogleFindMyTools select a device to locate before exporting.",
       "no_devices": "No devices found. Please ensure that Find My Device is enabled on your Google account.",
       "cannot_connect": "Failed to connect to the Google API. This may be temporary — please try again later.",
       "dependency_not_ready": "Required integration dependencies are missing. Install the Google Find My Device requirements and restart Home Assistant.",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Invalid JSON format in secrets.json content.",
+      "keys_missing": "secrets.json has no encryption key (shared_key); locations cannot be decrypted. Re-generate it with full key retrieval: the bundled CLI (main.py) fetches both keys automatically, or in GoogleFindMyTools select a device to locate before exporting.",
       "invalid": "Validation failed. Please check your input.",
       "invalid_auth": "Invalid authentication. Please provide a fresh token and/or sign in again.",
       "cannot_connect": "Failed to connect to the Google API.",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -84,6 +84,7 @@
       "cannot_connect": "No se pudo conectar con Google Find My Device.",
       "dependency_not_ready": "Las dependencias de Google Find My Device no están instaladas. Instala los requisitos e inténtalo de nuevo.",
       "invalid_discovery_info": "La carga de descubrimiento no es válida. Verifica las credenciales y vuelve a intentarlo.",
+      "keys_missing": "secrets.json no contiene la clave de cifrado (shared_key); no se pueden descifrar las ubicaciones. Vuelve a generarla con la recuperación completa de claves: la CLI incluida (main.py) obtiene ambas claves automáticamente, o en GoogleFindMyTools selecciona un dispositivo para localizar antes de exportar.",
       "reauth_successful": "Reautenticación correcta.",
       "migration_successful": "Migración completada.",
       "migration_failed": "Migración fallida. Elimina la integración y vuelve a agregarla.",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Autenticación no válida. Proporciona un token nuevo y/o vuelve a iniciar sesión.",
       "invalid_token": "Credenciales no válidas (token/correo) o faltan campos obligatorios.",
       "invalid_json": "Formato JSON no válido en el contenido de secrets.json.",
+      "keys_missing": "secrets.json no contiene la clave de cifrado (shared_key); no se pueden descifrar las ubicaciones. Vuelve a generarla con la recuperación completa de claves: la CLI incluida (main.py) obtiene ambas claves automáticamente, o en GoogleFindMyTools selecciona un dispositivo para localizar antes de exportar.",
       "no_devices": "No se han encontrado dispositivos. Asegúrate de que ‘Encontrar mi dispositivo’ esté activado en tu cuenta de Google.",
       "cannot_connect": "No se pudo conectar con la API de Google. Puede ser un problema temporal: inténtalo de nuevo más tarde.",
       "dependency_not_ready": "Faltan dependencias de la integración. Instala los requisitos de Google Find My Device y reinicia Home Assistant.",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Formato JSON no válido en el contenido de secrets.json.",
+      "keys_missing": "secrets.json no contiene la clave de cifrado (shared_key); no se pueden descifrar las ubicaciones. Vuelve a generarla con la recuperación completa de claves: la CLI incluida (main.py) obtiene ambas claves automáticamente, o en GoogleFindMyTools selecciona un dispositivo para localizar antes de exportar.",
       "invalid": "Falló la validación. Revisa tus datos.",
       "invalid_auth": "Autenticación no válida. Proporciona un token nuevo y/o vuelve a iniciar sesión.",
       "cannot_connect": "No se pudo conectar con la API de Google.",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -84,6 +84,7 @@
       "cannot_connect": "Échec de la connexion à Google Find My Device.",
       "dependency_not_ready": "Les dépendances de Google Find My Device ne sont pas installées. Installez les dépendances requises puis réessayez.",
       "invalid_discovery_info": "La charge de découverte est invalide. Vérifiez les identifiants et réessayez.",
+      "keys_missing": "secrets.json ne contient pas la clé de chiffrement (shared_key) ; les positions ne peuvent pas être déchiffrées. Régénérez-le avec une récupération complète des clés : la CLI fournie (main.py) récupère les deux clés automatiquement, ou dans GoogleFindMyTools sélectionnez un appareil à localiser avant l'export.",
       "reauth_successful": "Réauthentification réussie.",
       "migration_successful": "Migration terminée.",
       "migration_failed": "Échec de la migration. Supprimez puis réajoutez l’intégration.",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Authentification invalide. Fournissez un nouveau jeton et/ou reconnectez-vous.",
       "invalid_token": "Identifiants invalides (jeton/e-mail) ou champs requis manquants.",
       "invalid_json": "Format JSON invalide dans le contenu de secrets.json.",
+      "keys_missing": "secrets.json ne contient pas la clé de chiffrement (shared_key) ; les positions ne peuvent pas être déchiffrées. Régénérez-le avec une récupération complète des clés : la CLI fournie (main.py) récupère les deux clés automatiquement, ou dans GoogleFindMyTools sélectionnez un appareil à localiser avant l'export.",
       "no_devices": "Aucun appareil trouvé. Assurez-vous que « Localiser mon appareil » est activé sur votre compte Google.",
       "cannot_connect": "Échec de la connexion à l’API Google. Il peut s’agir d’un problème temporaire — réessayez plus tard.",
       "dependency_not_ready": "Des dépendances de l’intégration sont manquantes. Installez les dépendances requises de Google Find My Device et redémarrez Home Assistant.",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Format JSON invalide dans le contenu de secrets.json.",
+      "keys_missing": "secrets.json ne contient pas la clé de chiffrement (shared_key) ; les positions ne peuvent pas être déchiffrées. Régénérez-le avec une récupération complète des clés : la CLI fournie (main.py) récupère les deux clés automatiquement, ou dans GoogleFindMyTools sélectionnez un appareil à localiser avant l'export.",
       "invalid": "Échec de la validation. Veuillez vérifier vos saisies.",
       "invalid_auth": "Authentification invalide. Fournissez un nouveau jeton et/ou reconnectez-vous.",
       "cannot_connect": "Échec de la connexion à l’API Google.",

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -84,6 +84,7 @@
       "cannot_connect": "נכשל החיבור ל-Google Find My Device.",
       "dependency_not_ready": "תלויות של Google Find My Device לא מותקנות. יש להתקין את הדרישות ולנסות שוב.",
       "invalid_discovery_info": "מטען הגילוי לא היה תקין. יש לבדוק את האישורים ולנסות שוב.",
+      "keys_missing": "secrets.json אינו מכיל מפתח הצפנה (shared_key); לא ניתן לפענח מיקומים. צור אותו מחדש עם אחזור מלא של המפתחות: כלי ה-CLI המצורף (main.py) מאחזר את שני המפתחות אוטומטית, או ב-GoogleFindMyTools בחר התקן לאיתור לפני הייצוא.",
       "reauth_successful": "אימות מחדש הצליח.",
       "migration_successful": "ההעברה הושלמה.",
       "migration_failed": "ההעברה נכשלה. נא להסיר את השילוב ולהוסיף אותו מחדש.",

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -69,6 +69,7 @@
       "invalid_auth": "אימות לא תקין. נא לספק טוקן חדש ו/או להיכנס שוב.",
       "invalid_token": "טוקן/אימייל לא תקין או שחסרים שדות נדרשים.",
       "invalid_json": "פורמט JSON לא תקין בתוכן secrets.json.",
+      "keys_missing": "secrets.json אינו מכיל מפתח הצפנה (shared_key); לא ניתן לפענח מיקומים. צור אותו מחדש עם אחזור מלא של המפתחות: כלי ה-CLI המצורף (main.py) מאחזר את שני המפתחות אוטומטית, או ב-GoogleFindMyTools בחר התקן לאיתור לפני הייצוא.",
       "no_devices": "לא נמצאו התקנים. יש לוודא ששירות Find My Device מופעל בחשבון Google שלך.",
       "cannot_connect": "נכשל החיבור אל API של Google. ייתכן שזה זמני - נא לנסות שוב מאוחר יותר.",
       "dependency_not_ready": "תלויות נדרשות של השילוב חסרות. יש להתקין את דרישות Google Find My Device ולהפעיל מחדש את Home Assistant.",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "פורמט JSON לא תקין בתוכן secrets.json.",
+      "keys_missing": "secrets.json אינו מכיל מפתח הצפנה (shared_key); לא ניתן לפענח מיקומים. צור אותו מחדש עם אחזור מלא של המפתחות: כלי ה-CLI המצורף (main.py) מאחזר את שני המפתחות אוטומטית, או ב-GoogleFindMyTools בחר התקן לאיתור לפני הייצוא.",
       "invalid": "האימות נכשל. אנא בדוק את הקלט שלך.",
       "invalid_auth": "אימות לא תקין. נא לספק טוקן חדש ו/או להיכנס שוב.",
       "cannot_connect": "נכשל החיבור ל-API של Google.",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -84,6 +84,7 @@
       "cannot_connect": "Impossibile connettersi a Google Find My Device.",
       "dependency_not_ready": "Le dipendenze di Google Find My Device non sono installate. Installa i requisiti e riprova.",
       "invalid_discovery_info": "Il payload di rilevamento non è valido. Controlla le credenziali e riprova.",
+      "keys_missing": "secrets.json non contiene la chiave di crittografia (shared_key); le posizioni non possono essere decifrate. Rigeneralo con il recupero completo delle chiavi: la CLI inclusa (main.py) recupera entrambe le chiavi automaticamente, oppure in GoogleFindMyTools seleziona un dispositivo da localizzare prima di esportare.",
       "reauth_successful": "Riautenticazione riuscita.",
       "migration_successful": "Migrazione completata.",
       "migration_failed": "Migrazione non riuscita. Rimuovi l'integrazione e aggiungila di nuovo.",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Autenticazione non valida. Fornisci un nuovo token e/o accedi di nuovo.",
       "invalid_token": "Credenziali non valide (token/e-mail) o campi obbligatori mancanti.",
       "invalid_json": "Formato JSON non valido nel contenuto di secrets.json.",
+      "keys_missing": "secrets.json non contiene la chiave di crittografia (shared_key); le posizioni non possono essere decifrate. Rigeneralo con il recupero completo delle chiavi: la CLI inclusa (main.py) recupera entrambe le chiavi automaticamente, oppure in GoogleFindMyTools seleziona un dispositivo da localizzare prima di esportare.",
       "no_devices": "Nessun dispositivo trovato. Assicurati che ‘Trova il mio dispositivo’ sia attivato nel tuo account Google.",
       "cannot_connect": "Impossibile connettersi all’API di Google. Potrebbe trattarsi di un problema temporaneo — riprova più tardi.",
       "dependency_not_ready": "Mancano le dipendenze dell'integrazione. Installa i requisiti di Google Find My Device e riavvia Home Assistant.",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Formato JSON non valido nel contenuto di secrets.json.",
+      "keys_missing": "secrets.json non contiene la chiave di crittografia (shared_key); le posizioni non possono essere decifrate. Rigeneralo con il recupero completo delle chiavi: la CLI inclusa (main.py) recupera entrambe le chiavi automaticamente, oppure in GoogleFindMyTools seleziona un dispositivo da localizzare prima di esportare.",
       "invalid": "Convalida non riuscita. Controlla i tuoi dati.",
       "invalid_auth": "Autenticazione non valida. Fornisci un nuovo token e/o accedi di nuovo.",
       "cannot_connect": "Impossibile connettersi all’API di Google.",

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Ongeldige authenticatie. Geef een nieuwe token op en/of meld je opnieuw aan.",
       "invalid_token": "Ongeldige token/e-mail opgegeven of verplichte velden ontbreken.",
       "invalid_json": "Ongeldig JSON-formaat in secrets.json-inhoud.",
+      "keys_missing": "secrets.json bevat geen versleutelingssleutel (shared_key); locaties kunnen niet worden ontsleuteld. Genereer het opnieuw met volledige sleutelophaling: de meegeleverde CLI (main.py) haalt beide sleutels automatisch op, of selecteer in GoogleFindMyTools een apparaat om te lokaliseren vóór het exporteren.",
       "no_devices": "Geen apparaten gevonden. Zorg ervoor dat Vind mijn apparaat is ingeschakeld in je Google-account.",
       "cannot_connect": "Kan geen verbinding maken met de Google API. Dit kan tijdelijk zijn – probeer het later opnieuw.",
       "dependency_not_ready": "Vereiste integratie-afhankelijkheden ontbreken. Installeer de Google Find My Device-vereisten en herstart Home Assistant.",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Ongeldig JSON-formaat in secrets.json-inhoud.",
+      "keys_missing": "secrets.json bevat geen versleutelingssleutel (shared_key); locaties kunnen niet worden ontsleuteld. Genereer het opnieuw met volledige sleutelophaling: de meegeleverde CLI (main.py) haalt beide sleutels automatisch op, of selecteer in GoogleFindMyTools een apparaat om te lokaliseren vóór het exporteren.",
       "invalid": "Validatie mislukt. Controleer je invoer.",
       "invalid_auth": "Ongeldige authenticatie. Geef een nieuwe token op en/of meld je opnieuw aan.",
       "cannot_connect": "Kan geen verbinding maken met de Google API.",

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -84,6 +84,7 @@
       "cannot_connect": "Kan geen verbinding maken met Google Find My Device.",
       "dependency_not_ready": "Google Find My Device-afhankelijkheden zijn niet geïnstalleerd. Installeer de vereisten en probeer het opnieuw.",
       "invalid_discovery_info": "De discovery-payload was ongeldig. Controleer de inloggegevens en probeer het opnieuw.",
+      "keys_missing": "secrets.json bevat geen versleutelingssleutel (shared_key); locaties kunnen niet worden ontsleuteld. Genereer het opnieuw met volledige sleutelophaling: de meegeleverde CLI (main.py) haalt beide sleutels automatisch op, of selecteer in GoogleFindMyTools een apparaat om te lokaliseren vóór het exporteren.",
       "reauth_successful": "Herauthenticatie geslaagd.",
       "migration_successful": "Migratie voltooid.",
       "migration_failed": "Migratie mislukt. Verwijder de integratie en voeg deze opnieuw toe.",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -84,6 +84,7 @@
       "cannot_connect": "Nie udało się połączyć z Google Find My Device.",
       "dependency_not_ready": "Zależności Google Find My Device nie są zainstalowane. Zainstaluj wymagane pakiety i spróbuj ponownie.",
       "invalid_discovery_info": "Ładunek wykrywania jest nieprawidłowy. Sprawdź dane logowania i spróbuj ponownie.",
+      "keys_missing": "secrets.json nie zawiera klucza szyfrowania (shared_key); lokalizacji nie można odszyfrować. Wygeneruj go ponownie z pełnym pobraniem kluczy: dołączone narzędzie CLI (main.py) pobiera oba klucze automatycznie lub w GoogleFindMyTools wybierz urządzenie do zlokalizowania przed wyeksportowaniem.",
       "reauth_successful": "Ponowne uwierzytelnienie zakończone pomyślnie.",
       "migration_successful": "Migracja zakończona.",
       "migration_failed": "Migracja nie powiodła się. Usuń integrację i dodaj ją ponownie.",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Nieprawidłowe uwierzytelnienie. Podaj nowy token i/lub zaloguj się ponownie.",
       "invalid_token": "Nieprawidłowy token/e-mail lub brakuje wymaganych pól.",
       "invalid_json": "Nieprawidłowy format JSON w zawartości pliku secrets.json.",
+      "keys_missing": "secrets.json nie zawiera klucza szyfrowania (shared_key); lokalizacji nie można odszyfrować. Wygeneruj go ponownie z pełnym pobraniem kluczy: dołączone narzędzie CLI (main.py) pobiera oba klucze automatycznie lub w GoogleFindMyTools wybierz urządzenie do zlokalizowania przed wyeksportowaniem.",
       "no_devices": "Nie znaleziono urządzeń. Upewnij się, że „Znajdź moje urządzenie” jest włączone na Twoim koncie Google.",
       "cannot_connect": "Nie udało się połączyć z API Google. Może to być problem tymczasowy — spróbuj ponownie później.",
       "dependency_not_ready": "Brakuje wymaganych zależności integracji. Zainstaluj wymagania Google Find My Device i uruchom ponownie Home Assistant.",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Nieprawidłowy format JSON w zawartości pliku secrets.json.",
+      "keys_missing": "secrets.json nie zawiera klucza szyfrowania (shared_key); lokalizacji nie można odszyfrować. Wygeneruj go ponownie z pełnym pobraniem kluczy: dołączone narzędzie CLI (main.py) pobiera oba klucze automatycznie lub w GoogleFindMyTools wybierz urządzenie do zlokalizowania przed wyeksportowaniem.",
       "invalid": "Walidacja nie powiodła się. Sprawdź swoje dane.",
       "invalid_auth": "Nieprawidłowe uwierzytelnienie. Podaj nowy token i/lub zaloguj się ponownie.",
       "cannot_connect": "Nie udało się połączyć z API Google.",

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Autenticação inválida. ",
       "invalid_token": "Token/e-mail inválido fornecido ou campos obrigatórios ausentes.",
       "invalid_json": "Formato JSON inválido no conteúdo do secrets.json.",
+      "keys_missing": "secrets.json não contém a chave de criptografia (shared_key); não é possível descriptografar localizações. Gere-o novamente com a obtenção completa das chaves: a CLI incluída (main.py) obtém ambas as chaves automaticamente, ou no GoogleFindMyTools selecione um dispositivo para localizar antes de exportar.",
       "no_devices": "Nenhum dispositivo encontrado. ",
       "cannot_connect": "Falha ao conectar-se à API do Google. ",
       "dependency_not_ready": "As dependências de integração necessárias estão faltando. ",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Formato JSON inválido no conteúdo do secrets.json.",
+      "keys_missing": "secrets.json não contém a chave de criptografia (shared_key); não é possível descriptografar localizações. Gere-o novamente com a obtenção completa das chaves: a CLI incluída (main.py) obtém ambas as chaves automaticamente, ou no GoogleFindMyTools selecione um dispositivo para localizar antes de exportar.",
       "invalid": "A validação falhou. ",
       "invalid_auth": "Autenticação inválida. ",
       "cannot_connect": "Falha ao conectar-se à API do Google.",

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -84,6 +84,7 @@
       "cannot_connect": "Falha ao conectar-se ao Encontre Meu Dispositivo do Google.",
       "dependency_not_ready": "As dependências do Encontre Meu Dispositivo do Google não estão instaladas. ",
       "invalid_discovery_info": "A carga de descoberta era inválida. ",
+      "keys_missing": "secrets.json não contém a chave de criptografia (shared_key); não é possível descriptografar localizações. Gere-o novamente com a obtenção completa das chaves: a CLI incluída (main.py) obtém ambas as chaves automaticamente, ou no GoogleFindMyTools selecione um dispositivo para localizar antes de exportar.",
       "reauth_successful": "Reautenticação bem-sucedida.",
       "migration_successful": "Migração concluída.",
       "migration_failed": "A migração falhou. ",

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -84,6 +84,7 @@
       "cannot_connect": "Falha ao conectar-se ao Encontre Meu Dispositivo do Google.",
       "dependency_not_ready": "As dependências do Encontre Meu Dispositivo do Google não estão instaladas. ",
       "invalid_discovery_info": "A carga de descoberta era inválida. ",
+      "keys_missing": "secrets.json não contém a chave de encriptação (shared_key); não é possível desencriptar localizações. Gere-o novamente com a obtenção completa das chaves: a CLI incluída (main.py) obtém ambas as chaves automaticamente, ou no GoogleFindMyTools selecione um dispositivo para localizar antes de exportar.",
       "reauth_successful": "Reautenticação bem-sucedida.",
       "migration_successful": "Migração concluída.",
       "migration_failed": "A migração falhou. ",

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -69,6 +69,7 @@
       "invalid_auth": "Autenticação inválida. ",
       "invalid_token": "Token/e-mail inválido fornecido ou campos obrigatórios ausentes.",
       "invalid_json": "Formato JSON inválido no conteúdo secrets.json.",
+      "keys_missing": "secrets.json não contém a chave de encriptação (shared_key); não é possível desencriptar localizações. Gere-o novamente com a obtenção completa das chaves: a CLI incluída (main.py) obtém ambas as chaves automaticamente, ou no GoogleFindMyTools selecione um dispositivo para localizar antes de exportar.",
       "no_devices": "Nenhum dispositivo encontrado. ",
       "cannot_connect": "Falha ao conectar-se à API do Google. ",
       "dependency_not_ready": "As dependências de integração necessárias estão faltando. ",
@@ -316,6 +317,7 @@
     },
     "error": {
       "invalid_json": "Formato JSON inválido no conteúdo secrets.json.",
+      "keys_missing": "secrets.json não contém a chave de encriptação (shared_key); não é possível desencriptar localizações. Gere-o novamente com a obtenção completa das chaves: a CLI incluída (main.py) obtém ambas as chaves automaticamente, ou no GoogleFindMyTools selecione um dispositivo para localizar antes de exportar.",
       "invalid": "A validação falhou. ",
       "invalid_auth": "Autenticação inválida. ",
       "cannot_connect": "Falha ao conectar-se à API do Google.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -359,7 +359,12 @@ skip_covered = true
 # Raised to 70 with the accuracy_estimated producer-flag suite (PR #1124): the
 # new carry_reused_accuracy helper and chokepoint regression tests lift CI total
 # past 70 %; floor tracks the new CI total to lock the gain.
-fail_under = 70
+# Raised to 71 with the secrets shared_key validation suite (PR #1128): the
+# single-key gate, reauth/discovery guard tests and translation-parity tests
+# lift CI total to 71.84 %; floor tracks the new total to lock the gain. The
+# usual -1 Pp jitter margin is intentionally tightened here (0.84 Pp headroom)
+# per maintainer request to hold the floor at 71.
+fail_under = 71
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",

--- a/tests/test_config_flow_basics.py
+++ b/tests/test_config_flow_basics.py
@@ -586,6 +586,8 @@ class TestInterpretCredentialsChoice:
         secrets = {
             "googleHomeUsername": "user@example.com",
             "aas_token": "aas_token_value_padding_xxxxxxx",
+            # A shared_key is required to pass the single-key import gate.
+            "shared_key": "DDEEFF",
         }
         method, email, cands, err = cf._interpret_credentials_choice(
             {
@@ -603,8 +605,13 @@ class TestInterpretCredentialsChoice:
         assert err is None
 
     def test_secrets_path_invalid_token(self) -> None:
-        # Email valid but no plausible tokens → invalid_token.
-        secrets = {"googleHomeUsername": "user@example.com", "aas_token": "short"}
+        # Email valid but no plausible tokens → invalid_token. A shared_key is
+        # present so the single-key gate passes and the token check is reached.
+        secrets = {
+            "googleHomeUsername": "user@example.com",
+            "aas_token": "short",
+            "shared_key": "DDEEFF",
+        }
         method, _email, _cands, err = cf._interpret_credentials_choice(
             {
                 "secrets_json": json.dumps(secrets),
@@ -1105,6 +1112,8 @@ class TestNormalizeAndValidateDiscoveryPayload:
         secrets = {
             "googleHomeUsername": "user@example.com",
             "aas_token": "aas_token_value_padding_xxxxxxx",
+            # A shared_key is required to pass the single-key discovery gate.
+            "shared_key": "DDEEFF",
         }
         payload = {cf.DATA_SECRET_BUNDLE: secrets}
         result = cf._normalize_and_validate_discovery_payload(payload)
@@ -1118,6 +1127,8 @@ class TestNormalizeAndValidateDiscoveryPayload:
         secrets = {
             "googleHomeUsername": "user@example.com",
             "aas_token": "aas_token_value_padding_xxxxxxx",
+            # A shared_key is required to pass the single-key discovery gate.
+            "shared_key": "DDEEFF",
         }
         payload = {
             cf.CONF_GOOGLE_EMAIL: "user@example.com",

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -39,6 +39,8 @@ def test_normalize_and_validate_discovery_payload() -> None:
             "google_email": "DiscoveryUser@example.com",
             "aas_token": "aas_et/DISCOVERY",
             "oauth_token": "manually/PERSIST",
+            # A shared_key is required to pass the single-key discovery gate.
+            "shared_key": "DDEEFF",
         }
     }
 
@@ -94,6 +96,8 @@ def test_discovery_string_payload_still_normalizes_after_refactor() -> None:
                 "google_email": "DiscoveryUser@example.com",
                 "aas_token": "aas_et/DISCOVERY",
                 "owner_key": "EEEE FFFF",
+                # A shared_key is required to pass the single-key discovery gate.
+                "shared_key": "DDEEFF",
             }
         )
     }
@@ -127,7 +131,10 @@ def test_async_step_discovery_new_entry(
         secrets_bundle: dict[str, Any] | None = None,
     ) -> str | None:
         assert email == "new.user@example.com"
-        assert secrets_bundle == {"aas_token": "aas_et/VALID_TOKEN_VALUE"}
+        assert secrets_bundle == {
+            "aas_token": "aas_et/VALID_TOKEN_VALUE",
+            "shared_key": "DDEEFF",
+        }
         return candidates[0][1]
 
     monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
@@ -176,7 +183,11 @@ def test_async_step_discovery_new_entry(
 
         payload = {
             CONF_GOOGLE_EMAIL: "new.user@example.com",
-            "secrets_json": {"aas_token": "aas_et/VALID_TOKEN_VALUE"},
+            "secrets_json": {
+                "aas_token": "aas_et/VALID_TOKEN_VALUE",
+                # A shared_key is required to pass the single-key discovery gate.
+                "shared_key": "DDEEFF",
+            },
         }
 
         discovery_form = await flow.async_step_discovery(payload)
@@ -195,7 +206,8 @@ def test_async_step_discovery_new_entry(
         assert flow._auth_data.get(DATA_AUTH_METHOD) == config_flow._AUTH_METHOD_SECRETS  # type: ignore[attr-defined]
         assert flow._auth_data.get(DATA_AAS_TOKEN) == "aas_et/VALID_TOKEN_VALUE"  # type: ignore[attr-defined]
         assert flow._auth_data.get(DATA_SECRET_BUNDLE) == {  # type: ignore[attr-defined]
-            "aas_token": "aas_et/VALID_TOKEN_VALUE"
+            "aas_token": "aas_et/VALID_TOKEN_VALUE",
+            "shared_key": "DDEEFF",
         }
         assert device_form["type"] == "form"
         assert device_form.get("step_id") == "device_selection"
@@ -215,7 +227,8 @@ def test_async_step_discovery_new_entry(
     assert created_entry["data"][DATA_AUTH_METHOD] == config_flow._AUTH_METHOD_SECRETS
     assert created_entry["data"][DATA_AAS_TOKEN] == "aas_et/VALID_TOKEN_VALUE"
     assert created_entry["data"][DATA_SECRET_BUNDLE] == {
-        "aas_token": "aas_et/VALID_TOKEN_VALUE"
+        "aas_token": "aas_et/VALID_TOKEN_VALUE",
+        "shared_key": "DDEEFF",
     }
     assert created_entry["data"].get(DATA_SUBENTRY_KEY) is None
     assert recorded_forms == ["discovery", "device_selection"]

--- a/tests/test_config_flow_fcm_extraction.py
+++ b/tests/test_config_flow_fcm_extraction.py
@@ -31,6 +31,8 @@ async def test_secrets_json_extracts_fcm_credentials(
     secrets_payload = {
         "google_email": "fcm-user@example.com",
         "aas_token": "aas_et/FROM_SECRETS",
+        # A shared_key is required to pass the single-key import gate.
+        "shared_key": "DDEEFF",
         "fcm_credentials": {"installation": {"token": "install-token"}},
     }
 

--- a/tests/test_config_flow_reauth_single_key.py
+++ b/tests/test_config_flow_reauth_single_key.py
@@ -57,17 +57,22 @@ def _build_reauth_flow(
     monkeypatch: pytest.MonkeyPatch,
     *,
     pick_raises: BaseException | None = None,
+    pick_returns_none: bool = False,
 ) -> tuple[Any, _ReauthEntry, dict[str, Any]]:
     """Wire a ``ConfigFlow`` instance for ``async_step_reauth_confirm`` tests.
 
     ``pick_raises`` lets a test drive the multi-entry-guard *deferral* path by
-    making token validation raise an entry-scope guard error. ``captured``
-    records any ``async_update_reload_and_abort`` persistence so tests can assert
-    a blocked bundle never persists.
+    making token validation raise an entry-scope guard error.
+    ``pick_returns_none`` simulates a dead/expired token so the probe (if it is
+    reached at all) fails. ``captured`` records any
+    ``async_update_reload_and_abort`` persistence so tests can assert a blocked
+    bundle never persists, and records every ``async_pick_working_token`` call
+    so tests can assert the gate dominates the probe.
     """
 
     entry = _ReauthEntry("entry-reauth", "user@example.com")
     captured: dict[str, Any] = {}
+    captured["pick_calls"] = 0
 
     async def _fake_pick(
         hass: Any,
@@ -76,8 +81,11 @@ def _build_reauth_flow(
         *,
         secrets_bundle: dict[str, Any] | None = None,
     ) -> str | None:
+        captured["pick_calls"] += 1
         if pick_raises is not None:
             raise pick_raises
+        if pick_returns_none:
+            return None
         return candidates[0][1] if candidates else None
 
     monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
@@ -165,6 +173,34 @@ async def test_reauth_happy_path_blocks_when_shared_missing(
     assert result.get("type") == "form"
     assert result.get("errors") == {"base": "keys_missing"}
     assert "persist" not in captured
+
+
+@pytest.mark.asyncio
+async def test_reauth_gate_precedes_probe_when_token_dead_and_shared_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The single-key gate must precede the token probe on the reauth surface.
+
+    Category: gate must precede token probe on every secrets surface. A
+    shared_key-less bundle paired with a dead/expired token previously reached
+    the form with ``cannot_connect`` (the token probe ran first and failed),
+    masking the deterministic ``keys_missing`` the other import surfaces return.
+    With the gate hoisted above the probe, the gate dominates: the result is
+    ``keys_missing`` and ``async_pick_working_token`` is never called for this
+    bundle.
+    """
+    flow, _entry, captured = _build_reauth_flow(
+        monkeypatch, pick_returns_none=True
+    )
+
+    result = await _run_reauth(flow, _shared_missing_bundle())
+
+    assert result.get("type") == "form"
+    assert result.get("errors") == {"base": "keys_missing"}
+    assert "persist" not in captured
+    # Gate dominates the probe: a shared_key-less bundle is rejected before any
+    # token validation, so the (dead) token is never probed.
+    assert captured["pick_calls"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow_reauth_single_key.py
+++ b/tests/test_config_flow_reauth_single_key.py
@@ -1,0 +1,282 @@
+# tests/test_config_flow_reauth_single_key.py
+"""Single-key (shared_key) enforcement for the reauth confirm flow.
+
+The reauth flow (``async_step_reauth_confirm``) accepts a pasted ``secrets.json``
+bundle just like the initial, options, and discovery import surfaces. Those
+surfaces all gate on the single-key rule (a bundle is importable only if it
+carries a usable ``shared_key``), but the reauth persist paths historically only
+logged a warning and persisted anyway, bypassing the gate.
+
+These tests pin the gate at *both* reauth persist sub-paths:
+
+* the happy persist path (``async_update_reload_and_abort`` after token
+  validation), and
+* the multi-entry-guard *deferral* path (persist after an entry-scope guard
+  error short-circuits validation).
+
+A shared_key-less bundle must set ``errors["base"] == "keys_missing"`` and must
+not persist, while a bundle that carries a ``shared_key`` must still persist.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any
+
+import pytest
+from homeassistant.helpers import frame
+
+from custom_components.googlefindmy import config_flow
+from custom_components.googlefindmy.const import (
+    CONF_GOOGLE_EMAIL,
+    CONF_OAUTH_TOKEN,
+    DATA_SECRET_BUNDLE,
+)
+from tests.helpers.config_flow import (
+    ConfigEntriesDomainUniqueIdLookupMixin,
+    attach_config_entries_flow_manager,
+    prepare_flow_hass_config_entries,
+)
+
+# A realistic 32-byte (64 hex chars) shared key value.
+_SHARED_HEX = "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00"
+_GUARD_MESSAGE = "Multiple config entries active for this integration"
+
+
+class _ReauthEntry:
+    """Minimal ConfigEntry substitute for the reauth flow under test."""
+
+    def __init__(self, entry_id: str, email: str) -> None:
+        self.entry_id = entry_id
+        self.data: dict[str, Any] = {CONF_GOOGLE_EMAIL: email}
+        self.options: dict[str, Any] = {}
+
+
+def _build_reauth_flow(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pick_raises: BaseException | None = None,
+) -> tuple[Any, _ReauthEntry, dict[str, Any]]:
+    """Wire a ``ConfigFlow`` instance for ``async_step_reauth_confirm`` tests.
+
+    ``pick_raises`` lets a test drive the multi-entry-guard *deferral* path by
+    making token validation raise an entry-scope guard error. ``captured``
+    records any ``async_update_reload_and_abort`` persistence so tests can assert
+    a blocked bundle never persists.
+    """
+
+    entry = _ReauthEntry("entry-reauth", "user@example.com")
+    captured: dict[str, Any] = {}
+
+    async def _fake_pick(
+        hass: Any,
+        email: str,
+        candidates: list[tuple[str, str]],
+        *,
+        secrets_bundle: dict[str, Any] | None = None,
+    ) -> str | None:
+        if pick_raises is not None:
+            raise pick_raises
+        return candidates[0][1] if candidates else None
+
+    monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+    class _ConfigEntries(ConfigEntriesDomainUniqueIdLookupMixin):
+        def __init__(self) -> None:
+            attach_config_entries_flow_manager(self)
+
+        def async_get_entry(self, entry_id: str) -> _ReauthEntry | None:
+            return entry if entry_id == entry.entry_id else None
+
+        def async_entries(self, domain: str) -> list[Any]:
+            return [entry]
+
+    class _FlowHass:
+        def __init__(self) -> None:
+            prepare_flow_hass_config_entries(
+                self,
+                _ConfigEntries,
+                frame_module=frame,
+            )
+
+    hass = _FlowHass()
+    flow = config_flow.ConfigFlow()
+    flow.hass = hass  # type: ignore[assignment]
+    flow.context = {"entry_id": entry.entry_id}
+
+    def _update_reload_and_abort(
+        *, entry: Any, data: dict[str, Any], reason: str
+    ) -> dict[str, Any]:
+        captured["persist"] = {"entry": entry, "data": data, "reason": reason}
+        return {"type": "abort", "reason": reason}
+
+    def _abort(*, reason: str) -> dict[str, Any]:
+        captured["abort"] = reason
+        return {"type": "abort", "reason": reason}
+
+    async def _clear_cached_aas_token(_entry: Any) -> None:
+        return None
+
+    flow.async_update_reload_and_abort = _update_reload_and_abort  # type: ignore[assignment]
+    flow.async_abort = _abort  # type: ignore[assignment]
+    flow._async_clear_cached_aas_token = _clear_cached_aas_token  # type: ignore[attr-defined]
+    return flow, entry, captured
+
+
+async def _run_reauth(flow: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    """Drive ``async_step_reauth_confirm`` with a pasted secrets bundle."""
+    result = await flow.async_step_reauth_confirm(
+        {config_flow._REAUTH_FIELD_SECRETS: json.dumps(payload)}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+    assert isinstance(result, dict)
+    return result
+
+
+def _shared_missing_bundle() -> dict[str, Any]:
+    """A valid-token, shared_key-less secrets bundle (the blocked input)."""
+    return {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+        "owner_key": "AABBCC",
+    }
+
+
+def _shared_present_bundle() -> dict[str, Any]:
+    """A valid-token bundle carrying a usable shared_key (the accepted input)."""
+    return {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+        "shared_key": _SHARED_HEX,
+    }
+
+
+@pytest.mark.asyncio
+async def test_reauth_happy_path_blocks_when_shared_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reauth happy path rejects a shared_key-less bundle and does not persist."""
+    flow, _entry, captured = _build_reauth_flow(monkeypatch)
+
+    result = await _run_reauth(flow, _shared_missing_bundle())
+
+    assert result.get("type") == "form"
+    assert result.get("errors") == {"base": "keys_missing"}
+    assert "persist" not in captured
+
+
+@pytest.mark.asyncio
+async def test_reauth_happy_path_persists_when_shared_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reauth happy path persists a bundle that carries a shared_key."""
+    flow, _entry, captured = _build_reauth_flow(monkeypatch)
+
+    await _run_reauth(flow, _shared_present_bundle())
+
+    assert "persist" in captured
+    persisted = captured["persist"]["data"]
+    assert persisted[DATA_SECRET_BUNDLE]["shared_key"] == _SHARED_HEX
+    assert persisted[CONF_OAUTH_TOKEN] == "aas_et/FROM_SECRETS"
+
+
+@pytest.mark.asyncio
+async def test_reauth_deferral_path_blocks_when_shared_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reauth multi-entry-guard deferral path also gates on the shared_key.
+
+    Token validation raises an entry-scope guard error, which routes the flow
+    into the deferral persist branch. That branch must still reject a
+    shared_key-less bundle instead of persisting it.
+    """
+    flow, _entry, captured = _build_reauth_flow(
+        monkeypatch, pick_raises=RuntimeError(_GUARD_MESSAGE)
+    )
+
+    result = await _run_reauth(flow, _shared_missing_bundle())
+
+    assert result.get("type") == "form"
+    assert result.get("errors") == {"base": "keys_missing"}
+    assert "persist" not in captured
+
+
+@pytest.mark.asyncio
+async def test_reauth_deferral_path_persists_when_shared_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deferral path still persists a bundle that carries a shared_key."""
+    flow, _entry, captured = _build_reauth_flow(
+        monkeypatch, pick_raises=RuntimeError(_GUARD_MESSAGE)
+    )
+
+    await _run_reauth(flow, _shared_present_bundle())
+
+    assert "persist" in captured
+    persisted = captured["persist"]["data"]
+    assert persisted[DATA_SECRET_BUNDLE]["shared_key"] == _SHARED_HEX
+
+
+# ---------------------------------------------------------------------------
+# Reauth normalization parity: the reauth surface must normalize (and
+# scoped-key promote) the pasted bundle itself, so the gate, the credential
+# extraction, and the persisted bundle all agree -- rather than relying on an
+# implicit "already normalized" invariant from an upstream caller.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reauth_accepts_and_promotes_scoped_only_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scoped-only bundle is accepted on reauth and persisted promoted.
+
+    The bundle carries only a scoped ``shared_key_<email>`` (no top-level
+    ``shared_key``). The reauth surface must promote it to the canonical
+    top-level slot so the single-key gate passes and the persisted bundle
+    exposes the top-level ``shared_key`` the runtime reads first.
+    """
+    flow, _entry, captured = _build_reauth_flow(monkeypatch)
+
+    scoped_only = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+        "shared_key_user@example.com": _SHARED_HEX,
+    }
+
+    await _run_reauth(flow, scoped_only)
+
+    assert "persist" in captured, "scoped-only bundle must be accepted on reauth"
+    persisted = captured["persist"]["data"]
+    bundle = persisted[DATA_SECRET_BUNDLE]
+    assert bundle["shared_key"] == _SHARED_HEX
+    # The scoped entry is preserved alongside the promoted canonical key.
+    assert bundle["shared_key_user@example.com"] == _SHARED_HEX
+
+
+@pytest.mark.asyncio
+async def test_reauth_persists_whitespace_free_owner_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wrapped-paste owner_key is persisted with all whitespace removed.
+
+    A stray interior space in ``owner_key`` breaks AES-GCM decryption; the
+    reauth persist path must apply the same credential normalization every other
+    import surface uses.
+    """
+    flow, _entry, captured = _build_reauth_flow(monkeypatch)
+
+    bundle_in = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+        "shared_key": _SHARED_HEX,
+        "owner_key": "AA BB\nCC ",
+    }
+
+    await _run_reauth(flow, bundle_in)
+
+    assert "persist" in captured
+    persisted = captured["persist"]["data"]
+    assert persisted[DATA_SECRET_BUNDLE]["owner_key"] == "AABBCC"

--- a/tests/test_config_flow_secrets_normalization.py
+++ b/tests/test_config_flow_secrets_normalization.py
@@ -138,6 +138,182 @@ def test_non_mapping_input_returned_unchanged() -> None:
     assert normalize_secrets_bundle(None) is None
 
 
+# ---------------------------------------------------------------------------
+# Scoped-shared-key promotion (producer/consumer contract repair).
+#
+# A legacy/older secrets.json may carry a *scoped* ``shared_key_<email>`` entry
+# but no top-level ``shared_key``. The CLI producer and the runtime reader both
+# accept the scoped form, but ``_secrets_key_status`` only inspects the
+# top-level ``shared_key``, so the import gate would wrongly reject such a bundle
+# as ``keys_missing``. ``normalize_secrets_bundle`` promotes an unambiguous
+# scoped key to the canonical top-level slot so every import surface and the
+# runtime reader converge on one key definition.
+# ---------------------------------------------------------------------------
+
+# A realistic 32-byte (64 hex chars) shared key value.
+_SHARED_HEX = "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00"
+_SHARED_HEX_2 = "00ffeeddccbbaa998877665544332211090f8e7d6c5b4a3a291807f6e5d4c3b2a1"[:64]
+
+
+def test_scoped_only_shared_key_promoted_to_top_level() -> None:
+    """A scoped-only shared key is promoted to the canonical top-level slot."""
+    bundle = {
+        "shared_key_user@example.com": _SHARED_HEX,
+        "oauth_token": "aas_et/FROM_SECRETS",
+    }
+    result = normalize_secrets_bundle(bundle)
+    assert result["shared_key"] == _SHARED_HEX
+    # The scoped entry is preserved (runtime save path still writes it scoped).
+    assert result["shared_key_user@example.com"] == _SHARED_HEX
+
+
+def test_existing_top_level_shared_key_not_overwritten() -> None:
+    """An existing non-empty top-level shared_key wins over any scoped entry."""
+    bundle = {
+        "shared_key": _SHARED_HEX,
+        "shared_key_user@example.com": _SHARED_HEX_2,
+    }
+    result = normalize_secrets_bundle(bundle)
+    assert result["shared_key"] == _SHARED_HEX
+
+
+def test_multiple_scoped_same_value_promoted() -> None:
+    """Multiple scoped entries sharing the SAME value still promote (no ambiguity)."""
+    bundle = {
+        "shared_key_a@example.com": _SHARED_HEX,
+        "shared_key_b@example.com": _SHARED_HEX,
+    }
+    result = normalize_secrets_bundle(bundle)
+    assert result["shared_key"] == _SHARED_HEX
+
+
+def test_ambiguous_distinct_scoped_values_not_promoted() -> None:
+    """Two DISTINCT scoped values are ambiguous and must NOT be promoted."""
+    bundle = {
+        "shared_key_a@example.com": _SHARED_HEX,
+        "shared_key_b@example.com": _SHARED_HEX_2,
+    }
+    result = normalize_secrets_bundle(bundle)
+    assert "shared_key" not in result
+
+
+def test_bare_shared_key_prefix_not_matched_as_scoped() -> None:
+    """The bare ``shared_key`` must not be mistaken for a scoped entry.
+
+    Only keys with a non-empty suffix after the ``shared_key_`` prefix qualify;
+    an empty (``""``) top-level shared_key alongside no scoped entry stays absent.
+    """
+    bundle = {"shared_key": "", "oauth_token": "aas_et/X"}
+    result = normalize_secrets_bundle(bundle)
+    # No scoped entry exists to promote, and the empty value is not "present".
+    assert result["shared_key"] == ""
+
+
+def test_scoped_empty_value_not_promoted() -> None:
+    """A scoped entry whose value is empty/whitespace does not qualify."""
+    bundle = {"shared_key_user@example.com": "   ", "oauth_token": "aas_et/X"}
+    result = normalize_secrets_bundle(bundle)
+    assert "shared_key" not in result
+
+
+def test_promotion_does_not_descend_into_nested_dicts() -> None:
+    """Promotion is a top-level-only step; nested scoped keys are untouched."""
+    bundle = {
+        "oauth_token": "aas_et/X",
+        "nested": {"shared_key_user@example.com": _SHARED_HEX},
+    }
+    result = normalize_secrets_bundle(bundle)
+    # No top-level shared_key is synthesized from a nested scoped entry.
+    assert "shared_key" not in result
+    assert result["nested"]["shared_key_user@example.com"] == _SHARED_HEX
+    assert "shared_key" not in result["nested"]
+
+
+def test_promotion_idempotent() -> None:
+    """Promotion is idempotent: a second pass yields an identical bundle."""
+    bundle = {
+        "shared_key_user@example.com": _SHARED_HEX,
+        "oauth_token": "aas_et/X",
+    }
+    once = normalize_secrets_bundle(bundle)
+    assert normalize_secrets_bundle(once) == once
+
+
+def test_promotion_does_not_mutate_input() -> None:
+    """The scoped-only input mapping is never mutated by promotion."""
+    bundle = {
+        "shared_key_user@example.com": _SHARED_HEX,
+        "oauth_token": "aas_et/X",
+    }
+    normalize_secrets_bundle(bundle)
+    assert "shared_key" not in bundle
+
+
+def test_promoted_scoped_value_is_whitespace_normalized() -> None:
+    """A promoted scoped key is normalized like the canonical ``shared_key``.
+
+    Scoped ``shared_key_<id>`` keys are not whitelisted, so the recursive
+    whitespace pass only edge-trims them. Promotion must apply the canonical
+    credential normalization (all whitespace removed) so a wrapped-paste interior
+    space cannot survive into the top-level key and break AES-GCM decryption.
+    """
+    bundle = {"shared_key_user@example.com": " a b\nc ", "oauth_token": "aas_et/X"}
+    result = normalize_secrets_bundle(bundle)
+    assert result["shared_key"] == "abc"
+
+
+def test_scoped_values_differing_only_by_whitespace_not_ambiguous() -> None:
+    """Two scoped entries that normalize to the same key are not a conflict."""
+    bundle = {
+        "shared_key_a@example.com": "AA BB",
+        "shared_key_b@example.com": "AABB",
+    }
+    result = normalize_secrets_bundle(bundle)
+    # Both normalize to "AABB", so promotion proceeds with that single value.
+    assert result["shared_key"] == "AABB"
+
+
+def test_promotion_tolerates_non_string_keys() -> None:
+    """Promotion never raises on non-string keys (contract: input is ``Any``).
+
+    A bundle may carry non-string keys; the scoped-key scan must skip them rather
+    than call ``str``-only methods on them.
+    """
+    bundle: dict[Any, Any] = {
+        7: "numeric-key-value",
+        "shared_key_user@example.com": _SHARED_HEX,
+    }
+    result = normalize_secrets_bundle(bundle)
+    assert result["shared_key"] == _SHARED_HEX
+    assert result[7] == "numeric-key-value"
+
+
+def test_scoped_only_bundle_passes_key_status_gate() -> None:
+    """End-to-end: a scoped-only bundle is importable after normalization.
+
+    ``_secrets_key_status`` reads only the top-level ``shared_key``; the
+    promotion at the normalization chokepoint makes the scoped key visible to
+    the gate so ``has_shared`` is True and ``_interpret_credentials_choice`` does
+    not return ``keys_missing``.
+    """
+    raw = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+        "shared_key_user@example.com": _SHARED_HEX,
+    }
+    normalized = normalize_secrets_bundle(raw)
+    has_shared, _has_owner = config_flow._secrets_key_status(normalized)
+    assert has_shared is True
+
+    _method, _email, _cands, err = config_flow._interpret_credentials_choice(
+        {"secrets_json": json.dumps(raw)},
+        secrets_field="secrets_json",
+        token_field=CONF_OAUTH_TOKEN,
+        email_field=CONF_GOOGLE_EMAIL,
+    )
+    assert err != "keys_missing"
+
+
 @pytest.mark.asyncio
 async def test_config_flow_round_trip_strips_owner_key_space(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_config_flow_secrets_normalization.py
+++ b/tests/test_config_flow_secrets_normalization.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import inspect
 import json
+from importlib import import_module
 from typing import Any
 
 import pytest
@@ -238,35 +239,20 @@ async def test_config_flow_round_trip_strips_owner_key_space(
 
 
 # ---------------------------------------------------------------------------
-# RED characterization tests for the D1 gap and the D2 understated warning.
+# D1/D2 single-key enforcement tests.
 #
 # Design decision (single-key inversion, v5): the presence of ``shared_key`` is
 # the only gate that decides whether a pasted secrets bundle is importable. An
 # owner-only bundle without a ``shared_key`` is a non-renewable dead end and must
 # be blocked; conversely a bundle that carries a ``shared_key`` but lacks (or has
 # a stale) ``owner_key`` is tolerated because the integration can fetch/refresh
-# the owner key itself.
-#
-# Today's code does NOT enforce that rule, so these tests assert the *target*
-# behavior and are therefore expected to fail. They are marked
-# ``xfail(strict=True)`` so that once AP3/AP4 land the fix, the now-passing tests
-# turn into ``xpassed`` -> ``failed`` under strict mode, forcing the GREEN flip
-# to be made explicit.
+# the owner key itself. The D2 seeding warning names the real outage scope
+# (immediate FMDN loss plus the rotation-driven late outage for own devices).
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "D1 gap: _interpret_credentials_choice currently accepts a secrets "
-        "bundle that has a valid email and token but no shared_key. Under the "
-        "v5 single-key rule both owner-missing and owner-present inputs must be "
-        "blocked with the 'keys_missing' error. Flips to xpass once AP3/AP4 add "
-        "the shared_key gate."
-    ),
-)
-def test_d1_shared_missing_currently_accepted_xfail() -> None:
-    """Nail down the D1 gap: shared_key-less bundles must block under v5.
+def test_d1_shared_missing_blocked() -> None:
+    """The D1 single-key rule: shared_key-less bundles block under v5.
 
     ``_interpret_credentials_choice`` is a pure function, so no ConfigEntry or
     hass stub is required. Two input classes are pinned, both of which carry a
@@ -317,27 +303,24 @@ class _CapturingCache:
         self.saved[name] = value
 
 
+def _seeding_shared_missing_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> list[str]:
+    """Return the emitted missing-shared_key warning messages."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelname == "WARNING" and "shared_key" in record.getMessage()
+    ]
+
+
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "D2 understatement: when shared_key is missing, _async_save_secrets_data "
-        "warns only about FMDN crowdsourced reports and omits the rotation-driven "
-        "late outage. This test pins the current incomplete wording; it flips to "
-        "xpass once AP3/AP4 broaden the warning to cover the rotation outage."
-    ),
-)
-async def test_d2_seeding_warning_understates_outage_xfail(
+async def test_d2_seeding_warning_names_rotation_outage_when_owner_present(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Nail down the D2 understatement in the seeding warning text.
-
-    The current warning only claims an FMDN ("crowdsourced") restriction and
-    does not mention the rotation-driven late outage that follows once the
-    existing key rotates. We pin the present incomplete wording so the GREEN
-    flip becomes visible once the message is broadened.
-    """
-    from custom_components.googlefindmy import __init__ as integration_init
+    """D2 fix: an owner-only (shared_key missing) bundle warns about the
+    rotation-driven late outage, not only the immediate FMDN restriction."""
+    integration_init = import_module("custom_components.googlefindmy")
 
     cache = _CapturingCache()
     secrets_bundle = {
@@ -350,17 +333,435 @@ async def test_d2_seeding_warning_understates_outage_xfail(
     with caplog.at_level("WARNING"):
         await integration_init._async_save_secrets_data(cache, secrets_bundle)
 
-    warnings = [
-        record.getMessage()
-        for record in caplog.records
-        if record.levelname == "WARNING" and "shared_key" in record.getMessage()
-    ]
+    warnings = _seeding_shared_missing_warnings(caplog)
     assert warnings, "Expected a missing-shared_key warning to be emitted"
     message = warnings[0]
-    # The current text understates the outage: it only mentions the FMDN
-    # restriction and does not surface the rotation-driven late outage.
-    assert "FMDN network (crowdsourced) location reports will fail to decrypt" in message
-    assert "rotat" not in message.lower(), (
-        "Today's warning omits the rotation outage; once it is added this "
-        "assertion fails and the strict xfail flips to a forced GREEN."
+    # The corrected wording now surfaces the rotation-driven late outage.
+    assert "rotat" in message.lower()
+    assert "will fail" in message
+
+
+@pytest.mark.asyncio
+async def test_d2_seeding_warning_names_total_outage_when_owner_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """D2 fix: a bundle with neither key warns that no location can be
+    decrypted at all."""
+    integration_init = import_module("custom_components.googlefindmy")
+
+    cache = _CapturingCache()
+    secrets_bundle = {
+        "google_email": "user@example.com",
+        "username": "user@example.com",
+        # neither owner_key nor shared_key present.
+    }
+
+    with caplog.at_level("WARNING"):
+        await integration_init._async_save_secrets_data(cache, secrets_bundle)
+
+    warnings = _seeding_shared_missing_warnings(caplog)
+    assert warnings, "Expected a missing-shared_key warning to be emitted"
+    message = warnings[0]
+    assert "No location can be decrypted" in message
+    # The total-outage variant must not claim a (non-existent) rotation grace
+    # period.
+    assert "rotat" not in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_d2_seeding_warning_silent_when_shared_present(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """D2 fix: a bundle that carries a shared_key emits no seeding warning."""
+    integration_init = import_module("custom_components.googlefindmy")
+
+    cache = _CapturingCache()
+    secrets_bundle = {
+        "google_email": "user@example.com",
+        "username": "user@example.com",
+        "owner_key": "AABBCC",
+        "shared_key": "DDEEFF",
+    }
+
+    with caplog.at_level("WARNING"):
+        await integration_init._async_save_secrets_data(cache, secrets_bundle)
+
+    assert not _seeding_shared_missing_warnings(caplog), (
+        "A complete bundle (shared_key present) must not warn about a missing "
+        "shared_key."
     )
+
+
+# ---------------------------------------------------------------------------
+# AP2: unit coverage for the _secrets_key_status helper (four input classes).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("bundle", "expected"),
+    [
+        ({}, (False, False)),  # both missing
+        ({"shared_key": "AABB"}, (True, False)),  # shared only
+        ({"owner_key": "CCDD"}, (False, True)),  # owner only
+        ({"shared_key": "AABB", "owner_key": "CCDD"}, (True, True)),  # both
+    ],
+)
+def test_secrets_key_status_four_classes(
+    bundle: dict[str, Any], expected: tuple[bool, bool]
+) -> None:
+    """The helper reports presence for each of the four key combinations."""
+    assert config_flow._secrets_key_status(bundle) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "   ", "\n\t", 123, None, b"AABB", ["AABB"]],
+)
+def test_secrets_key_status_typechecks_presence(value: Any) -> None:
+    """Only a non-empty string (after stripping) counts as a present key."""
+    has_shared, has_owner = config_flow._secrets_key_status(
+        {"shared_key": value, "owner_key": value}
+    )
+    assert has_shared is False
+    assert has_owner is False
+
+
+# ---------------------------------------------------------------------------
+# AP3: call-site integration coverage for async_step_secrets_json.
+#
+# shared-missing (owner missing OR present) -> errors["base"] == "keys_missing"
+# shared-present -> the flow proceeds to the device-selection entry path.
+# ---------------------------------------------------------------------------
+
+
+def _make_secrets_flow(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, dict[str, Any]]:
+    """Build a ConfigFlow wired with the canonical _FlowHass stub pattern."""
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_pick(
+        hass: Any,
+        email: str,
+        candidates: list[tuple[str, str]],
+        *,
+        secrets_bundle: dict[str, Any] | None = None,
+    ) -> str | None:
+        return candidates[0][1] if candidates else None
+
+    monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+    class _ConfigEntries(ConfigEntriesDomainUniqueIdLookupMixin):
+        def __init__(self) -> None:
+            attach_config_entries_flow_manager(self)
+
+        def async_entries(self, domain: str) -> list[Any]:
+            assert domain == config_flow.DOMAIN
+            return []
+
+    class _FlowHass:
+        def __init__(self) -> None:
+            prepare_flow_hass_config_entries(
+                self,
+                _ConfigEntries,
+                frame_module=frame,
+            )
+
+    hass = _FlowHass()
+    flow = config_flow.ConfigFlow()
+    flow.hass = hass  # type: ignore[assignment]
+    flow.context = {}
+    flow._available_devices = [("Device", "device-id")]  # type: ignore[attr-defined]
+    set_config_flow_unique_id(flow, None)
+
+    async def _set_unique_id(value: str, *, raise_on_progress: bool = False) -> None:
+        set_config_flow_unique_id(flow, value)
+
+    async def _create_entry(
+        *,
+        title: str,
+        data: dict[str, Any],
+        options: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        captured["result"] = {"title": title, "data": data, "options": options}
+        return {"type": "create_entry", "title": title, "data": data}
+
+    flow.async_set_unique_id = _set_unique_id  # type: ignore[assignment]
+    flow._abort_if_unique_id_configured = lambda **_: None  # type: ignore[attr-defined]
+    flow.async_create_entry = _create_entry  # type: ignore[assignment]
+    return flow, captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_owner", [False, True])
+async def test_secrets_json_step_blocks_when_shared_missing(
+    monkeypatch: pytest.MonkeyPatch, with_owner: bool
+) -> None:
+    """async_step_secrets_json rejects a shared_key-less paste with keys_missing.
+
+    Both owner classes (owner missing and owner present) are blocked, since the
+    single-key rule gates only on the shared_key.
+    """
+    flow, captured = _make_secrets_flow(monkeypatch)
+
+    secrets_payload: dict[str, Any] = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+    }
+    if with_owner:
+        secrets_payload["owner_key"] = "AABBCC"
+
+    result = await flow.async_step_secrets_json(
+        {"secrets_json": json.dumps(secrets_payload)}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert isinstance(result, dict)
+    assert result.get("type") == "form"
+    assert result.get("errors") == {"base": "keys_missing"}
+    assert "result" not in captured
+
+
+@pytest.mark.asyncio
+async def test_secrets_json_step_accepts_when_shared_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """async_step_secrets_json accepts a shared_key bundle and proceeds to entry."""
+    flow, captured = _make_secrets_flow(monkeypatch)
+
+    secrets_payload = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+        "shared_key": "DDEEFF",
+    }
+
+    first = await flow.async_step_secrets_json(
+        {"secrets_json": json.dumps(secrets_payload)}
+    )
+    if inspect.isawaitable(first):
+        first = await first
+    assert isinstance(first, dict)
+    # No key error: the flow advanced to the device-selection form.
+    assert first.get("errors", {}) == {}
+
+    final = await flow.async_step_device_selection({})
+    if inspect.isawaitable(final):
+        final = await final
+    assert isinstance(final, dict)
+    assert final.get("type") == "create_entry"
+    assert captured["result"]["data"][DATA_SECRET_BUNDLE]["shared_key"] == "DDEEFF"
+
+
+# ---------------------------------------------------------------------------
+# AP3e: call-site integration coverage for async_step_credentials
+# (options "Refresh credentials"). Reuses the canonical options-flow harness.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_owner", [False, True])
+async def test_credentials_step_blocks_when_shared_missing(
+    monkeypatch: pytest.MonkeyPatch, with_owner: bool
+) -> None:
+    """async_step_credentials rejects a shared_key-less refresh in the field slot.
+
+    The error lands in the new_secrets_json field slot (not base) and no entry
+    update / reload is performed.
+    """
+    from custom_components.googlefindmy.const import TRACKER_SUBENTRY_KEY
+    from tests.test_options_flow_credentials_cache import (
+        _DummyEntry,
+        _DummyHass,
+        _MemoryCache,
+    )
+
+    cache = _MemoryCache()
+    entry = _DummyEntry(
+        entry_id="entry-1",
+        data={
+            CONF_GOOGLE_EMAIL: "user@example.com",
+            CONF_OAUTH_TOKEN: "oauth-original-token-123456",
+        },
+        cache=cache,
+    )
+    hass = _DummyHass(entry, cache)
+
+    flow = config_flow.OptionsFlowHandler()
+    flow.hass = hass  # type: ignore[assignment]
+    flow.config_entry = entry  # type: ignore[attr-defined]
+
+    async def _fail_pick(*args: Any, **kwargs: Any) -> str | None:
+        raise AssertionError("token validation must not run for a blocked bundle")
+
+    monkeypatch.setattr(config_flow, "async_pick_working_token", _fail_pick)
+
+    payload: dict[str, Any] = {
+        "google_email": "user@example.com",
+        "oauth_token": "oauth-token-from-secrets-123456",
+    }
+    if with_owner:
+        payload["owner_key"] = "AABBCC"
+
+    result = await flow.async_step_credentials(
+        {"new_secrets_json": json.dumps(payload), "subentry": TRACKER_SUBENTRY_KEY}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert isinstance(result, dict)
+    assert result.get("type") == "form"
+    assert result.get("errors") == {"new_secrets_json": "keys_missing"}
+    assert not hass.config_entries.updated_payloads
+    assert not hass.config_entries.reloaded
+
+
+@pytest.mark.asyncio
+async def test_credentials_step_accepts_when_shared_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """async_step_credentials accepts a shared_key refresh and finalizes."""
+    from custom_components.googlefindmy.const import TRACKER_SUBENTRY_KEY
+    from tests.test_options_flow_credentials_cache import (
+        _DummyEntry,
+        _DummyHass,
+        _MemoryCache,
+    )
+
+    cache = _MemoryCache()
+    entry = _DummyEntry(
+        entry_id="entry-1",
+        data={
+            CONF_GOOGLE_EMAIL: "user@example.com",
+            CONF_OAUTH_TOKEN: "oauth-original-token-123456",
+        },
+        cache=cache,
+    )
+    hass = _DummyHass(entry, cache)
+
+    flow = config_flow.OptionsFlowHandler()
+    flow.hass = hass  # type: ignore[assignment]
+    flow.config_entry = entry  # type: ignore[attr-defined]
+
+    async def _fake_pick(
+        hass: Any,
+        email: str,
+        candidates: list[tuple[str, str]],
+        *,
+        secrets_bundle: dict[str, Any] | None = None,
+    ) -> str | None:
+        return candidates[0][1] if candidates else None
+
+    monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+    payload = {
+        "google_email": "user@example.com",
+        "oauth_token": "oauth-token-from-secrets-123456",
+        "shared_key": "DDEEFF",
+    }
+
+    result = await flow.async_step_credentials(
+        {"new_secrets_json": json.dumps(payload), "subentry": TRACKER_SUBENTRY_KEY}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert isinstance(result, dict)
+    # _finalize_success was reached: the entry was updated with the new bundle.
+    assert hass.config_entries.updated_payloads
+    updated = hass.config_entries.updated_payloads[-1]
+    assert updated[DATA_SECRET_BUNDLE]["shared_key"] == "DDEEFF"
+    await hass.drain_tasks()
+
+
+@pytest.mark.asyncio
+async def test_credentials_step_shared_present_but_no_token_is_invalid_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shared_key-bearing bundle with no plausible token still fails on tokens.
+
+    This pins the branch that follows the single-key gate: the gate passes (the
+    shared_key is present) but the candidate-token check then rejects the bundle
+    with ``invalid_token`` in the base slot.
+    """
+    from custom_components.googlefindmy.const import TRACKER_SUBENTRY_KEY
+    from tests.test_options_flow_credentials_cache import (
+        _DummyEntry,
+        _DummyHass,
+        _MemoryCache,
+    )
+
+    cache = _MemoryCache()
+    entry = _DummyEntry(
+        entry_id="entry-1",
+        data={
+            CONF_GOOGLE_EMAIL: "user@example.com",
+            CONF_OAUTH_TOKEN: "oauth-original-token-123456",
+        },
+        cache=cache,
+    )
+    hass = _DummyHass(entry, cache)
+
+    flow = config_flow.OptionsFlowHandler()
+    flow.hass = hass  # type: ignore[assignment]
+    flow.config_entry = entry  # type: ignore[attr-defined]
+
+    async def _fail_pick(*args: Any, **kwargs: Any) -> str | None:
+        raise AssertionError("token validation must not run without candidates")
+
+    monkeypatch.setattr(config_flow, "async_pick_working_token", _fail_pick)
+
+    payload = {
+        "google_email": "user@example.com",
+        # shared_key present so the gate passes, but no plausible token.
+        "shared_key": "DDEEFF",
+    }
+
+    result = await flow.async_step_credentials(
+        {"new_secrets_json": json.dumps(payload), "subentry": TRACKER_SUBENTRY_KEY}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert isinstance(result, dict)
+    assert result.get("errors") == {"base": "invalid_token"}
+    assert not hass.config_entries.updated_payloads
+
+
+# ---------------------------------------------------------------------------
+# AP3c: discovery validator coverage for the single-key gate.
+#
+# shared-missing (owner missing OR present) -> DiscoveryFlowError("keys_missing")
+# shared-present -> the discovery payload validates normally.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("with_owner", [False, True])
+def test_discovery_payload_blocks_when_shared_missing(with_owner: bool) -> None:
+    """A discovered bundle without a shared_key is rejected with keys_missing."""
+    secrets: dict[str, Any] = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/DISCOVERY",
+    }
+    if with_owner:
+        secrets["owner_key"] = "AABBCC"
+
+    with pytest.raises(config_flow.DiscoveryFlowError) as exc_info:
+        config_flow._normalize_and_validate_discovery_payload(
+            {DATA_SECRET_BUNDLE: secrets}
+        )
+    assert exc_info.value.reason == "keys_missing"
+
+
+def test_discovery_payload_accepts_when_shared_present() -> None:
+    """A discovered bundle with a shared_key validates normally."""
+    secrets = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/DISCOVERY",
+        "shared_key": "DDEEFF",
+    }
+    result = config_flow._normalize_and_validate_discovery_payload(
+        {DATA_SECRET_BUNDLE: secrets}
+    )
+    assert result.email == "user@example.com"
+    assert result.secrets_bundle is not None
+    assert result.secrets_bundle["shared_key"] == "DDEEFF"

--- a/tests/test_config_flow_secrets_normalization.py
+++ b/tests/test_config_flow_secrets_normalization.py
@@ -235,3 +235,132 @@ async def test_config_flow_round_trip_strips_owner_key_space(
     # Token persisted from the (clean) aas_token.
     assert data[CONF_OAUTH_TOKEN] == "aas_et/FROM_SECRETS"
     assert data[CONF_GOOGLE_EMAIL] == "user@example.com"
+
+
+# ---------------------------------------------------------------------------
+# RED characterization tests for the D1 gap and the D2 understated warning.
+#
+# Design decision (single-key inversion, v5): the presence of ``shared_key`` is
+# the only gate that decides whether a pasted secrets bundle is importable. An
+# owner-only bundle without a ``shared_key`` is a non-renewable dead end and must
+# be blocked; conversely a bundle that carries a ``shared_key`` but lacks (or has
+# a stale) ``owner_key`` is tolerated because the integration can fetch/refresh
+# the owner key itself.
+#
+# Today's code does NOT enforce that rule, so these tests assert the *target*
+# behavior and are therefore expected to fail. They are marked
+# ``xfail(strict=True)`` so that once AP3/AP4 land the fix, the now-passing tests
+# turn into ``xpassed`` -> ``failed`` under strict mode, forcing the GREEN flip
+# to be made explicit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "D1 gap: _interpret_credentials_choice currently accepts a secrets "
+        "bundle that has a valid email and token but no shared_key. Under the "
+        "v5 single-key rule both owner-missing and owner-present inputs must be "
+        "blocked with the 'keys_missing' error. Flips to xpass once AP3/AP4 add "
+        "the shared_key gate."
+    ),
+)
+def test_d1_shared_missing_currently_accepted_xfail() -> None:
+    """Nail down the D1 gap: shared_key-less bundles must block under v5.
+
+    ``_interpret_credentials_choice`` is a pure function, so no ConfigEntry or
+    hass stub is required. Two input classes are pinned, both of which carry a
+    valid email and a plausible token and must block once the single-key rule
+    is enforced:
+
+    * (a) shared_key missing AND owner_key missing.
+    * (b) shared_key missing BUT owner_key present.
+    """
+    # Class (a): neither shared_key nor owner_key present.
+    bundle_no_owner = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+    }
+    # Class (b): owner_key present, shared_key still missing.
+    bundle_with_owner = {
+        "google_email": "user@example.com",
+        "aas_token": "aas_et/FROM_SECRETS",
+        "owner_key": "AABBCC",
+    }
+
+    for bundle in (bundle_no_owner, bundle_with_owner):
+        _method, _email, _cands, err = config_flow._interpret_credentials_choice(
+            {"secrets_json": json.dumps(bundle)},
+            secrets_field="secrets_json",
+            token_field=CONF_OAUTH_TOKEN,
+            email_field=CONF_GOOGLE_EMAIL,
+        )
+        # Target (v5) behavior: a missing shared_key blocks the import.
+        assert err == "keys_missing", (
+            "shared_key-less bundle must be rejected with 'keys_missing' "
+            f"(owner_key present={'owner_key' in bundle})"
+        )
+
+
+class _CapturingCache:
+    """Minimal cache stub recording values written by the secrets migrator.
+
+    Mirrors the ``_CapturingCache`` pattern in
+    ``tests/test_token_cache_secrets.py`` so the seeding helper can be exercised
+    without a real ``TokenCache`` or ConfigEntry.
+    """
+
+    def __init__(self) -> None:
+        self.saved: dict[str, Any] = {}
+
+    async def async_set_cached_value(self, name: str, value: Any) -> None:
+        self.saved[name] = value
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "D2 understatement: when shared_key is missing, _async_save_secrets_data "
+        "warns only about FMDN crowdsourced reports and omits the rotation-driven "
+        "late outage. This test pins the current incomplete wording; it flips to "
+        "xpass once AP3/AP4 broaden the warning to cover the rotation outage."
+    ),
+)
+async def test_d2_seeding_warning_understates_outage_xfail(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Nail down the D2 understatement in the seeding warning text.
+
+    The current warning only claims an FMDN ("crowdsourced") restriction and
+    does not mention the rotation-driven late outage that follows once the
+    existing key rotates. We pin the present incomplete wording so the GREEN
+    flip becomes visible once the message is broadened.
+    """
+    from custom_components.googlefindmy import __init__ as integration_init
+
+    cache = _CapturingCache()
+    secrets_bundle = {
+        "google_email": "user@example.com",
+        "username": "user@example.com",
+        "owner_key": "AABBCC",
+        # shared_key intentionally absent -> triggers the seeding warning.
+    }
+
+    with caplog.at_level("WARNING"):
+        await integration_init._async_save_secrets_data(cache, secrets_bundle)
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelname == "WARNING" and "shared_key" in record.getMessage()
+    ]
+    assert warnings, "Expected a missing-shared_key warning to be emitted"
+    message = warnings[0]
+    # The current text understates the outage: it only mentions the FMDN
+    # restriction and does not surface the rotation-driven late outage.
+    assert "FMDN network (crowdsourced) location reports will fail to decrypt" in message
+    assert "rotat" not in message.lower(), (
+        "Today's warning omits the rotation outage; once it is added this "
+        "assertion fails and the strict xfail flips to a forced GREEN."
+    )

--- a/tests/test_discovery_abort_reason_translations.py
+++ b/tests/test_discovery_abort_reason_translations.py
@@ -1,0 +1,207 @@
+# tests/test_discovery_abort_reason_translations.py
+"""Guard tests binding discovery abort reasons to their translation namespace.
+
+Background (regression class prevention)
+----------------------------------------
+The discovery validation chokepoint
+``config_flow._normalize_and_validate_discovery_payload`` raises
+``DiscoveryFlowError(<reason>)`` for rejected payloads. The two discovery
+catch sites (``async_step_discovery`` and ``async_step_discovery_update_info``)
+forward that reason verbatim via ``self.async_abort(reason=err.reason)``.
+Home Assistant resolves abort reasons from the ``config.abort`` translation
+namespace, NOT ``config.error``. A reason that only exists under
+``config.error`` therefore surfaces as an untranslated/unknown abort.
+
+PR #1128 introduced ``keys_missing`` (single-shared-key rule) but only added it
+to ``config.error`` / ``options.error``. The structural test below enumerates
+every reason the chokepoint can raise and asserts each one is resolvable as an
+abort reason, so the same "added to the wrong namespace" mistake fails fast for
+any future custom discovery-rejection reason — not just ``keys_missing``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from homeassistant.helpers import frame
+
+from custom_components.googlefindmy import config_flow
+from tests.helpers.config_flow import (
+    ConfigEntriesDomainUniqueIdLookupMixin,
+    prepare_flow_hass_config_entries,
+)
+
+CONFIG_FLOW_PATH = Path(config_flow.__file__)
+STRINGS_PATH = Path("custom_components/googlefindmy/strings.json")
+
+# Chokepoint whose raised reasons are forwarded verbatim to ``async_abort``.
+_DISCOVERY_VALIDATOR = "_normalize_and_validate_discovery_payload"
+_DISCOVERY_ERROR = "DiscoveryFlowError"
+
+# Reasons Home Assistant Core resolves from its shared ``common`` translation
+# strings even when an integration does not define them locally. Any reason on
+# this allowlist is treated as translatable without a local ``config.abort``
+# entry. Keep this list minimal and documented: it exists only so the
+# structural guard does not flag pre-existing Core reasons, while still failing
+# for integration-owned reasons (such as ``keys_missing``) that have no Core
+# fallback. See https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#aborting-a-flow
+_HA_CORE_COMMON_ABORT_REASONS = frozenset(
+    {
+        "cannot_connect",
+        "unknown",
+        "invalid_auth",
+        "already_configured",
+    }
+)
+
+
+def _raised_discovery_reasons() -> set[str]:
+    """Return literal reasons raised inside the discovery validation chokepoint.
+
+    Parses ``config_flow.py`` and collects every
+    ``raise DiscoveryFlowError("<literal>")`` inside
+    ``_normalize_and_validate_discovery_payload``. These reasons are forwarded
+    verbatim by the discovery catch sites, so each must resolve as an abort
+    reason. Dynamic (non-literal) reasons are reported so the guard never
+    silently ignores a reason it cannot statically classify.
+    """
+
+    tree = ast.parse(CONFIG_FLOW_PATH.read_text(encoding="utf-8"))
+    target: ast.FunctionDef | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == _DISCOVERY_VALIDATOR:
+            target = node
+            break
+    assert target is not None, (
+        f"Could not locate {_DISCOVERY_VALIDATOR} in {CONFIG_FLOW_PATH.name}; "
+        "the discovery-reason guard can no longer enumerate raised reasons."
+    )
+
+    reasons: set[str] = set()
+    for sub in ast.walk(target):
+        if not isinstance(sub, ast.Raise) or not isinstance(sub.exc, ast.Call):
+            continue
+        func = sub.exc.func
+        if not (isinstance(func, ast.Name) and func.id == _DISCOVERY_ERROR):
+            continue
+        assert sub.exc.args, f"{_DISCOVERY_ERROR} raised without a reason argument"
+        first = sub.exc.args[0]
+        # Dynamic reasons (e.g. a mapped variable) are surfaced via the special
+        # "<dynamic>" marker; the assertion below intentionally rejects it so a
+        # future non-literal reason cannot bypass the namespace guard unnoticed.
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            reasons.add(first.value)
+        else:
+            reasons.add("<dynamic>")
+    return reasons
+
+
+def _config_abort_reasons() -> set[str]:
+    """Return the abort reasons defined under ``config.abort`` in strings.json."""
+
+    data = json.loads(STRINGS_PATH.read_text(encoding="utf-8"))
+    abort = data.get("config", {}).get("abort", {})
+    return set(abort.keys())
+
+
+def test_discovery_validator_reasons_are_resolvable_abort_reasons() -> None:
+    """Every chokepoint discovery reason must resolve as an abort reason.
+
+    Structural invariant: each reason raised by
+    ``_normalize_and_validate_discovery_payload`` (forwarded verbatim to
+    ``async_abort``) is either defined in ``strings.json`` ``config.abort`` or a
+    known Home Assistant Core common abort reason. This catches the PR #1128
+    class of bug where an integration-owned reason lands only in
+    ``config.error`` and surfaces untranslated during discovery.
+    """
+
+    raised = _raised_discovery_reasons()
+    assert "<dynamic>" not in raised, (
+        "A discovery reason is raised from a non-literal expression; extend this "
+        "guard to resolve it statically before asserting translation coverage."
+    )
+
+    abort_reasons = _config_abort_reasons()
+    unresolved = {
+        reason
+        for reason in raised
+        if reason not in abort_reasons
+        and reason not in _HA_CORE_COMMON_ABORT_REASONS
+    }
+    assert not unresolved, (
+        "Discovery-rejection reasons surface via async_abort but are missing "
+        "from strings.json 'config.abort' (and are not Home Assistant Core "
+        f"common reasons): {sorted(unresolved)}. Add each to config.abort so "
+        "the user sees the actionable guidance instead of an untranslated abort."
+    )
+
+
+def test_keys_missing_is_defined_in_config_abort() -> None:
+    """``keys_missing`` must be present in ``config.abort`` (explicit anchor).
+
+    Narrow companion to the structural invariant: ``keys_missing`` is the
+    integration-owned discovery-rejection reason introduced by PR #1128. It has
+    no Home Assistant Core fallback, so it must be explicitly defined under
+    ``config.abort`` to render the shared-key guidance during discovery aborts.
+    """
+
+    assert "keys_missing" in _config_abort_reasons(), (
+        "strings.json 'config.abort' is missing 'keys_missing'; the discovery "
+        "abort path would surface an untranslated reason."
+    )
+
+
+@pytest.mark.asyncio
+async def test_discovery_without_shared_key_aborts_with_keys_missing() -> None:
+    """A discovered bundle without a shared_key must abort with ``keys_missing``.
+
+    Behavioral counterpart to the structural guard: it drives the real discovery
+    validation path with a shared-key-less secrets bundle and asserts the
+    surfaced abort reason is ``keys_missing``. This proves the reason genuinely
+    reaches ``async_abort`` (not merely that the string exists), so the
+    translation guard above protects an actually reachable surface.
+    """
+
+    class _ConfigEntries(ConfigEntriesDomainUniqueIdLookupMixin):
+        def __init__(self) -> None:
+            self.setup_calls: list[str] = []
+
+        def async_entries(self, domain: str) -> list[Any]:
+            return []
+
+        def async_get_subentries(self, _entry_id: str) -> list[Any]:
+            return []
+
+        async def async_setup(self, entry_id: str) -> bool:
+            self.setup_calls.append(entry_id)
+            return True
+
+    class _FlowHass:
+        def __init__(self) -> None:
+            prepare_flow_hass_config_entries(
+                self,
+                _ConfigEntries,
+                frame_module=frame,
+            )
+
+    flow = config_flow.ConfigFlow()
+    flow.hass = _FlowHass()  # type: ignore[assignment]
+    flow.context = {}
+
+    # secrets bundle with an oauth/aas token but deliberately no shared_key:
+    # the single-key discovery rule must reject it as a non-renewable dead end.
+    discovery_info = {
+        "secrets_json": {
+            "google_email": "DiscoveryUser@example.com",
+            "aas_token": "aas_et/DISCOVERY",
+        }
+    }
+
+    result = await flow.async_step_discovery(discovery_info)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "keys_missing"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -291,3 +291,461 @@ class TestResolveEffectiveEntryId:
         from custom_components.googlefindmy.main import _resolve_effective_entry_id
 
         assert _resolve_effective_entry_id("", "env_value") == ""
+
+
+# ---------------------------------------------------------------------------
+# AP-B1: atomic JSON write + clean vault-failure exit
+# ---------------------------------------------------------------------------
+
+
+class _AsyncDictCache:
+    """Minimal async cache mirroring the ``_FileCache`` get/set surface.
+
+    Used to exercise the eager key-retrieval helpers without a real
+    file-backed cache or Home Assistant.
+    """
+
+    def __init__(self, initial: dict | None = None) -> None:
+        self.data: dict = dict(initial or {})
+
+    async def get(self, name: str) -> object:
+        return self.data.get(name)
+
+    async def set(self, name: str, value: object) -> None:
+        if value is None:
+            self.data.pop(name, None)
+        else:
+            self.data[name] = value
+
+
+class TestAtomicWriteJson:
+    """`_atomic_write_json` writes atomically with restrictive permissions."""
+
+    def test_atomic_write_creates_file_0600(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        """A successful write produces valid JSON with mode 0600."""
+        import json
+        import os
+        import stat
+
+        from custom_components.googlefindmy.main import _atomic_write_json
+
+        target = tmp_path / "Auth" / "secrets.json"
+        payload = {"username": "user@example.com", "oauth_token": "tok"}
+
+        _atomic_write_json(target, payload)
+
+        assert json.loads(target.read_text(encoding="utf-8")) == payload
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o600
+        # No orphan temp artifact left behind in the target directory.
+        leftovers = [p.name for p in target.parent.iterdir() if p.name != "secrets.json"]
+        assert leftovers == []
+
+    def test_replace_failure_preserves_original_and_cleans_temp(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """An ``os.replace`` failure leaves the original file byte-identical,
+        writes no partial/0-byte JSON, and leaves no orphan temp file."""
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.main import _atomic_write_json
+
+        target = tmp_path / "secrets.json"
+        original_bytes = b'{"username": "old@example.com", "oauth_token": "keep"}'
+        target.write_bytes(original_bytes)
+
+        def _boom(src, dst):  # type: ignore[no-untyped-def]
+            raise OSError("simulated cross-device or interrupted replace")
+
+        monkeypatch.setattr(cli_main.os, "replace", _boom)
+
+        with pytest.raises(OSError, match="simulated"):
+            _atomic_write_json(target, {"username": "new@example.com"})
+
+        # (i) target byte-identical to the pre-write state.
+        assert target.read_bytes() == original_bytes
+        # (ii) not a 0-byte / partial truncation.
+        assert target.stat().st_size == len(original_bytes)
+        # (iii) no orphan temp file lingering next to the target.
+        leftovers = [p.name for p in target.parent.iterdir() if p.name != "secrets.json"]
+        assert leftovers == []
+
+    def test_chmod_failure_cleans_already_consumed_temp(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """If ``os.chmod`` fails *after* ``os.replace`` consumed the temp file,
+        the cleanup tolerates the missing temp (``FileNotFoundError``) and
+        re-raises the original error."""
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.main import _atomic_write_json
+
+        target = tmp_path / "secrets.json"
+
+        def _chmod_boom(path, mode):  # type: ignore[no-untyped-def]
+            raise PermissionError("simulated chmod failure")
+
+        monkeypatch.setattr(cli_main.os, "chmod", _chmod_boom)
+
+        with pytest.raises(PermissionError, match="simulated chmod"):
+            _atomic_write_json(target, {"username": "u@example.com"})
+
+        # The replace already happened, so the target exists; no orphan temp.
+        assert target.exists()
+        leftovers = [p.name for p in target.parent.iterdir() if p.name != "secrets.json"]
+        assert leftovers == []
+
+
+class TestFileCacheSave:
+    """`_FileCache._save` routes through the atomic writer and honors the
+    load-failure guard."""
+
+    @staticmethod
+    def _make_cache(tmp_path, monkeypatch: pytest.MonkeyPatch, initial_json: str | None):  # type: ignore[no-untyped-def]
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.Auth import token_cache
+
+        monkeypatch.setattr(token_cache, "_INSTANCES", {}, raising=False)
+        monkeypatch.setitem(token_cache._STATE, "default_entry_id", None)
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+        auth_dir = tmp_path / "Auth"
+        auth_dir.mkdir(parents=True, exist_ok=True)
+        if initial_json is not None:
+            (auth_dir / "secrets.json").write_text(initial_json, encoding="utf-8")
+        return cli_main._register_file_cache("entry_save")
+
+    @pytest.mark.asyncio
+    async def test_set_writes_atomically_with_0600(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """A successful ``set`` persists via the atomic writer (0600 file)."""
+        import json
+        import os
+        import stat
+
+        cache = self._make_cache(tmp_path, monkeypatch, '{"oauth_token": "tok"}')
+        await cache.set("shared_key", "abc")  # type: ignore[attr-defined]
+
+        secrets = tmp_path / "Auth" / "secrets.json"
+        on_disk = json.loads(secrets.read_text(encoding="utf-8"))
+        assert on_disk["shared_key"] == "abc"
+        assert on_disk["oauth_token"] == "tok"
+        assert stat.S_IMODE(os.stat(secrets).st_mode) == 0o600
+
+    @pytest.mark.asyncio
+    async def test_load_failed_empty_does_not_overwrite(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """A cache whose load failed must not clobber the on-disk file while it
+        still holds no data (the ``_load_failed and not _data`` guard)."""
+        # Corrupt JSON forces _load_failed = True while _data stays empty.
+        corrupt = "{ this is not valid json"
+        cache = self._make_cache(tmp_path, monkeypatch, corrupt)
+
+        await cache.flush()  # type: ignore[attr-defined]  # guard -> early return
+
+        secrets = tmp_path / "Auth" / "secrets.json"
+        # The corrupt file is left untouched (not overwritten with "{}").
+        assert secrets.read_text(encoding="utf-8") == corrupt
+
+
+class TestEnsureAuthenticatedPersist:
+    """`_ensure_authenticated` persists fresh credentials via the atomic writer."""
+
+    @pytest.mark.asyncio
+    async def test_persists_oauth_via_atomic_write(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """When no credentials exist, the OAuth login result is written to a
+        0600 ``secrets.json`` through ``_atomic_write_json``."""
+        import json
+        import os
+        import stat
+
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+
+        # Provide a stub Chrome-login flow so no browser is opened.
+        from custom_components.googlefindmy.Auth import auth_flow
+
+        monkeypatch.setattr(
+            auth_flow,
+            "request_oauth_account_token_flow",
+            lambda: ("oauth-token-value", "detected@example.com"),
+        )
+
+        cli_main._ensure_authenticated()
+
+        secrets = tmp_path / "Auth" / "secrets.json"
+        data = json.loads(secrets.read_text(encoding="utf-8"))
+        assert data["oauth_token"] == "oauth-token-value"
+        assert data["username"] == "detected@example.com"
+        assert stat.S_IMODE(os.stat(secrets).st_mode) == 0o600
+
+
+class TestEnsureVaultKeysExit:
+    """`_ensure_vault_keys` exits cleanly on vault failure without data loss."""
+
+    @pytest.mark.asyncio
+    async def test_vault_runtime_error_exits_one_with_message(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A vault ``RuntimeError`` yields ``SystemExit(1)`` and the
+        actionable ``vault key retrieval failed`` message; durable tokens
+        stay in the cache (no deletion on the error path)."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache(
+            {"username": "u@example.com", "oauth_token": "oauth", "aas_token": "aas"}
+        )
+
+        async def _raise(_cache):  # type: ignore[no-untyped-def]
+            raise RuntimeError("vault returned None")
+
+        monkeypatch.setattr(cli_main, "_ensure_shared_key", _raise)
+
+        with pytest.raises(SystemExit) as excinfo:
+            await cli_main._ensure_vault_keys(cache)
+
+        assert excinfo.value.code == 1
+        # AAS/oauth tokens are durable-by-design and must not be deleted.
+        assert cache.data["oauth_token"] == "oauth"
+        assert cache.data["aas_token"] == "aas"
+
+    @pytest.mark.asyncio
+    async def test_vault_failure_message_on_stderr(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The exact substring ``vault key retrieval failed`` is printed to
+        stderr (not a raw traceback)."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache({"username": "u@example.com"})
+
+        async def _raise(_cache):  # type: ignore[no-untyped-def]
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(cli_main, "_ensure_shared_key", _raise)
+
+        with pytest.raises(SystemExit):
+            await cli_main._ensure_vault_keys(cache)
+
+        assert "vault key retrieval failed" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_keyboard_interrupt_propagates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``KeyboardInterrupt`` (a ``BaseException``) is *not* swallowed by the
+        ``except Exception`` handler; it propagates as a user abort."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache({"username": "u@example.com"})
+
+        async def _interrupt(_cache):  # type: ignore[no-untyped-def]
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(cli_main, "_ensure_shared_key", _interrupt)
+
+        with pytest.raises(KeyboardInterrupt):
+            await cli_main._ensure_vault_keys(cache)
+
+
+# ---------------------------------------------------------------------------
+# AP-B2: eager owner-key retrieval + paste compatibility (F-B)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureOwnerKey:
+    """`_ensure_owner_key` fetches the owner key eagerly and stays idempotent."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_and_writes_top_level_hex(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing owner key triggers a non-interactive fetch; the resulting
+        key is stored as the top-level ``owner_key`` hex form (F-B)."""
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+            OwnerKeyInfo,
+        )
+
+        cache = _AsyncDictCache({"username": "u@example.com"})
+        key_bytes = bytes(range(32))
+
+        async def _fake_fetch(*, cache):  # type: ignore[no-untyped-def]
+            # Mirror production: the helper persists the scoped runtime key.
+            await cache.set("owner_key_u@example.com", key_bytes.hex())
+            return OwnerKeyInfo(key=key_bytes, version=None)
+
+        import custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key as gok
+
+        monkeypatch.setattr(gok, "async_get_owner_key", _fake_fetch)
+
+        await cli_main._ensure_owner_key(cache)
+
+        assert cache.data["owner_key"] == key_bytes.hex()
+        assert cache.data["owner_key_u@example.com"] == key_bytes.hex()
+
+    @pytest.mark.asyncio
+    async def test_short_circuits_on_top_level_cache(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An already-cached top-level ``owner_key`` skips the fetch entirely."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache({"username": "u@example.com", "owner_key": "deadbeef"})
+
+        async def _must_not_run(*, cache):  # type: ignore[no-untyped-def]
+            raise AssertionError("owner-key fetch must be short-circuited")
+
+        import custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key as gok
+
+        monkeypatch.setattr(gok, "async_get_owner_key", _must_not_run)
+
+        await cli_main._ensure_owner_key(cache)
+
+        assert cache.data["owner_key"] == "deadbeef"
+
+    @pytest.mark.asyncio
+    async def test_short_circuits_on_scoped_cache(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An already-cached scoped ``owner_key_{username}`` skips the fetch."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache(
+            {"username": "u@example.com", "owner_key_u@example.com": "cafe"}
+        )
+
+        async def _must_not_run(*, cache):  # type: ignore[no-untyped-def]
+            raise AssertionError("owner-key fetch must be short-circuited")
+
+        import custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key as gok
+
+        monkeypatch.setattr(gok, "async_get_owner_key", _must_not_run)
+
+        await cli_main._ensure_owner_key(cache)
+
+        assert "owner_key" not in cache.data
+
+    @pytest.mark.asyncio
+    async def test_fetches_when_username_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no cached username the scoped check is skipped and the fetch
+        runs; ``async_get_owner_key`` resolves the user itself."""
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+            OwnerKeyInfo,
+        )
+
+        cache = _AsyncDictCache()  # no username cached
+        key_bytes = bytes([7]) * 32
+
+        async def _fake_fetch(*, cache):  # type: ignore[no-untyped-def]
+            return OwnerKeyInfo(key=key_bytes, version=3)
+
+        import custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key as gok
+
+        monkeypatch.setattr(gok, "async_get_owner_key", _fake_fetch)
+
+        await cli_main._ensure_owner_key(cache)
+
+        assert cache.data["owner_key"] == key_bytes.hex()
+
+
+class TestVaultKeysCompleteness:
+    """`_ensure_vault_keys` sets both keys on success and stays non-destructive."""
+
+    @pytest.mark.asyncio
+    async def test_success_sets_both_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A successful run leaves both the shared and owner key in the cache."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache({"username": "u@example.com"})
+
+        async def _set_shared(_cache):  # type: ignore[no-untyped-def]
+            await _cache.set("shared_key", "shared-hex")
+
+        async def _set_owner(_cache):  # type: ignore[no-untyped-def]
+            await _cache.set("owner_key", "owner-hex")
+
+        monkeypatch.setattr(cli_main, "_ensure_shared_key", _set_shared)
+        monkeypatch.setattr(cli_main, "_ensure_owner_key", _set_owner)
+
+        await cli_main._ensure_vault_keys(cache)
+
+        assert cache.data["shared_key"] == "shared-hex"
+        assert cache.data["owner_key"] == "owner-hex"
+
+    @pytest.mark.asyncio
+    async def test_owner_key_failure_keeps_tokens(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An owner-key fetch failure exits cleanly and deletes no tokens."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache(
+            {"username": "u@example.com", "oauth_token": "oauth", "aas_token": "aas"}
+        )
+
+        async def _set_shared(_cache):  # type: ignore[no-untyped-def]
+            await _cache.set("shared_key", "shared-hex")
+
+        async def _owner_boom(_cache):  # type: ignore[no-untyped-def]
+            raise RuntimeError("SPOT failure")
+
+        monkeypatch.setattr(cli_main, "_ensure_shared_key", _set_shared)
+        monkeypatch.setattr(cli_main, "_ensure_owner_key", _owner_boom)
+
+        with pytest.raises(SystemExit) as excinfo:
+            await cli_main._ensure_vault_keys(cache)
+
+        assert excinfo.value.code == 1
+        assert cache.data["oauth_token"] == "oauth"
+        assert cache.data["aas_token"] == "aas"
+        # The shared key obtained before the failure also survives.
+        assert cache.data["shared_key"] == "shared-hex"
+
+
+class TestPasteRoundTrip:
+    """F-B: a CLI-produced bundle's top-level owner_key is paste-importable."""
+
+    @pytest.mark.asyncio
+    async def test_top_level_owner_key_seeds_into_cache(self) -> None:
+        """A ``secrets.json`` carrying a top-level ``owner_key`` hex (as written
+        by ``_ensure_owner_key``) lands ``owner_key_{username}`` in the cache
+        when re-imported via ``_async_save_secrets_data`` (the paste path)."""
+        from importlib import import_module
+
+        integration_init = import_module("custom_components.googlefindmy")
+
+        username = "user@example.com"
+        owner_hex = bytes(range(32)).hex()
+        # Shape mirrors what the CLI path writes: top-level owner_key hex,
+        # username, and the shared_key.
+        cli_bundle = {
+            "username": username,
+            "owner_key": owner_hex,
+            "shared_key": "ddeeff",
+        }
+
+        class _CapturingCache:
+            def __init__(self) -> None:
+                self.saved: dict = {}
+
+            async def async_set_cached_value(self, name: str, value: object) -> None:
+                self.saved[name] = value
+
+        cache = _CapturingCache()
+        await integration_init._async_save_secrets_data(cache, cli_bundle)
+
+        # The bundle carried the owner key ONLY at top level (no pre-scoped
+        # ``owner_key_{username}`` field); the seeding path must read that
+        # top-level field and produce the scoped runtime cache entry.
+        assert "owner_key_user@example.com" not in cli_bundle
+        assert cache.saved[f"owner_key_{username}"] == owner_hex
+        assert cache.saved[f"shared_key_{username}"] == "ddeeff"
+        # The top-level field itself is preserved verbatim.
+        assert cache.saved["owner_key"] == owner_hex

--- a/tests/test_options_flow_credentials_cache.py
+++ b/tests/test_options_flow_credentials_cache.py
@@ -464,6 +464,9 @@ def test_options_flow_secrets_reauth_strips_owner_key_space(
             "google_email": "user@example.com",
             "oauth_token": "oauth-token-from-secrets-123456",
             "owner_key": "AA BB\nCC ",
+            # A shared_key is required for the bundle to pass the single-key
+            # import gate; this test only asserts whitespace normalization.
+            "shared_key": "DDEEFF",
             "username": "  Keep Me  ",
         }
         result = await flow.async_step_credentials(
@@ -531,6 +534,9 @@ def test_options_flow_secrets_reauth_guard_error_fallback_normalizes(
             "google_email": "user@example.com",
             "oauth_token": "oauth-token-from-secrets-123456",
             "owner_key": "AA BB CC",
+            # A shared_key is required to pass the single-key import gate; this
+            # test exercises the multi-entry-guard fallback normalization.
+            "shared_key": "DDEEFF",
         }
         result = await flow.async_step_credentials(
             {"new_secrets_json": json.dumps(payload), "subentry": TRACKER_SUBENTRY_KEY}


### PR DESCRIPTION
## Summary

Enforces the v5 **single-key rule** for `secrets.json` import: the `shared_key` is the only gate. If it is missing, the import is blocked (a bundle without `shared_key` is a dead end — the owner key cannot be renewed without it). If it is present, the import is accepted and a missing owner key is fetched automatically at runtime.

Closes two defects:
- **D1**: config-flow validation accepts a token-only bundle without `shared_key`.
- **D2**: the seeding warning understates the outage (mentions only FMDN crowdsourced reports, omits the rotation-driven late outage).

Scope covers **all** secrets.json import surfaces plus the CLI generation path:
1. Paste import (`async_step_secrets_json`)
2. Discovery watcher
3. Options "Refresh credentials" (`async_step_credentials`)
4. Reauth warning text
5. CLI (`main.py`) — both keys fetched eagerly, no manual device-locate step required

GUI hints (`config_flow` / `strings.json`) are translated into all locales. The CLI's interactive device-locate menu remains unchanged (additive, not a replacement).

## Status

**Draft, in progress.** This PR is being built AP by AP behind a freshly audited plan (code-architekt + prompt-engineer + plan-architekt reviews, all grounded against the worktree).

- [x] AP1 — RED characterization tests for D1 gap and D2 understatement (strict xfail)
- [ ] remaining APs (DRY helper, single-key wiring across the four surfaces, eager owner-key fetch, docs, atomic 0600 write, GREEN flip)

Test approach: RED→GREEN, 100% changed-line + branch coverage on touched production lines, mutation cross-check, English-only.