### PR TITLE
test(decoder): lock canonicless transition stability across the within-poll double decode

### DIFF
--- a/tests/test_decoder_canonicless_device_warning.py
+++ b/tests/test_decoder_canonicless_device_warning.py
@@ -398,6 +398,57 @@ def test_transition_warns_exactly_once_per_poll_despite_double_call(
     assert len(_canonicless_warnings(caplog)) == 1
 
 
+def test_double_decode_mixed_drop_warns_once_with_stable_count(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Mixed-device double-decode (viii): aggregate count is stable across the two passes.
+
+    This pins the exact regression Codex flagged for the within-poll double-decode in
+    ``api.py::_process_device_list_response`` (capability probe with
+    ``emit_canonicless_diagnostics=False`` followed by the main poll with ``True`` on the
+    SAME payload): a poll where a previously visible phone disappears WHILE a tracker-shaped
+    device is missing must surface the aggregate WARNING exactly once with count 2, not
+    twice (count 2 then count 1). Because every cross-poll mutation (the visibility set and
+    the count guard) is gated to the main poll, the probe pass cannot pop the just-gone
+    phone out of the previous-run set before the main pass reads it, so the transition stays
+    intact and the count does not decay between the two decodes.
+    """
+    cache = SimpleNamespace(entry_id="entry-A")
+
+    # Run 1 (main poll): make the phone "Pixel" visible so it enters the visibility set.
+    visible = SimpleNamespace(
+        deviceMetadata=[
+            _make_phone_device(name="Pixel", canonic_ids=[SimpleNamespace(id="cid-p")])
+        ]
+    )
+    decoder.get_devices_with_location(
+        visible, cache=cache, emit_canonicless_diagnostics=True
+    )
+
+    # Run 2 payload: "Pixel" disappears (benign class but previously visible -> warn-worthy)
+    # WHILE the tracker "Tracker" is canonicless (warn-worthy by class). Both warn, so the
+    # aggregate count is 2 on the main pass.
+    poll = SimpleNamespace(
+        deviceMetadata=[
+            _make_phone_device(name="Pixel", canonic_ids=[]),
+            _make_tracker_device(name="Tracker"),
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="custom_components.googlefindmy"):
+        # Decode the SAME payload twice, exactly as api.py does within one poll:
+        decoder.get_devices_with_location(
+            poll, cache=cache, emit_canonicless_diagnostics=False
+        )  # capability probe: must stay silent and leave the guards untouched
+        decoder.get_devices_with_location(
+            poll, cache=cache, emit_canonicless_diagnostics=True
+        )  # main poll: the single diagnostic emission for this poll
+
+    warnings = _canonicless_warnings(caplog)
+    assert len(warnings) == 1, warnings
+    assert "2 device(s)" in warnings[0], warnings[0]
+
+
 def test_valid_canonic_id_produces_row_and_no_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Context

A Codex review of #1134 (reviewed commit `1a0d9e1559`, the merge-result) flagged a potential double-warning in `api.py::_process_device_list_response`, which decodes the same parsed payload twice per poll: the capability probe (`_build_can_ring_index` → `emit_canonicless_diagnostics=False`) and then the main poll (`emit_canonicless_diagnostics=True`). The concern: a poll where a **previously visible phone disappears while a tracker-shaped device is missing** might log the aggregate canonicless WARNING twice (count 2, then count 1) if the probe pass mutated the cross-poll visibility/count guards.

## Investigation (critical, grounded at the merged code)

In the merged `1.7` code, **every cross-poll mutation is already gated to the main poll** (`if emit_canonicless_diagnostics:` in `decoder.py`):
- the visibility-set read (`previously_visible_names`) short-circuits to an empty set on the probe pass,
- the visibility-set write (`_visible_device_names_by_entry[entry_scope] = ...`) is inside the gate,
- the count guard (`_last_canonicless_count_by_entry`) and the aggregate WARNING are inside the gate.

So the probe pass is silent and side-effect-free: it cannot pop the just-disappeared phone out of the previous-run set before the main pass reads it. **The reported scenario does not reproduce on the merged code** — the finding describes the pre-gating behaviour.

This was verified two ways:
- a reproduction test of the exact mixed-device double-decode → **one** WARNING with stable count 2;
- a counterfactual where the probe is forced to emit (simulating the ungated bug) → exactly the reported "count 2 then count 1", proving the test discriminates.

## Change

The single real gap was test coverage: the existing double-call test only covered a **single** disappearing device. This adds the previously missing **mixed-device** regression test (`test_double_decode_mixed_drop_warns_once_with_stable_count`) that pins the invariant exactly: one aggregate WARNING with a stable count across the two passes.

**Test-only; no production code change.**