### PR TITLE
fix(location_request): keep transient/empty-response exception imports lazy

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -28,9 +28,15 @@ from custom_components.googlefindmy.const import (
 )
 from custom_components.googlefindmy.example_data_provider import get_example_data
 from custom_components.googlefindmy.exceptions import MissingTokenCacheError
-from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
-    OwnerKeyLookupTransientError,
-)
+
+# NOTE: OwnerKeyLookupTransientError (from decrypt_locations) and
+# SpotApiEmptyResponseError (from get_eid_info_request) are intentionally NOT
+# imported at module scope. Both source modules are heavy protobuf/crypto
+# dependencies with dedicated lazy getters (_import_decrypt_locations_module /
+# _import_eid_info_module); a module-scope import would force them to load on
+# startup/listing paths that never process a locate callback (AGENTS.md import
+# deferral). They are resolved via getattr from the lazily imported modules at
+# their two use sites (the FCM callback and the locate path below).
 from custom_components.googlefindmy.NovaApi.ExecuteAction.nbe_execute_action import (
     create_action_request,
     serialize_action_request,
@@ -44,9 +50,6 @@ from custom_components.googlefindmy.NovaApi.nova_request import (
 )
 from custom_components.googlefindmy.NovaApi.scopes import NOVA_ACTION_API_SCOPE
 from custom_components.googlefindmy.NovaApi.util import generate_random_uuid
-from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
-    SpotApiEmptyResponseError,
-)
 from custom_components.googlefindmy.SpotApi.spot_request import SpotAuthPermanentError
 
 _LOGGER = logging.getLogger(__name__)
@@ -321,6 +324,10 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                 )
                 StaleOwnerKeyError = cast(
                     type[Exception], getattr(decrypt_module, "StaleOwnerKeyError")
+                )
+                OwnerKeyLookupTransientError = cast(
+                    type[Exception],
+                    getattr(decrypt_module, "OwnerKeyLookupTransientError"),
                 )
                 SpotApiEmptyResponseError = cast(
                     type[Exception],
@@ -665,12 +672,21 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
     except Exception as err:  # pragma: no cover - defensive logging
         _LOGGER.debug("Failed to persist contributor mode timestamp: %s", err)
 
-    # Bind the decryption exception type locally: this module imports
-    # decrypt_locations lazily (see _import_decrypt_locations_module) to avoid a
-    # heavy import cycle, so the name is not available at module scope. It is used
-    # below to surface an auth-fatal stale-key failure instead of swallowing it.
+    # Bind the decryption / eid-info exception types locally: this module imports
+    # decrypt_locations and get_eid_info_request lazily (see the _import_* helpers)
+    # to avoid heavy protobuf/crypto imports at module scope, so these names are
+    # not available at module scope. They are used below to surface auth-fatal
+    # stale-key failures and transient/empty-response misses instead of swallowing
+    # them into an empty result.
     decrypt_module = _import_decrypt_locations_module()
+    eid_info_module = _import_eid_info_module()
     DecryptionError = cast(type[Exception], getattr(decrypt_module, "DecryptionError"))
+    OwnerKeyLookupTransientError = cast(
+        type[Exception], getattr(decrypt_module, "OwnerKeyLookupTransientError")
+    )
+    SpotApiEmptyResponseError = cast(
+        type[Exception], getattr(eid_info_module, "SpotApiEmptyResponseError")
+    )
 
     try:
         # Generate request UUID

--- a/tests/test_location_request_decrypt_log_severity.py
+++ b/tests/test_location_request_decrypt_log_severity.py
@@ -26,6 +26,7 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
 )
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
+    OwnerKeyLookupTransientError,
     StaleOwnerKeyError,
 )
 from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
@@ -54,6 +55,7 @@ def _patch_callback_imports(
         async_decrypt_location_response_locations=_raise_decrypt,
         DecryptionError=DecryptionError,
         StaleOwnerKeyError=StaleOwnerKeyError,
+        OwnerKeyLookupTransientError=OwnerKeyLookupTransientError,
     )
     eid_module = SimpleNamespace(SpotApiEmptyResponseError=SpotApiEmptyResponseError)
 

--- a/tests/test_location_request_lazy_imports.py
+++ b/tests/test_location_request_lazy_imports.py
@@ -1,0 +1,55 @@
+# tests/test_location_request_lazy_imports.py
+"""Guard the module-scope lazy-import contract of ``location_request``.
+
+``location_request`` provides dedicated lazy getters
+(``_import_decrypt_locations_module`` / ``_import_eid_info_module``) for its
+heavy protobuf/crypto dependencies, and resolves the exception types it needs
+(``OwnerKeyLookupTransientError`` from ``decrypt_locations`` and
+``SpotApiEmptyResponseError`` from ``get_eid_info_request``) via ``getattr`` only
+inside the executor-backed runtime paths (the FCM callback and the locate path).
+
+Binding those exception types with a module-scope ``from ... import`` would
+bypass the file's own lazy getters and violate the AGENTS.md "Import deferral
+reminder". These tests lock that file-local contract so the deferral cannot
+silently regress.
+
+Scope note: this is a *file-local* guard. It does NOT assert that the heavy
+modules stay out of ``sys.modules`` package-wide, because several other
+module-scope importers on the Home Assistant setup path (``api.py``,
+``coordinator/locate.py``, ``coordinator/polling.py``, ``Auth/fcm_receiver_ha.py``)
+load ``decrypt_locations`` eagerly today. Making the whole startup path lazy is a
+separate, broader change tracked outside this fix.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def _location_request_module() -> object:
+    return importlib.import_module(
+        "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request"
+    )
+
+
+def test_owner_key_transient_error_not_bound_at_module_scope() -> None:
+    """Codex finding: ``OwnerKeyLookupTransientError`` must stay behind the getter.
+
+    A module-scope ``from decrypt_locations import OwnerKeyLookupTransientError``
+    would expose the name as a module attribute. The lazy getter pattern keeps it
+    a function-local instead, so the attribute must be absent.
+    """
+    module = _location_request_module()
+    assert not hasattr(module, "OwnerKeyLookupTransientError"), (
+        "OwnerKeyLookupTransientError is bound at module scope; resolve it via "
+        "getattr(_import_decrypt_locations_module(), ...) inside the runtime paths"
+    )
+
+
+def test_spot_empty_response_error_not_bound_at_module_scope() -> None:
+    """Variant of the same class: ``SpotApiEmptyResponseError`` getter must hold."""
+    module = _location_request_module()
+    assert not hasattr(module, "SpotApiEmptyResponseError"), (
+        "SpotApiEmptyResponseError is bound at module scope; resolve it via "
+        "getattr(_import_eid_info_module(), ...) inside the runtime paths"
+    )


### PR DESCRIPTION
## Summary

Codex flagged a module-scope `from decrypt_locations import OwnerKeyLookupTransientError` in `location_request.py` (commit `1a0d9e1`). That import forces the heavy protobuf/crypto `decrypt_locations` module to load whenever `location_request` is imported, bypassing the file's own lazy getter (`_import_decrypt_locations_module`) and violating the AGENTS.md import-deferral reminder.

## Changes

- **Codex finding:** `OwnerKeyLookupTransientError` is no longer imported at module scope; it is resolved via `getattr(_import_decrypt_locations_module(), ...)` at its two use sites (FCM callback + locate path), mirroring the existing `DecryptionError`/`StaleOwnerKeyError` pattern.
- **Variant (same class, same file):** `SpotApiEmptyResponseError` (from the equally heavy `get_eid_info_request`, which also has a lazy getter `_import_eid_info_module`) had the identical module-scope import. Made lazy the same way.
- **Test:** new `test_location_request_lazy_imports.py` locks the file-local contract (neither exception type is bound at module scope); the decrypt log-severity test stub surface was completed to mirror the real module.

## Verification

- Full suite `pytest --cov-fail-under=71`: **exit 0, 72.12%**. mypy/ruff green. English-only diff.
- 100% of changed executable lines in `location_request.py` covered.

## Scope note (honest limitation)

This is a **file-local** fix. The heavy decrypt modules are still imported eagerly on the Home Assistant setup path by `api.py`, `coordinator/locate.py`, `coordinator/polling.py` and `Auth/fcm_receiver_ha.py`, so package-wide startup laziness is **not** yet achieved. Those sites have no lazy getter and would need a broader, separate change.