### PR TITLE
fix(decrypt): classify absent shared key as reauth-worthy, not transient

### DIFF
--- a/custom_components/googlefindmy/KeyBackup/shared_key_retrieval.py
+++ b/custom_components/googlefindmy/KeyBackup/shared_key_retrieval.py
@@ -53,6 +53,23 @@ SHARED_KEY_LEN = 32
 _CACHE_KEY_BASE = "shared_key"  # canonical per-entry key in entry-scoped mode
 
 
+class SharedKeyUnavailableError(RuntimeError):
+    """The shared key is genuinely absent and cannot be obtained here.
+
+    Raised when an entry has no usable cached shared key and retrieval is
+    impossible in the current context (e.g. non-interactive / HA mode, where the
+    key must be pre-populated from the secrets bundle). This is a *genuine
+    credential defect*, not a transient miss: the user must re-import a complete
+    secrets bundle.
+
+    It is a ``RuntimeError`` subclass so the existing owner-key handlers that
+    catch ``(InvalidTag, RuntimeError)`` keep catching it. Downstream classifiers
+    (see ``decrypt_locations._classify_owner_key_failure``) key on this *type*
+    rather than the message wording, so the absent-key case escalates to reauth
+    robustly even if the human-readable message changes.
+    """
+
+
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
@@ -203,7 +220,7 @@ async def _retrieve_shared_key_hex() -> str:
                 "Ensure Chrome/Chromium is installed for the browser-based flow."
             ) from err
 
-    raise RuntimeError(
+    raise SharedKeyUnavailableError(
         "Shared key not available in non-interactive environment. "
         "Provide the key via secrets bundle or run the CLI with --reauth."
     )

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -35,6 +35,7 @@ from custom_components.googlefindmy.KeyBackup.cloud_key_decryptor import (
     decrypt_eik,
 )
 from custom_components.googlefindmy.KeyBackup.shared_key_retrieval import (
+    SharedKeyUnavailableError,
     async_get_shared_key,
 )
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypted_location import (
@@ -367,8 +368,13 @@ def _classify_owner_key_failure(exc: Exception, *, context: str) -> Exception:
           so a transient text that merely contains "401" (e.g. "retry after 4012
           ms") stays transient. See AP3.
       (a) ``InvalidTag`` -> ``SharedKeyMismatchError`` (genuine credential defect).
-      (b) a local "shared key ... missing or empty" bundle ->
-          ``SharedKeyMissingError`` (genuine credential defect).
+      (b) the shared key is genuinely absent/empty -> ``SharedKeyMissingError``
+          (genuine credential defect). Recognised primarily by the TYPED
+          ``SharedKeyUnavailableError`` raised at the retrieval source (robust to
+          message wording, e.g. the non-interactive "shared key not available"
+          case), and as a fallback by the legacy local "shared key ... missing or
+          empty" message of the defensive empty-return guard in
+          ``get_owner_key``.
       (b2) a local owner-key STRUCTURE defect (the stored owner key is missing,
           malformed, or the wrong length) -> ``_OwnerKeyRederiveRequired`` (an
           INTERNAL re-derive signal, NOT reauth). The defect is re-derivable from
@@ -412,7 +418,9 @@ def _classify_owner_key_failure(exc: Exception, *, context: str) -> Exception:
             "is required (re-authentication)."
         )
     text = str(exc).lower()
-    if "shared key" in text and "missing or empty" in text:
+    if isinstance(exc, SharedKeyUnavailableError) or (
+        "shared key" in text and "missing or empty" in text
+    ):
         return SharedKeyMissingError(
             f"Shared key is missing or empty during {context} (incomplete bundle). "
             "Re-import a complete secrets.json."

--- a/tests/test_decrypt_shared_key_unavailable_authclass.py
+++ b/tests/test_decrypt_shared_key_unavailable_authclass.py
@@ -1,0 +1,109 @@
+# tests/test_decrypt_shared_key_unavailable_authclass.py
+"""Absent-shared-key classification of owner-key lookup failures.
+
+When an existing entry has no usable ``shared_key`` (for example a pre-upgrade
+incomplete bundle), the shared-key retrieval layer raises in non-interactive
+(HA) mode. That is a *genuine credential defect*: the user must re-import a
+complete secrets bundle, so the coordinator has to escalate to reauth, not skip
+the device as a debug-only transient miss.
+
+The previous classifier recognised this case only via the substring
+``"missing or empty"``. The non-interactive absent message
+(``"Shared key not available in non-interactive environment..."``) carries no
+such substring, so it fell through to the transient default and the entry could
+never decrypt without a (never-shown) prompt.
+
+The robust fix raises a typed ``SharedKeyUnavailableError`` at the source and
+classifies on the *type*, not the message wording. These are pure synchronous
+unit tests against ``_classify_owner_key_failure``; they carry no asyncio
+marker. They go RED on HEAD because the typed signal and its classifier branch
+do not exist yet, so the positive case currently falls into the transient
+default.
+"""
+
+from __future__ import annotations
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    OwnerKeyLookupTransientError,
+    SharedKeyMissingError,
+    _classify_owner_key_failure,
+)
+
+# Soft import keeps this a clean assertion failure (RED) rather than a module
+# collection error while the typed signal is being introduced.
+try:
+    from custom_components.googlefindmy.KeyBackup.shared_key_retrieval import (
+        SharedKeyUnavailableError,
+    )
+
+    _SYMBOL_PRESENT = True
+except ImportError:  # pragma: no cover - the symbol exists once the fix lands
+    _SYMBOL_PRESENT = False
+    SharedKeyUnavailableError = None  # type: ignore[assignment,misc]
+
+
+# The exact message the non-interactive retrieval path raises today. The fix
+# must NOT depend on this wording (it classifies on the type), but pinning it
+# documents the real-world trigger the Codex review flagged.
+_NON_INTERACTIVE_ABSENT_MESSAGE = (
+    "Shared key not available in non-interactive environment. "
+    "Provide the key via secrets bundle or run the CLI with --reauth."
+)
+
+
+def test_shared_key_unavailable_is_typed_runtimeerror() -> None:
+    """The absent-shared-key signal is a ``RuntimeError`` subclass.
+
+    It must remain a ``RuntimeError`` subclass so the existing
+    ``except (InvalidTag, RuntimeError)`` owner-key handlers keep catching it and
+    the existing non-interactive retrieval test stays green.
+    """
+    assert _SYMBOL_PRESENT, "SharedKeyUnavailableError must exist (typed absent-key signal)"
+    assert issubclass(SharedKeyUnavailableError, RuntimeError)
+
+
+def test_typed_absent_shared_key_maps_to_reauth() -> None:
+    """RED: a typed absent-shared-key error => reauth-worthy, not transient.
+
+    A ``SharedKeyUnavailableError`` must classify as ``SharedKeyMissingError``
+    (a ``DecryptionError``, so the coordinator escalates to a bundle re-import /
+    reauth) and MUST NOT be an ``OwnerKeyLookupTransientError`` (which the
+    poll/locate paths skip silently without advancing the reauth counter).
+    RED today: HEAD has no typed branch, so this falls into the transient
+    default.
+    """
+    assert _SYMBOL_PRESENT, "SharedKeyUnavailableError must exist (typed absent-key signal)"
+    exc = SharedKeyUnavailableError(_NON_INTERACTIVE_ABSENT_MESSAGE)
+    result = _classify_owner_key_failure(exc, context="initial lookup")
+    assert isinstance(result, SharedKeyMissingError)
+    assert isinstance(result, DecryptionError)
+    assert not isinstance(result, OwnerKeyLookupTransientError)
+
+
+def test_typed_absent_shared_key_robust_to_wording() -> None:
+    """The classification holds even if the source message wording changes.
+
+    This is the whole point of the typed signal: classification keys on the
+    exception type, so a reworded absent-key message still escalates to reauth
+    instead of silently regressing to the transient default (the exact fragility
+    the substring matcher had).
+    """
+    assert _SYMBOL_PRESENT, "SharedKeyUnavailableError must exist (typed absent-key signal)"
+    exc = SharedKeyUnavailableError("shared key cannot be obtained right now")
+    result = _classify_owner_key_failure(exc, context="forced refresh")
+    assert isinstance(result, SharedKeyMissingError)
+    assert not isinstance(result, OwnerKeyLookupTransientError)
+
+
+def test_plain_transient_runtimeerror_still_transient() -> None:
+    """FP-pin: an untyped, unrelated RuntimeError stays transient.
+
+    Typing the absent-key case must not widen the reauth path: a generic lookup
+    failure with no typed signal and none of the credential-defect substrings
+    must remain ``OwnerKeyLookupTransientError`` (no speculative reauth).
+    """
+    result = _classify_owner_key_failure(
+        RuntimeError("temporary lookup hiccup"), context="initial lookup"
+    )
+    assert type(result) is OwnerKeyLookupTransientError

--- a/tests/test_shared_key_retrieval.py
+++ b/tests/test_shared_key_retrieval.py
@@ -250,8 +250,12 @@ async def test_force_refresh_tolerates_clear_failure() -> None:
 
 
 async def test_retrieve_raises_in_non_interactive_mode(no_tty_stdin: None) -> None:
-    with pytest.raises(RuntimeError, match="non-interactive environment"):
+    # The absent-key case raises the TYPED SharedKeyUnavailableError (a
+    # RuntimeError subclass) so downstream owner-key classification escalates to
+    # reauth on the exception type, not the message wording.
+    with pytest.raises(skr.SharedKeyUnavailableError, match="non-interactive environment"):
         await skr._retrieve_shared_key_hex()
+    assert issubclass(skr.SharedKeyUnavailableError, RuntimeError)
 
 
 async def test_retrieve_returns_interactive_result(


### PR DESCRIPTION
## Summary

Fixes a Codex P1 finding (PR #191 review): when an existing entry has no usable cached `shared_key` (e.g. a pre-upgrade incomplete bundle), the owner-key failure classifier mis-routed the absent-key error to the **transient** path. The poll/locate handlers then skipped the device as a debug-only transient miss **without advancing the reauth counter**, so the entry could never decrypt and the user was never prompted to import a complete secrets bundle.

## Root cause

`_classify_owner_key_failure` reconstructs typed credential-defect classes from lossy lower-layer `RuntimeError` messages. It recognised a genuine shared-key defect only via the substring `"missing or empty"`. The non-interactive retrieval path raises `RuntimeError("Shared key not available in non-interactive environment...")`, which carries no such substring, so it fell through to the transient default `OwnerKeyLookupTransientError` (a non-`DecryptionError`, silently skipped) instead of `SharedKeyMissingError` (a `DecryptionError`, reauth-worthy).

## Fix (architectural, not another substring)

Rather than add a second fragile substring (the very fragility this finding exposes), the absent-key signal is now **typed at its source**:

- New `SharedKeyUnavailableError(RuntimeError)` in `KeyBackup/shared_key_retrieval.py`, raised at the non-interactive absent site where the absence is known with certainty.
- `_classify_owner_key_failure` classifies on the exception **type** (`isinstance`) -> `SharedKeyMissingError`, robust to future message-wording changes.
- Because the fix is at the source/type, it heals **all three** classifier call sites uniformly (initial lookup, forced re-derive, version-mismatch refresh).
- The legacy `"missing or empty"` substring is kept as a fallback for the pre-existing defensive empty-return guard in `get_owner_key` (a distinct path), so that behaviour is unchanged.

`SharedKeyUnavailableError` subclasses `RuntimeError`, so the existing `except (InvalidTag, RuntimeError)` owner-key handlers keep catching it and no caller behaviour regresses.

## Variant analysis (all similar locations)

Swept every shared-key/owner-key `RuntimeError` source reachable by the classifier:
- The non-interactive **absent** shared key was the only genuine credential defect mis-classified as transient -> now typed.
- TTY/interactive-only shared-key retrieval failures never reach the HA classifier path (guarded behind `is_tty`), so they are intentionally out of scope.
- All owner-key structure / partial-server-field messages already classify correctly (re-derive / transient as documented) and are unchanged.

## Change Log

### Fixed
- Absent (non-interactive) shared key is now classified as a genuine credential defect (reauth-worthy) instead of a silent transient skip, so an incomplete-bundle entry surfaces a reauth prompt instead of failing to decrypt indefinitely.

### Added
- Typed `SharedKeyUnavailableError` for the absent-shared-key signal, classified by type rather than message wording.

## Tests
- New `tests/test_decrypt_shared_key_unavailable_authclass.py`: typed-signal classification, wording-robustness, and a transient FP-pin (an unrelated `RuntimeError` stays transient).
- Strengthened `tests/test_shared_key_retrieval.py` to assert the non-interactive path raises the typed subclass.
- Full suite green locally, coverage gate `--cov-fail-under=71` -> 72.12%; 100% of the changed executable lines covered.