### PR TITLE
fix: classify transient owner-key decrypt failures instead of demanding reauth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,6 +431,17 @@ Run `poetry lock` to fix the lock file.
 
 * Resolver scans currently seed three candidates: `ABSOLUTE` (wall-clock), `REL_PAIR` (pair-date anchored), and `REL_SECRETS` (secrets-creation anchored). Once a candidate yields a match, the resolver caches the winning epoch/offset per device to lock onto that timebase and narrow future rotation windows.
 
+### Owner-key error taxonomy (classify only from positive evidence)
+
+The owner-key decrypt chain is the source of the most user-confusing error messages, so the classifier must name the right layer and never guess a credential defect from a transient failure. The grounded facts:
+
+* **L1 - Key chain (directed):** `recovery -> application -> security_domain -> shared -> owner -> EIK`, where each stage decrypts the next (`KeyBackup/cloud_key_decryptor.py:443-449`). A fault low in the chain (EIK no longer matches server reports) is NOT the same as a fault high in the chain (wrong shared key); messages must name the layer, not collapse them.
+* **L2 - Owner key arrives encrypted from the server:** `DeviceUpdate.EncryptedOwnerKeyAndMetadata{encryptedOwnerKey, ownerKeyVersion, securityDomain}`, decrypted client-side with the `shared_key` via AES-GCM (`SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py:181-197`, `ProtoDecoders/DeviceUpdate.proto:13-16`).
+* **L3 - InvalidTag == wrong shared key:** an AES-GCM `InvalidTag` at the owner-key decrypt is the ONLY positive signal that the shared key is wrong/stale; it propagates unchanged to `SharedKeyMismatchError` (account-wide; a fresh `secrets.json` is required).
+* **L4 - ownerKeyVersion mismatch == per-tracker:** a single tracker encrypted with an older owner-key version raises `StaleOwnerKeyError` and needs that one tracker re-paired, NOT an account re-authentication (`NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py:636-641`).
+* **L5 - Classifier discipline:** classify only from positive evidence. A transient or partial server response is NOT a credential defect, and the `context` labels ("initial lookup" / "forced refresh") are internal phase markers, never a first-setup indicator (`NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py:288-312`). Unknown/transient owner-key lookup misses map to `OwnerKeyLookupTransientError` (base `Exception`, not a `DecryptionError`), so they never reach the account-wide reauth path.
+* **L6 - Own vs. foreign reports:** an own report (`publicKeyRandom == b""`) is decrypted with `SHA256(EIK)` via AES-GCM; if ALL own reports of a device fail, the result is `OwnReportIdentityMismatchError` (per-device, a fresh `secrets.json` does not help) (`NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py:1568-1574`).
+
 ---
 
 ## 2) Roles (right-sized)

--- a/custom_components/googlefindmy/Auth/adm_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/adm_token_retrieval.py
@@ -189,6 +189,16 @@ def _is_non_retryable_auth(err: Exception) -> bool:
     return any(pattern in text for pattern in _NON_RETRYABLE_PATTERNS)
 
 
+def is_non_retryable_auth_kind(err: Exception) -> bool:
+    """Return True only when the structured error_kind marks a definitively
+    non-recoverable auth failure. Substring-free counterpart to
+    _is_non_retryable_auth: callers outside the retry loop (e.g. the decrypt
+    owner-key classifier) must NOT inherit the HTTP-status substring matching
+    (a transient string like 'retry after 4012 ms' contains '401')."""
+    kind = getattr(err, "error_kind", "")
+    return isinstance(kind, str) and kind.lower() in _NON_RETRYABLE_KINDS
+
+
 async def _seed_username_in_cache(username: str, *, cache: TokenCache) -> None:
     """Ensure the canonical username cache key is populated (idempotent)."""
     if cache is None:

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -87,6 +87,7 @@ from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
 from custom_components.googlefindmy.exceptions import FatalRegistrationError
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    OwnerKeyLookupTransientError,
     StaleOwnerKeyError,
     any_real_location_record,
     async_decrypt_location_response_locations,
@@ -3019,7 +3020,7 @@ class FcmReceiverHA:
                     err,
                 )
 
-    async def _decode_background_location_async(  # noqa: PLR0911
+    async def _decode_background_location_async(  # noqa: PLR0911, PLR0912
         self, entry_id: str, hex_string: str
     ) -> JSONDict:
         """Decode background location using protobuf decoders.
@@ -3066,6 +3067,22 @@ class FcmReceiverHA:
                     )
                     self._note_decrypt_failure_for_entry(
                         entry_id, stale=False, error=dec_err
+                    )
+                    return {}
+                except OwnerKeyLookupTransientError as transient_err:
+                    # A transient owner-key lookup miss (partial/trailers-only
+                    # server response, transport failure, otherwise unclassified
+                    # miss). The credentials are presumed valid, so this is NOT a
+                    # decrypt-failure budget event: do NOT call
+                    # _note_decrypt_failure_for_entry and do NOT escalate to reauth.
+                    # Pure severity downgrade to DEBUG; the next push/poll retries.
+                    # Catches the _OwnerKeyRederiveRequired subclass too (fail-safe).
+                    _LOGGER.debug(
+                        "Background location update skipped (transient owner-key "
+                        "miss, %s) for entry %s: %s; presumed valid keys, will retry",
+                        type(transient_err).__name__,
+                        entry_id,
+                        transient_err,
                     )
                     return {}
                 except InvalidTag:

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -267,6 +267,25 @@ class SharedKeyMissingError(DecryptionError):
     """
 
 
+class OwnerKeyInvalidError(DecryptionError):
+    """Raised when the LOCALLY stored owner key is structurally invalid.
+
+    Account-wide credential defect, NOT a transient miss: the owner key was
+    obtained from the local cache/credentials but is missing, malformed (not a
+    valid hex/base64 key), or has the wrong length. Retrying can never repair such
+    a deterministic local defect, so it must surface as a reauth-worthy
+    ``DecryptionError`` (a fresh secrets.json is required), exactly like the
+    shared-key failures above.
+
+    Kept a DISTINCT ``DecryptionError`` subclass (NOT ``OwnerKeyLookupTransientError``)
+    so the failure class name is diagnosable in logs and the coordinator routes it
+    to the account-wide reauth path instead of swallowing it as a transient lookup
+    miss. Contrast ``OwnerKeyLookupTransientError`` (base ``Exception``), which is
+    reserved for partial/trailers-only server responses, transport failures and
+    otherwise unclassified misses where the credentials are presumed valid.
+    """
+
+
 class OwnReportIdentityMismatchError(DecryptionError):
     """Raised when a device's OWN server reports all fail authentication.
 
@@ -316,11 +335,28 @@ def _classify_owner_key_failure(exc: Exception, *, context: str) -> Exception:
       (a) ``InvalidTag`` -> ``SharedKeyMismatchError`` (genuine credential defect).
       (b) a local "shared key ... missing or empty" bundle ->
           ``SharedKeyMissingError`` (genuine credential defect).
+      (b2) a local owner-key validity defect (the stored owner key is missing,
+          malformed, or the wrong length) -> ``OwnerKeyInvalidError`` (genuine
+          credential defect; deterministic, never fixed by a retry, so it must
+          stay reauth-worthy and must NOT be swallowed by the transient default).
       (c) a partial server-field response (``encryptedOwnerKeyAndMetadata`` /
           ``encryptedOwnerKey`` / "Decrypted owner_key is empty") ->
           ``OwnerKeyLookupTransientError`` (transient server condition).
       (d) everything else (default, inverted) -> ``OwnerKeyLookupTransientError``
           (no "stale" / "re-authenticate" guess).
+
+    The order matters: (b2) anchors on owner-key validity wordings that are
+    distinct from the (c) server-field tokens, so a deterministic local defect is
+    classified before the transient fallthrough can hide it.
+
+    Scope of (b2): it covers only STRUCTURAL defects of an owner key that was
+    already obtained (missing/invalid value after retrieval, malformed encoding,
+    wrong length). Precondition failures raised BEFORE retrieval -- e.g.
+    ``get_owner_key.py``'s "Username is not configured" -- deliberately stay on the
+    transient default (d): an unset username can be a cold-start race (the username
+    cache is not populated yet), and escalating it to reauth would reintroduce the
+    cry-wolf prompt this classifier exists to avoid. They are NOT structural
+    owner-key defects, so they are intentionally not folded into (b2).
     """
     if isinstance(exc, InvalidTag):
         return SharedKeyMismatchError(
@@ -333,6 +369,16 @@ def _classify_owner_key_failure(exc: Exception, *, context: str) -> Exception:
         return SharedKeyMissingError(
             f"Shared key is missing or empty during {context} (incomplete bundle). "
             "Re-import a complete secrets.json."
+        )
+    if (
+        "owner key is missing or invalid" in text
+        or "invalid owner_key format" in text
+        or "owner key must be exactly" in text
+    ):
+        return OwnerKeyInvalidError(
+            f"The locally stored owner key is invalid during {context} (missing, "
+            "malformed, or wrong length). A fresh secrets.json is required "
+            "(re-authentication)."
         )
     if (
         "encryptedownerkeyandmetadata" in text

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -18,6 +18,9 @@ from typing import TYPE_CHECKING, Any, cast
 from cryptography.exceptions import InvalidTag
 
 from custom_components.googlefindmy import get_proto_decoder
+from custom_components.googlefindmy.Auth.adm_token_retrieval import (
+    is_non_retryable_auth_kind,
+)
 from custom_components.googlefindmy.Auth.username_provider import username_string
 from custom_components.googlefindmy.const import MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S
 from custom_components.googlefindmy.FMDNCrypto._lazy_crypto import get_aesgcm_class
@@ -321,6 +324,31 @@ class OwnerKeyLookupTransientError(Exception):
     """
 
 
+class _OwnerKeyRederiveRequired(OwnerKeyLookupTransientError):
+    """Internal signal that a locally structurally-defective owner key should
+    trigger a single-shot ``force_refresh`` re-derive.
+
+    A LOCAL owner-key STRUCTURE defect (the stored owner key is missing/invalid,
+    malformed, or the wrong length) is re-derivable from the (valid) shared key,
+    so the caller should re-derive once via ``async_get_owner_key(force_refresh=
+    True)`` BEFORE deciding anything -- never escalate the first defect straight
+    to reauth. Subclasses the transient base ``OwnerKeyLookupTransientError``
+    deliberately: should this internal signal ever leak past the caller's
+    orchestration, it fails safe as a benign transient miss (skipped by the
+    poll/locate paths, never caught by ``except DecryptionError``, never reaching
+    the account-wide reauth verdict). It is NOT a ``DecryptionError`` and makes no
+    "re-authenticate" claim.
+    """
+
+
+# Single-shot WARNING dedup for the R4 "persistent structure defect after a
+# successful re-derive" notice. Keyed on the entry-scope identity (here ``id(
+# cache)`` -- the closest available per-entry handle in this function; this keys
+# per cache OBJECT, so the dedup only suppresses cross-poll spam, not distinct
+# entries). The R4 contract asserts exactly one WARNING per key.
+_warned_rederive_persistent_defect: set[int] = set()
+
+
 def _classify_owner_key_failure(exc: Exception, *, context: str) -> Exception:
     """Map a low-level owner-key lookup failure to a specific error class.
 
@@ -332,22 +360,35 @@ def _classify_owner_key_failure(exc: Exception, *, context: str) -> Exception:
     preserves the original error via ``raise ... from exc``.
 
     Deterministic, field-specific matching (first match wins):
+      (auth) a non-retryable structured ``error_kind`` (badauthentication /
+          auth_error / invalid_grant) -> ``OwnerKeyInvalidError`` (reauth-worthy
+          ``DecryptionError``). This is the ONLY reauth-worthy branch and is keyed
+          on the structured ``error_kind`` attribute, NEVER on message substrings,
+          so a transient text that merely contains "401" (e.g. "retry after 4012
+          ms") stays transient. See AP3.
       (a) ``InvalidTag`` -> ``SharedKeyMismatchError`` (genuine credential defect).
       (b) a local "shared key ... missing or empty" bundle ->
           ``SharedKeyMissingError`` (genuine credential defect).
-      (b2) a local owner-key validity defect (the stored owner key is missing,
-          malformed, or the wrong length) -> ``OwnerKeyInvalidError`` (genuine
-          credential defect; deterministic, never fixed by a retry, so it must
-          stay reauth-worthy and must NOT be swallowed by the transient default).
+      (b2) a local owner-key STRUCTURE defect (the stored owner key is missing,
+          malformed, or the wrong length) -> ``_OwnerKeyRederiveRequired`` (an
+          INTERNAL re-derive signal, NOT reauth). The defect is re-derivable from
+          the (valid) shared key, so the caller force-refreshes the owner key once
+          before deciding anything. Fail-safe transient subclass; never reauth.
       (c) a partial server-field response (``encryptedOwnerKeyAndMetadata`` /
           ``encryptedOwnerKey`` / "Decrypted owner_key is empty") ->
           ``OwnerKeyLookupTransientError`` (transient server condition).
       (d) everything else (default, inverted) -> ``OwnerKeyLookupTransientError``
           (no "stale" / "re-authenticate" guess).
 
-    The order matters: (b2) anchors on owner-key validity wordings that are
-    distinct from the (c) server-field tokens, so a deterministic local defect is
-    classified before the transient fallthrough can hide it.
+    Order / reachability: the (auth) ``error_kind`` check runs first and is the
+    only path that yields a reauth-worthy ``OwnerKeyInvalidError``. It is
+    reachable via a bare ``RuntimeError`` carrying ``error_kind`` propagated from
+    the ADM/owner-key getters; ``error_kind``-tagged errors carry none of the
+    (a)-(c) wordings, so placing it first does not steal those branches.
+    ``InvalidAasTokenError`` does NOT reach this branch (the lower layers
+    pre-convert it). The (b2) anchor is distinct from the (c) server-field tokens,
+    so a deterministic local structure defect is routed to the re-derive signal
+    before the transient fallthrough can hide it.
 
     Scope of (b2): it covers only STRUCTURAL defects of an owner key that was
     already obtained (missing/invalid value after retrieval, malformed encoding,
@@ -358,6 +399,12 @@ def _classify_owner_key_failure(exc: Exception, *, context: str) -> Exception:
     cry-wolf prompt this classifier exists to avoid. They are NOT structural
     owner-key defects, so they are intentionally not folded into (b2).
     """
+    if is_non_retryable_auth_kind(exc):
+        return OwnerKeyInvalidError(
+            f"Owner key lookup hit a non-retryable auth failure during {context} "
+            "(structured error_kind). The stored credentials are rejected; "
+            "re-authentication is required."
+        )
     if isinstance(exc, InvalidTag):
         return SharedKeyMismatchError(
             f"Owner key decryption failed (InvalidTag) during {context}: the shared "
@@ -375,10 +422,11 @@ def _classify_owner_key_failure(exc: Exception, *, context: str) -> Exception:
         or "invalid owner_key format" in text
         or "owner key must be exactly" in text
     ):
-        return OwnerKeyInvalidError(
-            f"The locally stored owner key is invalid during {context} (missing, "
-            "malformed, or wrong length). A fresh secrets.json is required "
-            "(re-authentication)."
+        return _OwnerKeyRederiveRequired(
+            f"The locally stored owner key is structurally defective during "
+            f"{context} (missing, malformed, or wrong length). It is re-derivable "
+            "from the shared key; a single-shot owner-key re-derive (force_refresh) "
+            "is required. This is transient, not a credential rejection."
         )
     if (
         "encryptedownerkeyandmetadata" in text
@@ -526,6 +574,10 @@ async def async_retrieve_identity_key(
         )
 
     owner_key_version = getattr(encrypted_user_secrets, "ownerKeyVersion", 0)
+    # Set when the single-shot structural-defect re-derive below already forced a
+    # fresh owner key. It makes the later blind-refresh path a no-op so the owner
+    # key is force-refreshed at most once per call (R1: exactly one force_refresh).
+    did_force_rederive = False
     try:
         owner_key_info: OwnerKeyInfo = await async_get_owner_key(cache=cache)
     except SpotError as exc:
@@ -544,7 +596,60 @@ async def async_retrieve_identity_key(
         ) from exc
     except (InvalidTag, RuntimeError) as exc:
         _LOGGER.debug("Owner-key lookup phase=%s failed", "initial lookup")
-        raise _classify_owner_key_failure(exc, context="initial lookup") from exc
+        classified = _classify_owner_key_failure(exc, context="initial lookup")
+        if not isinstance(classified, _OwnerKeyRederiveRequired):
+            raise classified from exc
+        # single-shot re-derive: a structural owner-key defect is re-derivable from
+        # the (valid) shared key. Mirror the force_refresh pattern below; LINEAR,
+        # not recursive -> structurally single-shot (the re-derive's own failures
+        # are converted here, never re-entered into the re-derive branch).
+        _LOGGER.debug(
+            "Owner-key structural defect on initial lookup; re-deriving once "
+            "(force_refresh)."
+        )
+        did_force_rederive = True
+        try:
+            owner_key_info = await async_get_owner_key(cache=cache, force_refresh=True)
+            # Re-arm the persistent-defect WARNING guard: a successful re-derive
+            # means the structural defect is resolved, so a future recurrence must
+            # warn again instead of being suppressed by a lifetime-accumulating
+            # guard (re-arm-on-recovery, mirrors the dedup-guard lesson from the
+            # earlier device-drop work).
+            _warned_rederive_persistent_defect.discard(id(cache))
+        except SpotError as exc2:
+            _LOGGER.debug(
+                "Owner-key re-derive phase=%s hit a transient SpotError: %s",
+                "forced re-derive",
+                type(exc2).__name__,
+            )
+            raise OwnerKeyLookupTransientError(
+                "Owner key retrieval did not complete (transient): the forced "
+                "re-derive failed at the transport/gRPC layer. The crypto keys are "
+                "presumed valid; this will be retried."
+            ) from exc2
+        except (InvalidTag, RuntimeError) as exc2:
+            reclassified = _classify_owner_key_failure(
+                exc2, context="forced re-derive"
+            )
+            if isinstance(reclassified, _OwnerKeyRederiveRequired):
+                # R4 default: still structurally defective AFTER a successful-HTTP
+                # re-derive -> transient + WARNING-once (no reauth without an
+                # InvalidTag shared-key rejection). Dedup keyed on id(cache) (the
+                # per-entry handle available here) so polls do not spam the log.
+                rederive_warn_key = id(cache)
+                if rederive_warn_key not in _warned_rederive_persistent_defect:
+                    _warned_rederive_persistent_defect.add(rederive_warn_key)
+                    _LOGGER.warning(
+                        "Owner key remains structurally defective after a forced "
+                        "re-derive; treating as transient (no re-authentication). "
+                        "The lookup will be retried on the next poll."
+                    )
+                raise OwnerKeyLookupTransientError(
+                    "Owner key retrieval did not complete (transient): the owner "
+                    "key is still structurally defective after a re-derive. The "
+                    "crypto keys are presumed valid; this will be retried."
+                ) from exc2
+            raise reclassified from exc2
 
     # --- Proactive Owner Key Version Mismatch Check ---
     # If the tracker requires a newer owner key version than what we have cached,
@@ -757,7 +862,12 @@ async def async_retrieve_identity_key(
     # Blind refresh: version check unavailable but key is clearly wrong.
     # This mirrors the version-mismatch retry above but works when SPOT gRPC
     # fails to provide current_owner_key_version (common in standalone CLI).
-    if not candidates and current_owner_key_version is None and _retry:
+    if (
+        not candidates
+        and current_owner_key_version is None
+        and _retry
+        and not did_force_rederive
+    ):
         _LOGGER.info(
             "EIK decryption failed and SPOT version check unavailable; "
             "attempting blind owner key refresh."

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -48,6 +48,7 @@ from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_k
     OwnerKeyInfo,
     async_get_owner_key,
 )
+from custom_components.googlefindmy.SpotApi.spot_request import SpotError
 from google.protobuf.message import DecodeError
 
 if TYPE_CHECKING:
@@ -285,15 +286,41 @@ class OwnReportIdentityMismatchError(DecryptionError):
     """
 
 
-def _classify_owner_key_failure(exc: Exception, *, context: str) -> DecryptionError:
-    """Map a low-level owner-key lookup failure to a specific DecryptionError.
+class OwnerKeyLookupTransientError(Exception):
+    """Raised when the owner-key lookup did not complete for a transient reason.
+
+    Base class is ``Exception`` deliberately, NOT ``DecryptionError`` and NOT
+    ``RuntimeError``: a partial/trailers-only server response, a network/gRPC
+    transport failure or any otherwise unclassified owner-key retrieval miss is a
+    TRANSIENT condition, not a credential defect. Because it is not a
+    ``DecryptionError`` it is never caught by the coordinator's
+    ``except DecryptionError`` blocks and never reaches the account-wide reauth
+    verdict (Option B); because it is not a ``RuntimeError`` it is not swallowed by
+    a broad ``except RuntimeError`` (e.g. ``api.py``). It carries NO "stale" /
+    "re-authenticate" claim: the credentials are presumed valid and the right
+    recovery is an ordinary retry/skip, never an account re-authentication.
+    """
+
+
+def _classify_owner_key_failure(exc: Exception, *, context: str) -> Exception:
+    """Map a low-level owner-key lookup failure to a specific error class.
 
     ``async_get_owner_key`` collapses distinct root causes into either an
     ``InvalidTag`` (wrong/stale shared key) or a ``RuntimeError`` (missing/empty
-    shared key, or a generic failure). This helper restores the discriminator as a
-    typed subclass so the failure class name appears in logs and the coordinator
-    can pick the correct recovery path. The caller preserves the original error
-    via ``raise ... from exc``.
+    shared key, a partial server-field response, or a generic failure). This helper
+    restores the discriminator as a typed class so the failure class name appears
+    in logs and the coordinator can pick the correct recovery path. The caller
+    preserves the original error via ``raise ... from exc``.
+
+    Deterministic, field-specific matching (first match wins):
+      (a) ``InvalidTag`` -> ``SharedKeyMismatchError`` (genuine credential defect).
+      (b) a local "shared key ... missing or empty" bundle ->
+          ``SharedKeyMissingError`` (genuine credential defect).
+      (c) a partial server-field response (``encryptedOwnerKeyAndMetadata`` /
+          ``encryptedOwnerKey`` / "Decrypted owner_key is empty") ->
+          ``OwnerKeyLookupTransientError`` (transient server condition).
+      (d) everything else (default, inverted) -> ``OwnerKeyLookupTransientError``
+          (no "stale" / "re-authenticate" guess).
     """
     if isinstance(exc, InvalidTag):
         return SharedKeyMismatchError(
@@ -301,14 +328,26 @@ def _classify_owner_key_failure(exc: Exception, *, context: str) -> DecryptionEr
             "key is stale or incompatible with this account. A fresh secrets.json "
             "is required (re-authentication)."
         )
-    if isinstance(exc, RuntimeError) and "missing or empty" in str(exc):
+    text = str(exc).lower()
+    if "shared key" in text and "missing or empty" in text:
         return SharedKeyMissingError(
             f"Shared key is missing or empty during {context} (incomplete bundle). "
             "Re-import a complete secrets.json."
         )
-    return DecryptionError(
-        f"Owner key decryption failed during {context} (shared key may be stale). "
-        "Re-authenticate to refresh crypto keys."
+    if (
+        "encryptedownerkeyandmetadata" in text
+        or "encryptedownerkey" in text
+        or "decrypted owner_key is empty" in text
+    ):
+        return OwnerKeyLookupTransientError(
+            "Owner key retrieval did not complete (transient): the server response "
+            "was incomplete. The crypto keys are presumed valid; this will be "
+            "retried."
+        )
+    return OwnerKeyLookupTransientError(
+        "Owner key retrieval did not complete (transient): the lookup failed for "
+        "an unclassified reason. The crypto keys are presumed valid; this will be "
+        "retried."
     )
 
 
@@ -443,7 +482,22 @@ async def async_retrieve_identity_key(
     owner_key_version = getattr(encrypted_user_secrets, "ownerKeyVersion", 0)
     try:
         owner_key_info: OwnerKeyInfo = await async_get_owner_key(cache=cache)
+    except SpotError as exc:
+        # Typed transport/gRPC failure: always transient, never "stale". Caught
+        # before the generic block so a network/timeout/status error never lands
+        # in the speculative reauth path (Q5 invariant).
+        _LOGGER.debug(
+            "Owner-key lookup phase=%s hit a transient SpotError: %s",
+            "initial lookup",
+            type(exc).__name__,
+        )
+        raise OwnerKeyLookupTransientError(
+            "Owner key retrieval did not complete (transient): the SPOT request "
+            "failed at the transport/gRPC layer. The crypto keys are presumed "
+            "valid; this will be retried."
+        ) from exc
     except (InvalidTag, RuntimeError) as exc:
+        _LOGGER.debug("Owner-key lookup phase=%s failed", "initial lookup")
         raise _classify_owner_key_failure(exc, context="initial lookup") from exc
 
     # --- Proactive Owner Key Version Mismatch Check ---
@@ -463,7 +517,21 @@ async def async_retrieve_identity_key(
         )
         try:
             owner_key_info = await async_get_owner_key(cache=cache, force_refresh=True)
+        except SpotError as exc:
+            # Typed transport/gRPC failure during the forced refresh: transient,
+            # never "stale" (caught before the generic block, Q5 invariant).
+            _LOGGER.debug(
+                "Owner-key lookup phase=%s hit a transient SpotError: %s",
+                "forced refresh",
+                type(exc).__name__,
+            )
+            raise OwnerKeyLookupTransientError(
+                "Owner key retrieval did not complete (transient): the SPOT "
+                "request failed at the transport/gRPC layer during refresh. The "
+                "crypto keys are presumed valid; this will be retried."
+            ) from exc
         except (InvalidTag, RuntimeError) as exc:
+            _LOGGER.debug("Owner-key lookup phase=%s failed", "forced refresh")
             raise _classify_owner_key_failure(exc, context="forced refresh") from exc
 
     # Build key sources list (matches eid_resolver pattern: try owner + shared)
@@ -1145,8 +1213,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 identity_key = identity_key_bytes
         except Exception as exc:  # pragma: no cover - diagnostics only
             _LOGGER.warning(
-                "[DECRYPT] Failed to unwrap 60-byte EIK: %s. "
-                "The owner key in secrets.json may be outdated.",
+                "[DECRYPT] Failed to unwrap 60-byte EIK: %s; retrying with raw key.",
                 type(exc).__name__,
             )
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -28,6 +28,9 @@ from custom_components.googlefindmy.const import (
 )
 from custom_components.googlefindmy.example_data_provider import get_example_data
 from custom_components.googlefindmy.exceptions import MissingTokenCacheError
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    OwnerKeyLookupTransientError,
+)
 from custom_components.googlefindmy.NovaApi.ExecuteAction.nbe_execute_action import (
     create_action_request,
     serialize_action_request,
@@ -414,6 +417,24 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                     ctx.error = err
                     ctx.event.set()
                     return
+                except OwnerKeyLookupTransientError as err:
+                    # A transient owner-key lookup miss (partial/trailers-only
+                    # server response, transport failure, otherwise unclassified
+                    # miss; presumed-valid credentials). This is NOT a credential
+                    # defect, so it is logged at DEBUG and surfaced via ctx.error
+                    # WITHOUT touching any counter -- the awaiting coroutine
+                    # re-raises it so the coordinator sink performs a DEBUG skip.
+                    # Catches the _OwnerKeyRederiveRequired subclass too (fail-safe).
+                    _LOGGER.debug(
+                        "Transient owner-key lookup miss for %s (%s): %s; "
+                        "presumed valid credentials, will retry",
+                        name,
+                        type(err).__name__,
+                        err,
+                    )
+                    ctx.error = err
+                    ctx.event.set()
+                    return
                 except Exception as err:
                     _LOGGER.error(
                         "Unexpected error during async decryption for %s (%s): %s",
@@ -762,6 +783,14 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
                 raise ctx.error
             if isinstance(ctx.error, SpotAuthPermanentError):
                 raise ctx.error
+            # A transient owner-key lookup miss recorded by the decrypt callback
+            # (base Exception, NOT a DecryptionError) must propagate so the
+            # coordinator sink can perform a DEBUG skip without a counter touch.
+            # This is the only real arrival path for the transient type (AP3 records
+            # it on ctx.error); the broad outer ``except Exception`` would otherwise
+            # swallow it into an empty result.
+            if isinstance(ctx.error, OwnerKeyLookupTransientError):
+                raise ctx.error
             # A stale/incompatible shared key (SharedKeyMismatchError /
             # SharedKeyMissingError) or a per-tracker stale owner key
             # (StaleOwnerKeyError) is an auth-fatal crypto condition, not a
@@ -804,6 +833,12 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         # the coordinator can escalate (reauth or per-tracker repair). The broad
         # `except Exception` below would otherwise swallow it back into an empty
         # result -- that swallow is the original bug this fix removes.
+        raise
+    except OwnerKeyLookupTransientError:
+        # Symmetry with ``except DecryptionError`` above: a transient owner-key miss
+        # surfacing through the outer try-body must propagate to the coordinator sink
+        # (DEBUG skip, no counter touch) instead of being swallowed by the broad
+        # ``except Exception`` into ``return []``.
         raise
     except Exception as e:
         # R6 (AGENTS.md Section 5 redaction): the raw device display name must not

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -49,6 +49,27 @@ from custom_components.googlefindmy.SpotApi.spot_request import SpotAuthPermanen
 _LOGGER = logging.getLogger(__name__)
 
 
+def _format_cause_chain(exc: BaseException, *, max_depth: int = 8) -> str:
+    """Render the full exception cause chain as a ``Type: msg -> Type: msg`` string.
+
+    R9c: a single ``str(exc)`` only shows the outermost error, so a gRPC server
+    detail nested two levels deep (surfacing -> SpotError -> GRPCError) is lost.
+    Walk ``__cause__`` (explicit ``raise ... from``) and fall back to
+    ``__context__`` (implicit chaining) so the structured diagnostic record carries
+    the deepest server detail. Bounded depth and a seen-set guard against cycles.
+    """
+    parts: list[str] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and len(parts) < max_depth:
+        if id(current) in seen:
+            break
+        seen.add(id(current))
+        parts.append(f"{type(current).__name__}: {current}")
+        current = current.__cause__ or current.__context__
+    return " -> ".join(parts)
+
+
 class _DecryptLocationsCallable(Protocol):
     async def __call__(
         self, device_update: Any, *, cache: TokenCache
@@ -785,7 +806,19 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         # result -- that swallow is the original bug this fix removes.
         raise
     except Exception as e:
-        _LOGGER.error("Error requesting location for %s: %s", name, e)
+        # R6 (AGENTS.md Section 5 redaction): the raw device display name must not
+        # leak into a user-facing WARNING/ERROR. Surface only the error type and
+        # cause chain here; keep the name at DEBUG only (Name@DEBUG, PR #1129). This
+        # path handles a single device, so there is no meaningful index to report.
+        # R9c: include the FULL cause chain (Type: msg -> Type: msg) so a gRPC
+        # server detail nested two levels deep (surfacing -> SpotError -> GRPCError)
+        # survives instead of being overwritten by the outermost ``str(exc)``.
+        _LOGGER.error(
+            "Error requesting location (%s): %s",
+            type(e).__name__,
+            _format_cause_chain(e),
+        )
+        _LOGGER.debug("Location request failure detail for %s", name)
         _LOGGER.debug("Traceback: %s", traceback.format_exc())
         return []
     finally:

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_eid_info_request.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_eid_info_request.py
@@ -34,6 +34,7 @@ from custom_components.googlefindmy.ProtoDecoders import Common_pb2, DeviceUpdat
 from custom_components.googlefindmy.SpotApi import spot_request as spot_request_module
 from custom_components.googlefindmy.SpotApi.spot_request import (
     SpotAuthPermanentError,
+    SpotError,
     SpotTrailersOnlyError,
 )
 from google.protobuf.message import DecodeError  # parse-time error type for protobufs
@@ -108,6 +109,11 @@ async def _spot_call_async(scope: str, payload: bytes, *, cache: TokenCache) -> 
         raise SpotApiEmptyResponseError(
             "Empty gRPC body (trailers-only) for GetEidInfoForE2eeDevices"
         ) from e
+    except SpotError:
+        # Type-preserving re-raise (R8): a typed SpotError (network/gRPC status)
+        # must NOT be flattened into a bare RuntimeError, or the typed-transient
+        # discriminator is erased through this defensive path (Q5 invariant).
+        raise
     except Exception as exc:  # pragma: no cover - defensive
         raise RuntimeError("Synchronous SPOT request helper failed.") from exc
 

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -165,8 +165,9 @@ async def _retrieve_owner_key(
             ) from exc
         except SpotApiEmptyResponseError:
             _LOGGER.error(
-                "Owner key retrieval failed: SPOT returned empty/trailers-only body for "
-                "GetEidInfoForE2eeDevices (likely auth/session issue). Please re-authenticate."
+                "Owner key retrieval failed: SPOT returned an empty/trailers-only "
+                "response for GetEidInfoForE2eeDevices; the exact gRPC status is "
+                "logged for diagnosis."
             )
             raise
 
@@ -180,6 +181,16 @@ async def _retrieve_owner_key(
 
     metadata = getattr(eid_info, "encryptedOwnerKeyAndMetadata", None)
     if metadata is None:
+        # R9b: log WHICH eid_info fields the server populated (names only, never
+        # values/bytes) so a partial response is diagnosable beyond "Missing X".
+        _LOGGER.debug(
+            "eid_info field shape on missing metadata: populated=%s",
+            [
+                name
+                for name in ("encryptedOwnerKeyAndMetadata",)
+                if getattr(eid_info, name, None)
+            ],
+        )
         raise RuntimeError("Missing 'encryptedOwnerKeyAndMetadata' in eid_info")
 
     encrypted_owner_key = getattr(metadata, "encryptedOwnerKey", b"")
@@ -187,6 +198,21 @@ async def _retrieve_owner_key(
         not isinstance(encrypted_owner_key, (bytes, bytearray))
         or len(encrypted_owner_key) == 0
     ):
+        # R9b: list the metadata field NAMES the server populated (never values /
+        # decrypted bytes) so the missing-owner-key shape is visible at DEBUG.
+        _LOGGER.debug(
+            "eid_info.encryptedOwnerKeyAndMetadata field shape on missing "
+            "encryptedOwnerKey: populated=%s",
+            [
+                name
+                for name in (
+                    "encryptedOwnerKey",
+                    "ownerKeyVersion",
+                    "securityDomain",
+                )
+                if getattr(metadata, name, None)
+            ],
+        )
         raise RuntimeError(
             "Missing or empty 'encryptedOwnerKey' in eid_info.encryptedOwnerKeyAndMetadata"
         )
@@ -205,6 +231,13 @@ async def _retrieve_owner_key(
     owner_key_version = getattr(metadata, "ownerKeyVersion", None)
 
     if not isinstance(owner_key, (bytes, bytearray)) or len(owner_key) == 0:
+        # R9b: log the decrypted owner-key shape (type + length only, NEVER the
+        # bytes/value) so an empty/short result is diagnosable.
+        _LOGGER.debug(
+            "Decrypted owner_key shape on empty/invalid result: type=%s, len=%s",
+            type(owner_key).__name__,
+            len(owner_key) if isinstance(owner_key, (bytes, bytearray)) else "n/a",
+        )
         raise RuntimeError("Decrypted owner_key is empty or invalid type")
 
     _LOGGER.info(
@@ -358,9 +391,14 @@ async def async_get_owner_key(  # noqa: PLR0912,PLR0915
             force_refresh=force_refresh,
         )
     except SpotApiEmptyResponseError as exc:
+        # E3-W: ground the wording in the observed state only; the
+        # ConfigEntryAuthFailed type (and thus the reauth behavior) is kept
+        # UNCHANGED deliberately, because whether an empty/trailers-only response
+        # is transient or auth is not yet proven. The captured gRPC status (R9a)
+        # makes the next real incident diagnosable before any reclassification.
         raise ConfigEntryAuthFailed(
-            "Owner key retrieval failed: SPOT returned empty/trailers-only body"
-            " (auth/session issue). Please re-authenticate."
+            "Owner key retrieval failed: SPOT returned an empty/trailers-only "
+            "response; the exact gRPC status is logged for diagnosis."
         ) from exc
 
     cache_version: int | None = None

--- a/custom_components/googlefindmy/SpotApi/spot_request.py
+++ b/custom_components/googlefindmy/SpotApi/spot_request.py
@@ -116,6 +116,27 @@ class SpotRequestFailedAfterRetries(SpotError):
     """Transient failures exhausted the retry budget."""
 
 
+def _format_grpc_detail(err: Any) -> str:
+    """Render the server-sent gRPC detail (message/details) for a SpotError message.
+
+    R9a: ``GRPCError.message`` is the server-set ``grpc-message`` trailer and
+    ``GRPCError.details`` the optional structured details (grpclib 0.4.9). Both are
+    server status text, not credentials, so they are safe to surface; the auth
+    bearer token is never part of this exception. Returns a leading ``": ..."``
+    suffix when any detail is present, otherwise an empty string. Only the
+    ``GRPCError`` branch may call this; the SpotNetworkError branches carry no
+    ``.message`` and would raise ``AttributeError``.
+    """
+    parts: list[str] = []
+    message = getattr(err, "message", None)
+    if message:
+        parts.append(str(message))
+    details = getattr(err, "details", None)
+    if details:
+        parts.append(str(details))
+    return f": {' '.join(parts)}" if parts else ""
+
+
 def _compute_delay(attempt: int) -> float:
     """Compute exponential backoff with jitter bounded to sixty seconds."""
 
@@ -270,10 +291,13 @@ async def async_spot_request(
                     await _async_sleep(_compute_delay(attempt))
                     continue
                 raise SpotRequestFailedAfterRetries(
-                    f"Transient gRPC error ({status.name}) after retries."
+                    f"Transient gRPC error ({status.name}) after retries"
+                    f"{_format_grpc_detail(err)}."
                 ) from err
 
-            raise SpotGrpcStatusError(f"gRPC error: {status.name}") from err
+            raise SpotGrpcStatusError(
+                f"gRPC error: {status.name}{_format_grpc_detail(err)}"
+            ) from err
 
         except (
             grpclib_exceptions.ProtocolError,

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -46,6 +46,7 @@ from .const import (
 from .NovaApi import nova_request
 from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    OwnerKeyLookupTransientError,
     any_real_location_record,
 )
 from .NovaApi.ExecuteAction.LocateTracker.location_request import (
@@ -1354,6 +1355,15 @@ class GoogleFindMyAPI:
             # Re-raise it so the coordinator can count it and escalate to a reauth
             # flow (or per-tracker repair). This is the layer that must stay
             # transparent for the location_request fix to have any effect.
+            raise
+
+        except OwnerKeyLookupTransientError:
+            # A transient owner-key lookup miss (base Exception, NOT a
+            # DecryptionError and NOT a RuntimeError): the transient must reach the
+            # coordinator sink for a DEBUG skip without a counter touch. The broad
+            # `except Exception` below would otherwise turn it into an empty result,
+            # hiding the transient from the coordinator. Analog to the A1
+            # `except DecryptionError: raise` guard above.
             raise
 
         except RuntimeError as err:

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -27,6 +27,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from ..const import DEFAULT_MIN_POLL_INTERVAL
 from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    OwnerKeyLookupTransientError,
     StaleOwnerKeyError,
 )
 from ..NovaApi.nova_request import (
@@ -600,6 +601,23 @@ class LocateOperations(_MixinBase):
                 # DecryptionError handler below -- it is a subclass.
                 self.note_decrypt_failure(stale=True, error=stale_err, device=name)
                 self.note_error(stale_err, where="async_locate_device", device=name)
+                return {}
+            except OwnerKeyLookupTransientError as transient_err:
+                # Transient owner-key lookup miss (partial server response,
+                # network/gRPC failure). NOT a credential defect: do NOT feed the
+                # account-wide reauth counter and do NOT escalate. Treat it as a
+                # plain skip (empty result), like a "no pending report" cycle, so a
+                # transient single-device failure never drives a spurious reauth.
+                # Must precede the DecryptionError handler; it is NOT a subclass, so
+                # this explicit catch keeps it out of the escalation path.
+                _LOGGER.debug(
+                    "Manual locate for %s skipped (transient owner-key lookup): %s",
+                    name,
+                    transient_err,
+                )
+                self.note_error(
+                    transient_err, where="async_locate_device", device=name
+                )
                 return {}
             except DecryptionError as dec_err:
                 # Account-wide stale/missing shared key. Feed the SAME escalation

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -53,6 +53,7 @@ from ..const import (
 )
 from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    OwnerKeyLookupTransientError,
     OwnReportIdentityMismatchError,
     SharedKeyMissingError,
     StaleOwnerKeyError,
@@ -479,6 +480,13 @@ class PollingOperations(_MixinBase):
           refute them, so they keep their reauth prompt (the Codex finding class).
         """
         if cycle_decrypt_error is None:
+            return False
+        if not isinstance(cycle_decrypt_error, DecryptionError):
+            # A transient owner-key lookup miss (OwnerKeyLookupTransientError, base
+            # Exception, NOT a DecryptionError) is never an account-wide credential
+            # failure. Option B already keeps it out of the per-device
+            # ``except DecryptionError`` blocks; this is the defense-in-depth guard
+            # so the shared discriminator never drives a transient miss into reauth.
             return False
         if not cycle_had_successful_decrypt:
             return True
@@ -2091,6 +2099,23 @@ class PollingOperations(_MixinBase):
                         self._consecutive_timeouts = 0
                         if last_exception is None:
                             last_exception = stale_err
+                        continue
+                    except OwnerKeyLookupTransientError as owner_transient_err:
+                        # Transient owner-key lookup miss (partial server response,
+                        # network/gRPC failure). NOT a credential defect and NOT a
+                        # DecryptionError, so it never reaches the account-wide
+                        # reauth verdict (_finalize_cycle_decrypt_state). Treat it as
+                        # an ordinary per-device skip: keep polling the other
+                        # devices, do NOT advance the decrypt-failure counter and do
+                        # NOT set cycle_decrypt_error. Must precede the
+                        # DecryptionError handler; the explicit catch keeps a
+                        # transient miss from aborting the whole cycle.
+                        _LOGGER.debug(
+                            "Owner-key lookup for %s skipped (transient): %s",
+                            dev_name,
+                            owner_transient_err,
+                        )
+                        self._consecutive_timeouts = 0
                         continue
                     except DecryptionError as dec_err:
                         # Defer the cycle-failure bookkeeping (cycle_failed /

--- a/tests/test_api_transient_owner_key.py
+++ b/tests/test_api_transient_owner_key.py
@@ -1,0 +1,67 @@
+# tests/test_api_transient_owner_key.py
+"""RED contract: the API layer must not swallow a transient owner-key failure.
+
+``GoogleFindMyAPI.async_get_device_location`` re-raises ``DecryptionError`` (its
+audit-finding A1 guard) so the coordinator can escalate, but
+``OwnerKeyLookupTransientError`` has base ``Exception`` (NOT ``DecryptionError`` and
+NOT ``RuntimeError``), so it falls through to the broad ``except Exception`` and is
+turned into ``return {}``. The coordinator then cannot distinguish a transient
+owner-key miss from "no data". This test pins the intended propagation; it is RED
+until the API layer grows an explicit transient re-raise branch.
+
+Patch point: ``api.py`` binds ``get_location_data_for_device`` via ``from ... import``
+at module scope (lines ~51-52), so the API-local name
+``custom_components.googlefindmy.api.get_location_data_for_device`` must be patched,
+NOT the source module.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import custom_components.googlefindmy.api as api_module
+from custom_components.googlefindmy.api import GoogleFindMyAPI
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    OwnerKeyLookupTransientError,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_api() -> GoogleFindMyAPI:
+    """Build an API instance without running its normal __init__ wiring."""
+    api = GoogleFindMyAPI.__new__(GoogleFindMyAPI)
+    api._session = None
+    api._cache = MagicMock()
+    api._cache.entry_id = "entry-transient"
+    api._contributor_mode = None
+    api._contributor_mode_switch_epoch = 0
+    api._namespace = lambda: "entry-transient"
+    return api
+
+
+async def test_async_get_device_location_reraises_transient_owner_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED: a transient owner-key failure from the locate layer must propagate.
+
+    Today ``async_get_device_location`` returns ``{}`` because the broad
+    ``except Exception`` catches ``OwnerKeyLookupTransientError`` (base ``Exception``).
+    """
+    transient = OwnerKeyLookupTransientError("owner key lookup timed out")
+
+    async def _raise_transient(*_a: object, **_k: object) -> list[dict[str, Any]]:
+        raise transient
+
+    # Patch the API-LOCAL binding, not the source module (api.py imported the name).
+    monkeypatch.setattr(
+        api_module, "get_location_data_for_device", _raise_transient
+    )
+
+    api = _make_api()
+
+    with pytest.raises(OwnerKeyLookupTransientError):
+        await api.async_get_device_location("device-xyz", "Tracker")

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -40,6 +40,23 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_
 
 from .helpers.polling_mixin_stub import PollingStub
 
+# AP3 introduces ``OwnerKeyLookupTransientError`` (base ``Exception``, NOT a
+# ``DecryptionError``). Until it lands, import it softly so the new R4 transient
+# contracts go RED on the missing symbol, while every unchanged escalation test in
+# this module stays green instead of erroring out the whole collection.
+try:
+    from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (  # noqa: E501
+        OwnerKeyLookupTransientError,
+    )
+
+    _TRANSIENT_AVAILABLE = True
+except ImportError:  # pragma: no cover - RED phase before AP3 lands the class
+
+    class OwnerKeyLookupTransientError(Exception):  # type: ignore[no-redef]
+        """Local placeholder so R4 tests fail (not error) before AP3."""
+
+    _TRANSIENT_AVAILABLE = False
+
 
 def _make_stub(monotonic: Callable[[], float] | None = None) -> PollingStub:
     """Return a PollingStub seeded with the decrypt-escalation state fields.
@@ -762,3 +779,62 @@ def test_finalize_clean_cycle_stays_success() -> None:
     assert reauth_exc is None
     assert stub._consecutive_decrypt_failures == 0
     assert stub._crypto_status_state == CryptoStatus.OK
+
+
+# ---------------------------------------------------------------------------
+# R4: a transient owner-key lookup error must NOT drive the account-wide reauth
+# path. With Option B (the transient class is NOT a DecryptionError) the per-device
+# ``except DecryptionError`` block never catches it, so it never reaches the
+# escalation counter. These contracts go RED until AP3 lands the real class.
+# ---------------------------------------------------------------------------
+
+
+def test_r4_transient_class_exists_and_is_not_a_decryption_error() -> None:
+    """RED (R4 / Option B): the transient class exists and is NOT a DecryptionError.
+
+    This is the structural guarantee that keeps a transient owner-key miss out of
+    the account-wide reauth path: because it is not a ``DecryptionError`` subclass,
+    the per-device ``except DecryptionError`` blocks (``polling.py`` /
+    ``locate.py``) cannot catch it and feed it to ``note_decrypt_failure`` /
+    ``_resolve_cycle_decrypt_outcome``. RED today: the symbol does not exist
+    (``_TRANSIENT_AVAILABLE`` is False).
+    """
+    assert _TRANSIENT_AVAILABLE, (
+        "OwnerKeyLookupTransientError must be importable from decrypt_locations (AP3)"
+    )
+    assert not issubclass(OwnerKeyLookupTransientError, DecryptionError)
+
+
+def test_r4_transient_is_not_account_wide_failure() -> None:
+    """RED (R4): the per-cycle predicate must not treat a transient error as a
+    decrypt failure that advances/escalates the account-wide reauth budget.
+
+    ``_decrypt_failure_is_account_wide`` is the single discriminator that the
+    escalation verdict shares. A transient owner-key lookup error (not a
+    ``DecryptionError``) must never be classified as an account-wide decrypt
+    failure, even when no sibling decrypted this cycle. RED today: the class does
+    not exist, so the contract cannot hold.
+    """
+    assert _TRANSIENT_AVAILABLE, "OwnerKeyLookupTransientError missing (AP3)"
+    stub = _make_stub()
+    transient = OwnerKeyLookupTransientError("retrieval did not complete; transient")
+
+    assert stub._decrypt_failure_is_account_wide(transient, False) is False
+    assert stub._decrypt_failure_is_account_wide(transient, True) is False
+    stub._set_auth_state.assert_not_called()
+
+
+def test_r4_existing_invalid_tag_escalation_unchanged() -> None:
+    """Regression guard for R4: the genuine ``SharedKeyMismatchError`` (InvalidTag)
+    escalation must stay intact while the transient carve-out is added.
+
+    Mirrors ``test_t4_...`` so the transient routing change cannot silently weaken
+    the legitimate reauth path: N consecutive account-wide failures still escalate.
+    """
+    stub = _make_stub()
+    err = SharedKeyMismatchError("stale shared key")
+
+    for _ in range(_MAX_DECRYPT_FAILURES - 1):
+        assert stub.note_decrypt_failure(stale=False, error=err, device="dev") is False
+    assert stub.note_decrypt_failure(stale=False, error=err, device="dev") is True
+    stub._set_auth_state.assert_called_once()

--- a/tests/test_coordinator_locate_basics.py
+++ b/tests/test_coordinator_locate_basics.py
@@ -22,6 +22,7 @@ from homeassistant.exceptions import HomeAssistantError
 from custom_components.googlefindmy.const import DEFAULT_MIN_POLL_INTERVAL
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    OwnerKeyLookupTransientError,
     SharedKeyMismatchError,
     StaleOwnerKeyError,
 )
@@ -309,6 +310,30 @@ class TestAsyncLocateDeviceDecryptFailure:
         assert result == {}
         coord.note_decrypt_failure.assert_called_once()
         assert coord.note_decrypt_failure.call_args.kwargs.get("stale") is False
+        coord.config_entry.async_start_reauth.assert_not_called()
+
+    async def test_transient_owner_key_lookup_returns_empty_no_reauth_counter(
+        self, coord: LocateStub
+    ) -> None:
+        """R4/AP5: a transient owner-key lookup miss during a manual locate degrades
+        to an empty result WITHOUT feeding the account-wide reauth counter.
+
+        ``OwnerKeyLookupTransientError`` is not a ``DecryptionError``, so the
+        dedicated ``except OwnerKeyLookupTransientError`` block (before the
+        ``DecryptionError`` handler) skips the device without calling
+        ``note_decrypt_failure`` and never starts a reauth flow.
+        """
+        coord.note_decrypt_failure = MagicMock(return_value=False)
+        coord.config_entry.async_start_reauth = MagicMock()
+        coord.api.async_get_device_location.side_effect = OwnerKeyLookupTransientError(
+            "Owner key retrieval did not complete (transient)."
+        )
+
+        result = await coord.async_locate_device("dev-1")
+
+        assert result == {}
+        coord.note_decrypt_failure.assert_not_called()
+        coord._set_auth_state.assert_not_called()
         coord.config_entry.async_start_reauth.assert_not_called()
 
     async def test_decrypt_failure_at_threshold_starts_reauth(

--- a/tests/test_decrypt_owner_key_authclass.py
+++ b/tests/test_decrypt_owner_key_authclass.py
@@ -1,0 +1,116 @@
+# tests/test_decrypt_owner_key_authclass.py
+"""AUTH-vs-transient classification of owner-key lookup failures (v3 R5/R6).
+
+The v3 contract REPURPOSES ``OwnerKeyInvalidError`` into the reauth-worthy class
+for the NON-retryable AUTH case, recognised ONLY by an ``error_kind`` attribute on
+the raised exception -- never by substring matching of the message text. A bare
+``RuntimeError`` carrying ``error_kind in {"badauthentication", "auth_error",
+"invalid_grant"}`` must map to ``OwnerKeyInvalidError`` (a ``DecryptionError``,
+NOT transient). Everything else -- including messages that merely *contain*
+auth-looking substrings ("retry after 4012 ms" holds "401"), token-availability
+misses, and other ``error_kind`` values such as ``"exchange_error"`` -- stays an
+``OwnerKeyLookupTransientError``.
+
+These are pure synchronous unit tests against ``_classify_owner_key_failure``;
+they carry no asyncio marker. They go RED on HEAD because the classifier has no
+``error_kind`` AUTH branch yet, so the positive case currently falls into the
+transient default.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    OwnerKeyInvalidError,
+    _classify_owner_key_failure,
+)
+
+# ``OwnerKeyLookupTransientError`` is the transient base class. It exists on HEAD,
+# but importing it softly keeps the negative-case identity checks robust even in a
+# hypothetical RED phase where the symbol is being moved/renamed; the AUTH-branch
+# tests stay the load-bearing RED assertions either way.
+try:
+    from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (  # noqa: E501
+        OwnerKeyLookupTransientError,
+    )
+except ImportError:  # pragma: no cover - defensive, symbol present on HEAD
+
+    class _MissingTransientError:
+        """Sentinel so identity checks fail (not error) if the symbol moves."""
+
+    OwnerKeyLookupTransientError = _MissingTransientError  # type: ignore[assignment,misc]
+
+
+def _runtime_error_with_kind(message: str, error_kind: str) -> RuntimeError:
+    """Build a bare ``RuntimeError`` carrying an ``error_kind`` attribute.
+
+    Mirrors how the lower owner-key layers tag a non-retryable auth failure: the
+    discriminator must read the structured ``error_kind`` attribute, never parse
+    the human-readable message.
+    """
+    exc = RuntimeError(message)
+    exc.error_kind = error_kind  # type: ignore[attr-defined]
+    return exc
+
+
+@pytest.mark.parametrize(
+    "error_kind",
+    ["badauthentication", "auth_error", "invalid_grant"],
+)
+def test_error_kind_auth_maps_to_reauth_owner_key_invalid(error_kind: str) -> None:
+    """RED (R5): a structured ``error_kind`` auth tag => reauth-worthy, not transient.
+
+    A bare ``RuntimeError`` tagged with one of the non-retryable auth kinds must
+    classify as ``OwnerKeyInvalidError`` (a ``DecryptionError``, so the coordinator
+    escalates to account-wide reauth) and MUST NOT be an
+    ``OwnerKeyLookupTransientError`` (which the poll/locate paths skip silently).
+    RED today: HEAD has no ``error_kind`` branch, so this falls into the transient
+    default.
+    """
+    exc = _runtime_error_with_kind("auth failed", error_kind)
+    result = _classify_owner_key_failure(exc, context="initial lookup")
+    assert isinstance(result, OwnerKeyInvalidError)
+    assert isinstance(result, DecryptionError)
+    assert not isinstance(result, OwnerKeyLookupTransientError)
+
+
+def test_substring_401_lookalike_stays_transient() -> None:
+    """RED-guard (R7 FP-pin): a message merely CONTAINING "401" stays transient.
+
+    ``"retry after 4012 ms"`` contains the substring ``"401"`` but is a transient
+    backoff notice, not an auth failure. Because AUTH classification is structural
+    (``error_kind`` only, no substring matching), this must remain
+    ``OwnerKeyLookupTransientError`` -- exact type, never ``OwnerKeyInvalidError``.
+    """
+    result = _classify_owner_key_failure(
+        RuntimeError("retry after 4012 ms"), context="initial lookup"
+    )
+    assert type(result) is OwnerKeyLookupTransientError
+
+
+def test_no_valid_token_message_stays_transient() -> None:
+    """R6: a token-availability miss is transient, not an auth defect.
+
+    ``"No valid SPOT or ADM token available for the current user."`` is a
+    cold-start / transient token-availability condition. With no ``error_kind``
+    attribute it must stay ``OwnerKeyLookupTransientError``.
+    """
+    result = _classify_owner_key_failure(
+        RuntimeError("No valid SPOT or ADM token available for the current user."),
+        context="initial lookup",
+    )
+    assert type(result) is OwnerKeyLookupTransientError
+
+
+def test_non_auth_error_kind_stays_transient() -> None:
+    """R6: an ``error_kind`` outside the auth set stays transient.
+
+    ``error_kind="exchange_error"`` is a non-auth structured tag; only the
+    explicit auth kinds escalate to reauth. Everything else stays
+    ``OwnerKeyLookupTransientError``.
+    """
+    exc = _runtime_error_with_kind("token exchange failed", "exchange_error")
+    result = _classify_owner_key_failure(exc, context="initial lookup")
+    assert type(result) is OwnerKeyLookupTransientError

--- a/tests/test_decrypt_owner_key_discriminator.py
+++ b/tests/test_decrypt_owner_key_discriminator.py
@@ -2,18 +2,27 @@
 """Discriminator for stale-vs-missing shared key in owner-key decryption.
 
 When ``async_get_owner_key`` fails, the root cause (wrong shared key vs. missing
-shared key vs. generic failure) is otherwise collapsed into a single opaque
-message. These tests pin ``_classify_owner_key_failure``, which restores the
-discriminator as a typed ``DecryptionError`` subclass, and the Liskov property
-that keeps every existing ``except DecryptionError`` handler working.
+shared key vs. a transient/partial server response) is otherwise collapsed into a
+single opaque, speculative "shared key may be stale; re-authenticate" message.
+These tests pin ``_classify_owner_key_failure`` (genuine credential failures stay
+reauth-worthy ``DecryptionError`` subclasses; unknown/transient ones map to the
+new ``OwnerKeyLookupTransientError``), the Liskov property that keeps every
+existing ``except DecryptionError`` handler working, and the upstream
+error-surfacing contracts (R8 sync wrapper, R9a gRPC detail, R9b eid_info shape,
+R10 empty-response wording) the plan grounds those classifications on.
 """
 
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
 
+import grpclib.exceptions
 import pytest
 from cryptography.exceptions import InvalidTag
+from grpclib.const import Status
 
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
     decrypt_locations as _dl,
@@ -26,6 +35,40 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_
     _classify_owner_key_failure,
 )
 from custom_components.googlefindmy.ProtoDecoders import DeviceUpdate_pb2
+from custom_components.googlefindmy.SpotApi import spot_request as _spot
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices import (
+    get_eid_info_request as _eidreq,
+)
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices import (
+    get_owner_key as _gok,
+)
+from custom_components.googlefindmy.SpotApi.spot_request import (
+    SpotError,
+    SpotGrpcStatusError,
+)
+from tests.helpers.config_entries_stub import install_config_entries_stubs
+
+# AP3 introduces ``OwnerKeyLookupTransientError`` (NOT a ``DecryptionError``
+# subclass; base ``Exception``). Until then this symbol does not exist. Import it
+# softly so the *new* transient-contract tests below go RED on a missing/wrong
+# type, while the unchanged R2/Liskov characterization tests in this module keep
+# passing instead of erroring out the whole collection on a hard ImportError.
+try:
+    from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (  # noqa: E501
+        OwnerKeyLookupTransientError,
+    )
+except ImportError:  # pragma: no cover - RED phase before AP3 lands the class
+
+    class _MissingTransientError:
+        """Placeholder so transient-contract tests fail (not error) pre-AP3.
+
+        Identity comparisons (``type(result) is OwnerKeyLookupTransientError``)
+        and ``isinstance`` checks against this sentinel never match a real
+        ``DecryptionError``, so each transient test asserts RED while the R2
+        tests stay green.
+        """
+
+    OwnerKeyLookupTransientError = _MissingTransientError  # type: ignore[assignment,misc]
 
 
 def test_liskov_subclasses_are_decryption_errors() -> None:
@@ -51,11 +94,86 @@ def test_t2_missing_runtime_maps_to_shared_key_missing() -> None:
     assert isinstance(result, SharedKeyMissingError)
 
 
-def test_t2_generic_runtime_maps_to_plain_decryption_error() -> None:
-    """Any other RuntimeError => generic DecryptionError (still escalates, but is
-    not mis-labelled as a specific shared-key cause)."""
+def test_t2_generic_runtime_maps_to_transient_not_reauth() -> None:
+    """RED (AP3): the inverted default maps any other RuntimeError to the new
+    ``OwnerKeyLookupTransientError`` instead of a plain ``DecryptionError``.
+
+    Previously the generic fallback returned a ``DecryptionError`` carrying a
+    speculative "shared key may be stale; re-authenticate" wording. After the
+    default inversion (plan AP3, F3) an unclassified failure is a transient
+    owner-key lookup miss: NO reauth prompt, an explicit transient marker. This
+    rewrites the former ``type(result) is DecryptionError`` characterization and
+    stays RED until the production class exists.
+    """
     result = _classify_owner_key_failure(RuntimeError("boom"), context="x")
-    assert type(result) is DecryptionError
+    assert type(result) is OwnerKeyLookupTransientError
+
+
+def test_r1_generic_runtime_message_is_transient_not_stale() -> None:
+    """RED (R1): the transient class wording carries a transient marker and makes
+    NO stale / re-authenticate claim.
+
+    Negative: ``str(result)`` mentions neither "stale" nor "re-authenticate"
+    (the speculative wording the plan removes). Positive: it carries a transient
+    marker (``transient`` or ``temporar``) so callers/users see an honest
+    "retrieval did not complete" signal instead of a credential accusation.
+    """
+    result = _classify_owner_key_failure(RuntimeError("boom"), context="x")
+    assert type(result) is OwnerKeyLookupTransientError
+    text = str(result).lower()
+    assert "stale" not in text
+    assert "re-authenticate" not in text
+    assert "transient" in text or "temporar" in text
+
+
+def test_r1_server_field_error_is_transient_not_reauth_fallback() -> None:
+    """RED (R1): a partial-server-response field error must classify as transient.
+
+    ``get_owner_key.py`` raises ``RuntimeError("Missing or empty
+    'encryptedOwnerKey'")`` (capital M) on a degraded/partial SPOT response. The
+    legacy case-sensitive ``"missing or empty"`` check misses the capital M, so
+    this falls through to the speculative reauth fallback today. It is a transient
+    server condition, NOT a missing local bundle => ``OwnerKeyLookupTransientError``.
+    """
+    exc = RuntimeError("Missing or empty 'encryptedOwnerKey'")
+    result = _classify_owner_key_failure(exc, context="x")
+    assert type(result) is OwnerKeyLookupTransientError
+
+
+def test_ap3_shared_key_missing_and_server_field_do_not_collide() -> None:
+    """RED (AP3, mandatory boundary): two superficially similar strings must split.
+
+    ``"Shared key is missing or empty; cannot decrypt owner key"`` is the local
+    incomplete-bundle case and MUST stay ``SharedKeyMissingError`` (reauth-worthy).
+    ``"Missing or empty 'encryptedOwnerKey'"`` is a server-field/partial-response
+    case and MUST become ``OwnerKeyLookupTransientError``. The discriminator must
+    anchor on "shared key" rather than the shared "missing or empty" substring so
+    the two do not collapse into the same class.
+    """
+    missing_bundle = _classify_owner_key_failure(
+        RuntimeError("Shared key is missing or empty; cannot decrypt owner key"),
+        context="x",
+    )
+    assert isinstance(missing_bundle, SharedKeyMissingError)
+
+    server_field = _classify_owner_key_failure(
+        RuntimeError("Missing or empty 'encryptedOwnerKey'"),
+        context="x",
+    )
+    assert type(server_field) is OwnerKeyLookupTransientError
+
+
+def test_f6_shared_key_missing_verbatim_string_is_characterized() -> None:
+    """Characterization anchor (F6): pin the exact ``get_owner_key.py:179`` string.
+
+    ``decrypt_locations`` (this discriminator) and ``get_owner_key`` are edited by
+    AP3/AP6/AP7b in lockstep. Pin the verbatim source string so a later wording
+    drift in ``get_owner_key`` that desyncs the discriminator anchor is caught
+    here. This assertion is GREEN today and must stay green (regression guard).
+    """
+    exc = RuntimeError("Shared key is missing or empty; cannot decrypt owner key")
+    result = _classify_owner_key_failure(exc, context="initial lookup")
+    assert isinstance(result, SharedKeyMissingError)
 
 
 @pytest.mark.asyncio
@@ -159,3 +277,278 @@ async def test_owner_key_forced_refresh_invalid_tag_maps_to_mismatch(
 
     with pytest.raises(SharedKeyMismatchError):
         await _dl.async_retrieve_identity_key(registration, cache=object())
+
+
+# ---------------------------------------------------------------------------
+# R8: the synchronous SPOT fallback wrapper must NOT flatten a typed SpotError
+# into a bare RuntimeError, or the Q5 invariant (typed transient errors stay
+# transient) leaks through the defensive path.
+# ---------------------------------------------------------------------------
+
+
+class _DummyCache(_spot.TokenCache):
+    """Minimal entry-scoped cache double for the SPOT request path."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    async def get(self, key: str) -> Any:
+        return self._data.get(key)
+
+    async def set(self, key: str, value: Any) -> None:
+        self._data[key] = value
+
+
+@pytest.mark.asyncio
+async def test_r8_sync_wrapper_preserves_spot_error_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED (R8): a ``SpotError`` raised by the sync SPOT helper stays a ``SpotError``.
+
+    ``_spot_call_async`` falls back to the synchronous ``spot_request`` helper when
+    no async helper is available, wrapping ``except Exception`` into
+    ``RuntimeError("Synchronous SPOT request helper failed.")``. That flattening
+    erases the typed-transient discriminator. After R8 the wrapper must re-raise a
+    ``SpotError`` (network/grpc-status) type-preservingly. RED today: the wrapper
+    collapses it to a plain ``RuntimeError``.
+    """
+    sentinel = SpotGrpcStatusError("gRPC error: UNAVAILABLE")
+
+    def _sync_boom(*_a: object, **_k: object) -> bytes:
+        raise sentinel
+
+    # Force the sync fallback branch: hide the async helper, expose only sync.
+    monkeypatch.setattr(_eidreq.spot_request_module, "async_spot_request", None)
+    monkeypatch.setattr(
+        _eidreq.spot_request_module, "spot_request", _sync_boom, raising=False
+    )
+
+    with pytest.raises(SpotError) as excinfo:
+        await _eidreq._spot_call_async("Scope", b"payload", cache=_DummyCache())
+
+    # Type-preserving: not flattened into a bare RuntimeError clone.
+    assert type(excinfo.value) is not RuntimeError  # noqa: E721 - exact-type check
+
+
+# ---------------------------------------------------------------------------
+# R9a: the gRPC server detail text (GRPCError.message) must survive into the
+# SpotError message instead of being dropped in favor of status.name alone.
+# ---------------------------------------------------------------------------
+
+
+def _install_grpc_outcome(
+    monkeypatch: pytest.MonkeyPatch, outcome: Exception
+) -> None:
+    """Drive ``async_spot_request`` to hit ``outcome`` on the gRPC stream."""
+
+    class _Stream:
+        async def __aenter__(self) -> _Stream:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> bool:
+            return False
+
+        async def send_message(self, *_a: object, **_k: object) -> None:
+            return None
+
+        async def recv_message(self) -> Any:
+            raise outcome
+
+    class _Method:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        def open(self, **_k: object) -> _Stream:
+            return _Stream()
+
+    monkeypatch.setattr(_spot, "UnaryUnaryMethod", _Method)
+    monkeypatch.setattr(_spot, "_async_sleep", AsyncMock())
+    monkeypatch.setattr(_spot, "_compute_delay", lambda attempt: 0.0)
+    monkeypatch.setattr(_spot, "async_get_username", AsyncMock(return_value="user"))
+    monkeypatch.setattr(_spot, "async_get_spot_token", AsyncMock(return_value="token"))
+    monkeypatch.setattr(
+        _spot, "async_get_adm_token_api", AsyncMock(return_value="adm")
+    )
+
+
+@pytest.mark.asyncio
+async def test_r9a_grpc_message_and_status_reach_spot_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED (R9a): a non-retried ``GRPCError`` surfaces both status.name AND message.
+
+    ``FAILED_PRECONDITION`` is outside the retry/auth policy, so it maps directly
+    to ``SpotGrpcStatusError``. Today the message is ``f"gRPC error: {status.name}"``
+    and the server detail text is dropped. After R9a the resulting message must
+    contain both ``status.name`` and the server-sent ``SENTINEL_MSG``.
+    """
+    err = grpclib.exceptions.GRPCError(Status.FAILED_PRECONDITION, "SENTINEL_MSG")
+    _install_grpc_outcome(monkeypatch, err)
+
+    transport = AsyncMock()
+    transport.get_channel = AsyncMock(return_value=object())
+
+    with pytest.raises(SpotGrpcStatusError) as excinfo:
+        await _spot.async_spot_request(
+            "Scope", b"payload", cache=_DummyCache(), transport=transport
+        )
+
+    message = str(excinfo.value)
+    assert "FAILED_PRECONDITION" in message
+    assert "SENTINEL_MSG" in message
+
+
+@pytest.mark.asyncio
+async def test_r9a_auth_token_sentinel_not_leaked_into_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED (R9a redaction): the captured gRPC detail must not carry an auth secret.
+
+    The auth bearer token is injected as a unique sentinel; whatever R9a copies
+    from the gRPC error into the ``SpotError`` message must be the server status
+    text, never the request's authorization credential.
+    """
+    auth_sentinel = "AUTHTOKEN-CAFEBABE-DEADBEEF"
+    err = grpclib.exceptions.GRPCError(Status.FAILED_PRECONDITION, "server detail")
+    _install_grpc_outcome(monkeypatch, err)
+    monkeypatch.setattr(
+        _spot, "async_get_spot_token", AsyncMock(return_value=auth_sentinel)
+    )
+
+    transport = AsyncMock()
+    transport.get_channel = AsyncMock(return_value=object())
+
+    with pytest.raises(SpotGrpcStatusError) as excinfo:
+        await _spot.async_spot_request(
+            "Scope", b"payload", cache=_DummyCache(), transport=transport
+        )
+
+    assert auth_sentinel not in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# R9b: a partial proto response logs the eid_info field shape at DEBUG, listing
+# field NAMES only -- never raw values / decrypted bytes / a value sentinel.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r9b_proto_field_shape_logged_at_debug_without_value_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED (R9b): a missing-owner-key field error emits a DEBUG field-shape record.
+
+    ``_retrieve_owner_key`` raises ``RuntimeError("Missing or empty
+    'encryptedOwnerKey'...")`` when the server returns metadata without a usable
+    owner-key blob. Before that raise, R9b adds a DEBUG record listing the
+    available ``eid_info`` field names. The record must list a field name
+    (``encryptedOwnerKey``) and must NOT contain an injected value sentinel /
+    raw bytes. RED today: no such DEBUG field-shape record is emitted.
+    """
+    value_sentinel = "VALUE-SENTINEL-D00DFEED"
+
+    metadata = SimpleNamespace(
+        encryptedOwnerKey=b"",  # present field, empty value -> triggers the raise
+        ownerKeyVersion=value_sentinel,  # a value that must never be logged
+    )
+    eid_info = SimpleNamespace(encryptedOwnerKeyAndMetadata=metadata)
+
+    async def _eid_getter() -> Any:
+        return eid_info
+
+    async def _shared_getter() -> bytes:
+        return b"\x11" * 32
+
+    caplog.set_level(logging.DEBUG, logger=_gok.__name__)
+
+    with pytest.raises(RuntimeError):
+        await _gok._retrieve_owner_key(
+            "user@acct.example",
+            cache=_DummyCache(),
+            eid_info_getter=_eid_getter,
+            shared_key_getter=_shared_getter,
+        )
+
+    shape_records = [
+        rec
+        for rec in caplog.records
+        if rec.levelno == logging.DEBUG and "encryptedOwnerKey" in rec.getMessage()
+    ]
+    assert shape_records, "expected a DEBUG eid_info field-shape record"
+    for rec in shape_records:
+        assert value_sentinel not in rec.getMessage()
+
+
+# ---------------------------------------------------------------------------
+# R10 (E3-W): the SpotApiEmptyResponseError path is grounded in wording only;
+# behavior (ConfigEntryAuthFailed at the outer layer) stays unchanged, and the
+# new wording drops the speculative "auth/session issue" / "re-authenticate".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r10_outer_layer_still_raises_auth_failed_with_neutral_wording(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED (R10 b1): ``async_get_owner_key`` still raises ``ConfigEntryAuthFailed``.
+
+    E3-W keeps the reauth behavior at the outer layer deliberately (transient-vs-
+    auth nature unproven), but the wording must be cause-neutral: the message must
+    no longer claim ``auth/session issue`` or ``re-authenticate``. RED today: the
+    ``:360-364`` branch raises ``ConfigEntryAuthFailed`` with exactly that
+    speculative wording.
+    """
+    install_config_entries_stubs(_gok)
+
+    async def _inner_boom(*_a: object, **_k: object) -> Any:
+        raise _eidreq.SpotApiEmptyResponseError("trailers only")
+
+    monkeypatch.setattr(_gok, "_get_or_generate_user_owner_key_hex", _inner_boom)
+
+    with pytest.raises(_gok.ConfigEntryAuthFailed) as excinfo:
+        await _gok.async_get_owner_key(cache=_DummyCache(), username="x@acct.example")
+
+    text = str(excinfo.value).lower()
+    assert "auth/session issue" not in text
+    assert "re-authenticate" not in text
+
+
+@pytest.mark.asyncio
+async def test_r10_inner_layer_reraises_empty_response_with_neutral_wording(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED (R10 b2): the inner retrieval re-raises the EMPTY-response type, not auth.
+
+    ``_retrieve_owner_key`` must re-raise the ``SpotApiEmptyResponseError`` itself
+    (the outer layer owns the ConfigEntryAuthFailed conversion), and the
+    ``_LOGGER.error`` record must carry the new cause-neutral wording (no
+    ``auth/session issue``). The ``except SpotApiEmptyResponseError`` re-raise
+    sits in the default branch (``async_get_eid_info``), so no ``eid_info_getter``
+    is injected; the module-level fetch is mocked instead. RED today: the
+    ``:166-171`` record still says "(likely auth/session issue). Please
+    re-authenticate."
+    """
+    monkeypatch.setattr(
+        _gok,
+        "async_get_eid_info",
+        AsyncMock(side_effect=_eidreq.SpotApiEmptyResponseError("trailers only")),
+    )
+
+    async def _shared_getter() -> bytes:
+        return b"\x11" * 32
+
+    caplog.set_level(logging.ERROR, logger=_gok.__name__)
+
+    with pytest.raises(_eidreq.SpotApiEmptyResponseError):
+        await _gok._retrieve_owner_key(
+            "user@acct.example",
+            cache=_DummyCache(),
+            shared_key_getter=_shared_getter,
+        )
+
+    error_text = " ".join(
+        rec.getMessage() for rec in caplog.records if rec.levelno == logging.ERROR
+    ).lower()
+    assert "auth/session issue" not in error_text

--- a/tests/test_decrypt_owner_key_discriminator.py
+++ b/tests/test_decrypt_owner_key_discriminator.py
@@ -29,6 +29,7 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
 )
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    OwnerKeyInvalidError,
     SharedKeyMismatchError,
     SharedKeyMissingError,
     StaleOwnerKeyError,
@@ -47,7 +48,6 @@ from custom_components.googlefindmy.SpotApi.spot_request import (
     SpotGrpcStatusError,
     SpotNetworkError,
 )
-from tests.helpers.config_entries_stub import install_config_entries_stubs
 
 # AP3 introduces ``OwnerKeyLookupTransientError`` (NOT a ``DecryptionError``
 # subclass; base ``Exception``). Until then this symbol does not exist. Import it
@@ -78,6 +78,12 @@ def test_liskov_subclasses_are_decryption_errors() -> None:
     assert issubclass(SharedKeyMismatchError, DecryptionError)
     assert issubclass(SharedKeyMissingError, DecryptionError)
     assert issubclass(StaleOwnerKeyError, DecryptionError)
+    # OwnerKeyInvalidError is a reauth-worthy credential defect: it MUST be a
+    # DecryptionError (so ``except DecryptionError`` escalates it to reauth) and
+    # MUST NOT be an OwnerKeyLookupTransientError (which the poll/locate paths skip
+    # as a benign transient miss).
+    assert issubclass(OwnerKeyInvalidError, DecryptionError)
+    assert not issubclass(OwnerKeyInvalidError, OwnerKeyLookupTransientError)
 
 
 def test_t2_invalid_tag_maps_to_shared_key_mismatch() -> None:
@@ -175,6 +181,55 @@ def test_f6_shared_key_missing_verbatim_string_is_characterized() -> None:
     exc = RuntimeError("Shared key is missing or empty; cannot decrypt owner key")
     result = _classify_owner_key_failure(exc, context="initial lookup")
     assert isinstance(result, SharedKeyMissingError)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # get_owner_key.py:421 -- owner key absent/invalid after retrieval.
+        "Owner key is missing or invalid; please re-authenticate.",
+        # get_owner_key.py:442 -- owner key decoded but is not a valid hex/base64 key.
+        "Invalid owner_key format (expect 32-byte key in hex or base64).",
+        # get_owner_key.py:465 -- owner key has the wrong byte length.
+        "Owner key must be exactly 32 bytes long.",
+    ],
+)
+def test_local_owner_key_defect_is_reauth_worthy_not_transient(message: str) -> None:
+    """A LOCAL owner-key validity defect must stay reauth-worthy (Codex P2 fix).
+
+    ``async_get_owner_key`` raises these deterministic ``RuntimeError`` strings
+    when the locally stored owner key is missing/invalid, malformed, or the wrong
+    length. The inverted default (branch d) would swallow them as
+    ``OwnerKeyLookupTransientError``, which the poll/locate paths skip silently --
+    so an account with a corrupted owner key would never be prompted to re-import
+    secrets. Branch (b2) keeps them as ``OwnerKeyInvalidError`` (a reauth-worthy
+    ``DecryptionError``), not a transient miss.
+    """
+    result = _classify_owner_key_failure(RuntimeError(message), context="initial lookup")
+    assert isinstance(result, OwnerKeyInvalidError)
+    assert isinstance(result, DecryptionError)
+    assert not isinstance(result, OwnerKeyLookupTransientError)
+    text = str(result).lower()
+    # The reauth recovery is surfaced, not hidden behind a "transient/retry" claim.
+    assert "re-authentication" in text
+    assert "transient" not in text
+
+
+def test_local_owner_key_defect_does_not_collide_with_server_field_transient() -> None:
+    """The (b2) owner-key-defect anchor must not steal the (c) server-field cases.
+
+    ``"Missing or empty 'encryptedOwnerKey'"`` and ``"Decrypted owner_key is empty
+    or invalid type"`` are partial-server-response conditions and MUST stay
+    ``OwnerKeyLookupTransientError`` (transient), even though they mention the words
+    "owner" and "invalid". Only the deterministic local-defect wordings map to
+    ``OwnerKeyInvalidError``.
+    """
+    for server_msg in (
+        "Missing or empty 'encryptedOwnerKey'",
+        "Decrypted owner_key is empty or invalid type",
+    ):
+        result = _classify_owner_key_failure(RuntimeError(server_msg), context="x")
+        assert type(result) is OwnerKeyLookupTransientError
 
 
 @pytest.mark.asyncio
@@ -615,8 +670,15 @@ async def test_r10_outer_layer_still_raises_auth_failed_with_neutral_wording(
     no longer claim ``auth/session issue`` or ``re-authenticate``. RED today: the
     ``:360-364`` branch raises ``ConfigEntryAuthFailed`` with exactly that
     speculative wording.
+
+    Asserts against the ``ConfigEntryAuthFailed`` already present on ``_gok`` (the
+    shared ``homeassistant.exceptions`` stub installed once by ``conftest``). It
+    must NOT call ``install_config_entries_stubs(_gok)``: that rebinds the module
+    global to a fresh stub class without restoring it, so a later test that catches
+    the shared ``ConfigEntryAuthFailed`` would miss what ``_gok`` raises -- an
+    order-dependent contamination. No module mutation here keeps the suite
+    order-independent.
     """
-    install_config_entries_stubs(_gok)
 
     async def _inner_boom(*_a: object, **_k: object) -> Any:
         raise _eidreq.SpotApiEmptyResponseError("trailers only")

--- a/tests/test_decrypt_owner_key_discriminator.py
+++ b/tests/test_decrypt_owner_key_discriminator.py
@@ -72,6 +72,30 @@ except ImportError:  # pragma: no cover - RED phase before AP3 lands the class
     OwnerKeyLookupTransientError = _MissingTransientError  # type: ignore[assignment,misc]
 
 
+# v3 AP1 introduces ``_OwnerKeyRederiveRequired``: an INTERNAL re-derive signal
+# raised when a LOCAL owner-key STRUCTURE defect is detected, asking the caller to
+# re-derive the owner key (force_refresh) instead of escalating to reauth. It
+# subclasses ``OwnerKeyLookupTransientError`` (fail-safe: base ``Exception``, never
+# ``DecryptionError``, never reauth). The class does not exist on HEAD yet, so it
+# is imported softly through a sentinel -- the v3 re-derive tests below assert RED
+# on a missing/wrong type instead of erroring out the whole collection.
+try:
+    from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (  # noqa: E501
+        _OwnerKeyRederiveRequired,
+    )
+except ImportError:  # pragma: no cover - RED phase before AP1 lands the signal
+
+    class _MissingRederiveSignal:
+        """Placeholder so re-derive-contract tests fail (not error) pre-AP1.
+
+        ``type(result) is _OwnerKeyRederiveRequired`` and the subclass checks
+        below never match a real ``OwnerKeyInvalidError`` / ``DecryptionError``,
+        so each re-derive assertion is RED while the unchanged tests stay green.
+        """
+
+    _OwnerKeyRederiveRequired = _MissingRederiveSignal  # type: ignore[assignment,misc]
+
+
 def test_liskov_subclasses_are_decryption_errors() -> None:
     """All specific shared-key errors stay DecryptionError subclasses so existing
     ``except DecryptionError`` handlers keep catching them (no silent breakage)."""
@@ -84,6 +108,13 @@ def test_liskov_subclasses_are_decryption_errors() -> None:
     # as a benign transient miss).
     assert issubclass(OwnerKeyInvalidError, DecryptionError)
     assert not issubclass(OwnerKeyInvalidError, OwnerKeyLookupTransientError)
+    # v3 AP1: the internal re-derive signal is fail-safe -- it IS an
+    # OwnerKeyLookupTransientError (so a leak is skipped as a benign transient
+    # miss, never escalated to reauth) and is NOT a DecryptionError (so the
+    # ``except DecryptionError`` reauth handlers never catch it). RED-tolerant:
+    # the soft-imported sentinel makes these assertions fail (not error) on HEAD.
+    assert issubclass(_OwnerKeyRederiveRequired, OwnerKeyLookupTransientError)
+    assert not issubclass(_OwnerKeyRederiveRequired, DecryptionError)
 
 
 def test_t2_invalid_tag_maps_to_shared_key_mismatch() -> None:
@@ -194,25 +225,27 @@ def test_f6_shared_key_missing_verbatim_string_is_characterized() -> None:
         "Owner key must be exactly 32 bytes long.",
     ],
 )
-def test_local_owner_key_defect_is_reauth_worthy_not_transient(message: str) -> None:
-    """A LOCAL owner-key validity defect must stay reauth-worthy (Codex P2 fix).
+def test_local_owner_key_defect_requests_rederive_not_reauth(message: str) -> None:
+    """RED (v3 AP1): a LOCAL owner-key STRUCTURE defect now requests a RE-DERIVE.
 
     ``async_get_owner_key`` raises these deterministic ``RuntimeError`` strings
     when the locally stored owner key is missing/invalid, malformed, or the wrong
-    length. The inverted default (branch d) would swallow them as
-    ``OwnerKeyLookupTransientError``, which the poll/locate paths skip silently --
-    so an account with a corrupted owner key would never be prompted to re-import
-    secrets. Branch (b2) keeps them as ``OwnerKeyInvalidError`` (a reauth-worthy
-    ``DecryptionError``), not a transient miss.
+    length. The v3 contract REPURPOSES this path: instead of escalating straight
+    to ``OwnerKeyInvalidError``/reauth, the classifier returns the internal
+    ``_OwnerKeyRederiveRequired`` signal so the caller first re-derives the owner
+    key (force_refresh). The signal is fail-safe: an ``OwnerKeyLookupTransientError``
+    subclass (skipped as a benign miss, never reauth) and NOT a ``DecryptionError``
+    (so ``except DecryptionError`` reauth handlers never catch it), and it makes
+    no "re-authenticate" claim. RED today: HEAD still returns
+    ``OwnerKeyInvalidError`` (a reauth-worthy ``DecryptionError``).
     """
     result = _classify_owner_key_failure(RuntimeError(message), context="initial lookup")
-    assert isinstance(result, OwnerKeyInvalidError)
-    assert isinstance(result, DecryptionError)
-    assert not isinstance(result, OwnerKeyLookupTransientError)
-    text = str(result).lower()
-    # The reauth recovery is surfaced, not hidden behind a "transient/retry" claim.
-    assert "re-authentication" in text
-    assert "transient" not in text
+    assert type(result) is _OwnerKeyRederiveRequired
+    # Fail-safe: a transient subclass, never a reauth-worthy DecryptionError.
+    assert isinstance(result, OwnerKeyLookupTransientError)
+    assert not isinstance(result, DecryptionError)
+    # No speculative credential accusation: never asks to re-authenticate.
+    assert "re-authenticat" not in str(result).lower()
 
 
 def test_local_owner_key_defect_does_not_collide_with_server_field_transient() -> None:

--- a/tests/test_decrypt_owner_key_discriminator.py
+++ b/tests/test_decrypt_owner_key_discriminator.py
@@ -45,6 +45,7 @@ from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices import (
 from custom_components.googlefindmy.SpotApi.spot_request import (
     SpotError,
     SpotGrpcStatusError,
+    SpotNetworkError,
 )
 from tests.helpers.config_entries_stub import install_config_entries_stubs
 
@@ -279,6 +280,67 @@ async def test_owner_key_forced_refresh_invalid_tag_maps_to_mismatch(
         await _dl.async_retrieve_identity_key(registration, cache=object())
 
 
+@pytest.mark.asyncio
+async def test_r3_initial_lookup_spot_error_maps_to_transient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R3 (AP4): a typed ``SpotError`` from the initial owner-key lookup surfaces as
+    ``OwnerKeyLookupTransientError`` -- never a stale/reauth ``DecryptionError``.
+
+    ``SpotError`` is not a ``RuntimeError``, so the dedicated ``except SpotError``
+    block (placed before the generic handler) classifies the transport/gRPC
+    failure as transient and keeps it off the speculative reauth path (Q5).
+    """
+
+    async def _boom(**_kwargs: object) -> object:
+        raise SpotGrpcStatusError("gRPC error: UNAVAILABLE")
+
+    monkeypatch.setattr(_dl, "async_get_owner_key", _boom)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x00" * 60
+
+    with pytest.raises(OwnerKeyLookupTransientError) as excinfo:
+        await _dl.async_retrieve_identity_key(registration, cache=object())
+
+    text = str(excinfo.value).lower()
+    assert "stale" not in text
+    assert "re-authenticate" not in text
+    assert "transient" in text
+
+
+@pytest.mark.asyncio
+async def test_r3_forced_refresh_spot_error_maps_to_transient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R3 (AP4): a typed ``SpotError`` during the forced refresh surfaces as
+    ``OwnerKeyLookupTransientError`` (the forced-refresh wrap path mirrors the
+    initial-lookup carve-out, never a stale/reauth ``DecryptionError``)."""
+    from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+        OwnerKeyInfo,
+    )
+
+    async def _owner(
+        *, cache: object, force_refresh: bool = False, **_kw: object
+    ) -> object:
+        if force_refresh:
+            raise SpotNetworkError("Timeout after retries.")
+        return OwnerKeyInfo(key=b"\x00" * 32, version=1)
+
+    monkeypatch.setattr(_dl, "async_get_owner_key", _owner)
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x00" * 60
+    registration.encryptedUserSecrets.ownerKeyVersion = 5  # > cached version 1
+
+    with pytest.raises(OwnerKeyLookupTransientError) as excinfo:
+        await _dl.async_retrieve_identity_key(registration, cache=object())
+
+    assert "transient" in str(excinfo.value).lower()
+
+
 # ---------------------------------------------------------------------------
 # R8: the synchronous SPOT fallback wrapper must NOT flatten a typed SpotError
 # into a bare RuntimeError, or the Q5 invariant (typed transient errors stay
@@ -424,6 +486,61 @@ async def test_r9a_auth_token_sentinel_not_leaked_into_message(
         )
 
     assert auth_sentinel not in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_r9a_retries_exhausted_grpc_message_reaches_spot_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R9a: a retryable gRPC status that exhausts the budget carries the server
+    detail into the ``SpotRequestFailedAfterRetries`` message.
+
+    ``UNAVAILABLE`` is retried; once the budget is spent the transient error must
+    still surface the status name AND the last server-sent detail text (not only
+    ``status.name``).
+    """
+    err = grpclib.exceptions.GRPCError(Status.UNAVAILABLE, "RETRY_SENTINEL_MSG")
+    _install_grpc_outcome(monkeypatch, err)
+
+    transport = AsyncMock()
+    transport.get_channel = AsyncMock(return_value=object())
+
+    from custom_components.googlefindmy.SpotApi.spot_request import (
+        SpotRequestFailedAfterRetries,
+    )
+
+    with pytest.raises(SpotRequestFailedAfterRetries) as excinfo:
+        await _spot.async_spot_request(
+            "Scope", b"payload", cache=_DummyCache(), transport=transport
+        )
+
+    message = str(excinfo.value)
+    assert "UNAVAILABLE" in message
+    assert "RETRY_SENTINEL_MSG" in message
+
+
+def test_r9a_format_grpc_detail_message_details_and_empty() -> None:
+    """R9a helper: render message + details, and stay empty when neither is set.
+
+    ``_format_grpc_detail`` appends the server-sent ``message`` and (when present)
+    the structured ``details`` to the SpotError message, and returns an empty
+    string when the GRPCError carries neither (so a status-only error reads
+    cleanly).
+    """
+    with_message = grpclib.exceptions.GRPCError(
+        Status.FAILED_PRECONDITION, "detail-text"
+    )
+    assert _spot._format_grpc_detail(with_message) == ": detail-text"
+
+    with_details = grpclib.exceptions.GRPCError(
+        Status.FAILED_PRECONDITION, "msg", ["extra-1", "extra-2"]
+    )
+    rendered = _spot._format_grpc_detail(with_details)
+    assert "msg" in rendered
+    assert "extra-1" in rendered
+
+    status_only = grpclib.exceptions.GRPCError(Status.FAILED_PRECONDITION)
+    assert _spot._format_grpc_detail(status_only) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_decrypt_owner_key_rederive.py
+++ b/tests/test_decrypt_owner_key_rederive.py
@@ -1,0 +1,238 @@
+# tests/test_decrypt_owner_key_rederive.py
+"""Owner-key RE-DERIVE flow on a local structure defect (v3 R1-R4).
+
+When the INITIAL owner-key lookup reports a LOCAL structure defect (the stored
+owner key is missing/invalid, malformed, or the wrong length), the v3 caller must
+RE-DERIVE the owner key once via ``async_get_owner_key(force_refresh=True)``
+before deciding anything -- never escalate the first defect straight to reauth.
+
+These integration tests drive ``async_retrieve_identity_key`` and monkeypatch the
+module-level ``async_get_owner_key`` with a fake that:
+  * raises the structure-defect ``RuntimeError`` on the initial (force_refresh=False)
+    call, and
+  * counts and answers the force_refresh=True call distinctly,
+mirroring the existing discriminator integration tests
+(``test_owner_key_forced_refresh_invalid_tag_maps_to_mismatch`` and
+``test_r3_initial_lookup_spot_error_maps_to_transient``).
+
+They go RED on HEAD because the re-derive-on-structure-defect path does not exist
+yet: today the initial structure defect is classified by
+``_classify_owner_key_failure`` straight into ``OwnerKeyInvalidError`` (a
+reauth-worthy ``DecryptionError``), so ``force_refresh=True`` is never reached
+(R1/R4 counter stays 0) and R2/R3 never get a chance to map the refresh outcome.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    decrypt_locations as _dl,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    OwnerKeyInvalidError,
+    OwnerKeyLookupTransientError,
+    SharedKeyMismatchError,
+)
+from custom_components.googlefindmy.ProtoDecoders import DeviceUpdate_pb2
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
+    OwnerKeyInfo,
+)
+from custom_components.googlefindmy.SpotApi.spot_request import SpotGrpcStatusError
+
+pytestmark = pytest.mark.asyncio
+
+# The deterministic local structure-defect wording raised by the initial lookup.
+# Matches ``get_owner_key.py``'s "Owner key is missing or invalid" branch -- the
+# (b2) structure-defect anchor in ``_classify_owner_key_failure``.
+_STRUCTURE_DEFECT_MSG = "Owner key is missing or invalid; please re-authenticate."
+
+
+def _registration() -> object:
+    """Build a DeviceRegistration with a 60-byte garbage encrypted identity key."""
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x00" * 60
+    return registration
+
+
+class _RederiveFake:
+    """Fake ``async_get_owner_key``: structure defect first, scripted on refresh.
+
+    The initial call (``force_refresh`` falsey) raises the structure-defect
+    ``RuntimeError``. The ``force_refresh=True`` call is counted and dispatched to
+    ``on_refresh`` (a callable returning the ``OwnerKeyInfo`` or raising).
+    """
+
+    def __init__(self, on_refresh: object) -> None:
+        self._on_refresh = on_refresh
+        self.force_refresh_calls = 0
+
+    async def __call__(
+        self, *, cache: object, force_refresh: bool = False, **_kw: object
+    ) -> OwnerKeyInfo:
+        if force_refresh:
+            self.force_refresh_calls += 1
+            return self._on_refresh()  # type: ignore[operator,no-any-return]
+        raise RuntimeError(_STRUCTURE_DEFECT_MSG)
+
+
+async def test_r1_structure_defect_rederives_once_without_reauth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED (R1): initial structure defect triggers exactly one force_refresh; the
+    refreshed (valid) owner key keeps the flow OFF the reauth path.
+
+    The refresh returns a valid ``OwnerKeyInfo`` so the owner-key phase succeeds;
+    the garbage EIK still fails to decrypt, but NOT as a credential defect
+    (``SharedKeyMismatchError`` / ``OwnerKeyInvalidError``). We pin the re-derive
+    contract precisely: ``force_refresh=True`` is invoked exactly once, and no
+    owner-key-path ``DecryptionError`` subclass leaks. RED today: the initial
+    defect is classified straight to ``OwnerKeyInvalidError`` and the refresh is
+    never reached (counter stays 0).
+    """
+
+    def _valid_refresh() -> OwnerKeyInfo:
+        return OwnerKeyInfo(key=b"\x00" * 32, version=1)
+
+    fake = _RederiveFake(_valid_refresh)
+    monkeypatch.setattr(_dl, "async_get_owner_key", fake)
+
+    # The decrypt of the garbage EIK still fails; assert it is NOT routed to a
+    # reauth-worthy credential defect from the owner-key path.
+    with pytest.raises(Exception) as excinfo:  # noqa: PT011 - shape asserted below
+        await _dl.async_retrieve_identity_key(_registration(), cache=object())
+
+    assert fake.force_refresh_calls == 1
+    assert not isinstance(excinfo.value, SharedKeyMismatchError)
+    assert not isinstance(excinfo.value, OwnerKeyInvalidError)
+
+
+async def test_r2_structure_defect_then_invalid_tag_maps_to_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED (R2): initial structure defect, then the force_refresh raises InvalidTag
+    => ``SharedKeyMismatchError`` (the shared key cannot decrypt the owner key).
+
+    After the re-derive carve-out lands, the refresh failure is classified exactly
+    like the existing forced-refresh InvalidTag path. RED today: the initial defect
+    short-circuits to ``OwnerKeyInvalidError`` before any refresh runs.
+    """
+
+    def _refresh_invalid_tag() -> OwnerKeyInfo:
+        raise InvalidTag()
+
+    fake = _RederiveFake(_refresh_invalid_tag)
+    monkeypatch.setattr(_dl, "async_get_owner_key", fake)
+
+    with pytest.raises(SharedKeyMismatchError):
+        await _dl.async_retrieve_identity_key(_registration(), cache=object())
+
+    assert fake.force_refresh_calls == 1
+
+
+async def test_r3_structure_defect_then_spot_error_maps_to_transient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED (R3): initial structure defect, then the force_refresh raises a typed
+    ``SpotError`` => ``OwnerKeyLookupTransientError`` (transient transport failure),
+    text carries the "transient" marker, never stale/reauth.
+
+    RED today: the initial defect short-circuits to ``OwnerKeyInvalidError`` before
+    any refresh runs.
+    """
+
+    def _refresh_spot_error() -> OwnerKeyInfo:
+        raise SpotGrpcStatusError("gRPC error: UNAVAILABLE")
+
+    fake = _RederiveFake(_refresh_spot_error)
+    monkeypatch.setattr(_dl, "async_get_owner_key", fake)
+
+    with pytest.raises(OwnerKeyLookupTransientError) as excinfo:
+        await _dl.async_retrieve_identity_key(_registration(), cache=object())
+
+    assert fake.force_refresh_calls == 1
+    text = str(excinfo.value).lower()
+    assert "transient" in text
+    assert "stale" not in text
+    assert "re-authenticate" not in text
+
+
+async def test_r4_structure_defect_persists_after_refresh_is_transient(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED (R4 default): the structure defect REPEATS on force_refresh => transient.
+
+    When even the re-derived owner key reports the same structure defect, the flow
+    must NOT escalate to reauth: it surfaces as ``OwnerKeyLookupTransientError`` and
+    emits exactly one WARNING record (the re-derive-exhausted notice). RED today:
+    the initial defect short-circuits to ``OwnerKeyInvalidError`` (reauth), and no
+    such WARNING is emitted.
+    """
+
+    def _refresh_still_defective() -> OwnerKeyInfo:
+        raise RuntimeError(_STRUCTURE_DEFECT_MSG)
+
+    fake = _RederiveFake(_refresh_still_defective)
+    monkeypatch.setattr(_dl, "async_get_owner_key", fake)
+
+    caplog.set_level(logging.WARNING, logger=_dl.__name__)
+
+    with pytest.raises(OwnerKeyLookupTransientError):
+        await _dl.async_retrieve_identity_key(_registration(), cache=object())
+
+    assert fake.force_refresh_calls == 1
+    warning_records = [
+        rec for rec in caplog.records if rec.levelno == logging.WARNING
+    ]
+    assert len(warning_records) == 1
+    # The structure defect must never be re-routed to a DecryptionError/reauth.
+    transient_exc = OwnerKeyLookupTransientError
+    assert not issubclass(transient_exc, DecryptionError)
+
+
+async def test_error_kind_auth_failure_surfaces_as_reauth_from_caller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N1 integration: a non-retryable auth error (structured ``error_kind``) raised
+    on the initial owner-key lookup surfaces from ``async_retrieve_identity_key`` as
+    the reauth-worthy ``OwnerKeyInvalidError``.
+
+    Defect 2 hinges on a passed-through bare ``RuntimeError`` that carries
+    ``error_kind`` (e.g. ``badauthentication`` from the ADM/AAS token exchange)
+    reaching ``_classify_owner_key_failure`` via the ``except (InvalidTag,
+    RuntimeError)`` block. Unlike the (b2) structure-defect wordings this is NOT
+    re-derivable: the (auth) branch must classify it reauth-worthy, so the caller
+    re-raises it (no force_refresh, no transient swallow). This exercises the real
+    propagation path the unit tests in ``test_decrypt_owner_key_authclass.py``
+    only cover at the classifier boundary.
+    """
+
+    auth_exc = RuntimeError(
+        "Missing 'Token'/'Auth' in gpsoauth response (kind=badauthentication)"
+    )
+    auth_exc.error_kind = "badauthentication"  # type: ignore[attr-defined]
+
+    call_count = {"n": 0}
+
+    async def _auth_boom(
+        *, cache: object, force_refresh: bool = False, **_kw: object
+    ) -> object:
+        call_count["n"] += 1
+        raise auth_exc
+
+    monkeypatch.setattr(_dl, "async_get_owner_key", _auth_boom)
+
+    with pytest.raises(OwnerKeyInvalidError) as excinfo:
+        await _dl.async_retrieve_identity_key(_registration(), cache=object())
+
+    # Reauth-worthy DecryptionError, never the transient miss; no re-derive attempted.
+    assert isinstance(excinfo.value, DecryptionError)
+    assert not isinstance(excinfo.value, OwnerKeyLookupTransientError)
+    assert call_count["n"] == 1
+    assert "re-authentication" in str(excinfo.value).lower()

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -18,6 +18,7 @@ from custom_components.googlefindmy.Auth import fcm_receiver_ha
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    OwnerKeyLookupTransientError,
     StaleOwnerKeyError,
 )
 
@@ -248,6 +249,100 @@ async def test_decode_background_location_semantic_only_does_not_clear_counter(
     coordinator.note_background_decrypt_success.assert_not_called()
     coordinator.note_decrypt_failure.assert_not_called()
     entry.async_start_reauth.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_decode_background_location_transient_owner_key_is_skipped_without_counter_touch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INVARIANT (AP8 characterization, post-fix): a transient owner-key miss in the
+    background decode yields an empty result WITHOUT touching the reauth counter.
+
+    ``OwnerKeyLookupTransientError`` has base ``Exception`` and is now caught by the
+    dedicated scoped ``except OwnerKeyLookupTransientError`` branch inside
+    ``_decode_background_location_async`` (added in AP9, Path A), which logs at DEBUG
+    and returns ``{}`` without calling ``_note_decrypt_failure_for_entry``.
+
+    This test pins the counter-safety and empty-result halves of the contract, which
+    held both before and after the fix (the sibling test
+    ``..._downgrades_to_debug`` pins the DEBUG severity that the fix added). A
+    transient is not a decrypt-failure budget event, so the counter stays untouched.
+    """
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    receiver._entry_caches["entry-1"] = MagicMock()
+
+    note_failure = MagicMock()
+    monkeypatch.setattr(receiver, "_note_decrypt_failure_for_entry", note_failure)
+
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(side_effect=OwnerKeyLookupTransientError("owner key lookup timed out")),
+    )
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    # (1) counter untouched: the failure-budget hook is NOT called.
+    note_failure.assert_not_called()
+    # (2) return value is the empty result.
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_decode_background_location_transient_owner_key_downgrades_to_debug(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """GREEN (AP9 Path A): a transient owner-key miss is a pure severity downgrade.
+
+    The transient type is caught inside the scoped block BEFORE ``InvalidTag`` and
+    logged at DEBUG (not ERROR), the failure-budget hook is NOT called, and the
+    result is the empty mapping. This is the GREEN counterpart of the
+    characterization test above (which only pinned counter + return value); it adds
+    the severity assertion that drives the AP9 implementation.
+    """
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    receiver._entry_caches["entry-1"] = MagicMock()
+
+    note_failure = MagicMock()
+    monkeypatch.setattr(receiver, "_note_decrypt_failure_for_entry", note_failure)
+
+    monkeypatch.setattr(
+        fcm_receiver_ha.decoder_module,
+        "parse_device_update_protobuf",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(
+        fcm_receiver_ha,
+        "async_decrypt_location_response_locations",
+        AsyncMock(side_effect=OwnerKeyLookupTransientError("owner key lookup timed out")),
+    )
+
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger=fcm_receiver_ha.__name__)
+
+    result = await receiver._decode_background_location_async("entry-1", "deadbeef")
+
+    # (1) counter untouched.
+    note_failure.assert_not_called()
+    # (2) empty result.
+    assert result == {}
+    # (3) no ERROR record for a transient; the dedicated DEBUG record is present.
+    error_records = [rec for rec in caplog.records if rec.levelno >= logging.ERROR]
+    assert not error_records, (
+        "transient owner-key miss must not be logged at ERROR; "
+        f"got {[r.getMessage() for r in error_records]}"
+    )
+    debug_text = " ".join(
+        rec.getMessage() for rec in caplog.records if rec.levelno == logging.DEBUG
+    )
+    assert "transient owner-key" in debug_text.lower()
 
 
 def test_note_decrypt_success_for_entry_swallows_coordinator_errors() -> None:

--- a/tests/test_location_request_surfacing_diagnostics.py
+++ b/tests/test_location_request_surfacing_diagnostics.py
@@ -1,0 +1,188 @@
+# tests/test_location_request_surfacing_diagnostics.py
+"""Diagnostic surfacing contract for the locate-request error handler (R6/R9c).
+
+When a locate request fails with an unexpected error, the broad surfacing block
+(``location_request.get_location_data_for_device`` -> ``except Exception``) is the
+last place the failure is observable. Two plan requirements pin its behavior:
+
+* **R6** (AGENTS.md Section 5 redaction): the user-facing WARNING must not carry a
+  raw device display name; it states a count/index instead, while the full name
+  stays at DEBUG only (the Count@WARNING / Name@DEBUG line from PR #1129).
+* **R9c**: the surfacing record must contain the *full* cause chain so a gRPC
+  server detail nested two levels deep (surfacing -> SpotError -> GRPCError) is
+  not overwritten by the first level's ``str(exc)``.
+
+These are RED until the AP7 diagnostic-logging rework lands; they exercise the
+real surfacing path via the established locate-flow stubs (no ``asyncio.run``).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import grpclib.exceptions
+import pytest
+from grpclib.const import Status
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    location_request,
+)
+from custom_components.googlefindmy.SpotApi.spot_request import SpotGrpcStatusError
+
+pytestmark = pytest.mark.asyncio
+
+
+class _DummyFcmReceiver:
+    """Receiver that never delivers a report (the locate fails some other way)."""
+
+    async def async_register_for_location_updates(
+        self, device_id: str, callback: Callable[[str, str], None]
+    ) -> str:
+        return "fcm-token"
+
+    async def async_unregister_for_location_updates(self, device_id: str) -> None:
+        return None
+
+
+class _FakeTokenCache:
+    """Minimal entry-scoped cache stub for the locate flow."""
+
+    def __init__(self, label: str = "entry-surfacing") -> None:
+        self.entry_id = label
+        self.values: dict[str, Any] = {}
+
+    async def async_get_cached_value(self, key: str) -> Any:
+        return self.values.get(key)
+
+    async def async_set_cached_value(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+    async def get(self, key: str) -> Any:
+        return self.values.get(key)
+
+    async def set(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+
+def _wire_locate_flow(
+    monkeypatch: pytest.MonkeyPatch, *, surfacing_exc: Exception
+) -> None:
+    """Stub the locate flow so an unexpected error reaches the broad surfacing block.
+
+    ``create_location_request`` is raised from inside the outer try-body but
+    outside every specific ``except`` clause, so the error lands in the final
+    ``except Exception`` surfacing handler (the unit under test) rather than in the
+    inner Nova-request handler that returns an empty list.
+    """
+    receiver = _DummyFcmReceiver()
+    monkeypatch.setattr(location_request, "_FCM_ReceiverGetter", lambda: receiver)
+
+    def _fake_make_callback(
+        *, ctx: Any, canonic_device_id: str, **_: Any
+    ) -> Callable[[str, str], None]:
+        def _callback(_response_canonic_id: str, _hex: str) -> None:
+            return None
+
+        return _callback
+
+    monkeypatch.setattr(
+        location_request, "_make_location_callback", _fake_make_callback
+    )
+
+    def _boom(*_a: object, **_k: object) -> str:
+        raise surfacing_exc
+
+    monkeypatch.setattr(location_request, "create_location_request", _boom)
+
+
+_SENTINEL_NAME = "Jens-Privat-Tracker-SENTINEL-7Q"
+
+
+async def test_r6_surfacing_warning_omits_device_name_keeps_it_at_debug(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED (R6): a unique device name must not leak into a user-facing WARNING.
+
+    With a sentinel display name and a forced unexpected error, the surfacing block
+    must keep the raw name out of any WARNING/ERROR record (count/index only) and
+    only ever expose it at DEBUG. RED today: the broad ``except Exception`` block
+    logs ``"Error requesting location for %s"`` with the raw name at ERROR.
+    """
+    _wire_locate_flow(monkeypatch, surfacing_exc=RuntimeError("unexpected boom"))
+
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+
+    result = await location_request.get_location_data_for_device(
+        canonic_device_id="device-xyz",
+        name=_SENTINEL_NAME,
+        session=None,
+        username="user@example.com",
+        cache=_FakeTokenCache(),
+    )
+    assert result == []
+
+    user_facing = [
+        rec
+        for rec in caplog.records
+        if rec.levelno >= logging.WARNING
+    ]
+    assert user_facing, "expected at least one user-facing surfacing record"
+    for rec in user_facing:
+        assert _SENTINEL_NAME not in rec.getMessage()
+
+    debug_text = " ".join(
+        rec.getMessage() for rec in caplog.records if rec.levelno == logging.DEBUG
+    )
+    assert _SENTINEL_NAME in debug_text
+
+
+async def test_r9c_surfacing_includes_nested_grpc_cause_detail(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED (R9c): the surfacing diagnostic record carries the two-levels-deep gRPC
+    detail as a structured cause chain, not just as a raw traceback dump.
+
+    The failure chain is surfacing-exc -> SpotGrpcStatusError -> GRPCError, where the
+    GRPCError carries a server detail sentinel. AP7 must walk the full ``__cause__``
+    chain into the surfacing diagnostic record (a ``Type: msg -> Type: msg`` string)
+    so the sentinel survives at the user-facing diagnostic level. Today the
+    surfacing record only logs the outermost ``str(exc)`` ("locate failed"); the
+    nested gRPC detail appears solely in the unstructured ``traceback.format_exc()``
+    DEBUG dump that R9 is meant to replace. The assertion therefore excludes the
+    raw-traceback record (it must not be the only carrier) and requires a
+    non-traceback surfacing record to carry the sentinel. RED today.
+    """
+    grpc_detail = "GRPC-DETAIL-SENTINEL-NESTED"
+    grpc_err = grpclib.exceptions.GRPCError(Status.FAILED_PRECONDITION, grpc_detail)
+    spot_err = SpotGrpcStatusError("gRPC error: FAILED_PRECONDITION")
+    spot_err.__cause__ = grpc_err
+    outer = RuntimeError("locate failed")
+    outer.__cause__ = spot_err
+
+    _wire_locate_flow(monkeypatch, surfacing_exc=outer)
+
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+
+    result = await location_request.get_location_data_for_device(
+        canonic_device_id="device-xyz",
+        name="Tracker",
+        session=None,
+        username="user@example.com",
+        cache=_FakeTokenCache(),
+    )
+    assert result == []
+
+    # Exclude the raw ``traceback.format_exc()`` dump: R9c requires the structured
+    # cause chain in a dedicated surfacing record, not merely inside a stack trace.
+    structured_records = [
+        rec
+        for rec in caplog.records
+        if "Traceback:" not in rec.getMessage()
+        and "traceback" not in rec.getMessage().lower()
+    ]
+    structured_text = " ".join(rec.getMessage() for rec in structured_records)
+    assert grpc_detail in structured_text

--- a/tests/test_location_request_surfacing_diagnostics.py
+++ b/tests/test_location_request_surfacing_diagnostics.py
@@ -29,6 +29,9 @@ from grpclib.const import Status
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
     location_request,
 )
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    OwnerKeyLookupTransientError,
+)
 from custom_components.googlefindmy.SpotApi.spot_request import SpotGrpcStatusError
 
 pytestmark = pytest.mark.asyncio
@@ -186,6 +189,110 @@ async def test_r9c_surfacing_includes_nested_grpc_cause_detail(
     ]
     structured_text = " ".join(rec.getMessage() for rec in structured_records)
     assert grpc_detail in structured_text
+
+
+def _wire_transient_via_ctx_error(
+    monkeypatch: pytest.MonkeyPatch, *, transient: Exception
+) -> None:
+    """Wire the locate flow so the FCM callback sets ``ctx.error = transient``.
+
+    This reproduces the ONLY real arrival path for a transient owner-key failure:
+    the threadsafe decrypt dispatch in ``_decrypt_and_store`` never lets the
+    exception escape the callback; it records it on ``ctx.error`` and signals the
+    event. ``get_location_data_for_device`` then inspects ``ctx.error`` after the
+    wait. The Nova send and request build are stubbed to succeed so control reaches
+    that inspection block.
+    """
+    receiver = _DummyFcmReceiver()
+    monkeypatch.setattr(location_request, "_FCM_ReceiverGetter", lambda: receiver)
+
+    def _fake_make_callback(
+        *, ctx: Any, canonic_device_id: str, **_: Any
+    ) -> Callable[[str, str], None]:
+        def _callback(_response_canonic_id: str, _hex: str) -> None:
+            ctx.error = transient
+            ctx.event.set()
+
+        return _callback
+
+    monkeypatch.setattr(
+        location_request, "_make_location_callback", _fake_make_callback
+    )
+
+    # Request build + Nova send succeed so the flow reaches the ctx.error check.
+    monkeypatch.setattr(
+        location_request, "create_location_request", lambda *a, **k: "deadbeef"
+    )
+
+    async def _fake_nova(*_a: object, **_k: object) -> bytes:
+        return b""
+
+    monkeypatch.setattr(location_request, "async_nova_request", _fake_nova)
+
+    # Fire the callback synchronously once the locate flow registers it, so the
+    # subsequent ``await ctx.event.wait()`` returns immediately with ctx.error set.
+    real_register = receiver.async_register_for_location_updates
+
+    async def _register_and_fire(
+        device_id: str, callback: Callable[[str, str], None]
+    ) -> str:
+        token = await real_register(device_id, callback)
+        callback(device_id, "deadbeef")
+        return token
+
+    monkeypatch.setattr(
+        receiver, "async_register_for_location_updates", _register_and_fire
+    )
+
+
+async def test_transient_owner_key_via_ctx_error_is_reraised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED (real path, AP4 vector a): a transient owner-key failure recorded on
+    ``ctx.error`` must propagate out of ``get_location_data_for_device``.
+
+    This is the only real arrival path (thread-safe decrypt sets ctx.error). Today
+    the function returns ``[]`` because the ``if ctx.error:`` block only re-raises
+    ``SpotApiEmptyResponseError`` / ``SpotAuthPermanentError`` / ``DecryptionError``
+    and ``OwnerKeyLookupTransientError`` is none of those (base ``Exception``).
+    """
+    transient = OwnerKeyLookupTransientError("owner key lookup timed out")
+    _wire_transient_via_ctx_error(monkeypatch, transient=transient)
+
+    with pytest.raises(OwnerKeyLookupTransientError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id="device-xyz",
+            name="Tracker",
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
+
+
+async def test_transient_owner_key_synthetic_outer_raise_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SYNTHETIC / DEFENSIVE (AP4 vector b): a transient raised directly from the
+    outer try-body must propagate, mirroring ``except DecryptionError: raise``.
+
+    NOTE: this is NOT a real decrypt path -- the real decrypt never raises out of
+    the callback (it sets ctx.error, see vector a). This vector only pins the
+    symmetry of the outer-``try`` exception handling: an ``OwnerKeyLookupTransientError``
+    surfacing through the outer body (here forced via ``create_location_request``)
+    must re-raise just like ``DecryptionError`` does, not be swallowed by the broad
+    ``except Exception`` into ``return []``.
+    """
+    transient = OwnerKeyLookupTransientError("synthetic outer-body transient")
+    _wire_locate_flow(monkeypatch, surfacing_exc=transient)
+
+    with pytest.raises(OwnerKeyLookupTransientError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id="device-xyz",
+            name="Tracker",
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
 
 
 async def test_format_cause_chain_breaks_on_cyclic_cause() -> None:

--- a/tests/test_location_request_surfacing_diagnostics.py
+++ b/tests/test_location_request_surfacing_diagnostics.py
@@ -186,3 +186,20 @@ async def test_r9c_surfacing_includes_nested_grpc_cause_detail(
     ]
     structured_text = " ".join(rec.getMessage() for rec in structured_records)
     assert grpc_detail in structured_text
+
+
+async def test_format_cause_chain_breaks_on_cyclic_cause() -> None:
+    """R9c helper: a self-referential cause chain terminates (no infinite loop).
+
+    A pathological ``__cause__`` cycle must be broken by the seen-set guard so the
+    diagnostic formatter stays bounded. The rendered string lists each distinct
+    exception exactly once.
+    """
+    first = RuntimeError("first")
+    second = ValueError("second")
+    first.__cause__ = second
+    second.__cause__ = first  # cycle back to the first exception
+
+    rendered = location_request._format_cause_chain(first)
+
+    assert rendered == "RuntimeError: first -> ValueError: second"

--- a/tests/test_location_request_transient_owner_key.py
+++ b/tests/test_location_request_transient_owner_key.py
@@ -1,0 +1,149 @@
+# tests/test_location_request_transient_owner_key.py
+"""RED contract: a transient owner-key lookup failure must survive the decrypt callback.
+
+``decrypt_locations.async_decrypt_location_response_locations`` can raise
+``OwnerKeyLookupTransientError`` (base ``Exception``, NOT a ``DecryptionError``
+subclass) when the per-tracker owner key cannot be resolved against a transient
+server condition. The locate callback's inner decrypt body
+(``location_request._make_location_callback`` -> ``_decrypt_and_store``) catches a
+fixed tuple of ``(StaleOwnerKeyError, DecryptionError, SpotApiEmptyResponseError,
+SpotAuthPermanentError, InvalidTag)`` and otherwise drops into a broad
+``except Exception`` that wipes ``ctx.data`` to ``[]``, logs at ERROR, and leaves
+``ctx.error`` as ``None``. The transient type is therefore swallowed instead of being
+surfaced (as a DEBUG-level transient) to the awaiting coroutine through ``ctx.error``.
+
+These tests pin the intended behavior: the transient type (and its
+``_OwnerKeyRederiveRequired`` subclass) must reach ``ctx.error`` and be logged at
+DEBUG (not ERROR). They are RED until the AP3 classification rework lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    decrypt_locations,
+    location_request,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    OwnerKeyLookupTransientError,
+    _OwnerKeyRederiveRequired,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_CANONIC_ID = "device-abc"
+
+
+class _FakeTokenCache:
+    """Minimal entry-scoped cache stub for the locate callback."""
+
+    def __init__(self, label: str = "entry-transient") -> None:
+        self.entry_id = label
+        self.values: dict[str, Any] = {}
+
+    async def async_get_cached_value(self, key: str) -> Any:
+        return self.values.get(key)
+
+    async def async_set_cached_value(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+
+def _wire_callback(
+    monkeypatch: pytest.MonkeyPatch, *, decrypt_exc: Exception
+) -> location_request._CallbackContext:
+    """Stub the decoder + decrypt steps so the callback reaches ``_decrypt_and_store``.
+
+    The callback resolves ``parse_device_update_protobuf`` from the decoder module
+    and ``async_decrypt_location_response_locations`` from the decrypt module via
+    ``getattr`` on the lazily imported module objects, so we patch the real module
+    attributes (the names ``_decrypt_and_store`` actually resolves).
+    """
+    decoder_module = location_request._import_decoder_module()
+    monkeypatch.setattr(
+        decoder_module,
+        "parse_device_update_protobuf",
+        lambda _hex: MagicMock(),
+    )
+
+    async def _raise_decrypt(*_a: object, **_k: object) -> list[dict[str, Any]]:
+        raise decrypt_exc
+
+    monkeypatch.setattr(
+        decrypt_locations,
+        "async_decrypt_location_response_locations",
+        _raise_decrypt,
+    )
+    return location_request._CallbackContext()
+
+
+async def _drive_callback(
+    ctx: location_request._CallbackContext,
+) -> None:
+    """Build the real locate callback, invoke it, and await the decrypt handoff."""
+    loop = asyncio.get_running_loop()
+    callback = location_request._make_location_callback(
+        name="Tracker",
+        canonic_device_id=_CANONIC_ID,
+        ctx=ctx,
+        loop=loop,
+        cache=_FakeTokenCache(),
+        cache_provider=None,
+    )
+    # The callback runs in the receiver's worker thread and hands the async decrypt
+    # off to the loop via run_coroutine_threadsafe; calling it from the running loop
+    # schedules the coroutine, which we then await via the context event.
+    callback(_CANONIC_ID, "deadbeef")
+    await asyncio.wait_for(ctx.event.wait(), timeout=5.0)
+
+
+async def test_transient_owner_key_error_reaches_ctx_error_at_debug(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED: a transient owner-key failure is surfaced via ctx.error at DEBUG severity.
+
+    Today the broad ``except Exception`` swallows it: ``ctx.error is None``,
+    ``ctx.data == []`` and the record is logged at ERROR.
+    """
+    transient = OwnerKeyLookupTransientError("owner key lookup timed out")
+    ctx = _wire_callback(monkeypatch, decrypt_exc=transient)
+
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+
+    await _drive_callback(ctx)
+
+    # SOLL (RED today): the transient type survives to the awaiting coroutine.
+    assert isinstance(ctx.error, OwnerKeyLookupTransientError)
+
+    # SOLL (RED today): no ERROR record for a transient; severity is DEBUG.
+    error_records = [
+        rec for rec in caplog.records if rec.levelno >= logging.ERROR
+    ]
+    assert not error_records, (
+        "transient owner-key failure must not be logged at ERROR; "
+        f"got {[r.getMessage() for r in error_records]}"
+    )
+
+
+async def test_owner_key_rederive_required_also_reaches_ctx_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RED (fail-safe vector): the transient subclass is surfaced via ctx.error too.
+
+    ``_OwnerKeyRederiveRequired`` subclasses the transient base, so it must be caught
+    by the same transient branch and land in ``ctx.error`` (today it is swallowed by
+    the broad ``except Exception`` like its base, leaving ``ctx.error is None``).
+    """
+    transient = _OwnerKeyRederiveRequired("owner key must be re-derived")
+    ctx = _wire_callback(monkeypatch, decrypt_exc=transient)
+
+    await _drive_callback(ctx)
+
+    assert isinstance(ctx.error, OwnerKeyLookupTransientError)
+    assert isinstance(ctx.error, _OwnerKeyRederiveRequired)

--- a/tests/test_poll_timeout_hardening.py
+++ b/tests/test_poll_timeout_hardening.py
@@ -94,6 +94,19 @@ class _EmptyResultAPI:
         return []
 
 
+class _TransientOwnerKeyAPI:
+    """API stub raising a transient owner-key lookup error per device."""
+
+    async def async_get_device_location(self, _dev_id: str, _dev_name: str):
+        from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+            OwnerKeyLookupTransientError,
+        )
+
+        raise OwnerKeyLookupTransientError(
+            "Owner key retrieval did not complete (transient)."
+        )
+
+
 def _make_coordinator(
     monkeypatch: pytest.MonkeyPatch,
     loop: asyncio.AbstractEventLoop,
@@ -156,6 +169,38 @@ def test_outer_poll_budget_covers_http_plus_fcm_phases() -> None:
         POLL_DEVICE_OUTER_TIMEOUT_S
         >= NOVA_REQUEST_TOTAL_TIMEOUT_S + LOCATION_REQUEST_TIMEOUT_S
     )
+
+
+def test_transient_owner_key_lookup_skips_device_without_escalation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R4/AP5: a transient owner-key lookup error skips the device as an ordinary
+    cycle event and never drives the account-wide reauth budget.
+
+    ``OwnerKeyLookupTransientError`` is caught by the dedicated handler (before the
+    ``DecryptionError`` block) which continues to the next device without
+    advancing the consecutive decrypt-failure counter or setting an auth state, so
+    a transient miss cannot trip a spurious reauth.
+    """
+    loop = asyncio.new_event_loop()
+    devices = [{"id": "dev-transient", "name": "Transient Tag"}]
+    coordinator = _make_coordinator(
+        monkeypatch, loop, _TransientOwnerKeyAPI(), devices
+    )
+    coordinator._consecutive_decrypt_failures = 0
+    set_auth_state = AsyncMock()
+    coordinator._set_auth_state = set_auth_state
+
+    try:
+        loop.run_until_complete(
+            coordinator._async_start_poll_cycle(devices, force=True)
+        )
+    finally:
+        drain_loop(loop)
+
+    # Transient miss did not feed the account-wide reauth path.
+    assert coordinator._consecutive_decrypt_failures == 0
+    set_auth_state.assert_not_called()
 
 
 def test_empty_location_logs_info_not_warning(

--- a/tests/test_transient_owner_key_propagation.py
+++ b/tests/test_transient_owner_key_propagation.py
@@ -1,0 +1,209 @@
+# tests/test_transient_owner_key_propagation.py
+"""AP10 end-to-end: a transient owner-key miss propagates to the coordinator sink.
+
+A transient owner-key lookup miss (``OwnerKeyLookupTransientError``, base
+``Exception`` -- NOT a ``DecryptionError`` and NOT a ``RuntimeError``) raised deep
+in the decrypt layer must survive every intermediate surface
+(``location_request`` -> ``api`` -> coordinator) and land in the coordinator sink as
+a plain per-device skip: no account-wide reauth-budget touch
+(``note_decrypt_failure``), no reauth flow, no cycle failure.
+
+These tests exercise the two real coordinator sinks via their established fixtures,
+with the transient injected at the ``api.async_get_device_location`` seam -- the
+single chokepoint both sinks consume, and the layer the AP3/AP5/AP7 fixes made
+transparent so the transient reaches it instead of being swallowed into ``{}``.
+
+Counter-spy scope (precise): the spy targets ONLY the reauth-budget surfaces
+``note_decrypt_failure`` and the entry reauth start. ``note_error`` is the
+per-tracker diagnostic hook (NOT a counter); the transient locate sink calls it by
+design, so it is explicitly NOT treated as a violation here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    OwnerKeyLookupTransientError,
+)
+from tests.helpers import drain_loop
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.locate_mixin_stub import LocateStub
+
+
+# ---------------------------------------------------------------------------
+# Path (a): poll cycle -> coordinator/polling.py sink (~:2103)
+# ---------------------------------------------------------------------------
+class _DummyCache:
+    """Minimal cache stub for the real coordinator build."""
+
+    async def async_get_cached_value(self, _key: str):  # pragma: no cover - stub
+        return None
+
+    async def async_set_cached_value(self, _key: str, _value):  # pragma: no cover
+        return None
+
+
+class _DummyHass:
+    """Minimal HA stub exposing the loop and task helper the coordinator needs."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.loop = loop
+        self.data: dict = {}
+
+    def async_create_task(self, coro, *, name: str | None = None):  # noqa: D401
+        return self.loop.create_task(coro)
+
+
+class _TransientOwnerKeyAPI:
+    """API stub whose per-device locate raises the transient owner-key error.
+
+    This mirrors the post-fix production behaviour: ``api.async_get_device_location``
+    re-raises ``OwnerKeyLookupTransientError`` (AP7) instead of returning ``{}``.
+    """
+
+    async def async_get_device_location(self, _dev_id: str, _dev_name: str):
+        raise OwnerKeyLookupTransientError(
+            "Owner key retrieval did not complete (transient)."
+        )
+
+
+def _make_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+    loop: asyncio.AbstractEventLoop,
+    api: object,
+    devices: list[dict[str, str]],
+) -> GoogleFindMyCoordinator:
+    """Build a real coordinator wired with stubs (mirrors test_poll_timeout_hardening)."""
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.GoogleFindMyCoordinator._async_load_stats",
+        AsyncMock(return_value=None),
+    )
+
+    hass = _DummyHass(loop)
+    coordinator = GoogleFindMyCoordinator(hass, cache=_DummyCache())
+    coordinator.config_entry = SimpleNamespace(
+        entry_id="entry-id", options={}, data={}, title="Test Entry"
+    )
+    coordinator.api = api
+    coordinator._get_google_home_filter = lambda: None
+    coordinator._is_fcm_ready_soft = lambda: True
+    coordinator._get_ignored_set = set
+    coordinator._last_device_list = list(devices)
+
+    coordinator.data = []
+    coordinator.last_update_success = True
+    coordinator.last_exception = None
+
+    def _set_update_error(exc: Exception) -> None:
+        coordinator.last_update_success = False
+        coordinator.last_exception = exc
+
+    def _set_updated_data(data):
+        coordinator.data = data
+        coordinator.last_update_success = True
+        coordinator.last_exception = None
+
+    coordinator.async_set_update_error = _set_update_error
+    coordinator.async_set_updated_data = _set_updated_data
+    return coordinator
+
+
+def test_poll_cycle_transient_owner_key_skips_device_without_counter_touch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Path (a): a transient raised from ``api.async_get_device_location`` reaches the
+    poll sink and is skipped per-device WITHOUT a counter touch or cycle failure.
+
+    Asserts the sink at ``coordinator/polling.py`` (~:2103):
+      * ``note_decrypt_failure`` is NEVER called (no reauth-budget event),
+      * the account-wide decrypt counter stays at 0 (no ``cycle_decrypt_error``),
+      * no auth state is set / no reauth is requested,
+      * the cycle does not fail (``last_update_success`` stays True -> no
+        ``cycle_failed`` from this device).
+    """
+    loop = asyncio.new_event_loop()
+    devices = [{"id": "dev-transient", "name": "Transient Tag"}]
+    coordinator = _make_coordinator(
+        monkeypatch, loop, _TransientOwnerKeyAPI(), devices
+    )
+    coordinator._consecutive_decrypt_failures = 0
+
+    note_decrypt_failure = MagicMock(return_value=False)
+    coordinator.note_decrypt_failure = note_decrypt_failure
+    set_auth_state = MagicMock(return_value=None)
+    coordinator._set_auth_state = set_auth_state
+    request_reauth = MagicMock(return_value=None)
+    coordinator._request_poll_reauth = request_reauth
+
+    try:
+        loop.run_until_complete(
+            coordinator._async_start_poll_cycle(devices, force=True)
+        )
+    finally:
+        drain_loop(loop)
+        loop.close()
+
+    # Counter-spy: the reauth-budget surfaces were never touched.
+    note_decrypt_failure.assert_not_called()
+    request_reauth.assert_not_called()
+    set_auth_state.assert_not_called()
+    # The account-wide decrypt counter never advanced (no cycle_decrypt_error).
+    assert coordinator._consecutive_decrypt_failures == 0
+    # The transient did not fail the cycle.
+    assert coordinator.last_update_success is True
+
+
+# ---------------------------------------------------------------------------
+# Path (b): manual locate -> coordinator/locate.py sink (~:605)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def locate_coord(monkeypatch: pytest.MonkeyPatch) -> LocateStub:
+    """A LocateStub past every cooldown gate so the Nova seam is reached."""
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+        lambda: 1000.0,
+    )
+    entry = make_config_entry(entry_id="transient-locate-entry")
+    return LocateStub(config_entry=entry)
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_transient_owner_key_debug_skip_no_counter_no_reauth(
+    locate_coord: LocateStub,
+) -> None:
+    """Path (b): a transient raised from ``api.async_get_device_location`` reaches the
+    locate sink and degrades to an empty result without a counter touch or reauth.
+
+    Asserts the sink at ``coordinator/locate.py`` (~:605):
+      * the result is the empty mapping,
+      * ``note_decrypt_failure`` is NEVER called (no reauth-budget event),
+      * no auth state is set / no reauth flow is started.
+
+    ``note_error`` (per-tracker diagnostic, NOT a counter) is called by the
+    transient handler by design and is therefore explicitly NOT asserted as a
+    violation here (counter-spy precision per AP10).
+    """
+    coord = locate_coord
+    coord.note_decrypt_failure = MagicMock(return_value=False)
+    coord.config_entry.async_start_reauth = MagicMock()
+    coord.api.async_get_device_location = AsyncMock(
+        side_effect=OwnerKeyLookupTransientError(
+            "Owner key retrieval did not complete (transient)."
+        )
+    )
+
+    result = await coord.async_locate_device("dev-1")
+
+    # DEBUG skip: empty result, no escalation.
+    assert result == {}
+    coord.note_decrypt_failure.assert_not_called()
+    coord._set_auth_state.assert_not_called()
+    coord.config_entry.async_start_reauth.assert_not_called()
+    # note_error is the per-tracker diagnostic hook (NOT a counter); the transient
+    # path calls it by design, so its invocation is allowed, not a violation.


### PR DESCRIPTION
## Problem

A user saw 20 minutes of working location data, then 200+ errors:
`Owner key decryption failed during initial lookup (shared key may be stale). Re-authenticate to refresh crypto keys.`
while the shared key was valid. Root cause: a dangerous default in `_classify_owner_key_failure` (`decrypt_locations.py`) labels *anything* not positively recognised as `InvalidTag`/"missing or empty" as "stale shared key, re-authenticate". Transient/partial server responses and typed `SpotError` network failures thus leak into the account-reauth path.

## Approach (Scope B: diagnostics hardening)

- Invert the default: unknown/transient owner-key failures map to a new `OwnerKeyLookupTransientError` that does **not** inherit from `DecryptionError` (Option B) and never asks for reauth.
- Catch typed `SpotError` network errors explicitly as transient at the owner-key call sites; harden the sync wrapper so it stops flattening `SpotError` into `RuntimeError`.
- Repair misleading wording ("initial lookup"/"may be stale"); keep the correct `InvalidTag` and "no longer matches" messages.
- Capture the *speaking* server protocol feedback that is currently discarded: gRPC `message`/`details`, eid_info field shape at DEBUG (no values), full cause chain at the surfacing log (no raw device names).
- Empty-response path: cause-neutral wording, behaviour unchanged (E3-W); future reclassification gated on the newly captured gRPC status.
- Document the FMDN key/error protocol in AGENTS.md (was code-only).

## Status

Draft. This first commit is the **RED** characterization layer (13 failing tests pinning the contract; existing InvalidTag/missing-key tests stay green). The production fix lands in follow-up commits on this branch (TDD).

Plan: `PLAN_GFMY_DECRYPT_ERROR_DIAGNOSTICS` v7 (protocol-grounded, multi-audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)