### PR TITLE
fix(nova): log benign TTL recalibration at INFO, not WARNING

### DIFF
--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -891,7 +891,7 @@ class TTLPolicy:
                         )
                     # If clearly shorter than our current model (>10% shorter), recalibrate.
                     elif best and (age_sec + self.TTL_MARGIN_SEC) < 0.9 * float(best):
-                        self.log.warning(
+                        self.log.info(
                             "Unexpected short TTL – recalibrating best known TTL with safety buffer."
                         )
                         safe_calibration = age_sec * 0.95
@@ -1280,7 +1280,7 @@ class AsyncTTLPolicy(TTLPolicy):
                         elif best and (age_sec + self.TTL_MARGIN_SEC) < 0.9 * float(
                             best
                         ):
-                            self.log.warning(
+                            self.log.info(
                                 "Unexpected short TTL – recalibrating best known TTL with safety buffer (async)."
                             )
                             safe_calibration = age_sec * 0.95

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -34,6 +34,7 @@ from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaError,
     NovaHTTPError,
     NovaRateLimitError,
+    TTLPolicy,
     async_nova_request,
     register_cache_provider,
     unregister_cache_provider,
@@ -2813,6 +2814,135 @@ async def test_async_ttl_policy_accepts_legitimate_short_ttl_above_threshold() -
             await cache.close()
 
     await _run()
+
+
+async def test_async_ttl_policy_recalibration_logs_info_not_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The async recalibration path logs at INFO, not WARNING (severity downgrade).
+
+    A downward TTL recalibration after an unplanned 401 is correct, self-healing
+    behavior (a 6h probe re-explores the full lifetime upward), so the event is
+    not user-actionable and must not raise a WARNING.
+
+    Mutation sentinel: if the emitter is reverted to ``self.log.warning(...)``,
+    the level assertion turns red.
+    """
+
+    logger_name = "test_async_recal_info"
+
+    async def _run() -> None:
+        hass = _FakeHass()
+        cache = await TokenCache.create(hass, "entry-async-recal-info")
+        try:
+            namespace = "entry-async-recal-info"
+            username = "user@example.com"
+
+            async def _cache_get(key: str) -> Any:
+                return await cache.get(key)
+
+            async def _cache_set(key: str, value: Any) -> None:
+                await cache.set(key, value)
+
+            async def _refresh() -> str:
+                return "fresh-token"
+
+            policy = AsyncTTLPolicy(
+                username=username,
+                logger=logging.getLogger(logger_name),
+                get_value=_cache_get,
+                set_value=_cache_set,
+                refresh_fn=_refresh,
+                set_auth_header_fn=lambda _: None,
+                ns_prefix=namespace,
+            )
+
+            # best=7200s, observed=600s: above MIN_TTL (300s) yet markedly shorter
+            # (600 + 120 margin < 0.9 * 7200), so the recalibration branch fires.
+            original_ttl = 7200.0
+            await cache.set(policy.k_bestttl, original_ttl)
+            observed_ttl = 600.0
+            await cache.set(policy.k_issued, time.time() - observed_ttl)
+
+            with caplog.at_level(logging.INFO, logger=logger_name):
+                await policy.async_on_401(adaptive_downshift=True)
+
+            recal = [
+                r for r in caplog.records if "Unexpected short TTL" in r.getMessage()
+            ]
+            assert len(recal) == 1
+            assert recal[0].levelno == logging.INFO
+            assert not any(
+                r.levelno == logging.WARNING
+                and "Unexpected short TTL" in r.getMessage()
+                for r in caplog.records
+            )
+
+            # Behavior preserved: best TTL is still recalibrated to ~observed * 0.95.
+            best_ttl_after = await cache.get(policy.k_bestttl)
+            assert best_ttl_after is not None
+            assert abs(best_ttl_after - observed_ttl * 0.95) < 1.0
+
+        finally:
+            await cache.close()
+
+    await _run()
+
+
+def test_sync_ttl_policy_recalibration_logs_info_not_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The sync ``TTLPolicy.on_401`` recalibration path logs at INFO, not WARNING.
+
+    Twin of the async coverage above. The downward recalibration is benign and
+    self-healing, so it must not raise a WARNING.
+
+    Mutation sentinel: reverting the emitter to ``self.log.warning(...)`` turns
+    the level assertion red.
+    """
+
+    logger_name = "test_sync_recal_info"
+    store: dict[str, Any] = {}
+
+    def _get(key: str) -> Any:
+        return store.get(key)
+
+    def _set(key: str, value: Any) -> None:
+        if value is None:
+            store.pop(key, None)
+        else:
+            store[key] = value
+
+    policy = TTLPolicy(
+        username="user@example.com",
+        logger=logging.getLogger(logger_name),
+        get_value=_get,
+        set_value=_set,
+        refresh_fn=lambda: "fresh-token",
+        set_auth_header_fn=lambda _: None,
+        ns_prefix="entry-sync-recal-info",
+    )
+
+    # Mirror the async scenario: best=7200s, observed=600s triggers recalibration.
+    original_ttl = 7200.0
+    store[policy.k_bestttl] = original_ttl
+    observed_ttl = 600.0
+    store[policy.k_issued] = time.time() - observed_ttl
+
+    with caplog.at_level(logging.INFO, logger=logger_name):
+        policy.on_401(adaptive_downshift=True)
+
+    recal = [r for r in caplog.records if "Unexpected short TTL" in r.getMessage()]
+    assert len(recal) == 1
+    assert recal[0].levelno == logging.INFO
+    assert not any(
+        r.levelno == logging.WARNING and "Unexpected short TTL" in r.getMessage()
+        for r in caplog.records
+    )
+
+    # Behavior preserved: best TTL is still recalibrated to ~observed * 0.95.
+    # (_do_refresh clears only the token/issued keys, never k_bestttl.)
+    assert abs(float(store[policy.k_bestttl]) - observed_ttl * 0.95) < 1.0
 
 
 async def test_both_adm_and_aas_tokens_have_min_ttl_protection() -> None:


### PR DESCRIPTION
## What & why

The adaptive TTL policy in `NovaApi/nova_request.py` logs a **WARNING** when an unplanned 401 reveals a token lifetime markedly shorter than the learned model (`(age_sec + TTL_MARGIN_SEC) < 0.9 * best`), then recalibrates the best-known TTL downward with a 5 % safety buffer.

This recalibration is **correct, self-healing behavior**, not a fault:
- It only fires above the `MIN_TTL_FOR_LEARNING_SEC` (300 s) transient-noise floor.
- It is **not a ratchet-down trap**: a probe is armed every `PROBE_INTERVAL_SEC` (6 h); the next 401 then accepts the **full** observed `age_sec` (up *or* down), so a one-off short TTL does not permanently lower the model.

Because the event is not user-actionable, a WARNING produces log noise. This PR lowers the severity to **INFO** at both twin emitters:
- sync `TTLPolicy.on_401`
- async `AsyncTTLPolicy.async_on_401`

The log message text is unchanged. This mirrors the existing tiered-severity precedent already used for the network-retry path in the same module.

## Scope / out of scope

The neighboring `"Got 401 – token expired after %.1f min (unplanned)."` WARNING is **intentionally left unchanged** — it signals a genuinely unplanned token expiry and remains potentially actionable.

No behavioral or logic change: the recalibration math (`age_sec * 0.95`) and cache writes are untouched.

## Testing

- Regression test with a caplog mutation sentinel: asserts the recalibration record is emitted at INFO (not WARNING) on both the sync and async path, and that the best-known TTL is still recalibrated (behavior preserved). Reverting the level to WARNING turns the test red.
- Full `pytest` suite green; changed lines covered.