### PR TITLE
fix(decoder): couple canonicless-drop log severity to actionability

### DIFF
--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -57,21 +57,33 @@ _LOGGER = logging.getLogger(__name__)
 # argument-free reset is the test-isolation hook.
 _last_canonicless_count_by_entry: dict[str, int] = {}
 
+# Process-wide map of the device names that were emitted (visible) in the PREVIOUS run of
+# get_devices_with_location for each entry scope. It powers the "was visible, now gone"
+# transition discriminator: a benign-class device (phone or reduced-listing accessory)
+# normally drops silently, but if it was visible last run and disappears now, that is a
+# real regression and is treated as warn-worthy. The set is rebuilt after every run from
+# the names actually emitted in that run (mirroring the per-run semantics of the count
+# guard above), so a transition warns at most once before falling back to silence. It is
+# cleared per entry on the same unload/reset hook as the count guard.
+_visible_device_names_by_entry: dict[str, set[str]] = {}
+
 
 def _reset_canonicless_warning_state(entry_id: str | None = None) -> None:
-    """Clear the canonicless-device warning guard.
+    """Clear the canonicless-device warning guard and the visibility-transition map.
 
     Args:
-        entry_id: When ``None`` (test isolation), the whole guard is cleared. When an
-            entry id is given, only that entry's last-count is dropped, so unloading or
-            reloading one config entry re-arms its warning on the next poll without
-            disturbing other entries' guards. A whole-map clear per unload would
-            re-introduce the cross-entry coupling the keyed guard fixed.
+        entry_id: When ``None`` (test isolation), both module-level maps are cleared
+            entirely. When an entry id is given, only that entry's keys are dropped from
+            both maps, so unloading or reloading one config entry re-arms its warning on
+            the next poll without disturbing other entries' guards. A whole-map clear per
+            unload would re-introduce the cross-entry coupling the keyed guard fixed.
     """
     if entry_id is None:
         _last_canonicless_count_by_entry.clear()
+        _visible_device_names_by_entry.clear()
         return
     _last_canonicless_count_by_entry.pop(entry_id, None)
+    _visible_device_names_by_entry.pop(entry_id, None)
 
 
 _text_format_module: Any | None = None
@@ -899,6 +911,11 @@ def get_devices_with_location(
     # default-visible WARNING can report an aggregate count instead of per-device names.
     canonicless_count = 0
 
+    # Names emitted (visible) in THIS run, captured to rebuild the visibility-transition
+    # map after the loop. Compared against the previous run's set, never the running one.
+    emitted_names_this_run: set[str] = set()
+    previously_visible_names = _visible_device_names_by_entry.get(entry_scope, set())
+
     for device in getattr(device_list, "deviceMetadata", []):
         # Resolve canonic IDs for this device (Android vs. generic path)
         # FIX: For phones (IDENTIFIER_ANDROID), use only the FIRST canonical ID.
@@ -1214,21 +1231,55 @@ def get_devices_with_location(
             results.append(row)
             emitted_for_device += 1
 
-        if emitted_for_device == 0:
+        if emitted_for_device > 0:
+            # Remember this device as visible this run so a later disappearance can be
+            # told apart from a device that was never shown (the transition discriminator).
+            emitted_names_this_run.add(device_name)
+        else:
             # Google returned this device without a usable canonical ID, so no row was
-            # emitted and it silently vanishes from Home Assistant. Count it for the
-            # aggregate WARNING below, and name it at DEBUG only: the user-defined name
-            # is potentially identifying (AGENTS.md privacy guidance), so it is kept off
-            # the default-visible WARNING tier and surfaced only when the operator opts
-            # in by enabling debug logging. The DEBUG line is intentionally not guarded,
-            # so it always reveals the affected device once debug logging is turned on.
-            canonicless_count += 1
-            _LOGGER.debug(
-                "Device '%s' was returned without a canonical ID and is not shown "
-                "in Home Assistant. Make it findable again in the Find My Device app "
-                "(or your Google account), then reload the integration.",
-                device_name or "<unnamed>",
-            )
+            # emitted and it silently vanishes from Home Assistant. Severity tracks
+            # actionability: a benign class (an Android phone, or a reduced listing with
+            # no 'information' block such as a Bluetooth accessory) drops as expected for
+            # its class and is located -- if at all -- via the Locate flow, so it only
+            # logs at DEBUG. It becomes warn-worthy only when it is tracker-shaped (has an
+            # 'information' block and is not Android) OR when it was visible in the
+            # previous run and is now gone (a real regression). The per-device name stays
+            # at DEBUG (AGENTS.md privacy guidance); the default-visible tier is the count
+            # WARNING below. has_information_block is recomputed locally because the
+            # binding above lives inside the `if not encrypted_identity_key:` block and is
+            # not in scope when a key was present.
+            has_information_block = device.HasField("information")
+            benign = is_android_device or not has_information_block
+            was_visible = device_name in previously_visible_names
+            warn_worthy = (not benign) or was_visible
+
+            if warn_worthy:
+                canonicless_count += 1
+                _LOGGER.debug(
+                    "Device '%s' was returned without a canonical ID and is not shown "
+                    "in Home Assistant. Make it findable again in the Find My Device app "
+                    "(or your Google account), then reload the integration.",
+                    device_name or "<unnamed>",
+                )
+            else:
+                # Benign class, expected for this device type and not actionable: log at
+                # DEBUG with no remediation hint (no "reload"/"findable again") so the line
+                # is not mistaken for a problem the user can fix.
+                _LOGGER.debug(
+                    "Device '%s' was returned without a canonical ID in this listing and "
+                    "is not shown as its own entity. This is expected for this device "
+                    "class (phones and Bluetooth accessories are located via the owner's "
+                    "Locate flow, not as standalone Find My Device entries); no action is "
+                    "required.",
+                    device_name or "<unnamed>",
+                )
+
+    # Rebuild the per-entry visibility set from the names emitted in THIS run, strictly
+    # after the device loop so the transition check inside the loop compared against the
+    # PREVIOUS run's set. Dropped devices (no row emitted) are intentionally excluded, so
+    # a device that disappears next run is recognised as a "was visible, now gone"
+    # transition exactly once.
+    _visible_device_names_by_entry[entry_scope] = emitted_names_this_run
 
     if canonicless_count:
         # Default-visible aggregate: report only how many devices are affected, never

--- a/tests/test_decoder_canonicless_device_warning.py
+++ b/tests/test_decoder_canonicless_device_warning.py
@@ -1,19 +1,24 @@
 # tests/test_decoder_canonicless_device_warning.py
-"""Observability for devices that Google returns without a canonical ID.
+"""Severity of the canonicless-device signal is coupled to actionability.
 
 When Google's device list contains a device but provides no canonical ID for it
 (empty ``canonicIds`` list, or only blank/invalid IDs), ``get_devices_with_location``
-emits zero rows for that device, so it silently disappears from Home Assistant. The
-user has no way to tell why a phone is missing.
+emits zero rows for that device, so it silently disappears from Home Assistant.
 
-These tests pin a privacy-preserving two-tier signal:
+Not every such drop is actionable, though, and a class-blind WARNING trains the
+operator to ignore the signal (alert fatigue). These tests pin a severity policy that
+tracks *handling relevance*:
 
-* a default-visible WARNING that reports only the *count* of affected devices (never a
-  user-defined device name) and is de-duplicated per config entry, and
-* a DEBUG line per affected device that names it, so the operator can opt in to the
-  identifying detail by enabling debug logging.
+* **Benign classes** (Android phones and reduced-listing Bluetooth accessories such as
+  Pixel Buds) drop as expected for their device class, are located -- if at all -- via
+  the owner's Locate flow, and therefore produce **only a DEBUG line**, never a WARNING,
+  as long as they were not previously visible.
+* **Warn-worthy drops** still raise the de-duplicated, count-only WARNING:
+  a tracker-shaped device (has an ``information`` block, not Android) that lacks a
+  canonical ID, OR any device that was visible in the previous run and now disappears
+  (a real regression). The per-device name stays at DEBUG (privacy).
 
-Valid devices must stay silent on both tiers (no behavioural change to the happy path).
+Valid devices stay silent on both tiers (no behavioural change to the happy path).
 """
 
 from __future__ import annotations
@@ -28,11 +33,11 @@ from custom_components.googlefindmy.ProtoDecoders import DeviceUpdate_pb2, decod
 
 @pytest.fixture(autouse=True)
 def _reset_canonicless_warning_state() -> None:
-    """Clear the process-wide warned-count guard before each test.
+    """Clear the process-wide canonicless guards before each test.
 
-    The decoder de-duplicates the canonicless WARNING via a module-level set. Without
-    a reset the warning would be suppressed across tests depending on run order, so the
-    guard is cleared up front to keep every test order-independent.
+    The decoder de-duplicates the canonicless WARNING via a module-level count map and
+    tracks previously-visible device names in a second module-level map. The argument-free
+    reset clears both, so every test stays order-independent.
     """
     decoder._reset_canonicless_warning_state()
 
@@ -42,7 +47,7 @@ def _make_phone_device(
     name: str,
     canonic_ids: list[SimpleNamespace],
 ) -> SimpleNamespace:
-    """Build a minimal Android phone device with a configurable canonic-ID list."""
+    """Build a minimal Android phone device (benign class) with a configurable ID list."""
     return SimpleNamespace(
         identifierInformation=SimpleNamespace(
             type=DeviceUpdate_pb2.IDENTIFIER_ANDROID,
@@ -58,6 +63,66 @@ def _make_phone_device(
             (SimpleNamespace(name="identifierInformation"), None),
             (SimpleNamespace(name="userDefinedDeviceName"), None),
             (SimpleNamespace(name="imageInformation"), None),
+        ],
+    )
+
+
+def _make_buds_device(
+    *,
+    name: str,
+    canonic_ids: list[SimpleNamespace] | None = None,
+) -> SimpleNamespace:
+    """Build a reduced-listing Bluetooth accessory (benign class, no information block).
+
+    Mirrors the live Pixel Buds payload: ``identifierInformation`` plus a user-defined
+    name, but no ``information`` block (so ``HasField("information")`` is False) and an
+    empty generic canonic-ID list.
+    """
+    return SimpleNamespace(
+        identifierInformation=SimpleNamespace(
+            type=DeviceUpdate_pb2.IDENTIFIER_UNKNOWN,
+            canonicIds=SimpleNamespace(canonicId=canonic_ids or []),
+        ),
+        userDefinedDeviceName=name,
+        imageInformation=SimpleNamespace(url=""),
+        HasField=lambda field_name: False,
+        ListFields=lambda: [
+            (SimpleNamespace(name="identifierInformation"), None),
+            (SimpleNamespace(name="userDefinedDeviceName"), None),
+            (SimpleNamespace(name="imageInformation"), None),
+        ],
+    )
+
+
+def _make_tracker_device(
+    *,
+    name: str,
+    canonic_ids: list[SimpleNamespace] | None = None,
+) -> SimpleNamespace:
+    """Build a tracker-shaped device (warn-worthy class): non-Android, has an info block.
+
+    The ``information`` substructure is present (``HasField("information")`` True) so the
+    device is NOT in the benign ``not has_information_block`` class, but its nested
+    ``HasField`` returns False and ``ListFields`` is empty so the DEBUG dump and the
+    registration path stay inert. With ``cache=None`` no decryption is attempted.
+    """
+    information = SimpleNamespace(
+        HasField=lambda field_name: False,
+        ListFields=lambda: [],
+    )
+    return SimpleNamespace(
+        identifierInformation=SimpleNamespace(
+            type=DeviceUpdate_pb2.IDENTIFIER_SPOT,
+            canonicIds=SimpleNamespace(canonicId=canonic_ids or []),
+        ),
+        information=information,
+        userDefinedDeviceName=name,
+        imageInformation=SimpleNamespace(url=""),
+        HasField=lambda field_name: field_name == "information",
+        ListFields=lambda: [
+            (SimpleNamespace(name="identifierInformation"), None),
+            (SimpleNamespace(name="information"), None),
+            (SimpleNamespace(name="userDefinedDeviceName"), None),
         ],
     )
 
@@ -80,13 +145,19 @@ def _canonicless_debug_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
     ]
 
 
-def test_empty_canonic_list_emits_count_warning_without_name(
+# ----------------------------------------------------------------------------------------
+# Benign classes (phone, accessory): silent WARNING tier, named DEBUG line, no remediation
+# ----------------------------------------------------------------------------------------
+
+
+def test_phone_canonicless_never_visible_is_silent_with_benign_debug(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """An empty canonic-ID list yields zero rows, a count WARNING and a named DEBUG line.
+    """A never-before-visible phone with an empty canonic list warns NOT, only DEBUG (i).
 
-    The WARNING must report the count (``1``) and must NOT leak the user-defined device
-    name; the name appears only at DEBUG level.
+    The benign DEBUG line names the device but must not carry the actionable remediation
+    ("reload" / "findable again"), which would be misleading for a phone whose ID is known
+    via the Locate flow.
     """
     device = _make_phone_device(name="Lost Pixel", canonic_ids=[])
     device_list = SimpleNamespace(deviceMetadata=[device])
@@ -95,20 +166,40 @@ def test_empty_canonic_list_emits_count_warning_without_name(
         results = decoder.get_devices_with_location(device_list, cache=None)
 
     assert results == []
-
-    warnings = _canonicless_warnings(caplog)
-    assert len(warnings) == 1
-    assert "1" in warnings[0]
-    assert "Lost Pixel" not in warnings[0]
+    assert _canonicless_warnings(caplog) == []
 
     debug_lines = _canonicless_debug_lines(caplog)
     assert any("Lost Pixel" in line for line in debug_lines)
+    benign = [line for line in debug_lines if "Lost Pixel" in line]
+    assert benign, "expected a benign DEBUG line naming the device"
+    for line in benign:
+        assert "reload" not in line
+        assert "findable again" not in line
 
 
-def test_blank_canonic_id_is_treated_as_canonicless(
+def test_buds_canonicless_never_visible_is_silent_with_benign_debug(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A list whose only ID is a blank string is skipped, counted and named at DEBUG."""
+    """A never-visible Bluetooth accessory (no information block) warns NOT, only DEBUG (ii)."""
+    device = _make_buds_device(name="Pixel Buds Pro")
+    device_list = SimpleNamespace(deviceMetadata=[device])
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
+        results = decoder.get_devices_with_location(device_list, cache=None)
+
+    assert results == []
+    assert _canonicless_warnings(caplog) == []
+    debug_lines = _canonicless_debug_lines(caplog)
+    assert any("Pixel Buds Pro" in line for line in debug_lines)
+    for line in [d for d in debug_lines if "Pixel Buds Pro" in d]:
+        assert "reload" not in line
+        assert "findable again" not in line
+
+
+def test_blank_canonic_id_phone_is_silent_when_never_visible(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A blank-only ID list on a benign phone is treated as canonicless and stays silent."""
     device = _make_phone_device(
         name="Blank ID Phone", canonic_ids=[SimpleNamespace(id="")]
     )
@@ -118,29 +209,136 @@ def test_blank_canonic_id_is_treated_as_canonicless(
         results = decoder.get_devices_with_location(device_list, cache=None)
 
     assert results == []
+    assert _canonicless_warnings(caplog) == []
+    assert any(
+        "Blank ID Phone" in line for line in _canonicless_debug_lines(caplog)
+    )
+
+
+def test_never_visible_benign_device_no_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Explicit (v): a never-visible benign device produces zero WARNING records."""
+    device_list = SimpleNamespace(
+        deviceMetadata=[_make_buds_device(name="Earbuds")]
+    )
+    cache = SimpleNamespace(entry_id="entry-A")
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+        decoder.get_devices_with_location(device_list, cache=cache)
+
+    assert _canonicless_warnings(caplog) == []
+
+
+# ----------------------------------------------------------------------------------------
+# Warn-worthy: tracker-shaped drop, and previously-visible device disappearing
+# ----------------------------------------------------------------------------------------
+
+
+def test_tracker_canonicless_emits_count_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A tracker-shaped device without a canonical ID warns once with count 1 (iii).
+
+    The WARNING reports the count, keeps the actionable remediation ("reload the
+    integration"), and must NOT leak the device name; the name appears only at DEBUG.
+    """
+    device = _make_tracker_device(name="Garage Tracker")
+    device_list = SimpleNamespace(deviceMetadata=[device])
+    cache = SimpleNamespace(entry_id="entry-A")
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
+        results = decoder.get_devices_with_location(device_list, cache=cache)
+
+    assert results == []
     warnings = _canonicless_warnings(caplog)
     assert len(warnings) == 1
     assert "1" in warnings[0]
-    assert "Blank ID Phone" not in warnings[0]
-    assert any("Blank ID Phone" in line for line in _canonicless_debug_lines(caplog))
+    assert "Garage Tracker" not in warnings[0]
+    assert "reload the integration" in warnings[0]
+    assert any("Garage Tracker" in line for line in _canonicless_debug_lines(caplog))
 
 
-def test_repeated_call_does_not_warn_twice(
+def test_previously_visible_benign_device_drop_emits_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The count WARNING is de-duplicated across repeated decoder calls.
+    """A benign device that was visible and now drops is warn-worthy (iv).
 
-    ``get_devices_with_location`` runs at least twice per poll cycle (and once per
-    cycle thereafter). A persistent canonicless count must therefore warn only once.
+    Even though a phone is the benign class, a real disappearance ("was visible, now
+    gone") is a regression and must surface exactly one WARNING.
     """
-    device = _make_phone_device(name="Lost Pixel", canonic_ids=[])
-    device_list = SimpleNamespace(deviceMetadata=[device])
+    cache = SimpleNamespace(entry_id="entry-A")
+    visible = SimpleNamespace(
+        deviceMetadata=[
+            _make_phone_device(name="X", canonic_ids=[SimpleNamespace(id="cid-x")])
+        ]
+    )
+    dropped = SimpleNamespace(
+        deviceMetadata=[_make_phone_device(name="X", canonic_ids=[])]
+    )
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(device_list, cache=None)
-        decoder.get_devices_with_location(device_list, cache=None)
+        first = decoder.get_devices_with_location(visible, cache=cache)
+        assert len(first) == 1
+        decoder.get_devices_with_location(dropped, cache=cache)
 
     assert len(_canonicless_warnings(caplog)) == 1
+
+
+def test_previously_visible_benign_device_drop_warns_once_then_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Anti-spam (iv-extended): the transition warns once, then the redrop stays silent.
+
+    Run 1 makes "X" visible; run 2 drops it (one WARNING); run 3 drops it again. Because
+    the visibility set is rebuilt per run, "X" is no longer "previously visible" in run 3,
+    so it falls back to the benign class and emits no further WARNING.
+    """
+    cache = SimpleNamespace(entry_id="entry-A")
+    visible = SimpleNamespace(
+        deviceMetadata=[
+            _make_phone_device(name="X", canonic_ids=[SimpleNamespace(id="cid-x")])
+        ]
+    )
+    dropped = SimpleNamespace(
+        deviceMetadata=[_make_phone_device(name="X", canonic_ids=[])]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+        decoder.get_devices_with_location(visible, cache=cache)
+        decoder.get_devices_with_location(dropped, cache=cache)
+        assert len(_canonicless_warnings(caplog)) == 1
+        decoder.get_devices_with_location(dropped, cache=cache)
+
+    assert len(_canonicless_warnings(caplog)) == 1
+
+
+def test_transition_warns_at_most_once_per_poll(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Multi-run-per-poll invariant (vii): two calls in one poll warn at most once.
+
+    ``get_devices_with_location`` runs twice per poll with the same cache (api.py:361 and
+    api.py:702). After "X" was visible, the first drop warns and clears "X" from the
+    visibility set; the second call in the same poll no longer sees "X" as previously
+    visible, so the transition warns at most once per poll.
+    """
+    cache = SimpleNamespace(entry_id="entry-A")
+    visible = SimpleNamespace(
+        deviceMetadata=[
+            _make_phone_device(name="X", canonic_ids=[SimpleNamespace(id="cid-x")])
+        ]
+    )
+    dropped = SimpleNamespace(
+        deviceMetadata=[_make_phone_device(name="X", canonic_ids=[])]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+        decoder.get_devices_with_location(visible, cache=cache)
+        decoder.get_devices_with_location(dropped, cache=cache)
+        decoder.get_devices_with_location(dropped, cache=cache)
+
+    assert len(_canonicless_warnings(caplog)) <= 1
 
 
 def test_valid_canonic_id_produces_row_and_no_warning(
@@ -160,17 +358,33 @@ def test_valid_canonic_id_produces_row_and_no_warning(
     assert _canonicless_debug_lines(caplog) == []
 
 
-def test_same_count_in_distinct_entries_each_warns(
+# ----------------------------------------------------------------------------------------
+# Count-guard re-arm mechanics, now exercised on the warn-worthy (tracker) population
+# ----------------------------------------------------------------------------------------
+
+
+def test_tracker_repeated_call_does_not_warn_twice(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Two config entries each with a canonicless device each get their own count WARNING.
-
-    The de-duplication guard is process-wide, so a count-only key would let the first
-    entry's warning silence the second entry. The guard key must therefore include the
-    per-entry scope (``cache.entry_id``).
-    """
+    """The count WARNING is de-duplicated across repeated decoder calls (warn-worthy)."""
     device_list = SimpleNamespace(
-        deviceMetadata=[_make_phone_device(name="Shared Name", canonic_ids=[])]
+        deviceMetadata=[_make_tracker_device(name="Garage Tracker")]
+    )
+    cache = SimpleNamespace(entry_id="entry-A")
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+        decoder.get_devices_with_location(device_list, cache=cache)
+        decoder.get_devices_with_location(device_list, cache=cache)
+
+    assert len(_canonicless_warnings(caplog)) == 1
+
+
+def test_tracker_same_count_in_distinct_entries_each_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Two config entries each with a canonicless tracker each get their own WARNING."""
+    device_list = SimpleNamespace(
+        deviceMetadata=[_make_tracker_device(name="Shared Name")]
     )
     cache_a = SimpleNamespace(entry_id="entry-A")
     cache_b = SimpleNamespace(entry_id="entry-B")
@@ -182,18 +396,14 @@ def test_same_count_in_distinct_entries_each_warns(
     assert len(_canonicless_warnings(caplog)) == 2
 
 
-def test_multiple_canonicless_in_one_list_warn_once_with_count(
+def test_tracker_multiple_canonicless_in_one_list_warn_once_with_count(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Two canonicless devices in one list yield a single aggregate WARNING of count 2.
-
-    Each device is still named individually at DEBUG, but the default-visible tier is a
-    single count WARNING (no per-device name, no name-collision concern).
-    """
+    """Two warn-worthy trackers in one list yield a single aggregate WARNING of count 2."""
     device_list = SimpleNamespace(
         deviceMetadata=[
-            _make_phone_device(name="Twin", canonic_ids=[]),
-            _make_phone_device(name="Twin", canonic_ids=[]),
+            _make_tracker_device(name="Twin"),
+            _make_tracker_device(name="Twin"),
         ]
     )
     cache = SimpleNamespace(entry_id="entry-A")
@@ -206,21 +416,18 @@ def test_multiple_canonicless_in_one_list_warn_once_with_count(
     assert len(warnings) == 1
     assert "2" in warnings[0]
     assert "Twin" not in warnings[0]
-    # Both devices are named individually at DEBUG.
     assert len(_canonicless_debug_lines(caplog)) == 2
 
 
-def test_changed_count_in_one_entry_warns_again(
+def test_tracker_changed_count_in_one_entry_warns_again(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A changed canonicless count re-surfaces the WARNING (new information)."""
-    one = SimpleNamespace(
-        deviceMetadata=[_make_phone_device(name="A", canonic_ids=[])]
-    )
+    one = SimpleNamespace(deviceMetadata=[_make_tracker_device(name="A")])
     two = SimpleNamespace(
         deviceMetadata=[
-            _make_phone_device(name="A", canonic_ids=[]),
-            _make_phone_device(name="B", canonic_ids=[]),
+            _make_tracker_device(name="A"),
+            _make_tracker_device(name="B"),
         ]
     )
     cache = SimpleNamespace(entry_id="entry-A")
@@ -235,24 +442,15 @@ def test_changed_count_in_one_entry_warns_again(
     assert "2" in warnings[1]
 
 
-def test_count_returning_to_prior_value_warns_again(
+def test_tracker_count_returning_to_prior_value_warns_again(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A count that returns to an earlier value re-surfaces the WARNING.
-
-    The guard remembers only the *last* count per entry, not every count ever seen.
-    A cycle of 1 -> 2 -> 1 (one device recovers, leaving a different one missing, or a
-    transient extra drop clears) is three distinct states, so it must warn three times.
-    A lifetime set of seen counts would wrongly suppress the final ``1`` because the
-    ``(entry, 1)`` key is still present from the first state.
-    """
-    one = SimpleNamespace(
-        deviceMetadata=[_make_phone_device(name="A", canonic_ids=[])]
-    )
+    """A count that returns to an earlier value re-surfaces the WARNING (1 -> 2 -> 1)."""
+    one = SimpleNamespace(deviceMetadata=[_make_tracker_device(name="A")])
     two = SimpleNamespace(
         deviceMetadata=[
-            _make_phone_device(name="A", canonic_ids=[]),
-            _make_phone_device(name="B", canonic_ids=[]),
+            _make_tracker_device(name="A"),
+            _make_tracker_device(name="B"),
         ]
     )
     cache = SimpleNamespace(entry_id="entry-A")
@@ -269,22 +467,14 @@ def test_count_returning_to_prior_value_warns_again(
     assert "1" in warnings[2]
 
 
-def test_recovery_then_redrop_warns_again(
+def test_tracker_recovery_then_redrop_warns_again(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A full recovery (count 0) followed by a new drop re-surfaces the WARNING.
-
-    When an entry's affected count returns to 0 every device recovered, so the guard
-    must forget that entry. A later drop is then new information and warns again, even
-    if the count returns to a value seen before the recovery. The healthy (count 0)
-    poll itself must stay silent on the default-visible WARNING tier.
-    """
-    missing = SimpleNamespace(
-        deviceMetadata=[_make_phone_device(name="A", canonic_ids=[])]
-    )
+    """A full recovery (count 0) followed by a new drop re-surfaces the WARNING."""
+    missing = SimpleNamespace(deviceMetadata=[_make_tracker_device(name="A")])
     healthy = SimpleNamespace(
         deviceMetadata=[
-            _make_phone_device(name="A", canonic_ids=[SimpleNamespace(id="ok")])
+            _make_tracker_device(name="A", canonic_ids=[SimpleNamespace(id="ok")])
         ]
     )
     cache = SimpleNamespace(entry_id="entry-A")
@@ -292,24 +482,47 @@ def test_recovery_then_redrop_warns_again(
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
         decoder.get_devices_with_location(missing, cache=cache)
         decoder.get_devices_with_location(healthy, cache=cache)
-        # The healthy poll itself must stay silent on the default-visible tier: only the
-        # first drop has warned so far.
         assert len(_canonicless_warnings(caplog)) == 1
         decoder.get_devices_with_location(missing, cache=cache)
 
     assert len(_canonicless_warnings(caplog)) == 2
 
 
-def test_same_count_in_one_entry_warns_once_across_calls(
+def test_mixed_run_only_benign_left_pops_guard(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The entry-scoped count key de-duplicates a stable count across poll calls.
+    """(vi) When a tracker recovers and only never-visible benign drops remain, count is 0.
 
-    A single persistent canonicless device in one entry warns only once, even though
-    ``get_devices_with_location`` runs repeatedly per poll.
+    Run 1: a tracker drops (count 1, WARNING). Run 2: the tracker recovers and a benign,
+    never-visible accessory drops -- the warn-worthy count is 0, so the guard pops and no
+    second WARNING fires.
     """
+    cache = SimpleNamespace(entry_id="entry-A")
+    run1 = SimpleNamespace(deviceMetadata=[_make_tracker_device(name="Tracker")])
+    run2 = SimpleNamespace(
+        deviceMetadata=[
+            _make_tracker_device(
+                name="Tracker", canonic_ids=[SimpleNamespace(id="ok")]
+            ),
+            _make_buds_device(name="Earbuds"),
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+        decoder.get_devices_with_location(run1, cache=cache)
+        assert len(_canonicless_warnings(caplog)) == 1
+        decoder.get_devices_with_location(run2, cache=cache)
+
+    assert len(_canonicless_warnings(caplog)) == 1
+    assert decoder._last_canonicless_count_by_entry.get("entry-A") is None
+
+
+def test_tracker_same_count_in_one_entry_warns_once_across_calls(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The entry-scoped count key de-duplicates a stable count across poll calls."""
     device_list = SimpleNamespace(
-        deviceMetadata=[_make_phone_device(name="Lost Pixel", canonic_ids=[])]
+        deviceMetadata=[_make_tracker_device(name="Garage Tracker")]
     )
     cache = SimpleNamespace(entry_id="entry-A")
 
@@ -323,29 +536,17 @@ def test_same_count_in_one_entry_warns_once_across_calls(
 def test_reset_with_entry_id_re_arms_only_that_entry(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """An entry-scoped reset re-arms that entry's warning without touching others.
-
-    The guard is process-wide and survives a Home Assistant config-entry reload (the
-    module is not re-imported). Without an entry-scoped reset on unload, a reload would
-    leave the ``(entry, count)`` key in place, so a still-missing device would be
-    silently suppressed on the next poll. ``_reset_canonicless_warning_state(entry_id)``
-    must clear only that entry's keys, mirroring the per-entry isolation of the guard
-    key itself (a whole-set clear would re-introduce the cross-entry coupling fixed
-    earlier).
-    """
+    """An entry-scoped reset re-arms that entry's warning without touching others."""
     device_list = SimpleNamespace(
-        deviceMetadata=[_make_phone_device(name="Lost Pixel", canonic_ids=[])]
+        deviceMetadata=[_make_tracker_device(name="Garage Tracker")]
     )
     cache_a = SimpleNamespace(entry_id="entry-A")
     cache_b = SimpleNamespace(entry_id="entry-B")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        # Both entries warn once; the guard now holds a key per entry.
         decoder.get_devices_with_location(device_list, cache=cache_a)
         decoder.get_devices_with_location(device_list, cache=cache_b)
-        # Simulate a reload of entry-A only.
         decoder._reset_canonicless_warning_state("entry-A")
-        # entry-A is re-armed and warns again; entry-B stays suppressed.
         decoder.get_devices_with_location(device_list, cache=cache_a)
         decoder.get_devices_with_location(device_list, cache=cache_b)
 
@@ -357,7 +558,7 @@ def test_reset_without_entry_id_clears_all(
 ) -> None:
     """A reset with no entry id clears the whole guard (test-isolation contract)."""
     device_list = SimpleNamespace(
-        deviceMetadata=[_make_phone_device(name="Lost Pixel", canonic_ids=[])]
+        deviceMetadata=[_make_tracker_device(name="Garage Tracker")]
     )
     cache_a = SimpleNamespace(entry_id="entry-A")
     cache_b = SimpleNamespace(entry_id="entry-B")


### PR DESCRIPTION
## Problem
The `decoder.py` canonicless-device WARNING ("N device(s) returned by Google without a canonical ID are not shown in Home Assistant ... reload the integration") fires for **every** dropped device, regardless of class. In practice it fires for phones and Bluetooth accessories (Pixel Buds) that structurally cannot be shown as standalone entities, producing recurring noise that trains operators to ignore the signal (alert fatigue) and masks the real case.

## Change (severity coupled to actionability)
- **Benign classes** -- Android phones (`IDENTIFIER_ANDROID`) and reduced listings without an `information` block (e.g. Bluetooth accessories) -- now log at **DEBUG only**, with reworded text that drops the misleading "make it findable again / reload" remediation (a phone's ID is known via the Locate flow; accessories are not standalone entities).
- **WARNING is reserved for warn-worthy drops:** a tracker-shaped device (has an `information` block, not Android) lacking a canonical ID, **or** a device that was visible in the previous run and now disappears (a real regression).
- A per-entry visibility map (`_visible_device_names_by_entry`) implements the "was visible, now gone" transition discriminator with **per-run semantics** (mirroring the existing count guard), so a transition warns at most once per poll, then falls back to silence. The unload/reset hook clears both maps.

## Deliberate behaviour change
Phones and accessories that were previously visible WARNINGs now stay at DEBUG. Existing phone-warning tests are rewritten accordingly; the count-guard re-arm mechanics are now exercised on the warn-worthy (tracker) population. **No change to tracking, entities, or the decryption path** -- this only re-tunes log severity and wording.

## Tests
- New/rewritten `tests/test_decoder_canonicless_device_warning.py`: benign silence (phone/buds/blank-id), tracker WARNING with count + remediation, visible->gone transition (warns once, then silent), multi-run-per-poll invariant (<=1 WARNING/poll), mixed run pops the guard, full count-guard re-arm suite on trackers.
- 100% coverage of the changed lines (severity split, reset extension, set update).

## Negative protocol
- Latent positional-loss edge (a device with a key but an empty canonicId field) is documented but not addressed (not observed in the live payload); out of scope.
- The transition key is `userDefinedDeviceName` (best effort; not unique for same-named devices), consistent with the privacy constraint that dropped devices have no canonical ID.
- Process-wide state does not survive a reload without the unload reset; acceptable for a diagnostic log.

Draft: opened early for CI/Codex feedback; final gate run pending.