### PR TITLE
perf(eid): cut sustained EID-resolver CPU usage (memoization, skip-guard, executor offload)

### DIFF
--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -164,6 +164,24 @@ TOKEN_REFRESH_COOLDOWN_S: int = 180
 This cooldown is shared across all token regeneration buttons (AAS/ADM).
 """
 
+# EID resolver refresh trigger debounce policy
+_EID_REFRESH_DEBOUNCE_S: float = 3.0
+"""Debounce window (seconds) coalescing EID-resolver refresh *triggers*.
+
+Several read-only call sites and one inline cache path each request a resolver
+refresh whenever an active device set or identity changes. Under an FCM burst
+these requests arrive back-to-back, and without coalescing each one spawns its
+own ``async_create_task(resolver.async_refresh())``. This window collapses such
+bursts to a single scheduled task.
+
+The value (3.0 s, sensible band 2-5 s) is deliberately small relative to the
+device poll delay (``device_poll_delay`` 5-15 s) and the location poll interval
+(``location_poll_interval`` 300-600 s), so a legitimate change is still picked
+up promptly while same-burst triggers within 3 s coalesce. The debounce only
+delays *task creation*; the actual rebuild-vs-skip decision stays with the
+AP-B1 skip guard inside the resolver, so a genuine change is never dropped.
+"""
+
 # Quality/logic thresholds
 DEFAULT_ALLOW_HISTORY_FALLBACK: bool = False
 DEFAULT_SEMANTIC_DETECTION_RADIUS: float = (
@@ -623,6 +641,7 @@ __all__ = [
     "DEFAULT_OPTIONS",
     "CONFIG_FIELDS",
     "TOKEN_REFRESH_COOLDOWN_S",
+    "_EID_REFRESH_DEBOUNCE_S",
     "SERVICE_LOCATE_DEVICE",
     "SERVICE_PLAY_SOUND",
     "SERVICE_STOP_SOUND",

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -85,6 +85,12 @@ class _MixinBase:
     _subentry_metadata: dict[str, SubentryMetadata]
     _default_subentry_key_value: str
 
+    # AP-B2: pending debounce timer handles for EID-resolver refresh triggers.
+    # One per trigger site (central helper in identity.py, inline path in
+    # cache.py) so each site coalesces its own burst independently.
+    _eid_refresh_debounce_handle: asyncio.TimerHandle | None
+    _eid_inline_refresh_debounce_handle: asyncio.TimerHandle | None
+
     # Polling state
     _consecutive_timeouts: int
     _last_poll_result: str | None

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -23,7 +23,7 @@ from collections import deque
 from collections.abc import Mapping
 from typing import Any
 
-from ..const import DATA_EID_RESOLVER, DOMAIN
+from ..const import _EID_REFRESH_DEBOUNCE_S, DATA_EID_RESOLVER, DOMAIN
 from ._mixin_typing import _MixinBase
 from .helpers.cache import (
     merge_cache_row as _merge_cache_row_impl,
@@ -239,25 +239,72 @@ class CacheOperations(_MixinBase):
         if has_metadata or updated != existing:
             self._device_location_data[device_id] = updated
 
-        # Trigger EID resolver refresh when identity_key is present
+        # Trigger EID resolver refresh when identity_key is present.
         if "identity_key" in payload or "identityKey" in payload:
-            hass_obj = getattr(self, "hass", None)
-            if hass_obj is None:
-                return
-            domain_bucket = (
-                hass_obj.data.get(DOMAIN) if hasattr(hass_obj, "data") else None
+            self._schedule_inline_eid_resolver_refresh(device_id)
+
+    def _schedule_inline_eid_resolver_refresh(self, device_id: str) -> None:
+        """Debounced inline EID-resolver refresh trigger (AP-B2).
+
+        This is the separate inline trigger site (distinct from the central
+        ``_schedule_eid_resolver_refresh`` helper in identity.py). During an FCM
+        burst, ``_persist_anchor_metadata`` runs once per anchored payload, so
+        without coalescing each identity-bearing payload would spawn its own
+        ``async_create_task(resolver.async_refresh())``. We hold one pending
+        timer handle for this site: the first trigger arms a ``loop.call_later``
+        timer, further triggers within ``_EID_REFRESH_DEBOUNCE_S`` are dropped,
+        and the handle is cleared *before* the task is created so a trigger after
+        the window still produces a fresh task (no swallowed window-change). The
+        rebuild-vs-skip decision remains with the AP-B1 skip guard.
+        """
+        hass_obj = getattr(self, "hass", None)
+        if hass_obj is None:
+            return
+        domain_bucket = (
+            hass_obj.data.get(DOMAIN) if hasattr(hass_obj, "data") else None
+        )
+        if not isinstance(domain_bucket, dict):
+            return
+        eid_resolver = domain_bucket.get(DATA_EID_RESOLVER)
+        if eid_resolver is None:
+            return
+        refresh_coro = getattr(eid_resolver, "async_refresh", None)
+        if not callable(refresh_coro):
+            return
+
+        create_task = getattr(hass_obj, "async_create_task", None)
+        if not callable(create_task):
+            return
+
+        def _spawn_refresh_task() -> None:
+            """Clear the debounce handle, then create the single refresh task."""
+            # Clear first so a trigger after the window arms a fresh timer.
+            self._eid_inline_refresh_debounce_handle = None
+            _LOGGER.debug(
+                "Triggering EID Resolver refresh for %s (identity_key in anchor_payload)",
+                device_id,
             )
-            if not isinstance(domain_bucket, dict):
-                return
-            eid_resolver = domain_bucket.get(DATA_EID_RESOLVER)
-            if eid_resolver is not None:
-                _LOGGER.debug(
-                    "Triggering EID Resolver refresh for %s (identity_key in anchor_payload)",
-                    device_id,
-                )
-                refresh_coro = getattr(eid_resolver, "async_refresh", None)
-                if callable(refresh_coro):
-                    hass_obj.async_create_task(refresh_coro())
+            create_task(refresh_coro())
+
+        loop = getattr(hass_obj, "loop", None)
+        call_later = getattr(loop, "call_later", None)
+        if not callable(call_later):
+            # No event loop available (e.g. minimal stubs): fall back to the
+            # legacy immediate behaviour so a refresh is never lost.
+            _LOGGER.debug(
+                "Triggering EID Resolver refresh for %s (identity_key in anchor_payload)",
+                device_id,
+            )
+            create_task(refresh_coro())
+            return
+
+        # A timer is already pending for this window: coalesce this trigger.
+        if getattr(self, "_eid_inline_refresh_debounce_handle", None) is not None:
+            return
+
+        self._eid_inline_refresh_debounce_handle = call_later(
+            _EID_REFRESH_DEBOUNCE_S, _spawn_refresh_task
+        )
 
     def update_device_cache(
         self,

--- a/custom_components/googlefindmy/coordinator/identity.py
+++ b/custom_components/googlefindmy/coordinator/identity.py
@@ -22,6 +22,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 
 from ..const import (
+    _EID_REFRESH_DEBOUNCE_S,
     CONF_GOOGLE_EMAIL,
     DATA_EID_RESOLVER,
     DOMAIN,
@@ -140,7 +141,21 @@ class IdentityOperations(_MixinBase):
         return issue_present
 
     def _schedule_eid_resolver_refresh(self) -> None:
-        """Refresh the global EID resolver when active device sets change."""
+        """Refresh the global EID resolver when active device sets change.
+
+        AP-B2 trigger-task debounce: the four read-only call sites that drive
+        this helper can fire back-to-back during an FCM burst. Without
+        coalescing, each call spawns its own ``async_create_task`` even though
+        the resolver only needs one rebuild. We hold a single pending timer
+        handle per coordinator instance: the first trigger arms a
+        ``loop.call_later`` timer, and any further trigger within
+        ``_EID_REFRESH_DEBOUNCE_S`` is dropped (no second task). When the timer
+        fires the handle is cleared *before* the task is created, so a trigger
+        arriving after the window still arms a fresh timer and produces a new
+        task (no swallowed window-change). The rebuild-vs-skip decision stays in
+        the AP-B1 skip guard, so debouncing the trigger never drops a real
+        change.
+        """
 
         hass = getattr(self, "hass", None)
         hass_data = getattr(hass, "data", None)
@@ -153,10 +168,34 @@ class IdentityOperations(_MixinBase):
 
         resolver = bucket.get(DATA_EID_RESOLVER)
         refresh = getattr(resolver, "async_refresh", None)
-        if callable(refresh):
-            create_task = getattr(self.hass, "async_create_task", None)
-            if callable(create_task):
-                create_task(refresh())
+        if not callable(refresh):
+            return
+
+        create_task = getattr(hass, "async_create_task", None)
+        if not callable(create_task):
+            return
+
+        def _spawn_refresh_task() -> None:
+            """Clear the debounce handle, then create the single refresh task."""
+            # Clear first so a trigger after the window arms a fresh timer.
+            self._eid_refresh_debounce_handle = None
+            create_task(refresh())
+
+        loop = getattr(hass, "loop", None)
+        call_later = getattr(loop, "call_later", None)
+        if not callable(call_later):
+            # No event loop available (e.g. minimal stubs): fall back to the
+            # legacy immediate behaviour so a refresh is never lost.
+            create_task(refresh())
+            return
+
+        # A timer is already pending for this window: coalesce this trigger.
+        if getattr(self, "_eid_refresh_debounce_handle", None) is not None:
+            return
+
+        self._eid_refresh_debounce_handle = call_later(
+            _EID_REFRESH_DEBOUNCE_S, _spawn_refresh_task
+        )
 
     def _register_identity_key(
         self, device_id: str, identity_key: bytes

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -1133,6 +1133,21 @@ class GoogleFindMyCoordinator(
         if stats_save_task and not stats_save_task.done():
             stats_save_task.cancel()
 
+        # Cancel pending EID-resolver refresh debounce timers so no
+        # ``call_later`` callback fires (and creates a task) after unload.
+        for attr in (
+            "_eid_refresh_debounce_handle",
+            "_eid_inline_refresh_debounce_handle",
+        ):
+            handle = getattr(self, attr, None)
+            if handle is not None:
+                try:
+                    handle.cancel()
+                except Exception:
+                    pass
+                finally:
+                    setattr(self, attr, None)
+
         await self._async_unload()
 
     async def _async_unload(self) -> None:

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -1643,91 +1643,82 @@ class GoogleFindMyEIDResolver:
             )
         return generated
 
-    @staticmethod
-    def _rotation_time_counters(now_unix: int) -> tuple[tuple[int, int], ...]:
-        """Return ``(period, now_unix // period)`` for every rotation period.
-
-        One ``time_counter`` term per rotation period actually used by the
-        generator (1024 s standard, 900 s and 3600 s phone windows), sorted by
-        period for a stable order. These terms are essential to the build
-        signature: a single 1024 s term would miss the 900 s / 3600 s
-        phone-window rollovers and leave those trackers unresolvable (F5).
-        Because ``ROTATION_PERIOD_3600 == 4 * ROTATION_PERIOD_900``, the 3600 s
-        term can never roll over in isolation, but it is kept as an explicit,
-        independent term so the signature stays correct if the periods change.
-        """
-
-        return tuple(
-            (period, now_unix // period)
-            for period in sorted(
-                (ROTATION_PERIOD, ROTATION_PERIOD_900, ROTATION_PERIOD_3600)
-            )
-        )
-
-    def _build_signature(self, work_items: list[WorkItem], *, now_unix: int) -> str:
+    def _build_signature(
+        self,
+        work_items: list[WorkItem],
+        *,
+        now_unix: int,
+        params: RotationParams,
+    ) -> str:
         """Return a deterministic signature of the active-device build inputs.
 
         The signature is the skip-guard key for the expensive build phase: if it
         is unchanged, re-running the build would reproduce a byte-identical
         lookup table, so it can be safely skipped.
 
-        It hashes the per-period rotation ``time_counter`` terms from
-        ``_rotation_time_counters`` plus, for every work item, the fields the
-        build output actually depends on. The plan named the five core fields
-        ``(registry_id, key_bytes, locked_variant, basis_hint, rotation_ts)``;
-        this implementation additionally folds in the other build-output inputs
-        carried by the work item so the skip can never produce a stale table
-        (the explicit correctness-preserving / bit-identical constraint
-        overrides the narrower field list -- see AP-B1 report, SA-8 breadth):
+        Correctness model (Variant B -- fold the computed specs, not a time
+        formula). The expensive, skipped part of the build is the per-variant
+        crypto in ``_generate_eids_from_spec`` / ``_compute_flags_xor_mask``. Its
+        only inputs are the ``VariantSpec`` items the build loop fans out, which
+        are a deterministic, *pure* function of each work item and ``now_unix``:
+        ``_compute_time_windows`` (-> ``_compute_lock_windows`` /
+        ``_compute_relative_windows`` / ``_dedupe_windows``) reads the learned
+        ``_known_offsets`` snapshot but mutates no resolver state, and
+        ``_compute_variants`` is pure. The signature therefore replays exactly
+        that window/variant derivation and folds its *content* in: if the spec
+        set is identical the crypto output is byte-identical, so the skip is
+        correct by construction.
 
-        * ``canonical_id`` / ``config_entry_id`` -- emitted into every
-          ``EIDMatch`` produced for the item;
-        * ``identity.pair_date`` / ``identity.secrets_creation_date`` -- the
-          relative-window anchors used in ``_compute_relative_windows``;
-        * the learned ``_known_offsets`` entries for the item's ``registry_id``
-          -- they narrow the scan window in ``_compute_relative_windows``.
+        Folding the realized window timestamps (rather than a ``now_unix //
+        period`` term) closes the phase-relative drift gap: the lock-tracking
+        index is ``(now_unix - created_at) // period`` and the relative index is
+        ``(now_unix - anchor) // period``, so a non-period-aligned anchor rolls
+        a drift window at a different ``now_unix`` than the absolute rollover --
+        two clocks could share the old absolute-counter signature yet need
+        different window sets. By hashing the windows the build actually
+        produces, a missing or added drift window always changes the digest.
 
-        Sorting makes the digest independent of identity iteration order.
+        Per work item the digest additionally folds the identity fields that
+        reach the build output but never the window math -- ``registry_id`` /
+        ``canonical_id`` / ``config_entry_id`` are emitted verbatim into every
+        ``EIDMatch``. Sorting makes the digest independent of iteration order.
         """
 
         hasher = hashlib.blake2b(digest_size=32)
-        # Per-period rotation counters. Each term flips when its rotation window
-        # advances, forcing a rebuild on rollover.
-        for period, counter in self._rotation_time_counters(now_unix):
-            hasher.update(b"P")
-            hasher.update(f"{period}:{counter}".encode())
 
         def _item_key(item: WorkItem) -> tuple[str, ...]:
-            variant = "" if item.locked_variant is None else item.locked_variant.value
-            basis = "" if item.basis_hint is None else item.basis_hint
-            rotation = "" if item.rotation_ts is None else str(item.rotation_ts)
-            pair_date = (
-                "" if item.identity.pair_date is None else str(item.identity.pair_date)
-            )
-            secrets_date = (
-                ""
-                if item.identity.secrets_creation_date is None
-                else str(item.identity.secrets_creation_date)
-            )
-            # Learned offsets keyed by (registry_id, basis) for this item, sorted
-            # for stability and serialized into one field.
-            offsets = ";".join(
-                f"{offset_basis}={offset}"
-                for (reg, offset_basis), offset in sorted(self._known_offsets.items())
-                if reg == item.registry_id
-            )
-            return (
+            # Identity fields that flow straight into ``EIDMatch`` output but are
+            # invisible to the window/variant derivation below.
+            fields: list[str] = [
                 item.registry_id,
-                item.key_bytes.hex(),
-                variant,
-                basis,
-                rotation,
                 item.canonical_id,
                 item.config_entry_id,
-                pair_date,
-                secrets_date,
-                offsets,
+                item.key_bytes.hex(),
+                "" if item.locked_variant is None else item.locked_variant.value,
+            ]
+            # Replay the pure window/variant derivation and fold the realized
+            # specs. ``_compute_time_windows`` is read-only with respect to
+            # ``self`` (it only reads the ``_known_offsets`` snapshot); see the
+            # AP-C offload contract. The realized spec set fully determines the
+            # skipped crypto output, so identical specs => identical lookup.
+            windows, invalid_hint = self._compute_time_windows(
+                item, now_unix=now_unix, params=params
             )
+            fields.append("1" if invalid_hint else "0")
+            for window in windows:
+                for variant_spec in self._compute_variants(item, window):
+                    fields.append(
+                        "|".join(
+                            (
+                                variant_spec.variant.value,
+                                str(int(variant_spec.include_reverse)),
+                                window.time_basis,
+                                str(variant_spec.window.timestamp),
+                                str(variant_spec.window.semantic_offset),
+                            )
+                        )
+                    )
+            return tuple(fields)
 
         for key in sorted(_item_key(item) for item in work_items):
             hasher.update(b"W")
@@ -1768,7 +1759,9 @@ class GoogleFindMyEIDResolver:
         # signature means the hint state is unchanged; any newly invalid hint
         # changes ``basis_hint`` (read back from _known_timebases), which changes
         # the signature and forces a rebuild that runs the pop.
-        build_signature = self._build_signature(work_items, now_unix=now_unix)
+        build_signature = self._build_signature(
+            work_items, now_unix=now_unix, params=rotation_params
+        )
         if self._last_build_signature == build_signature:
             _LOGGER.debug(
                 "Refresh stage: build signature unchanged, skipping rebuild "
@@ -2007,6 +2000,7 @@ class GoogleFindMyEIDResolver:
         basis: HeuristicBasis,
         variant: EidVariant,
         anchor: int | None,
+        drift_offsets: tuple[int, ...] = (-1, 0, 1),
     ) -> list[HeuristicEidResult]:
         """Memoized wrapper around ``generate_heuristic_eid`` (AP-SWEEP).
 
@@ -2026,8 +2020,11 @@ class GoogleFindMyEIDResolver:
         ``(t // period) * period`` over the same time value the crypto aligns
         (``now_unix`` for ABSOLUTE, ``now_unix - anchor`` for RELATIVE).
         Invalidation is implicit: a new window or re-keying yields a fresh key
-        and stale entries age out via the LRU. ``drift_offsets`` is the
-        constant default at both call sites, so it is not part of the key.
+        and stale entries age out via the LRU. ``drift_offsets`` defaults to the
+        same value the underlying generator uses; it is folded into the key (and
+        forwarded explicitly rather than relying on the callee default) so a
+        future caller that varies it can never be served a stale entry. The
+        added key cardinality is negligible (one constant tuple in practice).
         """
 
         if basis == HeuristicBasis.RELATIVE and anchor is not None and anchor > 0:
@@ -2047,6 +2044,7 @@ class GoogleFindMyEIDResolver:
             basis,
             variant,
             anchor,
+            drift_offsets,
         )
         cached = self._heuristic_memo.get(cache_key)
         if cached is not None:
@@ -2059,6 +2057,7 @@ class GoogleFindMyEIDResolver:
             basis=basis,
             variant=variant,
             anchor=anchor,
+            drift_offsets=drift_offsets,
         )
         self._heuristic_memo.put(cache_key, results)
         return results

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -40,6 +40,7 @@ from .FMDNCrypto.eid_generator import (
     ROTATION_PERIOD_3600,
     EidVariant,
     HeuristicBasis,
+    HeuristicEidResult,
     compute_flags_xor_mask,
     generate_eid_variant,
     generate_heuristic_eid,
@@ -112,6 +113,25 @@ _EID_MEMO_MAXSIZE = 512
 # _EID_MASK_MEMO_MAXSIZE = 512: same dimensioning; mask key cardinality is
 # <= devices x windows x 2 curves < 512 (no per-variant fan-out for the mask).
 _EID_MASK_MEMO_MAXSIZE = 512
+
+# Heuristic phone-discovery memoization (AP-SWEEP).
+# ``generate_heuristic_eid`` is the on-loop sibling of the build-side crypto: it
+# runs inside ``_resolve_eid_internal`` -> ``_heuristic_resolve`` on every
+# cache-miss FMDN advertisement (an HA-Bluetooth callback that fires on the
+# event loop for EVERY advertisement). The slow path fans out over
+# HEURISTIC_HYPOTHESES x HEURISTIC_VARIANTS_TO_TEST (4 x 4) and each call derives
+# several EC points, yet its result list is a pure function of the rotation-
+# aligned time window plus the hypothesis parameters. Consecutive advertisements
+# from the same nearby phone fall in the same window and recompute identical
+# lists; a bounded LRU per resolver instance collapses that into a dict lookup
+# while staying byte-exact (the key carries every output-determining parameter,
+# so a window-boundary mismatch can only cause a benign miss, never a stale hit).
+#
+# _HEURISTIC_MEMO_MAXSIZE = 256: <= identities (~13) x hypotheses (4) x variants
+# (4) x ~2 concurrently live windows ~= 416 worst case for the learned + slow
+# paths combined, but in practice only a handful of phones reach the slow path;
+# 256 covers the realistic working set with LRU headroom and bounds memory.
+_HEURISTIC_MEMO_MAXSIZE = 256
 
 
 class _BoundedLRUCache:
@@ -826,6 +846,13 @@ class GoogleFindMyEIDResolver:
         init=False,
         default_factory=lambda: _BoundedLRUCache(_EID_MASK_MEMO_MAXSIZE),
     )
+    # On-loop heuristic phone-discovery memoization (AP-SWEEP). Same shape as the
+    # two AP-A caches; absorbs the per-advertisement ``generate_heuristic_eid``
+    # fan-out on the resolve hot path.
+    _heuristic_memo: _BoundedLRUCache = field(
+        init=False,
+        default_factory=lambda: _BoundedLRUCache(_HEURISTIC_MEMO_MAXSIZE),
+    )
     # Deterministic signature of the last successful build phase (AP-B1).
     # ``None`` means "no successful build yet", so the first refresh never
     # skips. Declared as a slots-backed dataclass field; stubs that bypass
@@ -890,6 +917,9 @@ class GoogleFindMyEIDResolver:
             self._eid_memo = _BoundedLRUCache(_EID_MEMO_MAXSIZE)
         if not hasattr(self, "_flags_mask_memo"):
             self._flags_mask_memo = _BoundedLRUCache(_EID_MASK_MEMO_MAXSIZE)
+        # On-loop heuristic discovery memoization (AP-SWEEP), same guard.
+        if not hasattr(self, "_heuristic_memo"):
+            self._heuristic_memo = _BoundedLRUCache(_HEURISTIC_MEMO_MAXSIZE)
         # Build-phase skip-guard signature (AP-B1). Same hasattr guard as the
         # AP-A memo caches so stubs that bypass __init__ get the default too.
         if not hasattr(self, "_last_build_signature"):
@@ -1968,6 +1998,71 @@ class GoogleFindMyEIDResolver:
         self._flags_mask_memo.put(cache_key, mask)
         return mask
 
+    def _generate_heuristic_eid(  # noqa: PLR0913
+        self,
+        key_bytes: bytes,
+        now_unix: int,
+        *,
+        rotation_period: int,
+        basis: HeuristicBasis,
+        variant: EidVariant,
+        anchor: int | None,
+    ) -> list[HeuristicEidResult]:
+        """Memoized wrapper around ``generate_heuristic_eid`` (AP-SWEEP).
+
+        ``generate_heuristic_eid`` runs on the event loop for every cache-miss
+        FMDN advertisement (``_resolve_eid_internal`` -> ``_heuristic_resolve``).
+        Its output list is a pure function of the rotation-aligned time window
+        and the hypothesis parameters, so consecutive advertisements from the
+        same nearby phone within one window recompute identical lists. This
+        wrapper turns that repeat into a dict lookup.
+
+        The cache key carries every parameter that influences the output --
+        ``key_bytes``, the rotation-aligned window start, ``rotation_period``,
+        ``basis``, ``variant`` and ``anchor`` -- so a stale value can never be
+        served: a window-boundary rounding difference can at worst miss the
+        cache and recompute (still byte-exact), never collide across distinct
+        inputs. The window start mirrors ``_align_to_rotation_flexible``'s
+        ``(t // period) * period`` over the same time value the crypto aligns
+        (``now_unix`` for ABSOLUTE, ``now_unix - anchor`` for RELATIVE).
+        Invalidation is implicit: a new window or re-keying yields a fresh key
+        and stale entries age out via the LRU. ``drift_offsets`` is the
+        constant default at both call sites, so it is not part of the key.
+        """
+
+        if basis == HeuristicBasis.RELATIVE and anchor is not None and anchor > 0:
+            aligned_source = max(now_unix - anchor, 0)
+        else:
+            aligned_source = now_unix
+        window_start = (
+            (aligned_source // rotation_period) * rotation_period
+            if rotation_period > 0
+            else aligned_source
+        )
+
+        cache_key = (
+            key_bytes,
+            window_start,
+            rotation_period,
+            basis,
+            variant,
+            anchor,
+        )
+        cached = self._heuristic_memo.get(cache_key)
+        if cached is not None:
+            return cast(list[HeuristicEidResult], cached)
+
+        results = generate_heuristic_eid(
+            key_bytes,
+            now_unix,
+            rotation_period=rotation_period,
+            basis=basis,
+            variant=variant,
+            anchor=anchor,
+        )
+        self._heuristic_memo.put(cache_key, results)
+        return results
+
     async def _collect_device_secrets(self) -> list[DeviceIdentity]:
         """Retrieve active tracker identities from all loaded coordinators."""
         bucket = self.hass.data.get(DOMAIN)
@@ -2333,7 +2428,7 @@ class GoogleFindMyEIDResolver:
         anchor = self._get_best_anchor(identity)
 
         try:
-            results = generate_heuristic_eid(
+            results = self._generate_heuristic_eid(
                 key_bytes,
                 now_unix,
                 rotation_period=learned.rotation_period,
@@ -2402,7 +2497,7 @@ class GoogleFindMyEIDResolver:
 
             for variant in HEURISTIC_VARIANTS_TO_TEST:
                 try:
-                    results = generate_heuristic_eid(
+                    results = self._generate_heuristic_eid(
                         key_bytes,
                         now_unix,
                         rotation_period=rotation_period,

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import threading
 import time
+from collections import OrderedDict
 from collections.abc import Coroutine, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, cast, runtime_checkable
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.event import async_call_later, async_track_time_interval
@@ -91,6 +93,72 @@ _VARIANT_CURVE_PARAMS: dict[EidVariant, tuple[int, int | None]] = {
     EidVariant.MODERN_P256_X32_LE_SCALAR: (MODERN_EID_LENGTH, P256_ORDER),
     EidVariant.MODERN_P256_X20_TRUNC_LE: (MODERN_EID_LENGTH, P256_ORDER),
 }
+
+# Per-variant crypto memoization (AP-A).
+# Both EID derivation (generate_eid_variant) and the flags XOR mask
+# (compute_flags_xor_mask) are pure functions of their inputs and run once per
+# (key, time_counter, variant/curve) tuple on every rotation refresh. A bounded
+# LRU per resolver instance turns the repeated within-rotation and
+# back-to-back-refresh recomputation into a dict lookup while staying byte-exact.
+#
+# functools.lru_cache is deliberately NOT used: as a method decorator it keys on
+# ``self`` (and pins it), leaking the resolver and preventing per-instance caches.
+# The minimal OrderedDict+Lock helper below keys only on the crypto inputs.
+#
+# _EID_MEMO_MAXSIZE = 512: 13 devices x 5 variants x 4 concurrently live
+# time_counter windows ~= 260, x ~2 headroom -> 512 (next power of two).
+_EID_MEMO_MAXSIZE = 512
+# _EID_MASK_MEMO_MAXSIZE = 512: same dimensioning; mask key cardinality is
+# <= devices x windows x 2 curves < 512 (no per-variant fan-out for the mask).
+_EID_MASK_MEMO_MAXSIZE = 512
+
+
+class _BoundedLRUCache:
+    """Thread-safe bounded LRU keyed on hashable crypto inputs.
+
+    A tiny instance-bound replacement for ``functools.lru_cache`` that keys on
+    explicit input tuples rather than ``self``. The lock guards only the
+    OrderedDict lookup/store, never the wrapped crypto call, so concurrent
+    worker threads (AP-C) can run the actual derivation in parallel and only
+    serialize on the cheap dict access.
+    """
+
+    def __init__(self, maxsize: int) -> None:
+        """Initialize an empty cache bounded to ``maxsize`` entries."""
+
+        self._maxsize = maxsize
+        self._store: OrderedDict[Any, Any] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(self, key: Any) -> Any:
+        """Return the cached value for ``key`` or ``None`` on a miss.
+
+        ``None`` is never stored as a value, so a ``None`` return is an
+        unambiguous miss signal for the callers in this module.
+        """
+
+        with self._lock:
+            if key not in self._store:
+                return None
+            # Mark as most-recently-used.
+            self._store.move_to_end(key)
+            return self._store[key]
+
+    def put(self, key: Any, value: Any) -> None:
+        """Store ``value`` under ``key``, evicting the LRU entry past maxsize."""
+
+        with self._lock:
+            self._store[key] = value
+            self._store.move_to_end(key)
+            while len(self._store) > self._maxsize:
+                self._store.popitem(last=False)
+
+    def __len__(self) -> int:
+        """Return the current number of cached entries."""
+
+        with self._lock:
+            return len(self._store)
+
 
 # Strategy Configuration
 # ENABLE_ABSOLUTE_UNIX_BASIS: If True, scans for EIDs based on absolute Unix time (Deep Scan).
@@ -752,6 +820,16 @@ class GoogleFindMyEIDResolver:
     )
     _ble_scan_info: dict[str, BLEScanInfo] = field(init=False, default_factory=dict)
     _cached_identities: list[DeviceIdentity] = field(init=False, default_factory=list)
+    # Per-variant crypto memoization caches (AP-A). Declared as slots-backed
+    # dataclass fields; stubs that bypass __init__ get them seeded by
+    # _ensure_cache_defaults under its hasattr guard.
+    _eid_memo: _BoundedLRUCache = field(
+        init=False, default_factory=lambda: _BoundedLRUCache(_EID_MEMO_MAXSIZE)
+    )
+    _flags_mask_memo: _BoundedLRUCache = field(
+        init=False,
+        default_factory=lambda: _BoundedLRUCache(_EID_MASK_MEMO_MAXSIZE),
+    )
 
     def __post_init__(self) -> None:
         """Set up caches and schedule the first rotation-aligned refresh."""
@@ -804,6 +882,13 @@ class GoogleFindMyEIDResolver:
             self._ble_scan_info = {}
         if not hasattr(self, "_cached_identities"):
             self._cached_identities = []
+        # Per-variant crypto memoization caches (AP-A). Initialized here under
+        # the same hasattr guard as the _known_* defaults so stubs that bypass
+        # __init__ (and call _ensure_cache_defaults directly) get them too.
+        if not hasattr(self, "_eid_memo"):
+            self._eid_memo = _BoundedLRUCache(_EID_MEMO_MAXSIZE)
+        if not hasattr(self, "_flags_mask_memo"):
+            self._flags_mask_memo = _BoundedLRUCache(_EID_MASK_MEMO_MAXSIZE)
 
     def _clear_lock_state(self, device_id: str) -> bool:
         """Remove all cached state associated with a device lock."""
@@ -1562,7 +1647,7 @@ class GoogleFindMyEIDResolver:
                         variant_spec.variant, (LEGACY_EID_LENGTH, None)
                     )
                     try:
-                        xor_mask = compute_flags_xor_mask(
+                        xor_mask = self._compute_flags_xor_mask(
                             variant_spec.key_bytes,
                             variant_spec.window.timestamp,
                             curve_byte_len=curve_len,
@@ -1653,14 +1738,63 @@ class GoogleFindMyEIDResolver:
         time_counter: int,
         variant: EidVariant,
     ) -> bytes:
-        """Generate an EID for a specific profile."""
+        """Generate an EID for a specific profile.
 
-        return generate_eid_variant(
+        Memoized per resolver instance on ``(key_bytes, time_counter,
+        variant)``. The derivation is pure, so a hit returns the byte-identical
+        EID without recomputation. Cache invalidation is implicit: key rotation
+        changes ``time_counter`` and re-keying changes ``key_bytes``, both of
+        which produce a fresh key and let stale entries age out via the LRU.
+        """
+
+        cache_key = (key_bytes, time_counter, variant)
+        cached = self._eid_memo.get(cache_key)
+        if cached is not None:
+            return cast(bytes, cached)
+
+        # Compute outside the cache lock so parallel workers (AP-C) are not
+        # serialized on the crypto call.
+        eid_bytes = generate_eid_variant(
             key_bytes,
             time_counter,
             variant,
             strict=False,
         )
+        self._eid_memo.put(cache_key, eid_bytes)
+        return eid_bytes
+
+    def _compute_flags_xor_mask(
+        self,
+        key_bytes: bytes,
+        time_counter: int,
+        *,
+        curve_byte_len: int,
+        curve_order: int | None,
+    ) -> int:
+        """Memoized wrapper around ``compute_flags_xor_mask``.
+
+        Keyed per resolver instance on ``(key_bytes, time_counter,
+        curve_byte_len, curve_order)``. The mask is a pure function of these
+        inputs, so a hit returns the identical integer without recomputation.
+        Invalidation is implicit via key rotation, identical to
+        ``_generate_variant``.
+        """
+
+        cache_key = (key_bytes, time_counter, curve_byte_len, curve_order)
+        cached = self._flags_mask_memo.get(cache_key)
+        if cached is not None:
+            return cast(int, cached)
+
+        # Compute outside the cache lock so parallel workers (AP-C) are not
+        # serialized on the crypto call.
+        mask = compute_flags_xor_mask(
+            key_bytes,
+            time_counter,
+            curve_byte_len=curve_byte_len,
+            curve_order=curve_order,
+        )
+        self._flags_mask_memo.put(cache_key, mask)
+        return mask
 
     async def _collect_device_secrets(self) -> list[DeviceIdentity]:
         """Retrieve active tracker identities from all loaded coordinators."""

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -10,6 +10,7 @@ outside the hot path; ``resolve_eid`` only performs lookups.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import math
 import threading
@@ -830,6 +831,11 @@ class GoogleFindMyEIDResolver:
         init=False,
         default_factory=lambda: _BoundedLRUCache(_EID_MASK_MEMO_MAXSIZE),
     )
+    # Deterministic signature of the last successful build phase (AP-B1).
+    # ``None`` means "no successful build yet", so the first refresh never
+    # skips. Declared as a slots-backed dataclass field; stubs that bypass
+    # __init__ get it seeded by _ensure_cache_defaults under its hasattr guard.
+    _last_build_signature: str | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         """Set up caches and schedule the first rotation-aligned refresh."""
@@ -889,6 +895,10 @@ class GoogleFindMyEIDResolver:
             self._eid_memo = _BoundedLRUCache(_EID_MEMO_MAXSIZE)
         if not hasattr(self, "_flags_mask_memo"):
             self._flags_mask_memo = _BoundedLRUCache(_EID_MASK_MEMO_MAXSIZE)
+        # Build-phase skip-guard signature (AP-B1). Same hasattr guard as the
+        # AP-A memo caches so stubs that bypass __init__ get the default too.
+        if not hasattr(self, "_last_build_signature"):
+            self._last_build_signature = None
 
     def _clear_lock_state(self, device_id: str) -> bool:
         """Remove all cached state associated with a device lock."""
@@ -1608,6 +1618,100 @@ class GoogleFindMyEIDResolver:
             )
         return generated
 
+    @staticmethod
+    def _rotation_time_counters(now_unix: int) -> tuple[tuple[int, int], ...]:
+        """Return ``(period, now_unix // period)`` for every rotation period.
+
+        One ``time_counter`` term per rotation period actually used by the
+        generator (1024 s standard, 900 s and 3600 s phone windows), sorted by
+        period for a stable order. These terms are essential to the build
+        signature: a single 1024 s term would miss the 900 s / 3600 s
+        phone-window rollovers and leave those trackers unresolvable (F5).
+        Because ``ROTATION_PERIOD_3600 == 4 * ROTATION_PERIOD_900``, the 3600 s
+        term can never roll over in isolation, but it is kept as an explicit,
+        independent term so the signature stays correct if the periods change.
+        """
+
+        return tuple(
+            (period, now_unix // period)
+            for period in sorted(
+                (ROTATION_PERIOD, ROTATION_PERIOD_900, ROTATION_PERIOD_3600)
+            )
+        )
+
+    def _build_signature(self, work_items: list[WorkItem], *, now_unix: int) -> str:
+        """Return a deterministic signature of the active-device build inputs.
+
+        The signature is the skip-guard key for the expensive build phase: if it
+        is unchanged, re-running the build would reproduce a byte-identical
+        lookup table, so it can be safely skipped.
+
+        It hashes the per-period rotation ``time_counter`` terms from
+        ``_rotation_time_counters`` plus, for every work item, the fields the
+        build output actually depends on. The plan named the five core fields
+        ``(registry_id, key_bytes, locked_variant, basis_hint, rotation_ts)``;
+        this implementation additionally folds in the other build-output inputs
+        carried by the work item so the skip can never produce a stale table
+        (the explicit correctness-preserving / bit-identical constraint
+        overrides the narrower field list -- see AP-B1 report, SA-8 breadth):
+
+        * ``canonical_id`` / ``config_entry_id`` -- emitted into every
+          ``EIDMatch`` produced for the item;
+        * ``identity.pair_date`` / ``identity.secrets_creation_date`` -- the
+          relative-window anchors used in ``_compute_relative_windows``;
+        * the learned ``_known_offsets`` entries for the item's ``registry_id``
+          -- they narrow the scan window in ``_compute_relative_windows``.
+
+        Sorting makes the digest independent of identity iteration order.
+        """
+
+        hasher = hashlib.blake2b(digest_size=32)
+        # Per-period rotation counters. Each term flips when its rotation window
+        # advances, forcing a rebuild on rollover.
+        for period, counter in self._rotation_time_counters(now_unix):
+            hasher.update(b"P")
+            hasher.update(f"{period}:{counter}".encode())
+
+        def _item_key(item: WorkItem) -> tuple[str, ...]:
+            variant = "" if item.locked_variant is None else item.locked_variant.value
+            basis = "" if item.basis_hint is None else item.basis_hint
+            rotation = "" if item.rotation_ts is None else str(item.rotation_ts)
+            pair_date = (
+                "" if item.identity.pair_date is None else str(item.identity.pair_date)
+            )
+            secrets_date = (
+                ""
+                if item.identity.secrets_creation_date is None
+                else str(item.identity.secrets_creation_date)
+            )
+            # Learned offsets keyed by (registry_id, basis) for this item, sorted
+            # for stability and serialized into one field.
+            offsets = ";".join(
+                f"{offset_basis}={offset}"
+                for (reg, offset_basis), offset in sorted(self._known_offsets.items())
+                if reg == item.registry_id
+            )
+            return (
+                item.registry_id,
+                item.key_bytes.hex(),
+                variant,
+                basis,
+                rotation,
+                item.canonical_id,
+                item.config_entry_id,
+                pair_date,
+                secrets_date,
+                offsets,
+            )
+
+        for key in sorted(_item_key(item) for item in work_items):
+            hasher.update(b"W")
+            for field_value in key:
+                hasher.update(field_value.encode())
+                hasher.update(b"\x00")
+
+        return hasher.hexdigest()
+
     async def _refresh_cache(self) -> None:
         """Rebuild the EID lookup table for all active devices."""
 
@@ -1625,6 +1729,30 @@ class GoogleFindMyEIDResolver:
         _LOGGER.debug("Refresh start: %d identities discovered", len(identities))
         work_items = self._collect_work_items(identities, now_unix=now_unix)
         _LOGGER.debug("Refresh stage: collected %d work items", len(work_items))
+
+        # Skip-guard (AP-B1): the build phase below is a pure function of the
+        # work items and the per-period rotation counters. When the signature is
+        # unchanged, rebuilding would reproduce a byte-identical lookup table, so
+        # we keep the existing one and skip the expensive CacheBuilder fan-out.
+        # The cheap mandatory side effects above (_purge_stale_locks,
+        # _cached_identities, _collect_device_secrets) and the invalid-hint
+        # bookkeeping in _collect_work_items still run on every trigger. The
+        # build-loop's own ``_known_timebases.pop`` (invalid-hint) is safe to
+        # skip: ``invalid_hint`` is a pure function of the work item's
+        # ``basis_hint`` (plus its lock-derived window basis), so an unchanged
+        # signature means the hint state is unchanged; any newly invalid hint
+        # changes ``basis_hint`` (read back from _known_timebases), which changes
+        # the signature and forces a rebuild that runs the pop.
+        build_signature = self._build_signature(work_items, now_unix=now_unix)
+        if self._last_build_signature == build_signature:
+            _LOGGER.debug(
+                "Refresh stage: build signature unchanged, skipping rebuild "
+                "(%d work items, %d cached EIDs)",
+                len(work_items),
+                len(self._lookup),
+            )
+            return
+
         builder = CacheBuilder()
         _yield_deadline = time.monotonic() + _YIELD_BUDGET_SECONDS
 
@@ -1679,6 +1807,9 @@ class GoogleFindMyEIDResolver:
                 _yield_deadline = time.monotonic() + _YIELD_BUDGET_SECONDS
 
         self._lookup, self._lookup_metadata = builder.finalize()
+        # Record the signature only after a successful build so a failure leaves
+        # the guard cleared and the next trigger rebuilds (AP-B1).
+        self._last_build_signature = build_signature
         _LOGGER.debug(
             "Refresh stage: finalize complete (lookup=%d, metadata=%d)",
             len(self._lookup),

--- a/custom_components/googlefindmy/eid_resolver.py
+++ b/custom_components/googlefindmy/eid_resolver.py
@@ -189,11 +189,6 @@ KNOWN_OFFSET_KEY_LENGTH = 2
 # of clock drift at 1024s rotation.
 LOCK_TRACKING_WINDOW_STEPS = 2
 
-# Maximum wall-clock time (seconds) the EID refresh loop may run before
-# yielding control back to the event loop via ``await asyncio.sleep(0)``.
-# Keeps the main thread responsive under HA's 10 ms watchdog budget.
-_YIELD_BUDGET_SECONDS: float = 0.008
-
 # =============================================================================
 # Heuristic Phone Discovery Configuration
 # =============================================================================
@@ -1753,15 +1748,79 @@ class GoogleFindMyEIDResolver:
             )
             return
 
+        # Offload the pure synchronous build to a worker thread (AP-C). The
+        # build block touches ``self`` only through the two thread-safe AP-A
+        # memo caches (``_eid_memo``/``_flags_mask_memo``), whose locks guard
+        # the dict access only, and reads the immutable learned ``_known_offsets``
+        # snapshot via ``_compute_time_windows``. Every genuine ``self.*``
+        # mutation stays on the loop: the invalid-hint ``_known_timebases.pop``
+        # below (driven by the registry ids returned from the build) and the
+        # ``_lookup``/``_lookup_metadata`` assignment after the executor returns.
+        # The cooperative ``asyncio.sleep(0)`` yield is gone because no event
+        # loop exists inside the worker thread; running the whole build off-loop
+        # keeps the loop reactive without per-item yields.
+        lookup, lookup_metadata, invalid_hint_ids = (
+            await self.hass.async_add_executor_job(
+                self._build_lookup_sync,
+                work_items,
+                now_unix,
+                rotation_params,
+            )
+        )
+
+        # Loop-side ``self.*`` mutations (single-threaded, no executor in flight).
+        for registry_id in invalid_hint_ids:
+            self._known_timebases.pop(registry_id, None)
+        self._lookup, self._lookup_metadata = lookup, lookup_metadata
+        # Record the signature only after a successful build so a failure leaves
+        # the guard cleared and the next trigger rebuilds (AP-B1).
+        self._last_build_signature = build_signature
+        _LOGGER.debug(
+            "Refresh stage: finalize complete (lookup=%d, metadata=%d)",
+            len(self._lookup),
+            len(self._lookup_metadata),
+        )
+        _LOGGER.debug(
+            "Refreshed EID cache for %d devices (%d cached EIDs)",
+            len(work_items),
+            len(self._lookup),
+        )
+
+    def _build_lookup_sync(
+        self,
+        work_items: list[WorkItem],
+        now_unix: int,
+        rotation_params: RotationParams,
+    ) -> tuple[
+        dict[bytes, list[EIDMatch]],
+        dict[bytes, dict[str, Any]],
+        list[str],
+    ]:
+        """Build the EID lookup table off the event loop (AP-C).
+
+        Pure synchronous build over the loop-side inputs ``work_items`` /
+        ``now_unix`` / ``rotation_params``. Designed to run inside a worker
+        thread via ``hass.async_add_executor_job``: it performs no ``await``,
+        touches no event loop, and mutates no resolver state except the two
+        thread-safe AP-A memo caches (``_eid_memo`` / ``_flags_mask_memo``),
+        which serialize only on the bounded dict access. ``_compute_time_windows``
+        and its callees read the learned ``_known_offsets`` snapshot but never
+        write it, and the ``CacheBuilder`` is thread-local to this call.
+
+        Returns the finalized ``(lookup, metadata)`` tables plus the list of
+        registry ids whose basis hint was invalid; the caller pops their
+        ``_known_timebases`` entries on the loop, where it is safe to mutate.
+        """
+
         builder = CacheBuilder()
-        _yield_deadline = time.monotonic() + _YIELD_BUDGET_SECONDS
+        invalid_hint_ids: list[str] = []
 
         for work_item in work_items:
             windows, invalid_hint = self._compute_time_windows(
                 work_item, now_unix=now_unix, params=rotation_params
             )
             if invalid_hint:
-                self._known_timebases.pop(work_item.registry_id, None)
+                invalid_hint_ids.append(work_item.registry_id)
             _LOGGER.debug(
                 "Refresh stage: %s produced %d window groups",
                 work_item.registry_id,
@@ -1800,26 +1859,8 @@ class GoogleFindMyEIDResolver:
                             flags_xor_mask=xor_mask,
                         )
 
-            # Cooperative yield: give the event loop a chance to process
-            # pending callbacks when the CPU budget for this tick is spent.
-            if time.monotonic() >= _yield_deadline:
-                await asyncio.sleep(0)
-                _yield_deadline = time.monotonic() + _YIELD_BUDGET_SECONDS
-
-        self._lookup, self._lookup_metadata = builder.finalize()
-        # Record the signature only after a successful build so a failure leaves
-        # the guard cleared and the next trigger rebuilds (AP-B1).
-        self._last_build_signature = build_signature
-        _LOGGER.debug(
-            "Refresh stage: finalize complete (lookup=%d, metadata=%d)",
-            len(self._lookup),
-            len(self._lookup_metadata),
-        )
-        _LOGGER.debug(
-            "Refreshed EID cache for %d devices (%d cached EIDs)",
-            len(work_items),
-            len(self._lookup),
-        )
+        lookup, lookup_metadata = builder.finalize()
+        return lookup, lookup_metadata, invalid_hint_ids
 
     def _normalize_variant_value(self, raw: object, *, eid_len: int) -> str:
         """Return a valid `EidVariant` value string for persistence."""

--- a/tests/test_eid_provisioning_counter.py
+++ b/tests/test_eid_provisioning_counter.py
@@ -7,6 +7,17 @@ from types import SimpleNamespace
 
 import pytest
 
+
+async def _run_in_executor(func, *args):
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C).
+
+    Runs the offloaded EID build inline so these correctness assertions keep
+    exercising the build surface; the executor-offload suite pins the genuine
+    worker-thread behavior.
+    """
+
+    return func(*args)
+
 from custom_components.googlefindmy.coordinator import DeviceIdentity
 from custom_components.googlefindmy.eid_resolver import (
     FMDN_FRAME_TYPE,
@@ -25,7 +36,9 @@ async def test_resolver_matches_unix_timebase(monkeypatch: pytest.MonkeyPatch) -
 
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = SimpleNamespace(
-        data={}, async_create_task=asyncio.create_task
+        data={},
+        async_create_task=asyncio.create_task,
+        async_add_executor_job=_run_in_executor,
     )
     resolver._lookup = {}
     resolver._lookup_metadata = {}

--- a/tests/test_eid_resolver.py
+++ b/tests/test_eid_resolver.py
@@ -26,12 +26,19 @@ def _close_coro(coro: object, name: object = None) -> None:
         coro.close()
 
 
+async def _run_in_executor(func, *args):
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C)."""
+
+    return func(*args)
+
+
 def _fake_hass() -> SimpleNamespace:
     """Return a lightweight hass stand-in with coroutine-closing helpers."""
 
     return SimpleNamespace(
         async_create_task=_close_coro,
         async_create_background_task=_close_coro,
+        async_add_executor_job=_run_in_executor,
         data={},
     )
 
@@ -114,6 +121,7 @@ async def test_resolver_saves_locks_via_store(monkeypatch: pytest.MonkeyPatch) -
     hass_with_real_tasks = SimpleNamespace(
         async_create_task=lambda coro, name=None: asyncio.create_task(coro),
         async_create_background_task=lambda coro, name=None: asyncio.create_task(coro),
+        async_add_executor_job=_run_in_executor,
         data={},
     )
 

--- a/tests/test_eid_resolver_characterization.py
+++ b/tests/test_eid_resolver_characterization.py
@@ -1,0 +1,136 @@
+# tests/test_eid_resolver_characterization.py
+"""Golden-gate characterization for the resolver EID derivation seam.
+
+This module pins the byte-exact EID output of the resolver seam
+``GoogleFindMyEIDResolver._generate_variant`` so that subsequent
+performance levers (memoization, skip-guards, work offloading) can prove
+they keep the derived EIDs bit-identical. The seam is the surface those
+levers will wrap, so we characterize it directly rather than only the
+underlying generator module. Each variant is anchored to a vector from
+``GOLDEN_VECTORS`` in ``tests/test_eid_generator_variants.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.googlefindmy.eid_resolver import GoogleFindMyEIDResolver
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    ROTATION_PERIOD,
+    EidVariant,
+    generate_eid_variant,
+)
+
+from .test_eid_generator_variants import (
+    GOLDEN_VECTORS,
+    SAMPLE_COUNTER,
+    SAMPLE_EIK,
+)
+
+
+def _build_resolver() -> GoogleFindMyEIDResolver:
+    """Construct a resolver without running __init__.
+
+    Production stubs and tests bypass ``__init__`` (which schedules timers
+    and storage I/O) and call ``_ensure_cache_defaults`` directly to
+    initialize the optional caches. ``_generate_variant`` is a pure wrapper
+    around ``generate_eid_variant`` and touches no instance state, so this
+    minimal construction is sufficient for the characterization pins.
+    """
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver._ensure_cache_defaults()
+    return resolver
+
+
+def test_seam_pins_golden_vectors_for_all_variants() -> None:
+    """The resolver seam must emit the golden hex EID for every variant.
+
+    GOLDEN_VECTORS covers all five EidVariant members; iterating it proves
+    the seam reproduces the canonical output for each one.
+    """
+
+    resolver = _build_resolver()
+
+    assert set(GOLDEN_VECTORS) == set(EidVariant)
+
+    for variant, expected_hex in GOLDEN_VECTORS.items():
+        eid = resolver._generate_variant(
+            SAMPLE_EIK,
+            time_counter=SAMPLE_COUNTER,
+            variant=variant,
+        )
+        assert eid.hex() == expected_hex
+
+
+def test_seam_matches_generator_module_per_variant() -> None:
+    """The seam must be bit-identical to generate_eid_variant per variant.
+
+    The seam delegates with ``strict=False``; for these in-range fixed
+    inputs the lenient path yields the same bytes as the default
+    ``generate_eid_variant`` call, which is what the golden vectors assert.
+    """
+
+    resolver = _build_resolver()
+
+    for variant in EidVariant:
+        seam_eid = resolver._generate_variant(
+            SAMPLE_EIK,
+            time_counter=SAMPLE_COUNTER,
+            variant=variant,
+        )
+        module_eid = generate_eid_variant(SAMPLE_EIK, SAMPLE_COUNTER, variant)
+        assert seam_eid == module_eid
+
+
+def test_seam_is_deterministic_for_repeated_inputs() -> None:
+    """The same (key_bytes, time_counter, variant) twice yields equal bytes.
+
+    Determinism is the precondition for memoization: a follow-up lever may
+    only cache the seam output if identical inputs always map to identical
+    bytes.
+    """
+
+    resolver = _build_resolver()
+
+    for variant in EidVariant:
+        first = resolver._generate_variant(
+            SAMPLE_EIK,
+            time_counter=SAMPLE_COUNTER,
+            variant=variant,
+        )
+        second = resolver._generate_variant(
+            SAMPLE_EIK,
+            time_counter=SAMPLE_COUNTER,
+            variant=variant,
+        )
+        assert first == second
+
+
+def test_seam_distinct_counters_yield_distinct_eids() -> None:
+    """Counters in different rotation windows must produce different EIDs.
+
+    This guards a future skip-guard / memoization lever against collapsing
+    distinct rotation windows onto a single cached EID. The offset is a full
+    ROTATION_PERIOD because counters inside the same window are masked to the
+    same value by design (see test_rotation_mask_equivalence_within_period).
+    """
+
+    resolver = _build_resolver()
+
+    variant = EidVariant.MODERN_P256_X32_BE
+    eid_a = resolver._generate_variant(
+        SAMPLE_EIK,
+        time_counter=SAMPLE_COUNTER,
+        variant=variant,
+    )
+    eid_b = resolver._generate_variant(
+        SAMPLE_EIK,
+        time_counter=SAMPLE_COUNTER + ROTATION_PERIOD,
+        variant=variant,
+    )
+    assert eid_a != eid_b
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_eid_resolver_debounce.py
+++ b/tests/test_eid_resolver_debounce.py
@@ -1,0 +1,383 @@
+# tests/test_eid_resolver_debounce.py
+"""Trigger-task debounce gate for EID-resolver refresh (AP-B2).
+
+Two distinct call sites each spawn an ``async_create_task`` that runs the
+global EID resolver's ``async_refresh``:
+
+* the central helper ``_schedule_eid_resolver_refresh`` in
+  ``coordinator/identity.py`` (driven by four read-only callers), and
+* the inline path ``_schedule_inline_eid_resolver_refresh`` in
+  ``coordinator/cache.py`` (driven from ``_persist_anchor_metadata`` when an
+  anchored payload carries an identity key).
+
+Under an FCM burst these triggers arrive back-to-back. AP-B2 adds a per-site
+task debounce that collapses a burst within ``_EID_REFRESH_DEBOUNCE_S`` to a
+single created task, while still arming a fresh timer (and thus a fresh task)
+for a trigger that arrives after the window. These tests pin three contracts
+per site:
+
+* **Burst coalescing** -- >= 3 triggers inside the window create <= 1 task.
+* **No swallowed window** -- a trigger after the window's timer has fired
+  creates exactly one further task.
+* **Independent fire** -- once the timer callback runs the resolver's
+  ``async_refresh`` coroutine is actually scheduled.
+
+These assertions count *task creation* (the ``async_create_task`` /
+``call_later`` seam), not refreshes; the resolver's own ``_pending_refresh``
+coalescing happens only after a task has started and is out of scope here.
+The byte-exact EID correctness lives in
+``tests/test_eid_resolver_characterization.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.const import (
+    _EID_REFRESH_DEBOUNCE_S,
+    DATA_EID_RESOLVER,
+    DOMAIN,
+)
+
+
+class _FakeLoop:
+    """Minimal event-loop stand-in capturing ``call_later`` scheduling.
+
+    ``call_later`` records the callback and returns a handle whose
+    ``cancel`` marks it cancelled. ``fire_all`` invokes every still-armed
+    callback once, mimicking the debounce window elapsing.
+    """
+
+    def __init__(self) -> None:
+        self.scheduled: list[tuple[float, Any, _FakeTimerHandle]] = []
+
+    def call_later(self, delay: float, callback: Any) -> _FakeTimerHandle:
+        handle = _FakeTimerHandle()
+        self.scheduled.append((delay, callback, handle))
+        return handle
+
+    def fire_all(self) -> None:
+        """Invoke all armed (non-cancelled) callbacks; drain the queue."""
+        pending = list(self.scheduled)
+        self.scheduled.clear()
+        for _delay, callback, handle in pending:
+            if not handle.cancelled:
+                callback()
+
+
+class _FakeTimerHandle:
+    """Stand-in for ``asyncio.TimerHandle`` recording cancellation."""
+
+    def __init__(self) -> None:
+        self.cancelled = False
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+def _fake_hass(eid_resolver: Any) -> SimpleNamespace:
+    """Return a hass stub with a fake loop and a task-counting create_task."""
+
+    created: list[Any] = []
+
+    def create_task(coro: Any, name: str | None = None) -> MagicMock:
+        created.append(coro)
+        if hasattr(coro, "close"):
+            coro.close()  # avoid un-awaited coroutine warnings
+        return MagicMock()
+
+    return SimpleNamespace(
+        async_create_task=create_task,
+        async_create_background_task=create_task,
+        loop=_FakeLoop(),
+        data={DOMAIN: {DATA_EID_RESOLVER: eid_resolver}},
+        _created_tasks=created,
+    )
+
+
+def _fake_resolver() -> SimpleNamespace:
+    """Return a resolver stub whose ``async_refresh`` yields a closeable coro."""
+
+    async def _async_refresh(payload: Any = None) -> None:
+        return None
+
+    return SimpleNamespace(async_refresh=_async_refresh)
+
+
+def _make_coordinator() -> Any:
+    """Create a minimal coordinator instance carrying both trigger sites."""
+
+    from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator.hass = _fake_hass(_fake_resolver())
+    coordinator._device_location_data = {}
+    coordinator._eid_refresh_debounce_handle = None
+    coordinator._eid_inline_refresh_debounce_handle = None
+    return coordinator
+
+
+# ---------------------------------------------------------------------------
+# Central helper site: _schedule_eid_resolver_refresh (identity.py)
+# ---------------------------------------------------------------------------
+
+
+def test_central_helper_coalesces_burst_to_single_task() -> None:
+    """>= 3 central-helper triggers inside the window create <= 1 task."""
+
+    coordinator = _make_coordinator()
+    loop: _FakeLoop = coordinator.hass.loop
+
+    for _ in range(5):
+        coordinator._schedule_eid_resolver_refresh()
+
+    # Burst armed exactly one timer and created no task yet.
+    assert len(loop.scheduled) == 1
+    assert loop.scheduled[0][0] == _EID_REFRESH_DEBOUNCE_S
+    assert len(coordinator.hass._created_tasks) == 0
+
+    # Window elapses -> exactly one task is created.
+    loop.fire_all()
+    assert len(coordinator.hass._created_tasks) == 1
+
+
+def test_central_helper_does_not_swallow_post_window_trigger() -> None:
+    """A central-helper trigger after the window fires creates one more task."""
+
+    coordinator = _make_coordinator()
+    loop: _FakeLoop = coordinator.hass.loop
+
+    coordinator._schedule_eid_resolver_refresh()
+    loop.fire_all()
+    assert len(coordinator.hass._created_tasks) == 1
+
+    # New window: a fresh trigger must arm a fresh timer and create a task.
+    coordinator._schedule_eid_resolver_refresh()
+    assert len(loop.scheduled) == 1
+    loop.fire_all()
+    assert len(coordinator.hass._created_tasks) == 2
+
+
+def test_central_helper_falls_back_without_loop() -> None:
+    """Without a usable loop the helper creates the task immediately (legacy)."""
+
+    coordinator = _make_coordinator()
+    coordinator.hass.loop = None  # no call_later available
+
+    coordinator._schedule_eid_resolver_refresh()
+    assert len(coordinator.hass._created_tasks) == 1
+
+
+# ---------------------------------------------------------------------------
+# Inline site: _schedule_inline_eid_resolver_refresh (cache.py)
+# ---------------------------------------------------------------------------
+
+
+def test_inline_site_coalesces_burst_to_single_task() -> None:
+    """>= 3 inline triggers inside the window create <= 1 task."""
+
+    coordinator = _make_coordinator()
+    loop: _FakeLoop = coordinator.hass.loop
+
+    for _ in range(4):
+        coordinator._schedule_inline_eid_resolver_refresh("dev-1")
+
+    assert len(loop.scheduled) == 1
+    assert loop.scheduled[0][0] == _EID_REFRESH_DEBOUNCE_S
+    assert len(coordinator.hass._created_tasks) == 0
+
+    loop.fire_all()
+    assert len(coordinator.hass._created_tasks) == 1
+
+
+def test_inline_site_does_not_swallow_post_window_trigger() -> None:
+    """An inline trigger after the window fires creates one more task."""
+
+    coordinator = _make_coordinator()
+    loop: _FakeLoop = coordinator.hass.loop
+
+    coordinator._schedule_inline_eid_resolver_refresh("dev-1")
+    loop.fire_all()
+    assert len(coordinator.hass._created_tasks) == 1
+
+    coordinator._schedule_inline_eid_resolver_refresh("dev-1")
+    assert len(loop.scheduled) == 1
+    loop.fire_all()
+    assert len(coordinator.hass._created_tasks) == 2
+
+
+def test_inline_site_triggered_via_persist_anchor_metadata() -> None:
+    """The public ``_persist_anchor_metadata`` path drives the inline debounce.
+
+    This proves the debounce sits on the real call site, not just on the
+    extracted helper: two anchored payloads carrying an identity key inside the
+    window still collapse to a single created task.
+    """
+
+    coordinator = _make_coordinator()
+    loop: _FakeLoop = coordinator.hass.loop
+
+    payload = {"identity_key": b"\x01" * 32, "pair_date": 1_765_910_348}
+    coordinator._persist_anchor_metadata("dev-1", dict(payload))
+    coordinator._persist_anchor_metadata("dev-1", dict(payload))
+
+    assert len(loop.scheduled) == 1
+    assert len(coordinator.hass._created_tasks) == 0
+
+    loop.fire_all()
+    assert len(coordinator.hass._created_tasks) == 1
+
+
+def test_persist_anchor_metadata_without_identity_key_schedules_nothing() -> None:
+    """An anchored payload without an identity key never arms the debounce."""
+
+    coordinator = _make_coordinator()
+    loop: _FakeLoop = coordinator.hass.loop
+
+    coordinator._persist_anchor_metadata("dev-1", {"pair_date": 1_765_910_348})
+
+    assert len(loop.scheduled) == 0
+    assert len(coordinator.hass._created_tasks) == 0
+
+
+def test_inline_site_falls_back_without_loop() -> None:
+    """Without a usable loop the inline path creates the task immediately."""
+
+    coordinator = _make_coordinator()
+    coordinator.hass.loop = None
+
+    coordinator._schedule_inline_eid_resolver_refresh("dev-1")
+    assert len(coordinator.hass._created_tasks) == 1
+
+
+# ---------------------------------------------------------------------------
+# Defensive guards: every early bail-out path must short-circuit cleanly
+# ---------------------------------------------------------------------------
+
+
+def _coordinator_without_resolver(**hass_overrides: Any) -> Any:
+    """Coordinator whose hass.data lacks a usable resolver, for guard tests."""
+
+    from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._device_location_data = {}
+    coordinator._eid_refresh_debounce_handle = None
+    coordinator._eid_inline_refresh_debounce_handle = None
+
+    created: list[Any] = []
+
+    def create_task(coro: Any, name: str | None = None) -> MagicMock:
+        created.append(coro)
+        if hasattr(coro, "close"):
+            coro.close()
+        return MagicMock()
+
+    base = {
+        "async_create_task": create_task,
+        "loop": _FakeLoop(),
+        "data": {},
+        "_created_tasks": created,
+    }
+    base.update(hass_overrides)
+    coordinator.hass = SimpleNamespace(**base)
+    return coordinator
+
+
+@pytest.mark.parametrize(
+    "scheduler",
+    ["_schedule_eid_resolver_refresh", "_schedule_inline_eid_resolver_refresh"],
+)
+def test_no_hass_short_circuits(scheduler: str) -> None:
+    """Either site bails out cleanly when ``self.hass`` is absent."""
+
+    from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._device_location_data = {}
+    coordinator._eid_refresh_debounce_handle = None
+    coordinator._eid_inline_refresh_debounce_handle = None
+    coordinator.hass = None  # type: ignore[assignment]
+
+    fn = getattr(coordinator, scheduler)
+    fn("dev-1") if "inline" in scheduler else fn()  # no raise = pass
+
+
+def test_inline_guards_bail_without_resolver_or_bucket() -> None:
+    """Inline site bails when the domain bucket / resolver is missing or unusable."""
+
+    # Non-dict bucket -> early return.
+    coord = _coordinator_without_resolver(data={DOMAIN: "not-a-dict"})
+    coord._schedule_inline_eid_resolver_refresh("dev-1")
+    assert len(coord.hass._created_tasks) == 0
+
+    # Bucket present but no resolver entry -> early return.
+    coord = _coordinator_without_resolver(data={DOMAIN: {}})
+    coord._schedule_inline_eid_resolver_refresh("dev-1")
+    assert len(coord.hass._created_tasks) == 0
+
+    # Resolver present but without a callable async_refresh -> early return.
+    coord = _coordinator_without_resolver(
+        data={DOMAIN: {DATA_EID_RESOLVER: SimpleNamespace(async_refresh=None)}}
+    )
+    coord._schedule_inline_eid_resolver_refresh("dev-1")
+    assert len(coord.hass._created_tasks) == 0
+
+    # Resolver usable but hass has no create_task -> early return.
+    coord = _coordinator_without_resolver(
+        data={DOMAIN: {DATA_EID_RESOLVER: _fake_resolver()}}
+    )
+    del coord.hass.async_create_task
+    coord._schedule_inline_eid_resolver_refresh("dev-1")
+    assert coord._eid_inline_refresh_debounce_handle is None
+
+
+def test_central_guards_bail_without_resolver_or_bucket() -> None:
+    """Central helper bails when bucket / resolver / create_task is unusable."""
+
+    coord = _coordinator_without_resolver(data={DOMAIN: "not-a-dict"})
+    coord._schedule_eid_resolver_refresh()
+    assert len(coord.hass._created_tasks) == 0
+
+    coord = _coordinator_without_resolver(data={DOMAIN: {}})
+    coord._schedule_eid_resolver_refresh()
+    assert len(coord.hass._created_tasks) == 0
+
+    coord = _coordinator_without_resolver(
+        data={DOMAIN: {DATA_EID_RESOLVER: SimpleNamespace(async_refresh=None)}}
+    )
+    coord._schedule_eid_resolver_refresh()
+    assert len(coord.hass._created_tasks) == 0
+
+    coord = _coordinator_without_resolver(
+        data={DOMAIN: {DATA_EID_RESOLVER: _fake_resolver()}}
+    )
+    del coord.hass.async_create_task
+    coord._schedule_eid_resolver_refresh()
+    assert len(coord.hass._created_tasks) == 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-site isolation: each site keeps its own pending handle
+# ---------------------------------------------------------------------------
+
+
+def test_sites_have_independent_debounce_handles() -> None:
+    """Central and inline sites coalesce independently (separate handles)."""
+
+    coordinator = _make_coordinator()
+    loop: _FakeLoop = coordinator.hass.loop
+
+    coordinator._schedule_eid_resolver_refresh()
+    coordinator._schedule_inline_eid_resolver_refresh("dev-1")
+
+    # Two independent timers armed (one per site), still no task yet.
+    assert len(loop.scheduled) == 2
+    assert len(coordinator.hass._created_tasks) == 0
+
+    loop.fire_all()
+    assert len(coordinator.hass._created_tasks) == 2

--- a/tests/test_eid_resolver_debounce.py
+++ b/tests/test_eid_resolver_debounce.py
@@ -381,3 +381,77 @@ def test_sites_have_independent_debounce_handles() -> None:
 
     loop.fire_all()
     assert len(coordinator.hass._created_tasks) == 2
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: shutdown cancels pending debounce timers (no task after unload)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_shutdown_cancels_pending_debounce_handles() -> None:
+    """``async_shutdown`` cancels both armed EID debounce timers.
+
+    Without the cancel a pending ``call_later`` callback would still fire after
+    unload and create an ``async_create_task`` against a torn-down coordinator.
+    Both handles are cancelled and cleared.
+    """
+
+    from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+
+    central = _FakeTimerHandle()
+    # Leave the inline handle unset to also cover the ``handle is None`` skip.
+    coordinator._eid_refresh_debounce_handle = central
+    coordinator._eid_inline_refresh_debounce_handle = None
+
+    # Stub the rest of the shutdown surface so we exercise only the new cancel.
+    coordinator._cancel_pending_subentry_repair = lambda: None
+    coordinator._dr_unsub = None
+    coordinator._short_retry_cancel = None
+    coordinator._stats_save_task = None
+
+    async def _async_unload() -> None:
+        return None
+
+    coordinator._async_unload = _async_unload
+
+    await coordinator.async_shutdown()
+
+    assert central.cancelled is True
+    assert coordinator._eid_refresh_debounce_handle is None
+    assert coordinator._eid_inline_refresh_debounce_handle is None
+
+
+@pytest.mark.asyncio
+async def test_async_shutdown_swallows_handle_cancel_error() -> None:
+    """A raising ``cancel()`` on a debounce handle must not break shutdown.
+
+    The cancel is wrapped defensively (mirroring ``_short_retry_cancel``); a
+    handle whose ``cancel`` raises is still cleared and shutdown completes.
+    """
+
+    from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+
+    class _RaisingHandle:
+        def cancel(self) -> None:
+            raise RuntimeError("boom")
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._eid_refresh_debounce_handle = _RaisingHandle()
+    coordinator._eid_inline_refresh_debounce_handle = _RaisingHandle()
+    coordinator._cancel_pending_subentry_repair = lambda: None
+    coordinator._dr_unsub = None
+    coordinator._short_retry_cancel = None
+    coordinator._stats_save_task = None
+
+    async def _async_unload() -> None:
+        return None
+
+    coordinator._async_unload = _async_unload
+
+    await coordinator.async_shutdown()
+
+    assert coordinator._eid_refresh_debounce_handle is None
+    assert coordinator._eid_inline_refresh_debounce_handle is None

--- a/tests/test_eid_resolver_executor_offload.py
+++ b/tests/test_eid_resolver_executor_offload.py
@@ -1,0 +1,446 @@
+# tests/test_eid_resolver_executor_offload.py
+"""Executor-offload gate for the resolver build phase (AP-C).
+
+The synchronous EID build inside ``GoogleFindMyEIDResolver._refresh_cache`` is
+offloaded to a worker thread via ``hass.async_add_executor_job`` so the event
+loop stays reactive under Home Assistant's watchdog budget. The extracted pure
+worker is ``GoogleFindMyEIDResolver._build_lookup_sync``.
+
+This module pins four contracts:
+
+* **Off-loop execution** -- the build runs on a worker thread whose identity
+  differs from the loop thread (asserted via a real executor, not a mock).
+* **Bit-identical output** -- the offloaded build produces a lookup/metadata
+  table byte-for-byte equal to a direct reference build over the same inputs.
+* **Deterministic memo-cache race safety** -- a bounded rendezvous instruments
+  the AP-A memo cache's lock so two threads attempt to co-occupy its critical
+  section; with the real lock the peer is parked on ``acquire()``, peak
+  occupancy stays 1, and the cache raises nothing.
+* **Mutation counter-probe** -- disabling the real lock lets both threads enter
+  the critical section together (peak occupancy reaches 2, possibly with
+  corruption), turning the same deterministic rendezvous red and proving the
+  lock is load-bearing rather than incidental.
+
+Byte-exact derivation per variant is pinned separately by
+``tests/test_eid_resolver_characterization.py``; here the golden assertion is
+relative (offloaded == reference) so it tracks the live build inputs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy import eid_resolver as resolver_mod
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import (
+    GoogleFindMyEIDResolver,
+    _BoundedLRUCache,
+)
+
+
+def _identity(*, identity_key: bytes = b"\xaa" * 32) -> DeviceIdentity:
+    """Return a minimal active identity that yields a non-empty build."""
+
+    return DeviceIdentity(
+        registry_id="registry-id",
+        canonical_id="canonical-id",
+        identity_key=identity_key,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-id",
+        fast_pair_model_id=None,
+    )
+
+
+def _build_refreshable_resolver(
+    hass: SimpleNamespace,
+) -> GoogleFindMyEIDResolver:
+    """Construct a resolver wired enough to run ``_refresh_cache`` end to end."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = hass
+    resolver._ensure_cache_defaults()
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._locks = {}
+
+    async def _async_noop(payload: object = None) -> None:
+        return None
+
+    resolver._store = SimpleNamespace(async_load=lambda: None, async_save=_async_noop)
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    return resolver
+
+
+def _close_coro(coro: object, name: object = None) -> None:
+    """Close a scheduled coroutine to avoid RuntimeWarning in tests."""
+
+    if hasattr(coro, "close"):
+        coro.close()
+
+
+def _patch_collection(
+    monkeypatch: pytest.MonkeyPatch, identities: list[DeviceIdentity]
+) -> None:
+    """Patch the device-secret collection seam and enable the unix basis."""
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return list(identities)
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_normalize_identities",
+        lambda self, identities, cache=None: identities,
+    )
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_runs_on_worker_thread_not_the_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The build must execute off the event-loop thread (AP-C contract a).
+
+    A real single-worker ``ThreadPoolExecutor`` backs
+    ``hass.async_add_executor_job``; ``_build_lookup_sync`` records the thread
+    identity it ran on, which must differ from the loop thread identity.
+    """
+
+    loop_thread_ident = threading.get_ident()
+    seen_idents: list[int] = []
+
+    real_build = GoogleFindMyEIDResolver._build_lookup_sync
+
+    def _recording_build(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        seen_idents.append(threading.get_ident())
+        return real_build(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver, "_build_lookup_sync", _recording_build
+    )
+
+    loop = asyncio.get_running_loop()
+    with ThreadPoolExecutor(max_workers=1) as pool:
+
+        async def _add_executor_job(func, *args):  # type: ignore[no-untyped-def]
+            return await loop.run_in_executor(pool, func, *args)
+
+        hass = SimpleNamespace(
+            async_create_task=_close_coro,
+            async_create_background_task=_close_coro,
+            async_add_executor_job=_add_executor_job,
+            data={},
+        )
+        resolver = _build_refreshable_resolver(hass)
+        _patch_collection(monkeypatch, [_identity()])
+
+        await resolver._refresh_cache()
+
+    assert seen_idents, "the build was never invoked"
+    assert all(ident != loop_thread_ident for ident in seen_idents)
+    assert resolver._lookup, "the offloaded build produced no EIDs"
+
+
+@pytest.mark.asyncio
+async def test_offloaded_build_is_bit_identical_to_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The offloaded build must be byte-identical to a direct build (contract b).
+
+    The lookup and metadata tables produced through the executor path must equal
+    a reference ``_build_lookup_sync`` run over the same work items, proving the
+    offload is correctness-preserving (EIDs bit-identical).
+    """
+
+    loop = asyncio.get_running_loop()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+
+        async def _add_executor_job(func, *args):  # type: ignore[no-untyped-def]
+            return await loop.run_in_executor(pool, func, *args)
+
+        hass = SimpleNamespace(
+            async_create_task=_close_coro,
+            async_create_background_task=_close_coro,
+            async_add_executor_job=_add_executor_job,
+            data={},
+        )
+        resolver = _build_refreshable_resolver(hass)
+        _patch_collection(monkeypatch, [_identity()])
+
+        # Freeze the clock so the reference build sees identical inputs.
+        monkeypatch.setattr(resolver_mod.time, "time", lambda: 1024.0)
+
+        await resolver._refresh_cache()
+
+        offloaded_lookup = dict(resolver._lookup)
+        offloaded_metadata = dict(resolver._lookup_metadata)
+
+        # Reference build over the exact same inputs on a fresh resolver.
+        reference = _build_refreshable_resolver(hass)
+        now_unix = 1024
+        identities = await reference._collect_device_secrets()
+        reference._cached_identities = list(identities)
+        work_items = reference._collect_work_items(identities, now_unix=now_unix)
+        rotation_params = reference._build_rotation_params()
+        ref_lookup, ref_metadata, _ids = reference._build_lookup_sync(
+            work_items, now_unix, rotation_params
+        )
+
+    assert offloaded_lookup, "no EIDs were built"
+    assert offloaded_lookup == ref_lookup
+    assert offloaded_metadata == ref_metadata
+
+
+@pytest.mark.asyncio
+async def test_invalid_basis_hint_is_popped_on_the_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The invalid-hint ``_known_timebases.pop`` must run loop-side (AP-C).
+
+    ``_build_lookup_sync`` only *collects* the registry ids whose basis hint was
+    invalid; the resolver mutates ``_known_timebases`` after the executor
+    returns. Seeding an unrecognized basis hint forces ``invalid_hint`` true and
+    pins that the stale entry is removed on the loop, not in the worker thread.
+    """
+
+    loop = asyncio.get_running_loop()
+    with ThreadPoolExecutor(max_workers=1) as pool:
+
+        async def _add_executor_job(func, *args):  # type: ignore[no-untyped-def]
+            return await loop.run_in_executor(pool, func, *args)
+
+        hass = SimpleNamespace(
+            async_create_task=_close_coro,
+            async_create_background_task=_close_coro,
+            async_add_executor_job=_add_executor_job,
+            data={},
+        )
+        resolver = _build_refreshable_resolver(hass)
+        _patch_collection(monkeypatch, [_identity()])
+
+        # Seed a basis hint that is not among the available bases: this makes
+        # ``_compute_relative_windows`` report ``invalid_hint`` for the item.
+        resolver._known_timebases["registry-id"] = "not-a-real-basis"
+
+        await resolver._refresh_cache()
+
+    # The stale hint was popped loop-side after the offloaded build returned.
+    assert "registry-id" not in resolver._known_timebases
+
+
+@pytest.mark.asyncio
+async def test_build_tolerates_flags_mask_failure_in_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flags-mask failure inside the worker must not abort the build (AP-C).
+
+    The offloaded build wraps ``_compute_flags_xor_mask`` in a defensive guard:
+    a mask computation error skips the mask but still registers the EID. Forcing
+    the mask to raise pins that guard and proves the worker-thread build is
+    resilient (the EIDs are still produced without a mask).
+    """
+
+    def _boom(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("mask boom")
+
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver, "_compute_flags_xor_mask", _boom
+    )
+
+    loop = asyncio.get_running_loop()
+    with ThreadPoolExecutor(max_workers=1) as pool:
+
+        async def _add_executor_job(func, *args):  # type: ignore[no-untyped-def]
+            return await loop.run_in_executor(pool, func, *args)
+
+        hass = SimpleNamespace(
+            async_create_task=_close_coro,
+            async_create_background_task=_close_coro,
+            async_add_executor_job=_add_executor_job,
+            data={},
+        )
+        resolver = _build_refreshable_resolver(hass)
+        _patch_collection(monkeypatch, [_identity()])
+
+        await resolver._refresh_cache()
+
+    # EIDs were still produced, but no entry carries a flags XOR mask.
+    assert resolver._lookup, "the build aborted on a mask failure"
+    assert all(
+        "flags_xor_mask" not in meta for meta in resolver._lookup_metadata.values()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Memo-cache race contract (c) and mutation counter-probe (d).
+# ---------------------------------------------------------------------------
+
+# Two contending threads suffice: the probe detects whether more than one
+# thread is ever simultaneously inside the cache's critical section.
+_RACE_THREADS = 2
+_RACE_MAXSIZE = 4
+_RACE_ROUNDS = 300
+
+
+class _WitnessLock:
+    """Lock wrapper that witnesses concurrent occupancy of the critical section.
+
+    Wraps the cache's real ``threading.Lock``. On ``__enter__`` it bumps a
+    shared occupancy counter, records the peak, then performs a bounded
+    "I am inside" handshake: it signals its own presence and waits a short,
+    timeout-bounded interval for the peer to also signal presence. This forces
+    both threads to be *inside* the section at the same time when (and only
+    when) mutual exclusion is absent.
+
+    * ``exclusive=True`` keeps the real lock: the peer is parked on
+      ``acquire()`` and can never enter, so its presence event never fires; the
+      wait simply times out, peak occupancy stays 1, and the OrderedDict
+      mutations are atomic.
+    * ``exclusive=False`` drops the real lock: both threads enter and signal
+      together, so peak occupancy reaches 2 -- a direct, deadlock-free witness
+      that mutual exclusion is gone and the unguarded mutation runs concurrently.
+
+    All waits are timeout-bounded, so this can never hang regardless of the
+    test harness's event-loop or threading instrumentation.
+    """
+
+    _HANDSHAKE_TIMEOUT = 0.5
+
+    def __init__(self, *, exclusive: bool, parties: int) -> None:
+        self._exclusive = exclusive
+        self._real = threading.Lock()
+        self._occupancy = 0
+        self._counter_guard = threading.Lock()
+        self.peak_occupancy = 0
+        # A single bounded rendezvous performed once per thread on its first
+        # entry. Under mutual exclusion only one thread can ever be inside, so
+        # the rendezvous can never complete and falls through on timeout
+        # (peak occupancy 1). Without exclusion all parties reach it together
+        # while each holds the section open, so peak occupancy equals ``parties``.
+        self._rendezvous = threading.Barrier(parties, timeout=self._HANDSHAKE_TIMEOUT)
+        self._handshaked: set[int] = set()
+
+    def __enter__(self) -> _WitnessLock:
+        if self._exclusive:
+            self._real.acquire()
+        ident = threading.get_ident()
+        first_entry = False
+        with self._counter_guard:
+            self._occupancy += 1
+            self.peak_occupancy = max(self.peak_occupancy, self._occupancy)
+            if ident not in self._handshaked:
+                self._handshaked.add(ident)
+                first_entry = True
+        if first_entry:
+            # Bounded rendezvous while holding the section open. Times out
+            # harmlessly under exclusion; completes (co-occupancy) without it.
+            try:
+                self._rendezvous.wait()
+            except threading.BrokenBarrierError:
+                pass
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        with self._counter_guard:
+            self._occupancy -= 1
+        if self._exclusive:
+            self._real.release()
+        return False
+
+
+def _hammer_cache(cache: _BoundedLRUCache, rounds: int) -> None:
+    """Drive put/get churn that forces eviction (``popitem``) every few calls."""
+
+    for round_idx in range(rounds):
+        for key in range(_RACE_MAXSIZE + 2):
+            cache.put((round_idx % 3, key), key)
+            cache.get((round_idx % 3, key))
+
+
+def _run_race(cache: _BoundedLRUCache) -> list[BaseException]:
+    """Run the two-thread interleaving and return any worker exceptions."""
+
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+
+    def _worker() -> None:
+        try:
+            _hammer_cache(cache, _RACE_ROUNDS)
+        except BaseException as exc:  # noqa: BLE001 - surface any race failure
+            with errors_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=_worker) for _ in range(_RACE_THREADS)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    return errors
+
+
+def test_memo_cache_race_is_safe_with_real_lock() -> None:
+    """Mutual exclusion must hold the memo cache to one occupant (contract c).
+
+    Two threads hammer interleaved put/get and the witness lock yields the GIL
+    while each thread sits inside the critical section. With the real lock the
+    peer is parked on ``acquire()``: peak occupancy stays 1, no worker raises,
+    and the cache stays within its declared bound. The single-occupancy
+    invariant is exactly what keeps the OrderedDict mutations atomic.
+    """
+
+    witness = _WitnessLock(exclusive=True, parties=_RACE_THREADS)
+    cache = _BoundedLRUCache(_RACE_MAXSIZE)
+    cache._lock = witness  # type: ignore[assignment]
+
+    errors = _run_race(cache)
+
+    assert not errors, f"locked cache raised under contention: {errors!r}"
+    assert witness.peak_occupancy == 1, (
+        f"real lock admitted {witness.peak_occupancy} concurrent occupants"
+    )
+    assert len(cache) <= _RACE_MAXSIZE
+
+
+def test_memo_cache_race_is_red_without_lock() -> None:
+    """Removing mutual exclusion must let two threads co-occupy (contract d).
+
+    The same witnessed interleaving with the real lock disabled lets both
+    threads enter the critical section together while one is preempted
+    mid-mutation. Peak occupancy deterministically reaches 2 (and the unguarded
+    OrderedDict mutation may additionally raise or overflow the bound). This
+    counter-probe proves the AP-A lock is load-bearing: it fails closed if the
+    unguarded run somehow never co-occupies.
+    """
+
+    witness = _WitnessLock(exclusive=False, parties=_RACE_THREADS)
+    cache = _BoundedLRUCache(_RACE_MAXSIZE)
+    # Drop the real lock: the witness records occupancy but enforces nothing.
+    cache._lock = witness  # type: ignore[assignment]
+
+    errors = _run_race(cache)
+
+    overflowed = len(cache) > _RACE_MAXSIZE
+    assert witness.peak_occupancy >= 2 or errors or overflowed, (
+        "unguarded cache was never co-occupied and never corrupted; the lock "
+        "probe is not exercising the critical section"
+    )
+    # The intended, deterministic signal is co-occupancy of the section.
+    assert witness.peak_occupancy >= 2, (
+        f"expected concurrent occupancy without the lock, saw peak "
+        f"{witness.peak_occupancy}"
+    )

--- a/tests/test_eid_resolver_logic.py
+++ b/tests/test_eid_resolver_logic.py
@@ -14,6 +14,12 @@ from custom_components.googlefindmy.eid_resolver import (
 )
 
 
+async def _run_in_executor(func, *args):
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C)."""
+
+    return func(*args)
+
+
 @pytest.mark.asyncio
 async def test_relative_time_calculation_uses_elapsed_anchor(
     monkeypatch: pytest.MonkeyPatch,
@@ -35,6 +41,7 @@ async def test_relative_time_calculation_uses_elapsed_anchor(
 
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = MagicMock()
+    resolver.hass.async_add_executor_job = _run_in_executor
     resolver._locks = {}
     resolver._ensure_cache_defaults()
     resolver._refresh_lock = asyncio.Lock()
@@ -81,6 +88,7 @@ async def test_unix_basis_disabled_by_default(
 
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = MagicMock()
+    resolver.hass.async_add_executor_job = _run_in_executor
     resolver._locks = {}
     resolver._ensure_cache_defaults()
     resolver._refresh_lock = asyncio.Lock()

--- a/tests/test_eid_resolver_memoization.py
+++ b/tests/test_eid_resolver_memoization.py
@@ -48,12 +48,24 @@ def _close_coro(coro: object, name: object = None) -> None:
         coro.close()
 
 
+async def _run_in_executor(func: object, *args: object) -> object:
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C).
+
+    Runs the offloaded build inline so the memoization assertions keep
+    exercising the same build surface; the dedicated executor-offload suite
+    pins the genuine worker-thread behavior.
+    """
+
+    return func(*args)  # type: ignore[operator]
+
+
 def _fake_hass() -> SimpleNamespace:
     """Return a lightweight hass stand-in that closes scheduled coroutines."""
 
     return SimpleNamespace(
         async_create_task=_close_coro,
         async_create_background_task=_close_coro,
+        async_add_executor_job=_run_in_executor,
         data={},
     )
 

--- a/tests/test_eid_resolver_memoization.py
+++ b/tests/test_eid_resolver_memoization.py
@@ -29,13 +29,17 @@ from custom_components.googlefindmy.coordinator import DeviceIdentity
 from custom_components.googlefindmy.eid_resolver import (
     _EID_MASK_MEMO_MAXSIZE,
     _EID_MEMO_MAXSIZE,
+    _HEURISTIC_MEMO_MAXSIZE,
     GoogleFindMyEIDResolver,
+    LearnedHeuristicParams,
 )
 from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
     LEGACY_EID_LENGTH,
     MODERN_EID_LENGTH,
     P256_ORDER,
     EidVariant,
+    HeuristicBasis,
+    generate_heuristic_eid,
 )
 
 from .test_eid_generator_variants import SAMPLE_COUNTER, SAMPLE_EIK
@@ -377,3 +381,276 @@ def test_flags_mask_memo_is_bounded_at_maxsize() -> None:
         )
 
     assert len(resolver._flags_mask_memo) == _EID_MASK_MEMO_MAXSIZE
+
+
+# ---------------------------------------------------------------------------
+# Heuristic phone-discovery memoization (AP-SWEEP)
+# ---------------------------------------------------------------------------
+# ``_generate_heuristic_eid`` wraps ``generate_heuristic_eid`` on the resolve
+# hot path (per cache-miss FMDN advertisement, on the event loop). It is the
+# on-loop sibling of the build-side AP-A caches and is keyed on the rotation-
+# aligned time window plus the hypothesis parameters.
+
+_HEURISTIC_PERIOD = 900
+_HEURISTIC_VARIANT = EidVariant.MODERN_P256_X32_BE
+
+
+def test_generate_heuristic_eid_memoizes_within_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated calls inside one rotation window recompute zero times.
+
+    Two ``now_unix`` values that fall in the same ABSOLUTE rotation window must
+    collapse to a single cache key, so the underlying ``generate_heuristic_eid``
+    runs once on the miss and never again on the in-window hits.
+    """
+
+    resolver = _build_resolver()
+
+    calls = {"count": 0}
+    real = resolver_mod.generate_heuristic_eid
+
+    def _counting(*args: object, **kwargs: object) -> object:
+        calls["count"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(resolver_mod, "generate_heuristic_eid", _counting)
+
+    # Same window: floor(t / 900) is identical for these timestamps.
+    base = 900 * 1000
+    first = resolver._generate_heuristic_eid(
+        SAMPLE_EIK,
+        base,
+        rotation_period=_HEURISTIC_PERIOD,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=_HEURISTIC_VARIANT,
+        anchor=None,
+    )
+    assert calls["count"] == 1
+
+    for delta in (1, 100, 899):
+        again = resolver._generate_heuristic_eid(
+            SAMPLE_EIK,
+            base + delta,
+            rotation_period=_HEURISTIC_PERIOD,
+            basis=HeuristicBasis.ABSOLUTE,
+            variant=_HEURISTIC_VARIANT,
+            anchor=None,
+        )
+        assert again == first
+
+    # Zero further computations: every in-window call hit the cache.
+    assert calls["count"] == 1
+
+
+def test_generate_heuristic_eid_recomputes_on_new_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Crossing a rotation-window boundary forces a fresh (correct) compute.
+
+    A timestamp in the next window must miss the cache and recompute, and the
+    new result must be byte-identical to a direct ``generate_heuristic_eid``
+    call -- proving the cache never serves a stale list across windows.
+    """
+
+    resolver = _build_resolver()
+
+    calls = {"count": 0}
+    real = resolver_mod.generate_heuristic_eid
+
+    def _counting(*args: object, **kwargs: object) -> object:
+        calls["count"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(resolver_mod, "generate_heuristic_eid", _counting)
+
+    base = 900 * 1000
+    resolver._generate_heuristic_eid(
+        SAMPLE_EIK,
+        base,
+        rotation_period=_HEURISTIC_PERIOD,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=_HEURISTIC_VARIANT,
+        anchor=None,
+    )
+    assert calls["count"] == 1
+
+    next_window = base + _HEURISTIC_PERIOD
+    cached_result = resolver._generate_heuristic_eid(
+        SAMPLE_EIK,
+        next_window,
+        rotation_period=_HEURISTIC_PERIOD,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=_HEURISTIC_VARIANT,
+        anchor=None,
+    )
+    # The new window is a miss: the crypto ran a second time.
+    assert calls["count"] == 2
+
+    # Byte-exact equivalence to the unmemoized reference for the same window.
+    reference = generate_heuristic_eid(
+        SAMPLE_EIK,
+        next_window,
+        rotation_period=_HEURISTIC_PERIOD,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=_HEURISTIC_VARIANT,
+        anchor=None,
+    )
+    assert [r.eid_bytes for r in cached_result] == [r.eid_bytes for r in reference]
+    assert cached_result == reference
+
+
+def test_generate_heuristic_eid_matches_unmemoized_reference() -> None:
+    """The wrapper is byte-exact with the raw function across hypotheses.
+
+    GOLDEN-style equivalence over the full ABSOLUTE/RELATIVE x variant matrix:
+    the memoized wrapper must never alter the derived EID bytes.
+    """
+
+    resolver = _build_resolver()
+    now_unix = 900 * 1234 + 17
+    anchor = 900 * 1000
+
+    cases = [
+        (HeuristicBasis.ABSOLUTE, None),
+        (HeuristicBasis.RELATIVE, anchor),
+    ]
+    for basis, anchor_value in cases:
+        for variant in EidVariant:
+            wrapped = resolver._generate_heuristic_eid(
+                SAMPLE_EIK,
+                now_unix,
+                rotation_period=_HEURISTIC_PERIOD,
+                basis=basis,
+                variant=variant,
+                anchor=anchor_value,
+            )
+            reference = generate_heuristic_eid(
+                SAMPLE_EIK,
+                now_unix,
+                rotation_period=_HEURISTIC_PERIOD,
+                basis=basis,
+                variant=variant,
+                anchor=anchor_value,
+            )
+            assert wrapped == reference
+
+
+def test_heuristic_memo_is_bounded_at_maxsize() -> None:
+    """Inserting more than maxsize heuristic keys keeps the cache at maxsize.
+
+    Varying the rotation window produces unique keys; the bounded LRU never
+    grows past ``_HEURISTIC_MEMO_MAXSIZE``.
+    """
+
+    resolver = _build_resolver()
+
+    overflow = _HEURISTIC_MEMO_MAXSIZE + 50
+    for window in range(overflow):
+        resolver._generate_heuristic_eid(
+            SAMPLE_EIK,
+            window * _HEURISTIC_PERIOD,
+            rotation_period=_HEURISTIC_PERIOD,
+            basis=HeuristicBasis.ABSOLUTE,
+            variant=_HEURISTIC_VARIANT,
+            anchor=None,
+        )
+
+    assert len(resolver._heuristic_memo) == _HEURISTIC_MEMO_MAXSIZE
+
+
+def _heuristic_identity() -> DeviceIdentity:
+    """Return a minimal identity whose key derives heuristic EIDs."""
+
+    return DeviceIdentity(
+        registry_id="phone-registry-id",
+        canonical_id="phone-canonical-id",
+        identity_key=SAMPLE_EIK,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-id",
+        fast_pair_model_id=None,
+    )
+
+
+def test_heuristic_check_learned_routes_through_memo() -> None:
+    """The learned fast path resolves a real EID via the memoized wrapper.
+
+    Drives ``_heuristic_check_learned`` (the call site redirected to
+    ``self._generate_heuristic_eid``) end to end: a candidate set seeded with a
+    genuine ABSOLUTE-basis EID must yield a HEURISTIC match, and the memo cache
+    must be populated by the resolve.
+    """
+
+    resolver = _build_resolver()
+    identity = _heuristic_identity()
+    resolver._cached_identities = [identity]
+
+    now_unix = 900 * 2000 + 5
+    reference = generate_heuristic_eid(
+        SAMPLE_EIK,
+        now_unix,
+        rotation_period=_HEURISTIC_PERIOD,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=_HEURISTIC_VARIANT,
+        anchor=None,
+    )
+    candidate_set = {reference[0].eid_bytes}
+
+    learned = LearnedHeuristicParams(
+        device_id=identity.registry_id,
+        canonical_id=identity.canonical_id,
+        rotation_period=_HEURISTIC_PERIOD,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=_HEURISTIC_VARIANT,
+        discovered_at=now_unix,
+        last_confirmed_at=now_unix,
+    )
+
+    match = resolver._heuristic_check_learned(
+        identity.registry_id,
+        learned,
+        candidate_set,
+        now_unix=now_unix,
+    )
+
+    assert match is not None
+    assert match.device_id == identity.registry_id
+    assert len(resolver._heuristic_memo) == 1
+
+
+def test_heuristic_test_hypotheses_routes_through_memo() -> None:
+    """The slow discovery path resolves a real EID via the memoized wrapper.
+
+    Drives ``_heuristic_test_hypotheses`` (the second redirected call site) end
+    to end: a candidate seeded with a genuine EID for one of the tested
+    hypotheses yields a match and records the learned parameters.
+    """
+
+    resolver = _build_resolver()
+    identity = _heuristic_identity()
+    resolver._cached_identities = [identity]
+
+    now_unix = 900 * 3000 + 11
+    reference = generate_heuristic_eid(
+        SAMPLE_EIK,
+        now_unix,
+        rotation_period=_HEURISTIC_PERIOD,
+        basis=HeuristicBasis.ABSOLUTE,
+        variant=EidVariant.MODERN_P256_X20_TRUNC_BE,
+        anchor=None,
+    )
+    candidate_set = {reference[0].eid_bytes}
+
+    match = resolver._heuristic_test_hypotheses(
+        identity,
+        candidate_set,
+        now_unix=now_unix,
+    )
+
+    assert match is not None
+    assert match.device_id == identity.registry_id
+    # The discovery path caches the learned parameters for the fast path.
+    assert identity.registry_id in resolver._learned_heuristic_params
+    assert len(resolver._heuristic_memo) >= 1

--- a/tests/test_eid_resolver_memoization.py
+++ b/tests/test_eid_resolver_memoization.py
@@ -1,0 +1,367 @@
+# tests/test_eid_resolver_memoization.py
+"""Memoization gate for the resolver's per-variant crypto seams (AP-A).
+
+These tests pin the behaviour of the two instance-bound LRU caches that wrap
+``GoogleFindMyEIDResolver._generate_variant`` (EID derivation) and
+``GoogleFindMyEIDResolver._compute_flags_xor_mask`` (flags XOR mask):
+
+* a repeated call with an unchanged key recomputes the underlying crypto zero
+  times (the caches absorb it), and
+* each cache stays bounded at its declared ``maxsize``.
+
+The byte-exact correctness of the cached EIDs is enforced separately by
+``tests/test_eid_resolver_characterization.py``; here we only prove the
+caching mechanics. A full ``_refresh_cache`` run requires a fully wired
+coordinator/storage stack, so the call-count assertions exercise the seams
+directly with a fixed key, which is the surface the build loop calls into.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy import eid_resolver as resolver_mod
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import (
+    _EID_MASK_MEMO_MAXSIZE,
+    _EID_MEMO_MAXSIZE,
+    GoogleFindMyEIDResolver,
+)
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    LEGACY_EID_LENGTH,
+    MODERN_EID_LENGTH,
+    P256_ORDER,
+    EidVariant,
+)
+
+from .test_eid_generator_variants import SAMPLE_COUNTER, SAMPLE_EIK
+
+
+def _close_coro(coro: object, name: object = None) -> None:
+    """Close a coroutine to avoid RuntimeWarning in the test context."""
+
+    if hasattr(coro, "close"):
+        coro.close()
+
+
+def _fake_hass() -> SimpleNamespace:
+    """Return a lightweight hass stand-in that closes scheduled coroutines."""
+
+    return SimpleNamespace(
+        async_create_task=_close_coro,
+        async_create_background_task=_close_coro,
+        data={},
+    )
+
+
+def _build_refreshable_resolver() -> GoogleFindMyEIDResolver:
+    """Construct a resolver wired enough to run ``_refresh_cache`` end to end."""
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = _fake_hass()
+    resolver._ensure_cache_defaults()
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._locks = {}
+
+    async def _async_noop(payload: object = None) -> None:
+        return None
+
+    resolver._store = SimpleNamespace(
+        async_load=lambda: None, async_save=_async_noop
+    )
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    return resolver
+
+
+def _build_resolver() -> GoogleFindMyEIDResolver:
+    """Construct a resolver without running __init__.
+
+    Mirrors the characterization test's construction: stubs bypass
+    ``__init__`` and call ``_ensure_cache_defaults`` directly, which now also
+    initializes the memoization caches.
+    """
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver._ensure_cache_defaults()
+    return resolver
+
+
+def test_ensure_cache_defaults_initializes_memo_caches() -> None:
+    """The memo caches must exist after _ensure_cache_defaults runs."""
+
+    resolver = _build_resolver()
+
+    assert resolver._eid_memo is not None
+    assert resolver._flags_mask_memo is not None
+    assert len(resolver._eid_memo) == 0
+    assert len(resolver._flags_mask_memo) == 0
+
+
+def test_generate_variant_memoizes_repeated_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repeated _generate_variant call must not recompute the EID.
+
+    Requirement 2 (for the derivation seam): with an unchanged key the
+    underlying ``generate_eid_variant`` is called exactly once for the first
+    miss and zero times on every subsequent hit.
+    """
+
+    resolver = _build_resolver()
+
+    calls = {"count": 0}
+    real_generate = resolver_mod.generate_eid_variant
+
+    def _counting_generate(*args: object, **kwargs: object) -> bytes:
+        calls["count"] += 1
+        return real_generate(*args, **kwargs)
+
+    monkeypatch.setattr(resolver_mod, "generate_eid_variant", _counting_generate)
+
+    first = resolver._generate_variant(
+        SAMPLE_EIK,
+        time_counter=SAMPLE_COUNTER,
+        variant=EidVariant.MODERN_P256_X32_BE,
+    )
+    assert calls["count"] == 1
+
+    for _ in range(5):
+        again = resolver._generate_variant(
+            SAMPLE_EIK,
+            time_counter=SAMPLE_COUNTER,
+            variant=EidVariant.MODERN_P256_X32_BE,
+        )
+        assert again == first
+
+    # Zero further computations after the initial miss.
+    assert calls["count"] == 1
+
+
+def test_compute_flags_xor_mask_memoizes_repeated_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repeated _compute_flags_xor_mask call must not recompute the mask.
+
+    Requirement 2 (for the mask seam): the underlying
+    ``compute_flags_xor_mask`` runs once on the miss and zero times on hits.
+    """
+
+    resolver = _build_resolver()
+
+    calls = {"count": 0}
+    real_mask = resolver_mod.compute_flags_xor_mask
+
+    def _counting_mask(*args: object, **kwargs: object) -> int:
+        calls["count"] += 1
+        return real_mask(*args, **kwargs)
+
+    monkeypatch.setattr(resolver_mod, "compute_flags_xor_mask", _counting_mask)
+
+    first = resolver._compute_flags_xor_mask(
+        SAMPLE_EIK,
+        SAMPLE_COUNTER,
+        curve_byte_len=MODERN_EID_LENGTH,
+        curve_order=P256_ORDER,
+    )
+    assert calls["count"] == 1
+
+    for _ in range(5):
+        again = resolver._compute_flags_xor_mask(
+            SAMPLE_EIK,
+            SAMPLE_COUNTER,
+            curve_byte_len=MODERN_EID_LENGTH,
+            curve_order=P256_ORDER,
+        )
+        assert again == first
+
+    assert calls["count"] == 1
+
+
+def test_both_seams_recompute_zero_times_on_second_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Second pass over the same inputs hits both caches (Requirement 2).
+
+    This emulates the back-to-back ``_refresh_cache`` runs the orchestrator
+    cares about: warm both caches in pass one, then assert pass two over the
+    identical (key, counter, variant) work set recomputes neither crypto.
+    """
+
+    resolver = _build_resolver()
+
+    gen_calls = {"count": 0}
+    mask_calls = {"count": 0}
+    real_generate = resolver_mod.generate_eid_variant
+    real_mask = resolver_mod.compute_flags_xor_mask
+
+    def _counting_generate(*args: object, **kwargs: object) -> bytes:
+        gen_calls["count"] += 1
+        return real_generate(*args, **kwargs)
+
+    def _counting_mask(*args: object, **kwargs: object) -> int:
+        mask_calls["count"] += 1
+        return real_mask(*args, **kwargs)
+
+    monkeypatch.setattr(resolver_mod, "generate_eid_variant", _counting_generate)
+    monkeypatch.setattr(resolver_mod, "compute_flags_xor_mask", _counting_mask)
+
+    variants = list(EidVariant)
+
+    def _pass() -> None:
+        for variant in variants:
+            resolver._generate_variant(
+                SAMPLE_EIK,
+                time_counter=SAMPLE_COUNTER,
+                variant=variant,
+            )
+            resolver._compute_flags_xor_mask(
+                SAMPLE_EIK,
+                SAMPLE_COUNTER,
+                curve_byte_len=MODERN_EID_LENGTH,
+                curve_order=P256_ORDER,
+            )
+
+    # Pass one warms the caches.
+    _pass()
+    gen_after_warm = gen_calls["count"]
+    mask_after_warm = mask_calls["count"]
+    assert gen_after_warm > 0
+    assert mask_after_warm > 0
+
+    # Pass two over identical inputs must add zero computations to both.
+    _pass()
+    assert gen_calls["count"] == gen_after_warm
+    assert mask_calls["count"] == mask_after_warm
+
+
+@pytest.mark.asyncio
+async def test_second_refresh_cache_recomputes_no_crypto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second _refresh_cache over an unchanged input set recomputes nothing.
+
+    Requirement 2 in its strongest form: run the full build loop twice with an
+    identical identity set and frozen clock, and assert that the second pass
+    invokes neither ``generate_eid_variant`` nor ``compute_flags_xor_mask``.
+    Both caches, warmed by pass one, absorb the entire second pass. This also
+    exercises the memoized call site inside ``_refresh_cache``.
+    """
+
+    resolver = _build_refreshable_resolver()
+
+    gen_calls = {"count": 0}
+    mask_calls = {"count": 0}
+    real_generate = resolver_mod.generate_eid_variant
+    real_mask = resolver_mod.compute_flags_xor_mask
+
+    def _counting_generate(*args: object, **kwargs: object) -> bytes:
+        gen_calls["count"] += 1
+        return real_generate(*args, **kwargs)
+
+    def _counting_mask(*args: object, **kwargs: object) -> int:
+        mask_calls["count"] += 1
+        return real_mask(*args, **kwargs)
+
+    monkeypatch.setattr(resolver_mod, "generate_eid_variant", _counting_generate)
+    monkeypatch.setattr(resolver_mod, "compute_flags_xor_mask", _counting_mask)
+
+    identity = DeviceIdentity(
+        registry_id="registry-id",
+        canonical_id="canonical-id",
+        identity_key=b"\xaa" * 32,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-id",
+        fast_pair_model_id=None,
+    )
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return [identity]
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
+    # Bound the deep-scan window fan-out so the unique-key count for this single
+    # synthetic device stays well under _EID_MEMO_MAXSIZE. Without this the
+    # absolute-basis deep scan emits > maxsize unique EID keys for one device,
+    # which (correctly) evicts early entries and would make pass two re-derive
+    # the evicted keys -- a property of the deliberately oversized deep-scan
+    # test path, not of the memoization itself.
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.MIN_UNIX_WINDOW_SIZE",
+        8,
+    )
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver, "_collect_device_secrets", _collect
+    )
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_normalize_identities",
+        lambda self, identities, cache=None: identities,
+    )
+    monkeypatch.setattr(time, "time", lambda: 1024.0)
+
+    # Pass one warms both caches and must do real work.
+    await resolver._refresh_cache()
+    gen_after_warm = gen_calls["count"]
+    mask_after_warm = mask_calls["count"]
+    assert gen_after_warm > 0
+    assert mask_after_warm > 0
+    assert resolver._lookup  # sanity: the build loop produced EIDs
+
+    # Pass two over the identical input set must recompute zero crypto.
+    await resolver._refresh_cache()
+    assert gen_calls["count"] == gen_after_warm
+    assert mask_calls["count"] == mask_after_warm
+
+
+def test_eid_memo_is_bounded_at_maxsize() -> None:
+    """Inserting more than maxsize EID keys keeps the cache at maxsize.
+
+    Requirement 3 (derivation cache): varying ``time_counter`` produces unique
+    keys; size never exceeds ``_EID_MEMO_MAXSIZE``.
+    """
+
+    resolver = _build_resolver()
+
+    overflow = _EID_MEMO_MAXSIZE + 50
+    for counter in range(overflow):
+        resolver._generate_variant(
+            SAMPLE_EIK,
+            time_counter=SAMPLE_COUNTER + counter,
+            variant=EidVariant.MODERN_P256_X32_BE,
+        )
+
+    assert len(resolver._eid_memo) == _EID_MEMO_MAXSIZE
+
+
+def test_flags_mask_memo_is_bounded_at_maxsize() -> None:
+    """Inserting more than maxsize mask keys keeps the cache at maxsize.
+
+    Requirement 3 (mask cache): varying ``time_counter`` produces unique keys;
+    size never exceeds ``_EID_MASK_MEMO_MAXSIZE``.
+    """
+
+    resolver = _build_resolver()
+
+    overflow = _EID_MASK_MEMO_MAXSIZE + 50
+    for counter in range(overflow):
+        resolver._compute_flags_xor_mask(
+            SAMPLE_EIK,
+            SAMPLE_COUNTER + counter,
+            curve_byte_len=LEGACY_EID_LENGTH,
+            curve_order=None,
+        )
+
+    assert len(resolver._flags_mask_memo) == _EID_MASK_MEMO_MAXSIZE

--- a/tests/test_eid_resolver_offset_semantics.py
+++ b/tests/test_eid_resolver_offset_semantics.py
@@ -19,6 +19,12 @@ from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
 )
 
 
+async def _run_in_executor(func, *args):
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C)."""
+
+    return func(*args)
+
+
 @pytest.mark.asyncio
 async def test_pair_date_offset_beats_drifted_unix(
     monkeypatch: pytest.MonkeyPatch,
@@ -28,6 +34,7 @@ async def test_pair_date_offset_beats_drifted_unix(
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = SimpleNamespace(
         async_create_task=asyncio.create_task,
+        async_add_executor_job=_run_in_executor,
         data={},
     )
 

--- a/tests/test_eid_resolver_optimization.py
+++ b/tests/test_eid_resolver_optimization.py
@@ -134,5 +134,12 @@ async def test_known_time_basis_skips_alternate_strategies(
     await resolver._refresh_cache()
 
     assert resolver._known_timebases["tracker-1"] == "pair_date"
-    assert seen_windows == [pair_target]
-    assert seen_counters == [pair_target + 1]
+    # The known basis hint narrows the relative-window scan to the single
+    # ``pair_date`` basis: every window/counter explored equals the pair target,
+    # and no secrets/unix basis is tried. Under the AP-B1 skip guard (Variant B)
+    # the pure window math runs once for the build signature and once for the
+    # build itself, so each list repeats the single value rather than appearing
+    # once; the expensive crypto stays single-pass via the AP-A memo. What this
+    # test pins is the *basis narrowing*, i.e. uniqueness, not the call count.
+    assert set(seen_windows) == {pair_target}
+    assert set(seen_counters) == {pair_target + 1}

--- a/tests/test_eid_resolver_optimization.py
+++ b/tests/test_eid_resolver_optimization.py
@@ -22,6 +22,12 @@ from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
 )
 
 
+async def _run_in_executor(func, *args):
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C)."""
+
+    return func(*args)
+
+
 @pytest.mark.asyncio
 async def test_known_time_basis_skips_alternate_strategies(
     monkeypatch: pytest.MonkeyPatch,
@@ -31,6 +37,7 @@ async def test_known_time_basis_skips_alternate_strategies(
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = SimpleNamespace(
         async_create_task=asyncio.create_task,
+        async_add_executor_job=_run_in_executor,
         data={},
     )
     resolver._store = SimpleNamespace(

--- a/tests/test_eid_resolver_pipeline.py
+++ b/tests/test_eid_resolver_pipeline.py
@@ -26,6 +26,12 @@ from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
 )
 
 
+async def _run_in_executor(func, *args):
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C)."""
+
+    return func(*args)
+
+
 def _build_resolver(monkeypatch: pytest.MonkeyPatch) -> GoogleFindMyEIDResolver:
     """Return a resolver with lightweight Home Assistant stand-ins."""
 
@@ -33,6 +39,7 @@ def _build_resolver(monkeypatch: pytest.MonkeyPatch) -> GoogleFindMyEIDResolver:
     resolver.hass = SimpleNamespace(
         async_create_task=lambda coro,
         name=None: asyncio.get_running_loop().create_task(coro),
+        async_add_executor_job=_run_in_executor,
         data={},
     )
     resolver._store = SimpleNamespace(async_load=lambda: None, async_save=AsyncMock())

--- a/tests/test_eid_resolver_skip_guard.py
+++ b/tests/test_eid_resolver_skip_guard.py
@@ -104,12 +104,24 @@ def _close_coro(coro: object, name: object = None) -> None:
         coro.close()
 
 
+async def _run_in_executor(func: object, *args: object) -> object:
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C).
+
+    Runs the offloaded build inline so the skip/rebuild assertions keep
+    exercising the same build surface; the dedicated executor-offload suite
+    pins the genuine worker-thread behavior.
+    """
+
+    return func(*args)  # type: ignore[operator]
+
+
 def _fake_hass() -> SimpleNamespace:
     """Return a lightweight hass stand-in that closes scheduled coroutines."""
 
     return SimpleNamespace(
         async_create_task=_close_coro,
         async_create_background_task=_close_coro,
+        async_add_executor_job=_run_in_executor,
         data={},
     )
 

--- a/tests/test_eid_resolver_skip_guard.py
+++ b/tests/test_eid_resolver_skip_guard.py
@@ -37,7 +37,11 @@ import pytest
 
 from custom_components.googlefindmy import eid_resolver as resolver_mod
 from custom_components.googlefindmy.coordinator import DeviceIdentity
-from custom_components.googlefindmy.eid_resolver import GoogleFindMyEIDResolver
+from custom_components.googlefindmy.eid_resolver import (
+    GoogleFindMyEIDResolver,
+    WindowCandidate,
+    WindowSpec,
+)
 from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
     ROTATION_PERIOD,
     ROTATION_PERIOD_900,
@@ -45,56 +49,56 @@ from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
 )
 
 
-def test_rotation_time_counters_cover_all_three_periods() -> None:
-    """The signature must carry one time_counter term per rotation period.
-
-    This pins the *independent* presence of the 1024 s, 900 s, and 3600 s terms.
-    The 3600 s term cannot be isolated by a clock rollover (every 3600 s
-    boundary is also a 900 s boundary, since 3600 == 4 * 900), so its standalone
-    contribution is asserted here directly rather than via the rebuild path.
-    """
-
-    now_unix = 1_234_567
-    counters = GoogleFindMyEIDResolver._rotation_time_counters(now_unix)
-
-    by_period = dict(counters)
-    assert set(by_period) == {
-        ROTATION_PERIOD,
-        ROTATION_PERIOD_900,
-        ROTATION_PERIOD_3600,
-    }
-    assert by_period[ROTATION_PERIOD] == now_unix // ROTATION_PERIOD
-    assert by_period[ROTATION_PERIOD_900] == now_unix // ROTATION_PERIOD_900
-    assert by_period[ROTATION_PERIOD_3600] == now_unix // ROTATION_PERIOD_3600
-
-
-def test_build_signature_changes_when_only_3600_counter_differs(
+def test_signature_folds_realized_window_timestamps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Two clocks with equal 1024 s/900 s counters but a different 3600 s
-    counter would be physically impossible (3600 == 4 * 900), so we pin the
-    3600 s term's effect on the signature by injecting the counter tuple
-    directly: dropping the 3600 s term changes the digest, proving it is hashed.
+    """The signature replays ``_compute_time_windows`` and folds its content.
+
+    Variant B (correctness by construction): the skipped crypto consumes only
+    the realized window/variant specs, so the signature must change iff that
+    spec set changes. Here we hold the work item and clock fixed but inject one
+    extra realized window via ``_compute_time_windows``; the digest must move,
+    proving the windows -- not a ``now_unix // period`` formula -- drive the key.
     """
 
     resolver = _build_refreshable_resolver()
-    work_items: list = []
-    now_unix = 230_400  # all counters on a boundary
-
-    full = resolver._build_signature(work_items, now_unix=now_unix)
-
-    # Recompute with the 3600 s term suppressed to confirm it participates.
-    # monkeypatch auto-restores the staticmethod wrapper after the test.
     monkeypatch.setattr(
-        GoogleFindMyEIDResolver,
-        "_rotation_time_counters",
-        staticmethod(
-            lambda n: tuple((p, n // p) for p in (ROTATION_PERIOD, ROTATION_PERIOD_900))
-        ),
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
     )
-    without_3600 = resolver._build_signature(work_items, now_unix=now_unix)
+    params = resolver._build_rotation_params()
+    items = resolver._collect_work_items([_identity()], now_unix=1024)
 
-    assert full != without_3600
+    baseline = resolver._build_signature(items, now_unix=1024, params=params)
+
+    real_windows = GoogleFindMyEIDResolver._compute_time_windows
+
+    def _extra_window(
+        self: GoogleFindMyEIDResolver, work_item, *, now_unix, params
+    ):  # type: ignore[no-untyped-def]
+        windows, invalid_hint = real_windows(
+            self, work_item, now_unix=now_unix, params=params
+        )
+        extra = WindowSpec(
+            time_basis="synthetic",
+            candidate_value=now_unix,
+            windows=(
+                WindowCandidate(
+                    timestamp=now_unix + params.rotation_period,
+                    semantic_offset=params.rotation_period,
+                    time_basis="synthetic",
+                    candidate_value=now_unix,
+                ),
+            ),
+        )
+        return [*windows, extra], invalid_hint
+
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver, "_compute_time_windows", _extra_window
+    )
+    with_extra = resolver._build_signature(items, now_unix=1024, params=params)
+
+    assert baseline != with_extra
 
 
 def _close_coro(coro: object, name: object = None) -> None:
@@ -348,20 +352,22 @@ async def test_rotation_window_rollover_forces_rebuild(
     period: int,
     label: str,
 ) -> None:
-    """Crossing any single rotation window changes the signature -> rebuild.
+    """Advancing the clock across a rotation boundary forces a rebuild.
 
-    The phone-window protection (F5): a one-period signature would miss the
-    900 s / 3600 s rollovers. We pick a base time and a one-second advance that
-    flips the ``//period`` counter under test, then assert the rebuild fires.
+    Under Variant B the signature folds the realized window timestamps, which
+    derive from ``now_unix`` (the unix basis is ``now_unix`` itself, with a
+    drift/tz-padded window), so advancing the clock shifts the window set and
+    forces a rebuild. We pick a base time and a one-second advance that flips
+    the ``//period`` counter under test, then assert the rebuild fires; this
+    keeps the original phone-window intent (no stale lookup across a rollover)
+    while exercising the new realized-window signature.
 
     Note on 3600 s: because ``ROTATION_PERIOD_3600 == 4 * ROTATION_PERIOD_900``,
     every 3600 s boundary is also a 900 s boundary, so a 3600 s rollover can
     never be isolated from the 900 s counter (a mathematical property of the
     periods, not a test defect). For 1024 s and 900 s we require exact
     isolation; for 3600 s we require that the target counter flips (the 900 s
-    counter is allowed to flip with it). The independent contribution of the
-    3600 s term to the signature is pinned by the mutation cross-check
-    documented in the AP-B1 report.
+    counter is allowed to flip with it).
     """
 
     resolver = _build_refreshable_resolver()
@@ -397,3 +403,174 @@ async def test_rotation_window_rollover_forces_rebuild(
     assert finalize_calls["count"] == 2, (
         f"rotation window {label} rollover did not force a rebuild"
     )
+
+
+def _lock_identity() -> DeviceIdentity:
+    """Return an identity that resolves through the lock-tracking window path."""
+
+    return DeviceIdentity(
+        registry_id="registry-id",
+        canonical_id="canonical-id",
+        identity_key=b"\xaa" * 32,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-id",
+        fast_pair_model_id=None,
+    )
+
+
+def _install_lock(resolver: GoogleFindMyEIDResolver, *, created_at: int) -> None:
+    """Register a non-legacy lock so ``_compute_lock_windows`` produces windows.
+
+    ``rotation_timestamp=0`` is a valid (non-``None``) counter, so the lock is
+    kept rather than discarded as legacy; ``created_at`` is phase-offset from the
+    rotation period so the lock-tracking index ``(now - created_at) // period``
+    rolls at a different ``now`` than the absolute ``now // period`` counter.
+    """
+
+    resolver._locks["registry-id"] = resolver_mod.EIDGenerationLock(
+        device_id="registry-id",
+        canonical_id="canonical-id",
+        variant=resolver_mod.EidVariant.LEGACY_SECP160R1_X20_BE.value,
+        advertisement_reversed=False,
+        eid_length=20,
+        rotation_timestamp=0,
+        frame_type=None,
+        time_basis="lock_tracking",
+        created_at=created_at,
+    )
+    # Keep the lock confirmed at both clock points so ``_purge_stale_locks`` does
+    # not drop it between the two refreshes.
+    resolver._last_lock_confirmation["registry-id"] = created_at
+
+
+@pytest.mark.asyncio
+async def test_phase_offset_lock_window_drift_forces_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a phase-offset lock must rebuild when a drift window appears.
+
+    Repro of the AP-B1 skip-guard correctness defect. With ``created_at=500`` and
+    period 1024, the lock-tracking window set is ``{0, 1024, 2048}`` at
+    ``now=1100`` but ``{0, 1024, 2048, 3072}`` at ``now=1524`` -- a genuine extra
+    drift window. Both clocks share ``now // 1024 == 1``, so the old
+    absolute-counter signature was identical and wrongly skipped the rebuild,
+    serving a stale lookup missing the 3072 window. The Variant B signature folds
+    the realized lock windows, so the spec change forces a rebuild here.
+    """
+
+    resolver = _build_refreshable_resolver()
+    _install_lock(resolver, created_at=500)
+    finalize_calls = _install_common_patches(
+        monkeypatch, identities=[_lock_identity()]
+    )
+    # Re-arm the confirmation timestamp on every purge so the lock survives.
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_purge_stale_locks",
+        lambda self, *, now: None,
+    )
+
+    monkeypatch.setattr(time, "time", lambda: 1100.0)
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 1
+
+    monkeypatch.setattr(time, "time", lambda: 1524.0)
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 2, (
+        "phase-offset lock drift window did not force a rebuild"
+    )
+
+
+@pytest.mark.asyncio
+async def test_phase_offset_relative_window_drift_forces_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a phase-offset pairing anchor must rebuild on window drift.
+
+    Repro of the AP-B1 skip-guard correctness defect on the relative path. With
+    ``pair_date=500`` the relative window set grows from ``...6144`` at
+    ``now=1100`` to ``...7168`` at ``now=1524``. Both clocks share
+    ``now // 1024 == 1``, so the old absolute-counter signature was identical and
+    wrongly skipped the rebuild. The Variant B signature folds the realized
+    relative windows, so the extra window forces a rebuild.
+    """
+
+    resolver = _build_refreshable_resolver()
+    identity = DeviceIdentity(
+        registry_id="registry-id",
+        canonical_id="canonical-id",
+        identity_key=b"\xaa" * 32,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-id",
+        fast_pair_model_id=None,
+        pair_date=500,
+    )
+    finalize_calls = _install_common_patches(monkeypatch, identities=[identity])
+
+    monkeypatch.setattr(time, "time", lambda: 1100.0)
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 1
+
+    monkeypatch.setattr(time, "time", lambda: 1524.0)
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 2, (
+        "phase-offset relative drift window did not force a rebuild"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mutation_old_absolute_counter_signature_misses_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mutation guard: the pre-fix absolute-counter signature would not rebuild.
+
+    Pins that the new regression tests above genuinely catch the defect rather
+    than passing trivially. We rebuild the *old* signature logic (the per-period
+    ``now // period`` counters plus the static work-item fields, with no realized
+    windows) and assert it is byte-identical across ``now=1100`` and
+    ``now=1524`` for the phase-offset lock case -- i.e. the old guard would have
+    skipped the rebuild and served the stale lookup.
+    """
+
+    resolver = _build_refreshable_resolver()
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
+    _install_lock(resolver, created_at=500)
+
+    def _legacy_signature(work_items: list, *, now_unix: int) -> str:
+        import hashlib
+
+        hasher = hashlib.blake2b(digest_size=32)
+        for period in sorted(
+            (ROTATION_PERIOD, ROTATION_PERIOD_900, ROTATION_PERIOD_3600)
+        ):
+            hasher.update(b"P")
+            hasher.update(f"{period}:{now_unix // period}".encode())
+        for item in sorted(
+            (i.registry_id, i.key_bytes.hex(), str(i.rotation_ts)) for i in work_items
+        ):
+            hasher.update(b"W")
+            for field_value in item:
+                hasher.update(field_value.encode())
+                hasher.update(b"\x00")
+        return hasher.hexdigest()
+
+    items_1100 = resolver._collect_work_items([_lock_identity()], now_unix=1100)
+    items_1524 = resolver._collect_work_items([_lock_identity()], now_unix=1524)
+
+    legacy_1100 = _legacy_signature(items_1100, now_unix=1100)
+    legacy_1524 = _legacy_signature(items_1524, now_unix=1524)
+    # The old logic could not tell the two clocks apart: it would have skipped.
+    assert legacy_1100 == legacy_1524
+
+    params = resolver._build_rotation_params()
+    fixed_1100 = resolver._build_signature(items_1100, now_unix=1100, params=params)
+    fixed_1524 = resolver._build_signature(items_1524, now_unix=1524, params=params)
+    # The Variant B signature does tell them apart: it rebuilds.
+    assert fixed_1100 != fixed_1524

--- a/tests/test_eid_resolver_skip_guard.py
+++ b/tests/test_eid_resolver_skip_guard.py
@@ -1,0 +1,387 @@
+# tests/test_eid_resolver_skip_guard.py
+"""Skip-guard gate for the resolver's expensive build phase (AP-B1).
+
+The build phase of ``GoogleFindMyEIDResolver._refresh_cache`` (constructing a
+``CacheBuilder``, fanning out work items into windows/variants, and calling
+``builder.finalize()``) is pure with respect to a deterministic signature over
+the active devices. AP-B1 adds a skip guard that recomputes that signature on
+every refresh and bypasses the build phase when it is unchanged, while keeping
+the cheap mandatory side effects (lock purging, identity caching,
+secret collection) running on every trigger.
+
+These tests pin three contracts:
+
+* **Skip on unchanged input** -- a second ``_refresh_cache`` over an identical
+  device set and frozen clock does not call ``builder.finalize`` again, leaves
+  ``self._lookup`` content-identical, yet still runs ``_purge_stale_locks``.
+* **Work-item sensitivity** -- mutating any signature-relevant work-item field
+  (here ``key_bytes``) forces a rebuild (no skip).
+* **Rotation-window sensitivity** -- advancing the clock across *any* of the
+  three rotation periods (1024 s, 900 s, 3600 s) changes the signature and
+  forces a rebuild. This is the phone-window protection (F5): a single 1024 s
+  term would miss the 900 s / 3600 s phone-window rollovers and leave those
+  trackers unresolvable.
+
+The byte-exact correctness of the cached EIDs is enforced separately by
+``tests/test_eid_resolver_characterization.py``; here we only prove the
+skip/rebuild decision logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy import eid_resolver as resolver_mod
+from custom_components.googlefindmy.coordinator import DeviceIdentity
+from custom_components.googlefindmy.eid_resolver import GoogleFindMyEIDResolver
+from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
+    ROTATION_PERIOD,
+    ROTATION_PERIOD_900,
+    ROTATION_PERIOD_3600,
+)
+
+
+def test_rotation_time_counters_cover_all_three_periods() -> None:
+    """The signature must carry one time_counter term per rotation period.
+
+    This pins the *independent* presence of the 1024 s, 900 s, and 3600 s terms.
+    The 3600 s term cannot be isolated by a clock rollover (every 3600 s
+    boundary is also a 900 s boundary, since 3600 == 4 * 900), so its standalone
+    contribution is asserted here directly rather than via the rebuild path.
+    """
+
+    now_unix = 1_234_567
+    counters = GoogleFindMyEIDResolver._rotation_time_counters(now_unix)
+
+    by_period = dict(counters)
+    assert set(by_period) == {
+        ROTATION_PERIOD,
+        ROTATION_PERIOD_900,
+        ROTATION_PERIOD_3600,
+    }
+    assert by_period[ROTATION_PERIOD] == now_unix // ROTATION_PERIOD
+    assert by_period[ROTATION_PERIOD_900] == now_unix // ROTATION_PERIOD_900
+    assert by_period[ROTATION_PERIOD_3600] == now_unix // ROTATION_PERIOD_3600
+
+
+def test_build_signature_changes_when_only_3600_counter_differs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two clocks with equal 1024 s/900 s counters but a different 3600 s
+    counter would be physically impossible (3600 == 4 * 900), so we pin the
+    3600 s term's effect on the signature by injecting the counter tuple
+    directly: dropping the 3600 s term changes the digest, proving it is hashed.
+    """
+
+    resolver = _build_refreshable_resolver()
+    work_items: list = []
+    now_unix = 230_400  # all counters on a boundary
+
+    full = resolver._build_signature(work_items, now_unix=now_unix)
+
+    # Recompute with the 3600 s term suppressed to confirm it participates.
+    # monkeypatch auto-restores the staticmethod wrapper after the test.
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_rotation_time_counters",
+        staticmethod(
+            lambda n: tuple((p, n // p) for p in (ROTATION_PERIOD, ROTATION_PERIOD_900))
+        ),
+    )
+    without_3600 = resolver._build_signature(work_items, now_unix=now_unix)
+
+    assert full != without_3600
+
+
+def _close_coro(coro: object, name: object = None) -> None:
+    """Close a coroutine to avoid RuntimeWarning in the test context."""
+
+    if hasattr(coro, "close"):
+        coro.close()
+
+
+def _fake_hass() -> SimpleNamespace:
+    """Return a lightweight hass stand-in that closes scheduled coroutines."""
+
+    return SimpleNamespace(
+        async_create_task=_close_coro,
+        async_create_background_task=_close_coro,
+        data={},
+    )
+
+
+def _build_refreshable_resolver() -> GoogleFindMyEIDResolver:
+    """Construct a resolver wired enough to run ``_refresh_cache`` end to end.
+
+    Mirrors the helper in ``tests/test_eid_resolver_memoization.py`` so both
+    performance levers exercise the same build-loop surface.
+    """
+
+    resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
+    resolver.hass = _fake_hass()
+    resolver._ensure_cache_defaults()
+    resolver._lookup = {}
+    resolver._lookup_metadata = {}
+    resolver._locks = {}
+
+    async def _async_noop(payload: object = None) -> None:
+        return None
+
+    resolver._store = SimpleNamespace(async_load=lambda: None, async_save=_async_noop)
+    resolver._unsub_interval = None
+    resolver._unsub_alignment = None
+    resolver._refresh_lock = asyncio.Lock()
+    resolver._pending_refresh = False
+    resolver._load_task = None
+    return resolver
+
+
+def _identity(*, identity_key: bytes = b"\xaa" * 32) -> DeviceIdentity:
+    """Return a minimal active identity for build-loop coverage."""
+
+    return DeviceIdentity(
+        registry_id="registry-id",
+        canonical_id="canonical-id",
+        identity_key=identity_key,
+        encrypted_identity_key=None,
+        owner_key_version=None,
+        device_type=None,
+        config_entry_id="entry-id",
+        fast_pair_model_id=None,
+    )
+
+
+def _install_common_patches(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    identities: list[DeviceIdentity],
+) -> dict[str, int]:
+    """Patch collection seams and a finalize counter; return the counter dict."""
+
+    finalize_calls = {"count": 0}
+    real_finalize = resolver_mod.CacheBuilder.finalize
+
+    def _counting_finalize(self: resolver_mod.CacheBuilder):  # type: ignore[no-untyped-def]
+        finalize_calls["count"] += 1
+        return real_finalize(self)
+
+    monkeypatch.setattr(resolver_mod.CacheBuilder, "finalize", _counting_finalize)
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return list(identities)
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_normalize_identities",
+        lambda self, identities, cache=None: identities,
+    )
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
+    return finalize_calls
+
+
+@pytest.mark.asyncio
+async def test_second_refresh_skips_build_but_still_purges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unchanged input set: second refresh skips finalize, still purges locks."""
+
+    resolver = _build_refreshable_resolver()
+    finalize_calls = _install_common_patches(monkeypatch, identities=[_identity()])
+
+    purge_calls = {"count": 0}
+    real_purge = GoogleFindMyEIDResolver._purge_stale_locks
+
+    def _counting_purge(self: GoogleFindMyEIDResolver, *, now: int) -> None:
+        purge_calls["count"] += 1
+        real_purge(self, now=now)
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_purge_stale_locks", _counting_purge)
+    monkeypatch.setattr(time, "time", lambda: 1024.0)
+
+    # Pass one must do the real build.
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 1
+    assert resolver._lookup  # sanity: produced EIDs
+    lookup_after_first = dict(resolver._lookup)
+
+    # Pass two over identical input and frozen clock skips the build phase ...
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 1  # no second finalize
+    # ... but keeps the lookup content-identical ...
+    assert resolver._lookup == lookup_after_first
+    # ... and still runs the mandatory side effect on every trigger.
+    assert purge_calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_work_item_field_change_forces_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing a signature-relevant work-item field (key_bytes) forces rebuild."""
+
+    resolver = _build_refreshable_resolver()
+    # Two-element holder so the second collect returns a different key.
+    state = {"identities": [_identity(identity_key=b"\xaa" * 32)]}
+    finalize_calls = {"count": 0}
+    real_finalize = resolver_mod.CacheBuilder.finalize
+
+    def _counting_finalize(self: resolver_mod.CacheBuilder):  # type: ignore[no-untyped-def]
+        finalize_calls["count"] += 1
+        return real_finalize(self)
+
+    monkeypatch.setattr(resolver_mod.CacheBuilder, "finalize", _counting_finalize)
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return list(state["identities"])
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_normalize_identities",
+        lambda self, identities, cache=None: identities,
+    )
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
+    monkeypatch.setattr(time, "time", lambda: 1024.0)
+
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 1
+
+    # Mutate the key material -> different work-item signature -> rebuild.
+    state["identities"] = [_identity(identity_key=b"\xbb" * 32)]
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_anchor_change_forces_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing the window anchor (pair_date) forces a rebuild.
+
+    ``pair_date`` is not one of the plan's five core work-item fields, but it
+    drives the relative-window anchor in ``_compute_relative_windows`` and thus
+    the build output. The signature folds it in so the skip stays
+    correctness-preserving (no stale lookup table). This pins that extension.
+    """
+
+    resolver = _build_refreshable_resolver()
+    state = {"identities": [_identity()]}
+    finalize_calls = {"count": 0}
+    real_finalize = resolver_mod.CacheBuilder.finalize
+
+    def _counting_finalize(self: resolver_mod.CacheBuilder):  # type: ignore[no-untyped-def]
+        finalize_calls["count"] += 1
+        return real_finalize(self)
+
+    monkeypatch.setattr(resolver_mod.CacheBuilder, "finalize", _counting_finalize)
+
+    async def _collect(_self: GoogleFindMyEIDResolver) -> list[DeviceIdentity]:
+        return list(state["identities"])
+
+    monkeypatch.setattr(GoogleFindMyEIDResolver, "_collect_device_secrets", _collect)
+    monkeypatch.setattr(
+        GoogleFindMyEIDResolver,
+        "_normalize_identities",
+        lambda self, identities, cache=None: identities,
+    )
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.eid_resolver.ENABLE_ABSOLUTE_UNIX_BASIS",
+        True,
+    )
+    monkeypatch.setattr(time, "time", lambda: 1024.0)
+
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 1
+
+    # Re-provision with a different pairing anchor -> rebuild required.
+    state["identities"] = [
+        DeviceIdentity(
+            registry_id="registry-id",
+            canonical_id="canonical-id",
+            identity_key=b"\xaa" * 32,
+            encrypted_identity_key=None,
+            owner_key_version=None,
+            device_type=None,
+            config_entry_id="entry-id",
+            fast_pair_model_id=None,
+            pair_date=999,
+        )
+    ]
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("period", "label"),
+    [
+        (ROTATION_PERIOD, "1024s"),
+        (ROTATION_PERIOD_900, "900s"),
+        (ROTATION_PERIOD_3600, "3600s"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rotation_window_rollover_forces_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+    period: int,
+    label: str,
+) -> None:
+    """Crossing any single rotation window changes the signature -> rebuild.
+
+    The phone-window protection (F5): a one-period signature would miss the
+    900 s / 3600 s rollovers. We pick a base time and a one-second advance that
+    flips the ``//period`` counter under test, then assert the rebuild fires.
+
+    Note on 3600 s: because ``ROTATION_PERIOD_3600 == 4 * ROTATION_PERIOD_900``,
+    every 3600 s boundary is also a 900 s boundary, so a 3600 s rollover can
+    never be isolated from the 900 s counter (a mathematical property of the
+    periods, not a test defect). For 1024 s and 900 s we require exact
+    isolation; for 3600 s we require that the target counter flips (the 900 s
+    counter is allowed to flip with it). The independent contribution of the
+    3600 s term to the signature is pinned by the mutation cross-check
+    documented in the AP-B1 report.
+    """
+
+    resolver = _build_refreshable_resolver()
+    finalize_calls = _install_common_patches(monkeypatch, identities=[_identity()])
+
+    all_periods = (ROTATION_PERIOD, ROTATION_PERIOD_900, ROTATION_PERIOD_3600)
+    require_isolation = period != ROTATION_PERIOD_3600
+
+    def _acceptable(base: int, advanced: int) -> bool:
+        flipped = [p for p in all_periods if base // p != advanced // p]
+        if require_isolation:
+            return flipped == [period]
+        return period in flipped
+
+    # Search for a base time whose next ``period`` boundary satisfies the
+    # isolation requirement above. Start from a fixed anchor for determinism.
+    anchor = 1_000_000
+    base = 0
+    advanced = 0
+    for candidate in range(anchor, anchor + 8 * max(all_periods)):
+        nxt = candidate + 1
+        if candidate // period != nxt // period and _acceptable(candidate, nxt):
+            base, advanced = candidate, nxt
+            break
+    assert advanced, f"no qualifying base found for {label}"
+
+    monkeypatch.setattr(time, "time", lambda: float(base))
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 1
+
+    monkeypatch.setattr(time, "time", lambda: float(advanced))
+    await resolver._refresh_cache()
+    assert finalize_calls["count"] == 2, (
+        f"rotation window {label} rollover did not force a rebuild"
+    )

--- a/tests/test_eid_resolver_tracking.py
+++ b/tests/test_eid_resolver_tracking.py
@@ -17,6 +17,12 @@ from custom_components.googlefindmy.eid_resolver import (
 )
 
 
+async def _run_in_executor(func, *args):
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C)."""
+
+    return func(*args)
+
+
 @pytest.mark.asyncio
 async def test_tracking_mode_predicts_next_rotation(
     monkeypatch: pytest.MonkeyPatch,
@@ -27,6 +33,7 @@ async def test_tracking_mode_predicts_next_rotation(
     resolver.hass = SimpleNamespace(
         async_create_task=lambda coro, name=None: asyncio.create_task(coro),
         async_create_background_task=lambda coro, name=None: asyncio.create_task(coro),
+        async_add_executor_job=_run_in_executor,
     )
     resolver._locks = {}
     resolver._ensure_cache_defaults()

--- a/tests/test_eid_resolver_variants.py
+++ b/tests/test_eid_resolver_variants.py
@@ -26,11 +26,18 @@ from custom_components.googlefindmy.FMDNCrypto.eid_generator import (
 )
 
 
+async def _run_in_executor(func, *args):
+    """Synchronous stand-in for ``hass.async_add_executor_job`` (AP-C)."""
+
+    return func(*args)
+
+
 def _build_resolver(monkeypatch: pytest.MonkeyPatch) -> GoogleFindMyEIDResolver:
     _ = monkeypatch
     resolver = GoogleFindMyEIDResolver.__new__(GoogleFindMyEIDResolver)
     resolver.hass = SimpleNamespace(
         async_create_task=asyncio.create_task,
+        async_add_executor_job=_run_in_executor,
         data={},
     )
 


### PR DESCRIPTION
Fixes sustained high CPU usage (~100% on Raspberry Pi 4) caused by the EID resolver rebuilding the full EID lookup table on every trigger.

## Root cause (verified in code)
- Over-triggering: a full rebuild runs at the end of every poll cycle and on every incoming location update carrying an identity key (FCM/crowd-sourced bursts).
- No skip-guard: each refresh builds a fresh lookup table even when nothing changed.
- No memoization: the per-variant EID crypto (and the flags XOR mask) is recomputed every refresh.
- The legacy secp160r1 path is pure-Python and runs on the event loop, so weak CPUs (Pi 4) saturate.

## Approach (three levers, correctness-preserving)
- **A** Memoize both per-variant crypto calls (bounded LRU, thread-safe).
- **B1** Skip the expensive build phase when the active-device signature and all rotation windows are unchanged. **B2** Debounce the trigger task creation so bursts coalesce.
- **C** Offload the pure synchronous build sub-block to an executor thread so the loop stays responsive.

Every lever is gated by a byte-exact golden characterization of the EID output (this PR, AP-0) and proven by a mutation counter-probe.

This is a **draft / work in progress**; commits land lever by lever. Not yet ready for review.