### PR TITLE
fix(decoder): CQS gate for canonicless diagnostics, plus P1 per-device diagnostics

### DIFF
--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -72,6 +72,31 @@ _last_canonicless_count_by_entry: dict[str, int] = {}
 # as the count guard.
 _visible_device_names_by_entry: dict[str, set[str]] = {}
 
+# Process-wide, entry-scoped tally of canonicless drops observed on the LAST main
+# poll, for the anonymized diagnostics aggregate (P1-2). Unlike the WARNING guard
+# above, this is transition-independent: each entry maps to {"total", "benign",
+# "warn"} where total == benign + warn and warn counts the tracker-shaped
+# (not-benign) drops only, with no "was visible" component. Only the main poll
+# (emit_canonicless_diagnostics=True) rewrites it; the capability probe leaves it
+# untouched (CQS). The coordinator reads it per poll via get_canonicless_counts.
+_canonicless_counts_by_entry: dict[str, dict[str, int]] = {}
+
+
+def get_canonicless_counts(entry_id: str) -> dict[str, int]:
+    """Return the last main-poll canonicless drop tally for an entry scope.
+
+    Args:
+        entry_id: The entry scope (``cache.entry_id`` or ``"<no-entry>"``).
+
+    Returns:
+        A ``{"total", "benign", "warn"}`` dict; all-zero for an entry that has
+        not yet recorded a main-poll drop tally.
+    """
+    counts = _canonicless_counts_by_entry.get(entry_id)
+    if counts is None:
+        return {"total": 0, "benign": 0, "warn": 0}
+    return dict(counts)
+
 
 def _reset_canonicless_warning_state(entry_id: str | None = None) -> None:
     """Clear the canonicless-device warning guard and the visibility-transition map.
@@ -86,9 +111,11 @@ def _reset_canonicless_warning_state(entry_id: str | None = None) -> None:
     if entry_id is None:
         _last_canonicless_count_by_entry.clear()
         _visible_device_names_by_entry.clear()
+        _canonicless_counts_by_entry.clear()
         return
     _last_canonicless_count_by_entry.pop(entry_id, None)
     _visible_device_names_by_entry.pop(entry_id, None)
+    _canonicless_counts_by_entry.pop(entry_id, None)
 
 
 _text_format_module: Any | None = None
@@ -931,6 +958,13 @@ def get_devices_with_location(
     # default-visible WARNING can report an aggregate count instead of per-device names.
     canonicless_count = 0
 
+    # Transition-independent canonicless tally for the diagnostics aggregate (P1-2),
+    # kept separate from canonicless_count (which is warn-worthy AND transition-aware).
+    # total == benign + warn; warn counts the tracker-shaped (not-benign) drops only.
+    canonicless_total = 0
+    canonicless_benign = 0
+    canonicless_warn = 0
+
     # Names emitted (visible) in THIS run, captured to rebuild the visibility-transition
     # map after the loop. Compared against the previous run's set, never the running one.
     emitted_names_this_run: set[str] = set()
@@ -1280,6 +1314,17 @@ def get_devices_with_location(
             # key was present.
             has_information_block = device.HasField("information")
             benign = is_android_device or not has_information_block
+
+            # Transition-independent diagnostics tally (P1-2): every canonicless
+            # drop counts once into total, then into benign or warn purely by
+            # class (no was_visible component). Deliberately decoupled from the
+            # warn_worthy logic below so the aggregate is deterministic per poll.
+            canonicless_total += 1
+            if benign:
+                canonicless_benign += 1
+            else:
+                canonicless_warn += 1
+
             was_visible = device_name in previously_visible_names
             warn_worthy = (not benign) or was_visible
 
@@ -1315,6 +1360,15 @@ def get_devices_with_location(
         # excluded, so a device that disappears next run is recognised as a "was visible,
         # now gone" transition exactly once.
         _visible_device_names_by_entry[entry_scope] = emitted_names_this_run
+
+        # Publish the transition-independent diagnostics tally for this entry,
+        # set absolutely from this poll (the coordinator reads it per poll). The
+        # probe pass skips this block, so only the main poll writes the counts.
+        _canonicless_counts_by_entry[entry_scope] = {
+            "total": canonicless_total,
+            "benign": canonicless_benign,
+            "warn": canonicless_warn,
+        }
 
         if canonicless_count:
             # Default-visible aggregate: report only how many devices are affected, never

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -37,9 +37,12 @@ from custom_components.googlefindmy.ProtoDecoders import (
 _LOGGER = logging.getLogger(__name__)
 
 # Process-wide guard so the aggregate canonicless-device WARNING (how many devices
-# Google returned without a canonical ID) is announced only once per config entry,
-# despite get_devices_with_location running multiple times per poll. The key is the
-# pair (entry scope, count): entry scope (cache.entry_id) keeps two config entries
+# Google returned without a canonical ID) is announced only once per config entry.
+# get_devices_with_location still runs more than once per poll (a capability probe pass
+# plus the main poll), but only the main poll passes emit_canonicless_diagnostics=True
+# and touches this guard, so the diagnostics are emitted exactly once per poll (CQS). The
+# key is the pair (entry scope, count): entry scope (cache.entry_id) keeps two config
+# entries
 # from silencing each other, and the count re-surfaces the WARNING only when the
 # number of affected devices changes (new information). The per-device name is logged
 # at DEBUG instead (not guarded), so enabling debug logging always reveals which
@@ -61,10 +64,12 @@ _last_canonicless_count_by_entry: dict[str, int] = {}
 # get_devices_with_location for each entry scope. It powers the "was visible, now gone"
 # transition discriminator: a benign-class device (phone or reduced-listing accessory)
 # normally drops silently, but if it was visible last run and disappears now, that is a
-# real regression and is treated as warn-worthy. The set is rebuilt after every run from
-# the names actually emitted in that run (mirroring the per-run semantics of the count
-# guard above), so a transition warns at most once before falling back to silence. It is
-# cleared per entry on the same unload/reset hook as the count guard.
+# real regression and is treated as warn-worthy. The set is rebuilt from the names
+# actually emitted, but only on the main poll (emit_canonicless_diagnostics=True); the
+# capability probe pass leaves it untouched so the main poll reads the genuine previous
+# poll, not a set the probe already overwrote. A transition therefore warns at most once
+# before falling back to silence. It is cleared per entry on the same unload/reset hook
+# as the count guard.
 _visible_device_names_by_entry: dict[str, set[str]] = {}
 
 
@@ -866,6 +871,7 @@ def get_devices_with_location(
     device_list: DeviceUpdate_pb2.DevicesList,
     *,
     cache: TokenCache | None = None,
+    emit_canonicless_diagnostics: bool = False,
 ) -> list[dict[str, Any]]:
     """Extract one consolidated row per canonic device ID from a device list.
 
@@ -885,6 +891,20 @@ def get_devices_with_location(
           in consumer code.
         * **Data Hygiene**: All numeric fields are coerced to `float`, validated
           for finiteness (no `NaN`/`Inf`), and sanitized before being returned.
+
+    Args:
+        device_list: The decoded ``DevicesList`` to extract rows from.
+        cache: Optional ``TokenCache``; when provided, encrypted payloads are
+            decrypted, otherwise sanitized stubs are returned.
+        emit_canonicless_diagnostics: Command-Query-Separation gate. The function
+            runs more than once per poll (a capability probe at ``api.py:361`` and
+            the main poll at ``api.py:702``). Only the main poll passes ``True`` and
+            is allowed to emit the canonicless drop diagnostics (DEBUG lines, the
+            aggregate count WARNING) and to mutate the module-level visibility/count
+            guards. The probe pass keeps the default ``False`` and stays silent and
+            side-effect free, so the main poll reads the genuine previous-poll
+            visibility set instead of one the probe already overwrote. Pure row
+            extraction (the query) is identical for both values.
 
     Returns:
         A list of device data dictionaries. Fields may be `None` if no valid
@@ -914,7 +934,14 @@ def get_devices_with_location(
     # Names emitted (visible) in THIS run, captured to rebuild the visibility-transition
     # map after the loop. Compared against the previous run's set, never the running one.
     emitted_names_this_run: set[str] = set()
-    previously_visible_names = _visible_device_names_by_entry.get(entry_scope, set())
+    # Only the main poll reads (and below, rewrites) the cross-poll visibility set. The
+    # capability probe pass (emit_canonicless_diagnostics=False) short-circuits to an empty
+    # set so it neither sees nor mutates the transition state (CQS).
+    previously_visible_names = (
+        _visible_device_names_by_entry.get(entry_scope, set())
+        if emit_canonicless_diagnostics
+        else set()
+    )
 
     for device in getattr(device_list, "deviceMetadata", []):
         # Resolve canonic IDs for this device (Android vs. generic path)
@@ -1235,19 +1262,22 @@ def get_devices_with_location(
             # Remember this device as visible this run so a later disappearance can be
             # told apart from a device that was never shown (the transition discriminator).
             emitted_names_this_run.add(device_name)
-        else:
+        elif emit_canonicless_diagnostics:
             # Google returned this device without a usable canonical ID, so no row was
-            # emitted and it silently vanishes from Home Assistant. Severity tracks
-            # actionability: a benign class (an Android phone, or a reduced listing with
-            # no 'information' block such as a Bluetooth accessory) drops as expected for
-            # its class and is located -- if at all -- via the Locate flow, so it only
-            # logs at DEBUG. It becomes warn-worthy only when it is tracker-shaped (has an
-            # 'information' block and is not Android) OR when it was visible in the
-            # previous run and is now gone (a real regression). The per-device name stays
-            # at DEBUG (AGENTS.md privacy guidance); the default-visible tier is the count
-            # WARNING below. has_information_block is recomputed locally because the
-            # binding above lives inside the `if not encrypted_identity_key:` block and is
-            # not in scope when a key was present.
+            # emitted and it silently vanishes from Home Assistant. Emitting the drop
+            # diagnostics is a query-side concern gated to the main poll: the capability
+            # probe pass (emit_canonicless_diagnostics=False) skips this whole branch, so
+            # it neither logs nor advances the count. Severity tracks actionability: a
+            # benign class (an Android phone, or a reduced listing with no 'information'
+            # block such as a Bluetooth accessory) drops as expected for its class and is
+            # located -- if at all -- via the Locate flow, so it only logs at DEBUG. It
+            # becomes warn-worthy only when it is tracker-shaped (has an 'information'
+            # block and is not Android) OR when it was visible in the previous run and is
+            # now gone (a real regression). The per-device name stays at DEBUG (AGENTS.md
+            # privacy guidance); the default-visible tier is the count WARNING below.
+            # has_information_block is recomputed locally because the binding above lives
+            # inside the `if not encrypted_identity_key:` block and is not in scope when a
+            # key was present.
             has_information_block = device.HasField("information")
             benign = is_android_device or not has_information_block
             was_visible = device_name in previously_visible_names
@@ -1274,36 +1304,41 @@ def get_devices_with_location(
                     device_name or "<unnamed>",
                 )
 
-    # Rebuild the per-entry visibility set from the names emitted in THIS run, strictly
-    # after the device loop so the transition check inside the loop compared against the
-    # PREVIOUS run's set. Dropped devices (no row emitted) are intentionally excluded, so
-    # a device that disappears next run is recognised as a "was visible, now gone"
-    # transition exactly once.
-    _visible_device_names_by_entry[entry_scope] = emitted_names_this_run
+    # Diagnostics emission and the cross-poll guard mutations are gated to the main poll
+    # (emit_canonicless_diagnostics=True). The capability probe pass returns here without
+    # touching either module-level map, so the main poll always reads a previous-poll
+    # visibility set that the probe has not overwritten (CQS).
+    if emit_canonicless_diagnostics:
+        # Rebuild the per-entry visibility set from the names emitted in THIS run, strictly
+        # after the device loop so the transition check inside the loop compared against
+        # the PREVIOUS run's set. Dropped devices (no row emitted) are intentionally
+        # excluded, so a device that disappears next run is recognised as a "was visible,
+        # now gone" transition exactly once.
+        _visible_device_names_by_entry[entry_scope] = emitted_names_this_run
 
-    if canonicless_count:
-        # Default-visible aggregate: report only how many devices are affected, never
-        # their names. Re-arm per entry whenever the affected-device COUNT changes:
-        # compare against this entry's last warned count, so a stable count warns once
-        # while any change (a device dropped or recovered) re-surfaces it — including a
-        # count that returns to an earlier value (1 -> 2 -> 1), which a lifetime set of
-        # every count ever seen would wrongly suppress.
-        last_count = _last_canonicless_count_by_entry.get(entry_scope)
-        if last_count != canonicless_count:
-            _last_canonicless_count_by_entry[entry_scope] = canonicless_count
-            _LOGGER.warning(
-                "%d device(s) returned by Google without a canonical ID are not shown "
-                "in Home Assistant. Enable debug logging for "
-                "custom_components.googlefindmy to see which devices are affected, then "
-                "make them findable again in the Find My Device app (or your Google "
-                "account) and reload the integration.",
-                canonicless_count,
-            )
-    else:
-        # This entry currently has no affected devices: forget its last count so a later
-        # drop re-surfaces the warning even if the count returns to a pre-recovery value.
-        # Keeps the guard scoped to entries that are actually affected.
-        _last_canonicless_count_by_entry.pop(entry_scope, None)
+        if canonicless_count:
+            # Default-visible aggregate: report only how many devices are affected, never
+            # their names. Re-arm per entry whenever the affected-device COUNT changes:
+            # compare against this entry's last warned count, so a stable count warns once
+            # while any change (a device dropped or recovered) re-surfaces it, including a
+            # count that returns to an earlier value (1 -> 2 -> 1), which a lifetime set of
+            # every count ever seen would wrongly suppress.
+            last_count = _last_canonicless_count_by_entry.get(entry_scope)
+            if last_count != canonicless_count:
+                _last_canonicless_count_by_entry[entry_scope] = canonicless_count
+                _LOGGER.warning(
+                    "%d device(s) returned by Google without a canonical ID are not shown "
+                    "in Home Assistant. Enable debug logging for "
+                    "custom_components.googlefindmy to see which devices are affected, then "
+                    "make them findable again in the Find My Device app (or your Google "
+                    "account) and reload the integration.",
+                    canonicless_count,
+                )
+        else:
+            # This entry currently has no affected devices: forget its last count so a
+            # later drop re-surfaces the warning even if the count returns to a
+            # pre-recovery value. Keeps the guard scoped to entries that are affected.
+            _last_canonicless_count_by_entry.pop(entry_scope, None)
 
     return results
 

--- a/custom_components/googlefindmy/ProtoDecoders/decoder.py
+++ b/custom_components/googlefindmy/ProtoDecoders/decoder.py
@@ -1174,7 +1174,14 @@ def get_devices_with_location(
         # Phones (IDENTIFIER_ANDROID) and similar devices may not have keys in the
         # device listing payload, but keys ARE available via the Locate flow (FCM).
         # Only warn for tracker-like devices that unexpectedly lack keys.
-        if not encrypted_identity_key:
+        #
+        # This whole block is a diagnostic (logging only, no row/return effect), so it is
+        # gated to the main poll (emit_canonicless_diagnostics=True) for the same CQS
+        # reason as the canonicless drop diagnostics below: get_devices_with_location runs
+        # twice per poll (capability probe + main poll), and an ungated dump here would
+        # duplicate the "Missing Key" WARNING once per poll for every keyless tracker on
+        # the probe pass. The probe pass stays diagnostically silent.
+        if emit_canonicless_diagnostics and not encrypted_identity_key:
             ids_str = ", ".join(
                 [str(getattr(canonic_id, "id", "")) for canonic_id in canonic_ids]
             )

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -358,7 +358,12 @@ def _build_can_ring_index(
     """
     index: dict[str, bool] = {}
     try:
-        devices = get_devices_with_location(parsed_device_list, cache=cache)
+        # Capability probe only: stay diagnostically silent so this pass does not consume
+        # the canonicless visibility transition or pop the count guard (CQS). The main poll
+        # below emits the diagnostics exactly once per poll.
+        devices = get_devices_with_location(
+            parsed_device_list, cache=cache, emit_canonicless_diagnostics=False
+        )
     except Exception:
         devices = []
 
@@ -699,7 +704,11 @@ class GoogleFindMyAPI:
             self._device_capabilities.update(cap_index)
 
         devices_by_id: OrderedDict[str, dict[str, Any]] = OrderedDict()
-        device_rows = get_devices_with_location(parsed, cache=token_cache)
+        # Main poll: the single pass per poll that emits the canonicless diagnostics and
+        # updates the cross-poll visibility/count guards (CQS, see decoder gate).
+        device_rows = get_devices_with_location(
+            parsed, cache=token_cache, emit_canonicless_diagnostics=True
+        )
         if device_rows:
             for device in device_rows:
                 canonical_id = device.get("id")

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -134,6 +134,9 @@ class _MixinBase:
     def increment_stat(self, stat_name: str) -> None:
         raise NotImplementedError
 
+    def _refresh_canonicless_drop_stats(self, entry_id: str | None) -> None:
+        raise NotImplementedError
+
     def push_updated(
         self,
         device_ids: list[str] | None = None,

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -386,7 +386,7 @@ def _device_class(device_type: Any) -> str:
     """Map a ``device_type`` slot int to a coarse three-class label.
 
     ``20`` -> ``phone``; ``None`` or ``0`` (unknown) -> ``other``; any other
-    known int -> ``bt_tracker``. Deliberately abrupt (Negativprotokoll 3): the
+    known int -> ``bt_tracker``. Deliberately abrupt (limitations note 3): the
     maintainer needs phone vs. physical tracker vs. unknown, not a fine class.
     """
     if device_type == _DEVICE_TYPE_PHONE:

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -1905,15 +1905,22 @@ class GoogleFindMyCoordinator(
                 else:
                     last_poll_age_s = None
 
+                # Runtime ``self.data`` snapshot rows carry the radius under
+                # ``accuracy``; ``accuracy_m`` is only produced later by
+                # ``_as_ha_attributes()`` for HA entity attributes. Prefer the
+                # HA-shaped key when present (defensive), else read the snapshot
+                # field, so the bucket is populated on the normal runtime path.
+                accuracy_raw = row.get("accuracy_m")
+                if accuracy_raw is None:
+                    accuracy_raw = row.get("accuracy")
+
                 entries.append(
                     {
                         "index": index,
                         "device_class": _device_class(slot.get("device_type")),
                         "last_poll_age_s": last_poll_age_s,
                         "last_fix_age_s": last_fix_age_s,
-                        "last_accuracy_bucket": _accuracy_bucket(
-                            row.get("accuracy_m")
-                        ),
+                        "last_accuracy_bucket": _accuracy_bucket(accuracy_raw),
                         "is_own_report": row.get("is_own_report", None),
                         "has_key": bool(slot.get("encrypted_identity_key")),
                     }

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -157,6 +157,7 @@ from ..const import (
     coerce_ignored_mapping,
 )
 from ..ha_typing import DataUpdateCoordinator
+from ..ProtoDecoders import decoder
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -346,6 +347,53 @@ def _resolve_last_seen_from_attributes(
     if ts is not None:
         return ts
     return fallback
+
+
+# Privacy-hardened mapping helpers for the anonymized per-device diagnostics list
+# (P1-3). Kept as pure module functions so the boundary tables are testable in
+# isolation and contain no device identifiers.
+
+# device_type ints that map to the "phone" class (SpotDeviceType.DEVICE_TYPE_PHONE).
+_DEVICE_TYPE_PHONE = 20
+
+
+def _accuracy_bucket(accuracy_m: Any) -> str | None:
+    """Bucket a raw accuracy radius into a coarse, non-correlating class.
+
+    Half-open intervals: ``<10`` = [0,10), ``10-50`` = [10,50), ``50-200`` =
+    [50,200), ``>200`` = [200, inf). ``None`` or a negative/non-numeric value
+    collapses to ``None`` (a raw float would be re-identifying, POPETS'25).
+    """
+    if not isinstance(accuracy_m, (int, float)) or isinstance(accuracy_m, bool):
+        return None
+    if accuracy_m < 0 or not math.isfinite(accuracy_m):
+        return None
+    if accuracy_m < 10:
+        return "<10"
+    if accuracy_m < 50:
+        return "10-50"
+    if accuracy_m < 200:
+        return "50-200"
+    return ">200"
+
+
+def _round_age(age_seconds: float) -> int:
+    """Round an age in seconds to the nearest 10 s (sub-poll timing is hidden)."""
+    return int(round(age_seconds / 10) * 10)
+
+
+def _device_class(device_type: Any) -> str:
+    """Map a ``device_type`` slot int to a coarse three-class label.
+
+    ``20`` -> ``phone``; ``None`` or ``0`` (unknown) -> ``other``; any other
+    known int -> ``bt_tracker``. Deliberately abrupt (Negativprotokoll 3): the
+    maintainer needs phone vs. physical tracker vs. unknown, not a fine class.
+    """
+    if device_type == _DEVICE_TYPE_PHONE:
+        return "phone"
+    if device_type is None or device_type == 0:
+        return "other"
+    return "bt_tracker"
 
 
 def _as_ha_attributes(row: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -777,6 +825,13 @@ class GoogleFindMyCoordinator(
             "drop_reason_invalid_ts": 0,  # invalid/stale timestamps (detail bucket)
             "fused_updates": 0,  # overlapping fixes fused to stabilize coordinates
             "accuracy_sanitized_count": 0,  # accuracy values clamped to valid range
+            # Canonicless drops on the last main poll (transition-independent
+            # diagnostics aggregate). Absolute per-poll values, not increments;
+            # listed here so the restore path (iterates self.stats.keys()) and the
+            # diagnostics stats block both see them.
+            "canonicless_drop_total": 0,
+            "canonicless_drop_benign": 0,
+            "canonicless_drop_warn": 0,
         }
         _LOGGER.debug("Initialized stats: %s", self.stats)
 
@@ -1783,6 +1838,89 @@ class GoogleFindMyCoordinator(
             self._increment_stat_on_loop(stat_name)
         else:
             self._run_on_hass_loop(self._increment_stat_on_loop, stat_name)
+
+    def _refresh_canonicless_drop_stats(self, entry_id: str | None) -> None:
+        """Pull the decoder's per-poll canonicless tally into ``self.stats``.
+
+        The decoder publishes the transition-independent drop tally for the entry
+        scope (written by the main poll); the coordinator mirrors it into the
+        three persisted stat counters. Values are set ABSOLUTELY (the accessor
+        already returns the per-poll aggregate, so a recovering count goes down)
+        rather than incremented, then persistence is scheduled so the values
+        survive a restart. A missing entry id is a no-op.
+        """
+        if not entry_id:
+            return
+        counts = decoder.get_canonicless_counts(entry_id)
+        self.stats["canonicless_drop_total"] = counts["total"]
+        self.stats["canonicless_drop_benign"] = counts["benign"]
+        self.stats["canonicless_drop_warn"] = counts["warn"]
+        self._schedule_stats_persist()
+
+    def build_per_device_diagnostics(self) -> list[dict[str, Any]]:
+        """Build the anonymized per-device telemetry list for diagnostics (P1-3).
+
+        Each entry carries an opaque position ``index`` over ``sorted(device_ids)``
+        plus exactly seven fields: ``device_class``, ``last_poll_age_s``,
+        ``last_fix_age_s``, ``last_accuracy_bucket``, ``is_own_report``,
+        ``has_key``. No names, canonical IDs, coordinates, or clear-text keys are
+        emitted. Empty/None ``self.data`` yields ``[]``; any failure degrades to
+        ``[]`` rather than leaking a partial record.
+        """
+        try:
+            rows = self.data or []
+            by_id: dict[str, dict[str, Any]] = {}
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                dev_id = row.get("device_id")
+                if isinstance(dev_id, str) and dev_id:
+                    by_id[dev_id] = row
+
+            now_epoch = time.time()
+            now_mono = time.monotonic()
+
+            entries: list[dict[str, Any]] = []
+            for index, dev_id in enumerate(sorted(by_id)):
+                row = by_id[dev_id]
+                slot = self._device_location_data.get(dev_id) or {}
+
+                last_seen = row.get("last_seen")
+                if isinstance(last_seen, (int, float)) and not isinstance(
+                    last_seen, bool
+                ):
+                    last_fix_age_s: int | None = _round_age(
+                        max(0.0, now_epoch - float(last_seen))
+                    )
+                else:
+                    last_fix_age_s = None
+
+                poll_mono = self._present_last_seen.get(dev_id)
+                if isinstance(poll_mono, (int, float)) and not isinstance(
+                    poll_mono, bool
+                ):
+                    last_poll_age_s: int | None = _round_age(
+                        max(0.0, now_mono - float(poll_mono))
+                    )
+                else:
+                    last_poll_age_s = None
+
+                entries.append(
+                    {
+                        "index": index,
+                        "device_class": _device_class(slot.get("device_type")),
+                        "last_poll_age_s": last_poll_age_s,
+                        "last_fix_age_s": last_fix_age_s,
+                        "last_accuracy_bucket": _accuracy_bucket(
+                            row.get("accuracy_m")
+                        ),
+                        "is_own_report": row.get("is_own_report", None),
+                        "has_key": bool(slot.get("encrypted_identity_key")),
+                    }
+                )
+            return entries
+        except Exception:  # pragma: no cover - defensive: never break diagnostics
+            return []
 
     # Cache methods moved to cache.py (CacheOperations mixin):
     # get_device_location_data, prime_device_location_cache, seed_device_last_seen,

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1231,6 +1231,10 @@ class PollingOperations(_MixinBase):
                 # 1) Fetch the lightweight FULL device list using the native async API
                 payload = await self.api.async_get_basic_device_list()
 
+                # Mirror the decoder's per-poll canonicless drop tally (written by
+                # the main poll inside the fetch above) into the persisted stats.
+                self._refresh_canonicless_drop_stats(self._entry_id())
+
                 # Success path: if we were in an auth error state, clear it now.
                 self._set_auth_state(failed=False)
                 self._set_api_status(ApiStatus.OK)

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -158,6 +158,22 @@ def _monotonic_to_wall_seconds(last_mono: float | None) -> float | None:
     return max(0.0, now_wall - (now_mono - float(last_mono)))
 
 
+def _ha_core_version() -> str | None:
+    """Return the Home Assistant core version string, or None if unavailable.
+
+    Read lazily from ``homeassistant.const.__version__`` (the stable public
+    API; ``hass.config.version`` is not). The import is guarded so stripped or
+    stubbed environments that omit ``__version__`` degrade to ``None`` instead
+    of breaking diagnostics collection.
+    """
+    try:
+        from homeassistant.const import __version__ as ha_version
+
+        return str(ha_version)
+    except Exception:
+        return None
+
+
 def _count_keywords(value: Any) -> int:
     """Count comma-separated keywords without exposing their content."""
     if not value:
@@ -447,10 +463,14 @@ async def async_get_config_entry_diagnostics(
         integration_meta = {
             "name": integ.name,
             "version": str(integ.version),
+            # Home Assistant core version: lets a maintainer correlate
+            # core-specific regressions.
+            "ha_core_version": _ha_core_version(),
         }
     except Exception:
-        # Stay resilient if loader fails in custom environments
-        integration_meta = {}
+        # Stay resilient if loader fails in custom environments. Still expose
+        # the core version (best-effort, may be None).
+        integration_meta = {"ha_core_version": _ha_core_version()}
 
     # --- Coordinator / runtime_data (typed container) ---
     coordinator: Any | None = None
@@ -637,6 +657,14 @@ async def async_get_config_entry_diagnostics(
             coordinator_block["setup_performance"] = setup_perf
         if recent_errors:
             coordinator_block["recent_errors"] = recent_errors
+
+        # Anonymized per-device telemetry (P1-3): opaque index plus seven coarse
+        # fields, no names/IDs/coordinates/keys. Resilient: [] on any failure.
+        try:
+            builder = getattr(coordinator, "build_per_device_diagnostics", None)
+            coordinator_block["devices"] = builder() if callable(builder) else []
+        except Exception:
+            coordinator_block["devices"] = []
 
         diag_buffer = getattr(coordinator, "_diag", None)
         if diag_buffer is not None and hasattr(diag_buffer, "to_dict"):

--- a/tests/test_api_device_list_dedup.py
+++ b/tests/test_api_device_list_dedup.py
@@ -98,7 +98,9 @@ def test_process_device_list_response_scales_e7_coordinates(
     ]
 
     monkeypatch.setattr(
-        api_module, "get_devices_with_location", lambda message, cache=None: device_rows
+        api_module,
+        "get_devices_with_location",
+        lambda message, cache=None, **_kwargs: device_rows,
     )
 
     devices = api._process_device_list_response("beadfeed")

--- a/tests/test_coordinator_canonicless_stats.py
+++ b/tests/test_coordinator_canonicless_stats.py
@@ -1,0 +1,142 @@
+# tests/test_coordinator_canonicless_stats.py
+"""Coordinator wiring of the canonicless drop counters (P1-2b).
+
+The decoder tallies the per-poll canonicless drops; the coordinator lifts the
+three aggregates into ``self.stats`` so they (a) restore from the persisted
+``integration_stats`` cache and (b) surface in diagnostics.
+
+These tests pin:
+
+* the three keys are part of the persisted/restored stat surface (the restore
+  path iterates ``self.stats.keys()``),
+* ``_refresh_canonicless_drop_stats`` reads the decoder accessor and sets the
+  three values **absolutely** (not incrementally) and schedules persistence.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.coordinator.main import GoogleFindMyCoordinator
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.main_coordinator_stub import MainCoordinatorStub
+
+_DROP_KEYS = (
+    "canonicless_drop_total",
+    "canonicless_drop_benign",
+    "canonicless_drop_warn",
+)
+
+
+def _coordinator_with_stats(stats: dict[str, int]) -> MainCoordinatorStub:
+    """Build a bypassed coordinator stub carrying the given ``stats`` dict."""
+    entry = make_config_entry(entry_id="entry-A")
+    coord = MainCoordinatorStub(config_entry=entry)
+    coord.stats = stats
+    coord._stats_save_task = None
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_restore_loads_canonicless_drop_keys() -> None:
+    """A2: the restore path loads the three drop keys from the cache.
+
+    ``_async_load_stats`` iterates ``self.stats.keys()``; seeding the init
+    surface with the three keys (production default 0) lets a cached payload
+    rehydrate them after a restart.
+    """
+
+    async def _cached(key: str) -> dict[str, int] | None:
+        if key == "integration_stats":
+            return {
+                "canonicless_drop_total": 7,
+                "canonicless_drop_benign": 4,
+                "canonicless_drop_warn": 3,
+            }
+        return None
+
+    coord = _coordinator_with_stats(
+        {
+            "canonicless_drop_total": 0,
+            "canonicless_drop_benign": 0,
+            "canonicless_drop_warn": 0,
+        }
+    )
+    coord._cache.async_get_cached_value = AsyncMock(side_effect=_cached)
+
+    await coord._async_load_stats()
+
+    assert coord.stats["canonicless_drop_total"] == 7
+    assert coord.stats["canonicless_drop_benign"] == 4
+    assert coord.stats["canonicless_drop_warn"] == 3
+
+
+def test_refresh_sets_counts_absolutely(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A2: ``_refresh_canonicless_drop_stats`` overwrites the stats from the accessor.
+
+    The accessor returns the per-poll aggregate; the coordinator must SET (not
+    increment) so a recovering count goes down rather than monotonically rising.
+    """
+    coord = _coordinator_with_stats(
+        {
+            "canonicless_drop_total": 99,  # stale prior value
+            "canonicless_drop_benign": 50,
+            "canonicless_drop_warn": 49,
+        }
+    )
+    persist = MagicMock()
+    coord._schedule_stats_persist = persist  # type: ignore[method-assign]
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.main.decoder.get_canonicless_counts",
+        lambda entry_id: {"total": 3, "benign": 2, "warn": 1},
+    )
+
+    coord._refresh_canonicless_drop_stats("entry-A")  # type: ignore[attr-defined]
+
+    assert coord.stats["canonicless_drop_total"] == 3
+    assert coord.stats["canonicless_drop_benign"] == 2
+    assert coord.stats["canonicless_drop_warn"] == 1
+    persist.assert_called_once()
+
+
+def test_refresh_noop_without_entry_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A2/defensive: a missing entry id leaves the stats untouched."""
+    coord = _coordinator_with_stats(
+        {
+            "canonicless_drop_total": 5,
+            "canonicless_drop_benign": 3,
+            "canonicless_drop_warn": 2,
+        }
+    )
+    persist = MagicMock()
+    coord._schedule_stats_persist = persist  # type: ignore[method-assign]
+
+    called: dict[str, Any] = {}
+
+    def _spy(entry_id: str) -> dict[str, int]:
+        called["hit"] = entry_id
+        return {"total": 0, "benign": 0, "warn": 0}
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.main.decoder.get_canonicless_counts",
+        _spy,
+    )
+
+    coord._refresh_canonicless_drop_stats(None)  # type: ignore[attr-defined]
+
+    assert coord.stats["canonicless_drop_total"] == 5
+    assert "hit" not in called
+    persist.assert_not_called()
+
+
+def test_refresh_helper_is_defined_on_real_class() -> None:
+    """The wiring helper lives on the production coordinator class, not the stub."""
+    assert hasattr(GoogleFindMyCoordinator, "_refresh_canonicless_drop_stats")

--- a/tests/test_decoder_canonicless_counts.py
+++ b/tests/test_decoder_canonicless_counts.py
@@ -1,0 +1,274 @@
+# tests/test_decoder_canonicless_counts.py
+"""Transition-independent canonicless drop counters (P1-2a).
+
+The existing WARNING logic counts only warn-worthy AND transition-affected drops
+(``warn_worthy = (not benign) or was_visible``) and de-duplicates them across
+polls. For the diagnostics aggregate we need a separate, *deterministic* tally:
+
+* ``total`` -- every canonicless drop in the main poll,
+* ``benign`` -- ``is_android_device or not has_information_block`` drops,
+* ``warn`` -- the remaining (tracker-shaped) drops,
+
+with the invariant ``total == benign + warn`` and **no** ``was_visible``
+component. The counters live in the emit-gated drop block, so only the main poll
+(``emit_canonicless_diagnostics=True``) writes them; the capability probe
+(``False``) must leave them untouched (CQS / V6).
+
+The decoder exposes the per-entry tally via
+``decoder.get_canonicless_counts(entry_id)`` (entry-scoped module state mirroring
+``_last_canonicless_count_by_entry``), reset by
+``decoder._reset_canonicless_warning_state``.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy.ProtoDecoders import DeviceUpdate_pb2, decoder
+
+
+@pytest.fixture(autouse=True)
+def _reset_canonicless_warning_state() -> None:
+    """Clear all process-wide canonicless guards (incl. the new counts) per test."""
+    decoder._reset_canonicless_warning_state()
+
+
+def _make_phone_device(
+    *,
+    name: str,
+    canonic_ids: list[SimpleNamespace] | None = None,
+) -> SimpleNamespace:
+    """Benign class: Android phone with a configurable (default empty) ID list."""
+    return SimpleNamespace(
+        identifierInformation=SimpleNamespace(
+            type=DeviceUpdate_pb2.IDENTIFIER_ANDROID,
+            phoneInformation=SimpleNamespace(
+                canonicIds=SimpleNamespace(canonicId=canonic_ids or [])
+            ),
+        ),
+        userDefinedDeviceName=name,
+        imageInformation=SimpleNamespace(url=""),
+        HasField=lambda field_name: field_name
+        not in ("information", "deviceRegistration"),
+        ListFields=lambda: [
+            (SimpleNamespace(name="identifierInformation"), None),
+            (SimpleNamespace(name="userDefinedDeviceName"), None),
+            (SimpleNamespace(name="imageInformation"), None),
+        ],
+    )
+
+
+def _make_buds_device(*, name: str) -> SimpleNamespace:
+    """Benign class: reduced-listing accessory with no information block."""
+    return SimpleNamespace(
+        identifierInformation=SimpleNamespace(
+            type=DeviceUpdate_pb2.IDENTIFIER_UNKNOWN,
+            canonicIds=SimpleNamespace(canonicId=[]),
+        ),
+        userDefinedDeviceName=name,
+        imageInformation=SimpleNamespace(url=""),
+        HasField=lambda field_name: False,
+        ListFields=lambda: [
+            (SimpleNamespace(name="identifierInformation"), None),
+            (SimpleNamespace(name="userDefinedDeviceName"), None),
+            (SimpleNamespace(name="imageInformation"), None),
+        ],
+    )
+
+
+def _make_tracker_device(*, name: str) -> SimpleNamespace:
+    """Warn-worthy class: non-Android device with an information block."""
+    information = SimpleNamespace(
+        HasField=lambda field_name: False,
+        ListFields=lambda: [],
+    )
+    return SimpleNamespace(
+        identifierInformation=SimpleNamespace(
+            type=DeviceUpdate_pb2.IDENTIFIER_SPOT,
+            canonicIds=SimpleNamespace(canonicId=[]),
+        ),
+        information=information,
+        userDefinedDeviceName=name,
+        imageInformation=SimpleNamespace(url=""),
+        HasField=lambda field_name: field_name == "information",
+        ListFields=lambda: [
+            (SimpleNamespace(name="identifierInformation"), None),
+            (SimpleNamespace(name="information"), None),
+            (SimpleNamespace(name="userDefinedDeviceName"), None),
+        ],
+    )
+
+
+def _canonicless_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return the rendered canonicless WARNING messages."""
+    return [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING and "canonical ID" in rec.getMessage()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Split tally: total == benign + warn, transition-independent
+# ---------------------------------------------------------------------------
+
+
+def test_counts_split_total_benign_warn() -> None:
+    """A2: N benign + M tracker drops give total=N+M, benign=N, warn=M."""
+    device_list = SimpleNamespace(
+        deviceMetadata=[
+            _make_phone_device(name="Phone"),  # benign
+            _make_buds_device(name="Buds"),  # benign
+            _make_tracker_device(name="Tracker A"),  # warn
+            _make_tracker_device(name="Tracker B"),  # warn
+        ]
+    )
+    cache = SimpleNamespace(entry_id="entry-A")
+
+    decoder.get_devices_with_location(
+        device_list, cache=cache, emit_canonicless_diagnostics=True
+    )
+
+    counts = decoder.get_canonicless_counts("entry-A")
+    assert counts["total"] == 4
+    assert counts["benign"] == 2
+    assert counts["warn"] == 2
+    assert counts["total"] == counts["benign"] + counts["warn"]
+
+
+def test_counts_are_transition_independent() -> None:
+    """A2: a previously-visible benign drop counts as benign, not warn.
+
+    The existing WARNING logic would treat the "was visible, now gone" phone as
+    warn-worthy; the diagnostics tally must NOT -- benign stays benign regardless
+    of the transition.
+    """
+    cache = SimpleNamespace(entry_id="entry-A")
+    visible = SimpleNamespace(
+        deviceMetadata=[
+            _make_phone_device(
+                name="X", canonic_ids=[SimpleNamespace(id="cid-x")]
+            )
+        ]
+    )
+    dropped = SimpleNamespace(deviceMetadata=[_make_phone_device(name="X")])
+
+    decoder.get_devices_with_location(
+        visible, cache=cache, emit_canonicless_diagnostics=True
+    )
+    decoder.get_devices_with_location(
+        dropped, cache=cache, emit_canonicless_diagnostics=True
+    )
+
+    counts = decoder.get_canonicless_counts("entry-A")
+    assert counts["total"] == 1
+    assert counts["benign"] == 1
+    assert counts["warn"] == 0
+
+
+def test_counts_default_zero_for_unknown_entry() -> None:
+    """A2: an entry that never dropped a device reports all-zero counts."""
+    counts = decoder.get_canonicless_counts("never-seen")
+    assert counts == {"total": 0, "benign": 0, "warn": 0}
+
+
+def test_counts_absolute_per_poll_not_accumulated() -> None:
+    """A2: each main poll overwrites the tally (absolute, not incremental)."""
+    cache = SimpleNamespace(entry_id="entry-A")
+    two = SimpleNamespace(
+        deviceMetadata=[
+            _make_tracker_device(name="A"),
+            _make_tracker_device(name="B"),
+        ]
+    )
+    one = SimpleNamespace(deviceMetadata=[_make_tracker_device(name="A")])
+
+    decoder.get_devices_with_location(
+        two, cache=cache, emit_canonicless_diagnostics=True
+    )
+    assert decoder.get_canonicless_counts("entry-A")["warn"] == 2
+
+    decoder.get_devices_with_location(
+        one, cache=cache, emit_canonicless_diagnostics=True
+    )
+    assert decoder.get_canonicless_counts("entry-A")["warn"] == 1
+    assert decoder.get_canonicless_counts("entry-A")["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# CQS: the capability probe (emit=False) must not touch the counters (V6)
+# ---------------------------------------------------------------------------
+
+
+def test_probe_pass_does_not_write_counts(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """V6: emit=False leaves the tally at zero; the emit=True poll then fills it."""
+    device_list = SimpleNamespace(
+        deviceMetadata=[
+            _make_phone_device(name="Phone"),
+            _make_tracker_device(name="Tracker"),
+        ]
+    )
+    cache = SimpleNamespace(entry_id="entry-A")
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+        # Capability probe: silent and counter-free.
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=False
+        )
+        assert decoder.get_canonicless_counts("entry-A") == {
+            "total": 0,
+            "benign": 0,
+            "warn": 0,
+        }
+        assert _canonicless_warnings(caplog) == []
+
+        # Main poll: fills the tally exactly once (no double counting).
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=True
+        )
+
+    counts = decoder.get_canonicless_counts("entry-A")
+    assert counts == {"total": 2, "benign": 1, "warn": 1}
+
+
+def test_reset_clears_counts() -> None:
+    """The argument-free reset clears the counts map (test isolation)."""
+    cache = SimpleNamespace(entry_id="entry-A")
+    device_list = SimpleNamespace(
+        deviceMetadata=[_make_tracker_device(name="Tracker")]
+    )
+    decoder.get_devices_with_location(
+        device_list, cache=cache, emit_canonicless_diagnostics=True
+    )
+    assert decoder.get_canonicless_counts("entry-A")["total"] == 1
+
+    decoder._reset_canonicless_warning_state()
+    assert decoder.get_canonicless_counts("entry-A") == {
+        "total": 0,
+        "benign": 0,
+        "warn": 0,
+    }
+
+
+def test_entry_scoped_reset_isolates_counts() -> None:
+    """An entry-scoped reset clears only that entry's tally."""
+    list_a = SimpleNamespace(deviceMetadata=[_make_tracker_device(name="A")])
+    list_b = SimpleNamespace(deviceMetadata=[_make_tracker_device(name="B")])
+    decoder.get_devices_with_location(
+        list_a, cache=SimpleNamespace(entry_id="entry-A"),
+        emit_canonicless_diagnostics=True,
+    )
+    decoder.get_devices_with_location(
+        list_b, cache=SimpleNamespace(entry_id="entry-B"),
+        emit_canonicless_diagnostics=True,
+    )
+
+    decoder._reset_canonicless_warning_state("entry-A")
+
+    assert decoder.get_canonicless_counts("entry-A")["total"] == 0
+    assert decoder.get_canonicless_counts("entry-B")["total"] == 1

--- a/tests/test_decoder_canonicless_device_warning.py
+++ b/tests/test_decoder_canonicless_device_warning.py
@@ -19,10 +19,21 @@ tracks *handling relevance*:
   (a real regression). The per-device name stays at DEBUG (privacy).
 
 Valid devices stay silent on both tiers (no behavioural change to the happy path).
+
+Command-Query-Separation contract (``emit_canonicless_diagnostics``):
+    ``get_devices_with_location`` runs twice per poll with the same cache: once as a
+    capability probe (``api.py:361``, ``_build_can_ring_index``) and once as the main
+    poll (``api.py:702``). Only the main poll passes ``emit_canonicless_diagnostics=True``
+    and is allowed to emit the canonicless diagnostics (DEBUG lines, the count WARNING)
+    and to mutate the module-level visibility/count maps. The capability probe runs with
+    the default ``False`` and is diagnostically silent and side-effect free, so the
+    main poll reads the correct previous-poll visibility set instead of one already
+    overwritten by the probe pass.
 """
 
 from __future__ import annotations
 
+import copy
 import logging
 from types import SimpleNamespace
 
@@ -147,6 +158,9 @@ def _canonicless_debug_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
 
 # ----------------------------------------------------------------------------------------
 # Benign classes (phone, accessory): silent WARNING tier, named DEBUG line, no remediation
+#
+# These model the MAIN poll, so they pass emit_canonicless_diagnostics=True: only the main
+# poll is allowed to emit the per-device DEBUG line the benign tier asserts.
 # ----------------------------------------------------------------------------------------
 
 
@@ -163,7 +177,9 @@ def test_phone_canonicless_never_visible_is_silent_with_benign_debug(
     device_list = SimpleNamespace(deviceMetadata=[device])
 
     with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
-        results = decoder.get_devices_with_location(device_list, cache=None)
+        results = decoder.get_devices_with_location(
+            device_list, cache=None, emit_canonicless_diagnostics=True
+        )
 
     assert results == []
     assert _canonicless_warnings(caplog) == []
@@ -185,7 +201,9 @@ def test_buds_canonicless_never_visible_is_silent_with_benign_debug(
     device_list = SimpleNamespace(deviceMetadata=[device])
 
     with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
-        results = decoder.get_devices_with_location(device_list, cache=None)
+        results = decoder.get_devices_with_location(
+            device_list, cache=None, emit_canonicless_diagnostics=True
+        )
 
     assert results == []
     assert _canonicless_warnings(caplog) == []
@@ -206,22 +224,24 @@ def test_blank_canonic_id_phone_is_silent_when_never_visible(
     device_list = SimpleNamespace(deviceMetadata=[device])
 
     with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
-        results = decoder.get_devices_with_location(device_list, cache=None)
+        results = decoder.get_devices_with_location(
+            device_list, cache=None, emit_canonicless_diagnostics=True
+        )
 
     assert results == []
     assert _canonicless_warnings(caplog) == []
-    assert any(
-        "Blank ID Phone" in line for line in _canonicless_debug_lines(caplog)
-    )
+    assert any("Blank ID Phone" in line for line in _canonicless_debug_lines(caplog))
 
 
 def test_never_visible_benign_device_no_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Explicit (v): a never-visible benign device produces zero WARNING records."""
-    device_list = SimpleNamespace(
-        deviceMetadata=[_make_buds_device(name="Earbuds")]
-    )
+    """Explicit (v): a never-visible benign device produces zero WARNING records.
+
+    Left at the default emit_canonicless_diagnostics=False so it additionally pins the
+    capability-probe pass as WARNING-silent.
+    """
+    device_list = SimpleNamespace(deviceMetadata=[_make_buds_device(name="Earbuds")])
     cache = SimpleNamespace(entry_id="entry-A")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
@@ -248,7 +268,9 @@ def test_tracker_canonicless_emits_count_warning(
     cache = SimpleNamespace(entry_id="entry-A")
 
     with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
-        results = decoder.get_devices_with_location(device_list, cache=cache)
+        results = decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     assert results == []
     warnings = _canonicless_warnings(caplog)
@@ -265,7 +287,8 @@ def test_previously_visible_benign_device_drop_emits_warning(
     """A benign device that was visible and now drops is warn-worthy (iv).
 
     Even though a phone is the benign class, a real disappearance ("was visible, now
-    gone") is a regression and must surface exactly one WARNING.
+    gone") is a regression and must surface exactly one WARNING. Both calls model main
+    polls (emit_canonicless_diagnostics=True).
     """
     cache = SimpleNamespace(entry_id="entry-A")
     visible = SimpleNamespace(
@@ -278,9 +301,13 @@ def test_previously_visible_benign_device_drop_emits_warning(
     )
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        first = decoder.get_devices_with_location(visible, cache=cache)
+        first = decoder.get_devices_with_location(
+            visible, cache=cache, emit_canonicless_diagnostics=True
+        )
         assert len(first) == 1
-        decoder.get_devices_with_location(dropped, cache=cache)
+        decoder.get_devices_with_location(
+            dropped, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     assert len(_canonicless_warnings(caplog)) == 1
 
@@ -292,7 +319,8 @@ def test_previously_visible_benign_device_drop_warns_once_then_silent(
 
     Run 1 makes "X" visible; run 2 drops it (one WARNING); run 3 drops it again. Because
     the visibility set is rebuilt per run, "X" is no longer "previously visible" in run 3,
-    so it falls back to the benign class and emits no further WARNING.
+    so it falls back to the benign class and emits no further WARNING. Every run models a
+    main poll (emit_canonicless_diagnostics=True).
     """
     cache = SimpleNamespace(entry_id="entry-A")
     visible = SimpleNamespace(
@@ -305,23 +333,30 @@ def test_previously_visible_benign_device_drop_warns_once_then_silent(
     )
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(visible, cache=cache)
-        decoder.get_devices_with_location(dropped, cache=cache)
+        decoder.get_devices_with_location(
+            visible, cache=cache, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            dropped, cache=cache, emit_canonicless_diagnostics=True
+        )
         assert len(_canonicless_warnings(caplog)) == 1
-        decoder.get_devices_with_location(dropped, cache=cache)
+        decoder.get_devices_with_location(
+            dropped, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     assert len(_canonicless_warnings(caplog)) == 1
 
 
-def test_transition_warns_at_most_once_per_poll(
+def test_transition_warns_exactly_once_per_poll_despite_double_call(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Multi-run-per-poll invariant (vii): two calls in one poll warn at most once.
+    """Multi-run-per-poll invariant (vii): the capability probe must not consume it.
 
-    ``get_devices_with_location`` runs twice per poll with the same cache (api.py:361 and
-    api.py:702). After "X" was visible, the first drop warns and clears "X" from the
-    visibility set; the second call in the same poll no longer sees "X" as previously
-    visible, so the transition warns at most once per poll.
+    A poll calls ``get_devices_with_location`` twice with the same cache: the capability
+    probe (emit_canonicless_diagnostics=False) and the main poll (True). After "X" was
+    visible, the probe pass on the dropped list must NOT touch the visibility map, so the
+    main pass still sees "X" as previously visible and fires the transition WARNING exactly
+    once (``== 1``, not the pre-fix ``<= 1`` where the probe zertrat the map).
     """
     cache = SimpleNamespace(entry_id="entry-A")
     visible = SimpleNamespace(
@@ -334,17 +369,29 @@ def test_transition_warns_at_most_once_per_poll(
     )
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(visible, cache=cache)
-        decoder.get_devices_with_location(dropped, cache=cache)
-        decoder.get_devices_with_location(dropped, cache=cache)
+        # Poll 1: main poll makes "X" visible.
+        decoder.get_devices_with_location(
+            visible, cache=cache, emit_canonicless_diagnostics=True
+        )
+        # Poll 2: capability probe (silent) then main poll (emits) on the dropped list.
+        decoder.get_devices_with_location(
+            dropped, cache=cache, emit_canonicless_diagnostics=False
+        )
+        decoder.get_devices_with_location(
+            dropped, cache=cache, emit_canonicless_diagnostics=True
+        )
 
-    assert len(_canonicless_warnings(caplog)) <= 1
+    assert len(_canonicless_warnings(caplog)) == 1
 
 
 def test_valid_canonic_id_produces_row_and_no_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Negative control: a valid canonic ID yields one row and no canonicless signal."""
+    """Negative control: a valid canonic ID yields one row and no canonicless signal.
+
+    Left at the default emit_canonicless_diagnostics=False: the happy path is identical on
+    both passes, so this also pins that the probe pass produces the row without diagnostics.
+    """
     device = _make_phone_device(
         name="Healthy Phone", canonic_ids=[SimpleNamespace(id="valid-canonic-id")]
     )
@@ -359,7 +406,112 @@ def test_valid_canonic_id_produces_row_and_no_warning(
 
 
 # ----------------------------------------------------------------------------------------
-# Count-guard re-arm mechanics, now exercised on the warn-worthy (tracker) population
+# Command-Query-Separation: the capability probe pass (emit=False) is silent and pure
+# ----------------------------------------------------------------------------------------
+
+
+def test_emit_false_pass_leaves_count_state_for_main_pass(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """T2: the capability probe pass does not pre-load or pop the entry's count state.
+
+    A poll runs the probe (emit=False) before the main poll (emit=True) on the same
+    canonicless tracker list. The probe must leave ``_last_canonicless_count_by_entry``
+    untouched (no premature dedup, no spurious pop), so the subsequent main pass fires the
+    WARNING exactly once and records the count.
+    """
+    device_list = SimpleNamespace(
+        deviceMetadata=[_make_tracker_device(name="Garage Tracker")]
+    )
+    cache = SimpleNamespace(entry_id="entry-A")
+
+    assert decoder._last_canonicless_count_by_entry.get("entry-A") is None
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
+        # Capability probe pass: silent, no state change.
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=False
+        )
+        assert _canonicless_warnings(caplog) == []
+        assert _canonicless_debug_lines(caplog) == []
+        assert decoder._last_canonicless_count_by_entry.get("entry-A") is None
+
+        # Main poll pass: fires exactly one WARNING and records the count.
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=True
+        )
+
+    assert len(_canonicless_warnings(caplog)) == 1
+    assert decoder._last_canonicless_count_by_entry.get("entry-A") == 1
+
+
+def test_emit_false_mutates_no_module_state_and_logs_nothing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """T3: an emit=False call is side-effect free and logs neither WARNING nor DEBUG.
+
+    Pre-seeds both module maps, then runs a canonicless tracker through the probe pass and
+    asserts: (a) the visibility map is unchanged (not overwritten with this run's set),
+    (b) the count map is unchanged (its pre-seeded entry is NOT popped by the 0-count
+    ``else`` branch of the count guard), and (c) no canonicless WARNING/DEBUG is emitted.
+    """
+    cache = SimpleNamespace(entry_id="entry-A")
+    decoder._last_canonicless_count_by_entry["entry-A"] = 1
+    decoder._visible_device_names_by_entry["entry-A"] = {"Previously Seen"}
+
+    count_snapshot = copy.deepcopy(decoder._last_canonicless_count_by_entry)
+    visible_snapshot = copy.deepcopy(decoder._visible_device_names_by_entry)
+
+    device_list = SimpleNamespace(
+        deviceMetadata=[_make_tracker_device(name="Garage Tracker")]
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=False
+        )
+
+    assert decoder._last_canonicless_count_by_entry == count_snapshot
+    assert decoder._visible_device_names_by_entry == visible_snapshot
+    assert _canonicless_warnings(caplog) == []
+    assert _canonicless_debug_lines(caplog) == []
+
+
+def test_emit_false_rows_match_emit_true(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """T4: the returned rows are identical between the probe and the main pass.
+
+    Only the diagnostics differ between the two passes; the produced rows (the query
+    result) must not. A list with a valid phone plus a canonicless tracker yields exactly
+    the valid phone's row in both passes.
+    """
+
+    def _build_list() -> SimpleNamespace:
+        return SimpleNamespace(
+            deviceMetadata=[
+                _make_phone_device(
+                    name="Healthy", canonic_ids=[SimpleNamespace(id="valid-id")]
+                ),
+                _make_tracker_device(name="Garage Tracker"),
+            ]
+        )
+
+    rows_probe = decoder.get_devices_with_location(
+        _build_list(), cache=None, emit_canonicless_diagnostics=False
+    )
+    decoder._reset_canonicless_warning_state()
+    rows_main = decoder.get_devices_with_location(
+        _build_list(), cache=None, emit_canonicless_diagnostics=True
+    )
+
+    assert len(rows_probe) == 1
+    assert rows_probe == rows_main
+
+
+# ----------------------------------------------------------------------------------------
+# Count-guard re-arm mechanics, now exercised on the warn-worthy (tracker) population.
+# All model the main poll, so each call passes emit_canonicless_diagnostics=True.
 # ----------------------------------------------------------------------------------------
 
 
@@ -373,8 +525,12 @@ def test_tracker_repeated_call_does_not_warn_twice(
     cache = SimpleNamespace(entry_id="entry-A")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(device_list, cache=cache)
-        decoder.get_devices_with_location(device_list, cache=cache)
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     assert len(_canonicless_warnings(caplog)) == 1
 
@@ -390,8 +546,12 @@ def test_tracker_same_count_in_distinct_entries_each_warns(
     cache_b = SimpleNamespace(entry_id="entry-B")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(device_list, cache=cache_a)
-        decoder.get_devices_with_location(device_list, cache=cache_b)
+        decoder.get_devices_with_location(
+            device_list, cache=cache_a, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            device_list, cache=cache_b, emit_canonicless_diagnostics=True
+        )
 
     assert len(_canonicless_warnings(caplog)) == 2
 
@@ -409,7 +569,9 @@ def test_tracker_multiple_canonicless_in_one_list_warn_once_with_count(
     cache = SimpleNamespace(entry_id="entry-A")
 
     with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
-        results = decoder.get_devices_with_location(device_list, cache=cache)
+        results = decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     assert results == []
     warnings = _canonicless_warnings(caplog)
@@ -433,8 +595,12 @@ def test_tracker_changed_count_in_one_entry_warns_again(
     cache = SimpleNamespace(entry_id="entry-A")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(one, cache=cache)
-        decoder.get_devices_with_location(two, cache=cache)
+        decoder.get_devices_with_location(
+            one, cache=cache, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            two, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     warnings = _canonicless_warnings(caplog)
     assert len(warnings) == 2
@@ -456,9 +622,15 @@ def test_tracker_count_returning_to_prior_value_warns_again(
     cache = SimpleNamespace(entry_id="entry-A")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(one, cache=cache)
-        decoder.get_devices_with_location(two, cache=cache)
-        decoder.get_devices_with_location(one, cache=cache)
+        decoder.get_devices_with_location(
+            one, cache=cache, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            two, cache=cache, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            one, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     warnings = _canonicless_warnings(caplog)
     assert len(warnings) == 3
@@ -480,10 +652,16 @@ def test_tracker_recovery_then_redrop_warns_again(
     cache = SimpleNamespace(entry_id="entry-A")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(missing, cache=cache)
-        decoder.get_devices_with_location(healthy, cache=cache)
+        decoder.get_devices_with_location(
+            missing, cache=cache, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            healthy, cache=cache, emit_canonicless_diagnostics=True
+        )
         assert len(_canonicless_warnings(caplog)) == 1
-        decoder.get_devices_with_location(missing, cache=cache)
+        decoder.get_devices_with_location(
+            missing, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     assert len(_canonicless_warnings(caplog)) == 2
 
@@ -495,7 +673,7 @@ def test_mixed_run_only_benign_left_pops_guard(
 
     Run 1: a tracker drops (count 1, WARNING). Run 2: the tracker recovers and a benign,
     never-visible accessory drops -- the warn-worthy count is 0, so the guard pops and no
-    second WARNING fires.
+    second WARNING fires. Both runs model the main poll.
     """
     cache = SimpleNamespace(entry_id="entry-A")
     run1 = SimpleNamespace(deviceMetadata=[_make_tracker_device(name="Tracker")])
@@ -509,9 +687,13 @@ def test_mixed_run_only_benign_left_pops_guard(
     )
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(run1, cache=cache)
+        decoder.get_devices_with_location(
+            run1, cache=cache, emit_canonicless_diagnostics=True
+        )
         assert len(_canonicless_warnings(caplog)) == 1
-        decoder.get_devices_with_location(run2, cache=cache)
+        decoder.get_devices_with_location(
+            run2, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     assert len(_canonicless_warnings(caplog)) == 1
     assert decoder._last_canonicless_count_by_entry.get("entry-A") is None
@@ -527,8 +709,12 @@ def test_tracker_same_count_in_one_entry_warns_once_across_calls(
     cache = SimpleNamespace(entry_id="entry-A")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(device_list, cache=cache)
-        decoder.get_devices_with_location(device_list, cache=cache)
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=True
+        )
 
     assert len(_canonicless_warnings(caplog)) == 1
 
@@ -544,11 +730,19 @@ def test_reset_with_entry_id_re_arms_only_that_entry(
     cache_b = SimpleNamespace(entry_id="entry-B")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(device_list, cache=cache_a)
-        decoder.get_devices_with_location(device_list, cache=cache_b)
+        decoder.get_devices_with_location(
+            device_list, cache=cache_a, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            device_list, cache=cache_b, emit_canonicless_diagnostics=True
+        )
         decoder._reset_canonicless_warning_state("entry-A")
-        decoder.get_devices_with_location(device_list, cache=cache_a)
-        decoder.get_devices_with_location(device_list, cache=cache_b)
+        decoder.get_devices_with_location(
+            device_list, cache=cache_a, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            device_list, cache=cache_b, emit_canonicless_diagnostics=True
+        )
 
     assert len(_canonicless_warnings(caplog)) == 3
 
@@ -564,10 +758,18 @@ def test_reset_without_entry_id_clears_all(
     cache_b = SimpleNamespace(entry_id="entry-B")
 
     with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
-        decoder.get_devices_with_location(device_list, cache=cache_a)
-        decoder.get_devices_with_location(device_list, cache=cache_b)
+        decoder.get_devices_with_location(
+            device_list, cache=cache_a, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            device_list, cache=cache_b, emit_canonicless_diagnostics=True
+        )
         decoder._reset_canonicless_warning_state()
-        decoder.get_devices_with_location(device_list, cache=cache_a)
-        decoder.get_devices_with_location(device_list, cache=cache_b)
+        decoder.get_devices_with_location(
+            device_list, cache=cache_a, emit_canonicless_diagnostics=True
+        )
+        decoder.get_devices_with_location(
+            device_list, cache=cache_b, emit_canonicless_diagnostics=True
+        )
 
     assert len(_canonicless_warnings(caplog)) == 4

--- a/tests/test_decoder_canonicless_device_warning.py
+++ b/tests/test_decoder_canonicless_device_warning.py
@@ -156,6 +156,20 @@ def _canonicless_debug_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
     ]
 
 
+def _missing_key_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return the ``DEBUG STRUCTURE: Missing Key`` WARNING records (rendered).
+
+    These are the hidden-key diagnostic dump emitted for a tracker-shaped device that
+    lacks an ``encryptedIdentityKey``. Like the canonicless diagnostics, they are a
+    main-poll concern: the capability probe pass must stay diagnostically silent.
+    """
+    return [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING and "Missing Key" in rec.getMessage()
+    ]
+
+
 # ----------------------------------------------------------------------------------------
 # Benign classes (phone, accessory): silent WARNING tier, named DEBUG line, no remediation
 #
@@ -507,6 +521,54 @@ def test_emit_false_rows_match_emit_true(
 
     assert len(rows_probe) == 1
     assert rows_probe == rows_main
+
+
+def test_missing_key_diagnostics_silent_on_probe_pass(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """T5: the hidden-key diagnostic dump is suppressed on the capability probe pass.
+
+    A tracker-shaped device (has an ``information`` block, not Android) that lacks an
+    ``encryptedIdentityKey`` triggers the ``DEBUG STRUCTURE: Missing Key`` WARNING dump.
+    That dump is a diagnostic, so the probe pass (emit_canonicless_diagnostics=False) must
+    stay silent: otherwise the capability probe duplicates the WARNING once per poll for
+    that device class, defeating the diagnostically-silent contract.
+    """
+    device_list = SimpleNamespace(
+        deviceMetadata=[_make_tracker_device(name="Keyless Tracker")]
+    )
+    cache = SimpleNamespace(entry_id="entry-A")
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=False
+        )
+
+    assert _missing_key_warnings(caplog) == []
+
+
+def test_missing_key_diagnostics_emitted_on_main_pass(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """T6: the hidden-key diagnostic dump is preserved on the main poll.
+
+    The companion to T5: gating the dump must not silence it on the main poll
+    (emit_canonicless_diagnostics=True), where the tracker-shaped keyless device is a real
+    signal worth surfacing.
+    """
+    device_list = SimpleNamespace(
+        deviceMetadata=[_make_tracker_device(name="Keyless Tracker")]
+    )
+    cache = SimpleNamespace(entry_id="entry-A")
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+        decoder.get_devices_with_location(
+            device_list, cache=cache, emit_canonicless_diagnostics=True
+        )
+
+    warnings = _missing_key_warnings(caplog)
+    assert len(warnings) == 1
+    assert "Keyless Tracker" in warnings[0]
 
 
 # ----------------------------------------------------------------------------------------

--- a/tests/test_decoder_canonicless_device_warning.py
+++ b/tests/test_decoder_canonicless_device_warning.py
@@ -356,7 +356,7 @@ def test_transition_warns_exactly_once_per_poll_despite_double_call(
     probe (emit_canonicless_diagnostics=False) and the main poll (True). After "X" was
     visible, the probe pass on the dropped list must NOT touch the visibility map, so the
     main pass still sees "X" as previously visible and fires the transition WARNING exactly
-    once (``== 1``, not the pre-fix ``<= 1`` where the probe zertrat the map).
+    once (``== 1``, not the pre-fix ``<= 1`` where the probe clobbered the map).
     """
     cache = SimpleNamespace(entry_id="entry-A")
     visible = SimpleNamespace(

--- a/tests/test_diagnostics_p1_per_device.py
+++ b/tests/test_diagnostics_p1_per_device.py
@@ -331,10 +331,18 @@ def test_per_device_never_polled_slot_missing_defaults() -> None:
     assert entry["is_own_report"] is None
 
 
-def test_per_device_accuracy_bucketed_not_raw() -> None:
-    """A5/A8: a raw accuracy float is bucketed, never echoed verbatim."""
+@pytest.mark.parametrize("accuracy_field", ["accuracy", "accuracy_m"])
+def test_per_device_accuracy_bucketed_not_raw(accuracy_field: str) -> None:
+    """A5/A8: a raw accuracy float is bucketed, never echoed verbatim.
+
+    The runtime ``self.data`` snapshot rows carry the radius under
+    ``accuracy``; ``accuracy_m`` is only produced later by
+    ``_as_ha_attributes()`` for HA entity attributes. The diagnostics must read
+    the snapshot field, so both the real ``accuracy`` path and a defensive
+    ``accuracy_m`` fallback have to bucket correctly.
+    """
     coordinator = _PerDeviceCoordinator(
-        data=[{"device_id": "dev-acc", "accuracy_m": 137.4, "is_own_report": False}],
+        data=[{"device_id": "dev-acc", accuracy_field: 137.4, "is_own_report": False}],
     )
     entry = coordinator.build_per_device_diagnostics()[0]  # type: ignore[attr-defined]
     assert entry["last_accuracy_bucket"] == "50-200"

--- a/tests/test_diagnostics_p1_per_device.py
+++ b/tests/test_diagnostics_p1_per_device.py
@@ -1,0 +1,514 @@
+# tests/test_diagnostics_p1_per_device.py
+"""P1 diagnostics expansion: HA core version, drop counters, per-device telemetry.
+
+These tests pin the additive, privacy-hardened P1 diagnostics surface:
+
+* **P1-1** -- ``integration["ha_core_version"]`` carries the Home Assistant core
+  version string so a maintainer can correlate core-specific regressions.
+* **P1-2** -- the three canonicless-drop counters (``canonicless_drop_total`` /
+  ``_benign`` / ``_warn``) surface under ``coordinator["stats"]``.
+* **P1-3** -- ``coordinator["devices"]`` is an anonymous per-device telemetry list:
+  an opaque position index over ``sorted(device_ids)`` plus exactly seven fields
+  (``device_class``, ``last_poll_age_s``, ``last_fix_age_s``,
+  ``last_accuracy_bucket``, ``is_own_report``, ``has_key``). No names, canonical
+  IDs, coordinates, or clear-text keys may appear (POPETS'25 hardening).
+
+The per-device list is produced by ``coordinator.build_per_device_diagnostics()``
+and the pure mapping helpers ``_accuracy_bucket`` / ``_round_age`` /
+``_device_class`` on the coordinator module, exercised directly here for the
+boundary tables.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy import diagnostics
+from custom_components.googlefindmy.coordinator import main as coordinator_main
+from custom_components.googlefindmy.coordinator.main import GoogleFindMyCoordinator
+from tests.helpers import drain_loop
+from tests.helpers.config_entries_stub import make_config_entry
+
+# DEVICE_TYPE_PHONE == 20, DEVICE_TYPE_UNKNOWN == 0 (SpotDeviceType enum).
+_DEVICE_TYPE_PHONE = 20
+_DEVICE_TYPE_TRACKER = 1  # DEVICE_TYPE_BEACON (any non-phone, non-zero known int)
+
+_EXPECTED_DEVICE_KEYS = {
+    "index",
+    "device_class",
+    "last_poll_age_s",
+    "last_fix_age_s",
+    "last_accuracy_bucket",
+    "is_own_report",
+    "has_key",
+}
+
+
+def _run(coro: Any) -> Any:
+    """Execute an async coroutine within an isolated, drained event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        drain_loop(loop)
+
+
+class _PerDeviceCoordinator(GoogleFindMyCoordinator):
+    """Coordinator stub exposing the data/slot surface the P1-3 helper consumes.
+
+    Subclasses the production coordinator so ``build_per_device_diagnostics`` is
+    the real method under test, but bypasses ``__init__`` (which needs the HA
+    runtime). ``data`` mirrors the published snapshot (a list of row dicts keyed
+    by ``device_id``); ``_device_location_data`` mirrors the per-device slot that
+    preserves ``device_type`` and ``encrypted_identity_key``;
+    ``_present_last_seen`` mirrors the monotonic poll-age map.
+    """
+
+    def __init__(  # noqa: D107 - documented at class level
+        self,
+        *,
+        data: list[dict[str, Any]] | None = None,
+        slots: dict[str, dict[str, Any]] | None = None,
+        present_last_seen: dict[str, float] | None = None,
+        stats: dict[str, int] | None = None,
+    ) -> None:
+        self.data = data
+        self._device_location_data: dict[str, dict[str, Any]] = slots or {}
+        self._present_last_seen: dict[str, float] = present_last_seen or {}
+        # Minimal surface consumed by the rest of async_get_config_entry_diagnostics.
+        self._device_names: dict[str, str] = {}
+        self._last_poll_mono: float | None = None
+        self.stats: dict[str, int] = stats or {}
+        self.performance_metrics: dict[str, float] = {}
+        self.recent_errors: list[object] = []
+        self._enabled_poll_device_ids: set[str] = set()
+        self._present_device_ids: set[str] = set()
+
+
+def _patch_registries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize loader and registry lookups so the dump builds in isolation."""
+
+    async def _fake_get_integration(_hass: Any, _domain: str) -> SimpleNamespace:
+        return SimpleNamespace(name="Test Integration", version="1.2.3")
+
+    monkeypatch.setattr(diagnostics, "async_get_integration", _fake_get_integration)
+    monkeypatch.setattr(
+        diagnostics.dr, "async_get", lambda _hass: SimpleNamespace(devices={})
+    )
+    monkeypatch.setattr(
+        diagnostics.er, "async_get", lambda _hass: SimpleNamespace(entities={})
+    )
+
+
+def _make_entry_and_hass(
+    coordinator: _PerDeviceCoordinator,
+) -> tuple[Any, SimpleNamespace]:
+    """Build a canonical config entry plus a minimal hass referencing it."""
+    entry = make_config_entry(
+        entry_id="entry-p1",
+        data={},
+        options={},
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+    )
+    hass = SimpleNamespace(data={diagnostics.DOMAIN: {}})
+    return entry, hass
+
+
+# ---------------------------------------------------------------------------
+# P1-1: HA core version
+# ---------------------------------------------------------------------------
+
+
+def test_ha_core_version_present_in_integration_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A1: ``integration["ha_core_version"]`` equals the mocked core version string.
+
+    The integration reads ``homeassistant.const.__version__`` via ``sys.modules``
+    at call time; the test suite swaps that module for a lightweight stub, so the
+    version is mocked on the active ``sys.modules`` object rather than on the real
+    package (which the stub shadows).
+    """
+    import sys
+
+    ha_const = sys.modules["homeassistant.const"]
+    monkeypatch.setattr(ha_const, "__version__", "2099.9.9", raising=False)
+    coordinator = _PerDeviceCoordinator(data=[])
+    entry, hass = _make_entry_and_hass(coordinator)
+    _patch_registries(monkeypatch)
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+
+    integration = payload["integration"]
+    assert integration["ha_core_version"] == "2099.9.9"
+    assert isinstance(integration["ha_core_version"], str)
+
+
+# ---------------------------------------------------------------------------
+# P1-2: canonicless drop counters surfaced under coordinator["stats"]
+# ---------------------------------------------------------------------------
+
+
+def test_drop_counters_surface_in_stats_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A3: the three drop counters appear under ``coordinator["stats"]`` as ints."""
+    coordinator = _PerDeviceCoordinator(
+        data=[],
+        stats={
+            "canonicless_drop_total": 5,
+            "canonicless_drop_benign": 3,
+            "canonicless_drop_warn": 2,
+        },
+    )
+    entry, hass = _make_entry_and_hass(coordinator)
+    _patch_registries(monkeypatch)
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+
+    stats = payload["coordinator"]["stats"]
+    assert stats["canonicless_drop_total"] == 5
+    assert stats["canonicless_drop_benign"] == 3
+    assert stats["canonicless_drop_warn"] == 2
+    for key in (
+        "canonicless_drop_total",
+        "canonicless_drop_benign",
+        "canonicless_drop_warn",
+    ):
+        assert isinstance(stats[key], int)
+
+
+# ---------------------------------------------------------------------------
+# P1-3: per-device telemetry list -- pure mapping helpers (boundary tables)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("accuracy", "expected"),
+    [
+        (0, "<10"),
+        (9.9, "<10"),
+        (10, "10-50"),
+        (49.9, "10-50"),
+        (50, "50-200"),
+        (199.9, "50-200"),
+        (200, ">200"),
+        (500, ">200"),
+        (None, None),
+        (-1, None),
+    ],
+)
+def test_accuracy_bucket_boundaries(accuracy: Any, expected: str | None) -> None:
+    """A5: half-open accuracy intervals with None/negative collapsing to null."""
+    assert coordinator_main._accuracy_bucket(accuracy) == expected
+
+
+@pytest.mark.parametrize(
+    ("age", "expected"),
+    [
+        (0, 0),
+        (3725, 3720),
+        (3727, 3730),
+        (4, 0),
+        (5, 0),
+        (6, 10),
+    ],
+)
+def test_round_age_to_ten_seconds(age: float, expected: int) -> None:
+    """A5: ages are rounded via ``round(x/10)*10``."""
+    assert coordinator_main._round_age(age) == expected
+
+
+@pytest.mark.parametrize(
+    ("device_type", "expected"),
+    [
+        (20, "phone"),
+        (None, "other"),
+        (0, "other"),
+        (1, "bt_tracker"),
+        (19, "bt_tracker"),
+        (24, "bt_tracker"),
+    ],
+)
+def test_device_class_mapping(device_type: Any, expected: str) -> None:
+    """V3: the abrupt three-class mapping over the device_type int."""
+    assert coordinator_main._device_class(device_type) == expected
+
+
+# ---------------------------------------------------------------------------
+# P1-3: per-device telemetry list -- coordinator helper
+# ---------------------------------------------------------------------------
+
+
+def test_per_device_empty_data_is_empty_list() -> None:
+    """A4: empty/None ``self.data`` yields ``[]`` (no crash, no None)."""
+    assert _PerDeviceCoordinator(data=None).build_per_device_diagnostics() == []  # type: ignore[attr-defined]
+    assert _PerDeviceCoordinator(data=[]).build_per_device_diagnostics() == []  # type: ignore[attr-defined]
+
+
+def test_per_device_schema_exact_keys_and_contiguous_index() -> None:
+    """A4/A6: each entry has exactly the seven fields plus a 0..n-1 index.
+
+    Two device IDs sorted as ``dev-a`` < ``dev-b`` deterministically map to index
+    0 and 1; no extra keys appear.
+    """
+    coordinator = _PerDeviceCoordinator(
+        data=[
+            {"device_id": "dev-b", "is_own_report": False},
+            {"device_id": "dev-a", "is_own_report": True},
+        ],
+        slots={
+            "dev-a": {"device_type": 20, "encrypted_identity_key": b"k"},
+            "dev-b": {"device_type": 1},
+        },
+    )
+    entries = coordinator.build_per_device_diagnostics()  # type: ignore[attr-defined]
+
+    assert [e["index"] for e in entries] == [0, 1]
+    for entry in entries:
+        assert set(entry.keys()) == _EXPECTED_DEVICE_KEYS
+    # sorted(device_ids) -> dev-a (index 0) is the phone with a key.
+    assert entries[0]["device_class"] == "phone"
+    assert entries[0]["has_key"] is True
+    assert entries[0]["is_own_report"] is True
+    assert entries[1]["device_class"] == "bt_tracker"
+    assert entries[1]["has_key"] is False
+
+
+def test_per_device_age_disambiguation() -> None:
+    """A4b: fix age (epoch ``last_seen``) and poll age (monotonic) are independent.
+
+    A device with an OLD wall-clock fix but a FRESH monotonic poll must yield a
+    large ``last_fix_age_s`` and a small ``last_poll_age_s``.
+    """
+    now_epoch = time.time()
+    now_mono = time.monotonic()
+    coordinator = _PerDeviceCoordinator(
+        data=[
+            {
+                "device_id": "dev-old-fix",
+                "last_seen": now_epoch - 3600.0,
+                "is_own_report": False,
+            }
+        ],
+        present_last_seen={"dev-old-fix": now_mono - 5.0},
+    )
+    entries = coordinator.build_per_device_diagnostics()  # type: ignore[attr-defined]
+    entry = entries[0]
+    assert entry["last_fix_age_s"] is not None
+    assert entry["last_fix_age_s"] >= 3000
+    assert entry["last_poll_age_s"] is not None
+    assert entry["last_poll_age_s"] <= 60
+
+
+def test_per_device_missing_timestamps_yield_null() -> None:
+    """A4b: missing ``last_seen`` -> null fix age; missing slot -> null poll age."""
+    coordinator = _PerDeviceCoordinator(
+        data=[{"device_id": "dev-x", "is_own_report": None}],
+        present_last_seen={},
+    )
+    entry = coordinator.build_per_device_diagnostics()[0]  # type: ignore[attr-defined]
+    assert entry["last_fix_age_s"] is None
+    assert entry["last_poll_age_s"] is None
+    # V2/F3: is_own_report key stays present, value may be None.
+    assert entry["is_own_report"] is None
+
+
+def test_per_device_never_polled_slot_missing_defaults() -> None:
+    """V2/R-P3: a never-polled device with no slot defaults to other/has_key=False."""
+    coordinator = _PerDeviceCoordinator(
+        data=[{"device_id": "ghost"}],
+        slots={},
+    )
+    entry = coordinator.build_per_device_diagnostics()[0]  # type: ignore[attr-defined]
+    assert entry["device_class"] == "other"
+    assert entry["has_key"] is False
+    assert entry["is_own_report"] is None
+
+
+def test_per_device_accuracy_bucketed_not_raw() -> None:
+    """A5/A8: a raw accuracy float is bucketed, never echoed verbatim."""
+    coordinator = _PerDeviceCoordinator(
+        data=[{"device_id": "dev-acc", "accuracy_m": 137.4, "is_own_report": False}],
+    )
+    entry = coordinator.build_per_device_diagnostics()[0]  # type: ignore[attr-defined]
+    assert entry["last_accuracy_bucket"] == "50-200"
+    assert 137.4 not in entry.values()
+
+
+def test_per_device_skips_non_dict_rows() -> None:
+    """Defensive: a non-dict entry in ``self.data`` is skipped, not crashed on."""
+    coordinator = _PerDeviceCoordinator(
+        data=["junk", {"device_id": "dev-a", "is_own_report": True}, None],  # type: ignore[list-item]
+    )
+    entries = coordinator.build_per_device_diagnostics()
+    assert len(entries) == 1
+    assert entries[0]["index"] == 0
+
+
+# ---------------------------------------------------------------------------
+# P1-1 / P1-3: resilience fallbacks
+# ---------------------------------------------------------------------------
+
+
+def test_ha_core_version_survives_loader_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A1/R-P3: if the manifest loader fails, ``ha_core_version`` is still present."""
+    import sys
+
+    ha_const = sys.modules["homeassistant.const"]
+    monkeypatch.setattr(ha_const, "__version__", "2099.9.9", raising=False)
+
+    async def _boom(_hass: Any, _domain: str) -> SimpleNamespace:
+        raise RuntimeError("loader unavailable")
+
+    monkeypatch.setattr(diagnostics, "async_get_integration", _boom)
+    monkeypatch.setattr(
+        diagnostics.dr, "async_get", lambda _hass: SimpleNamespace(devices={})
+    )
+    monkeypatch.setattr(
+        diagnostics.er, "async_get", lambda _hass: SimpleNamespace(entities={})
+    )
+    coordinator = _PerDeviceCoordinator(data=[])
+    entry, hass = _make_entry_and_hass(coordinator)
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+    assert payload["integration"]["ha_core_version"] == "2099.9.9"
+
+
+def test_devices_block_empty_when_builder_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A coordinator without the P1-3 builder yields ``coordinator["devices"] == []``."""
+
+    class _NoBuilderCoordinator:
+        def __init__(self) -> None:
+            self._device_names: dict[str, str] = {}
+            self._device_location_data: dict[str, Any] = {}
+            self._last_poll_mono: float | None = None
+            self.stats: dict[str, int] = {}
+            self.performance_metrics: dict[str, float] = {}
+            self.recent_errors: list[object] = []
+            self._enabled_poll_device_ids: set[str] = set()
+            self._present_device_ids: set[str] = set()
+
+    coordinator = _NoBuilderCoordinator()
+    entry = make_config_entry(
+        entry_id="entry-nb",
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+    )
+    hass = SimpleNamespace(data={diagnostics.DOMAIN: {}})
+    _patch_registries(monkeypatch)
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+    assert payload["coordinator"]["devices"] == []
+
+
+def test_devices_block_empty_when_builder_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A builder that raises degrades to ``coordinator["devices"] == []`` (defensive)."""
+
+    class _RaisingCoordinator(_PerDeviceCoordinator):
+        def build_per_device_diagnostics(self) -> list[dict[str, Any]]:
+            raise RuntimeError("boom")
+
+    coordinator = _RaisingCoordinator(data=[])
+    entry, hass = _make_entry_and_hass(coordinator)
+    _patch_registries(monkeypatch)
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+    assert payload["coordinator"]["devices"] == []
+
+
+# ---------------------------------------------------------------------------
+# P1-3: per-device list inside the dump -- privacy net (A7/A8)
+# ---------------------------------------------------------------------------
+
+
+def test_per_device_list_in_dump_introduces_no_redaction_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A7: the new list survives ``async_redact_data`` without TO_REDACT keys."""
+    coordinator = _PerDeviceCoordinator(
+        data=[
+            {
+                "device_id": "dev-secret",
+                "last_seen": time.time() - 30.0,
+                "accuracy_m": 12.0,
+                "is_own_report": True,
+            }
+        ],
+        slots={"dev-secret": {"device_type": 20, "encrypted_identity_key": b"k"}},
+    )
+    entry, hass = _make_entry_and_hass(coordinator)
+    _patch_registries(monkeypatch)
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+
+    devices = payload["coordinator"]["devices"]
+    assert isinstance(devices, list)
+    assert len(devices) == 1
+    record = devices[0]
+    # No entry key is a redaction-pending key, and nothing was redacted.
+    for key in record:
+        assert key not in diagnostics.TO_REDACT
+        assert record[key] != diagnostics.REDACTED
+    assert set(record.keys()) == _EXPECTED_DEVICE_KEYS
+
+
+def test_per_device_block_has_no_identifying_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A8: a recursive scan of the per-device block finds no forbidden artifacts."""
+    coordinator = _PerDeviceCoordinator(
+        data=[
+            {
+                "device_id": "dev-secret",
+                "device_name": "Garage Tracker",
+                "latitude": 52.5,
+                "longitude": 13.4,
+                "last_seen": time.time() - 30.0,
+                "accuracy_m": 12.0,
+                "is_own_report": True,
+            }
+        ],
+        slots={"dev-secret": {"device_type": 20, "encrypted_identity_key": b"secret"}},
+    )
+    entry, hass = _make_entry_and_hass(coordinator)
+    _patch_registries(monkeypatch)
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+    devices = payload["coordinator"]["devices"]
+
+    forbidden_substrings = ("garage", "tracker", "dev-secret", "secret")
+
+    def _scan(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                assert "name" not in key.lower()
+                _scan(value)
+        elif isinstance(node, list):
+            for item in node:
+                _scan(item)
+        elif isinstance(node, str):
+            lowered = node.lower()
+            for needle in forbidden_substrings:
+                assert needle not in lowered
+        elif isinstance(node, (bytes, bytearray)):
+            raise AssertionError("raw bytes leaked into the per-device block")
+        else:
+            # numeric / bool / None are safe.
+            assert isinstance(node, (int, float, bool)) or node is None
+
+    _scan(devices)
+    # Forbidden float coordinates must not appear anywhere in the block.
+    flat = repr(devices)
+    assert "52.5" not in flat
+    assert "13.4" not in flat

--- a/tests/test_phone_device_key_handling.py
+++ b/tests/test_phone_device_key_handling.py
@@ -138,6 +138,11 @@ def test_phone_device_no_missing_key_warning(caplog: pytest.LogCaptureFixture) -
     """Phone devices should NOT trigger 'Missing Key' warnings.
 
     Phones get their keys from the Locate flow (FCM), not from list_devices.
+
+    Models the main poll (emit_canonicless_diagnostics=True): the hidden-key diagnostic
+    block (both its WARNING and its benign "Locate flow" DEBUG line) is gated to the main
+    poll, so the benign DEBUG line this test asserts on only appears there. The probe pass
+    silence is pinned separately in test_decoder_canonicless_device_warning.py (T5/T6).
     """
     from custom_components.googlefindmy.ProtoDecoders import decoder
 
@@ -146,7 +151,9 @@ def test_phone_device_no_missing_key_warning(caplog: pytest.LogCaptureFixture) -
 
     with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
         # Use cache=None to skip decryption attempts
-        results = decoder.get_devices_with_location(device_list, cache=None)
+        results = decoder.get_devices_with_location(
+            device_list, cache=None, emit_canonicless_diagnostics=True
+        )
 
     # Should produce a result (device was parsed)
     assert len(results) == 1
@@ -199,6 +206,10 @@ def test_tracker_device_missing_key_triggers_warning(
     """Tracker devices without keys SHOULD trigger 'Missing Key' warnings.
 
     This is the expected behavior for trackers that should have keys.
+
+    Models the main poll (emit_canonicless_diagnostics=True): the hidden-key diagnostic is
+    gated to the main poll so the capability probe stays diagnostically silent (CQS). The
+    probe-pass silence is pinned separately in test_decoder_canonicless_device_warning.py.
     """
     from custom_components.googlefindmy.ProtoDecoders import decoder
 
@@ -206,7 +217,9 @@ def test_tracker_device_missing_key_triggers_warning(
     device_list = SimpleNamespace(deviceMetadata=[tracker_device])
 
     with caplog.at_level(logging.DEBUG, logger="custom_components.googlefindmy"):
-        results = decoder.get_devices_with_location(device_list, cache=None)
+        results = decoder.get_devices_with_location(
+            device_list, cache=None, emit_canonicless_diagnostics=True
+        )
 
     assert len(results) == 1
     assert results[0]["name"] == "Moto Tag"


### PR DESCRIPTION
## Problem

`get_devices_with_location` runs **twice per poll**: a capability probe (`api.py:361`, `_build_can_ring_index`) and the main poll (`api.py:702`), both with the same cache/entry scope. Both passes emitted the canonicless drop diagnostics and mutated the two module-level guards. So the probe pass overwrote `_visible_device_names_by_entry` *before* the main poll read it:

- the `was_visible` transition discriminator (the "was visible, now gone" signal from #1133) was **ineffective on the main path** (it read an already-overwritten set), and
- the aggregate count WARNING could fire from the probe pass and **flicker** relative to the main poll.

A latent Command-Query-Separation (CQS) defect introduced with the #1133 severity reclassification. No user-visible crash, but the new transition WARNING did not behave as designed.

## Fix

A keyword-only gate `emit_canonicless_diagnostics: bool = False` on `get_devices_with_location`. Only the **main poll** passes `True`; the capability probe keeps the default `False` and is **diagnostically silent and side-effect free**. Default `False` makes the defect structurally impossible for any future ungated caller (not just the two of today).

## Constraint checklist

- [x] **C1** Parameter-gating, not call-reorder (root cause is the CQS violation).
- [x] **C2** Main poll `api.py:702` passes `emit_canonicless_diagnostics=True`.
- [x] **C3** Capability probe `api.py:361` passes `emit_canonicless_diagnostics=False` (explicit).
- [x] **C4** Gate spans READ (visibility set), both DEBUG branches, the visibility WRITE, and the full count-guard block (WARNING + map mutation + recovery pop).
- [x] **C5** Row production and `emitted_names_this_run` accumulation stay ungated (the query is identical on both passes).
- [x] **C6** `_infer_can_ring_slot`, `_reset_canonicless_warning_state`, the unload hook untouched.
- [x] **C7** Map comments + docstring updated to the corrected per-poll semantics.
- [x] **C8** TDD: RED first, then GREEN.
- [x] **C9** Default `False` heals future ungated callers.

## Tests

New CQS contract tests: probe pass leaves count state untouched, probe pass mutates no module map and logs nothing (incl. the 0-count pop gegenprobe), probe/main rows identical, transition fires exactly once per poll despite the double call. The existing re-arm/severity suite was re-pointed to the main poll (`emit_canonicless_diagnostics=True`); two pure no-signal controls stay at the default `False`.

## Negative protocol (intentionally out of scope)

1. The double **decrypt** per poll (both passes decrypt) is a separate performance concern, not touched here.
2. No `_decoder_token_cache` None-guard added (gating is cache-orthogonal).
3. No decrypt-free can-ring extraction (the probe needs the full decoder run for its verdicts).
4. Call order (361 before 702) unchanged (symptom, not root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added in this PR: P1 diagnostics enrichment

Built on top of the CQS gate above (the new tallies live inside the same `emit_canonicless_diagnostics=True` block, so the capability probe stays diagnostically silent).

- **P1-1 HA core version:** the diagnostics dump now reports `integration["ha_core_version"]` so maintainers can place core-specific regressions. Read lazily via a guarded helper (`_ha_core_version()`), degrading to `null` in stripped/test environments instead of breaking diagnostics collection.
- **P1-2 canonicless drop counters:** three new, **transition-independent** counters (`canonicless_drop_total/benign/warn`, with `total == benign + warn`) flow from the decoder through `coordinator.stats` into `coordinator["stats"]`. They are set absolutely once per main poll and persisted; the existing canonicless WARNING logic (which keeps its `was_visible` transition component) is unchanged.
- **P1-3 anonymized per-device telemetry:** `coordinator["devices"]` lists one entry per device with an opaque positional `index` (over `sorted(device_ids)`, no hash) plus exactly `{device_class, last_poll_age_s, last_fix_age_s, last_accuracy_bucket, is_own_report, has_key}`. Accuracy is bucketed (`<10`/`10-50`/`50-200`/`>200`), ages are 10s-rounded, fix-age (wall clock) and poll-age (monotonic) are kept strictly separate. No names, canonical IDs, coordinates, or clear-text keys; the block flows through the final `async_redact_data` and introduces no new redactable keys.

TDD throughout; full gate green (coverage 72.12% ≥ 71%); `decoder.py` change verified via the isolated coverage path (it is coverage-`omit`).
