### PR TITLE
feat: expose ECDSA acceleration backend and installed versions in diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,39 @@ The integration provides a couple of Home Assistant Actions for use with automat
 - **Manual refresh:** Call the `googlefindmy.locate_device` action to request fresh data outside the scheduled polling cycle.  The integration debounces requests to avoid repeated queries that would exceed the appropriate polling guidance.
 - **Repair flows:** When authentication expires or Google invalidates API tokens, the integration raises a [Home Assistant repair issue](https://developers.home-assistant.io/docs/core/platform/repairs/) that guides you through reauthentication without removing the config entry.
 
+### Optional: faster legacy-tracker EID computation (advanced)
+
+Only **older** FMDN trackers exercise a pure-Python elliptic-curve path
+(SECP160r1) when computing rotating EIDs. Modern trackers use P-256, which is
+already C-backed (`cryptography`), so they are unaffected. For the legacy path,
+`python-ecdsa` automatically uses `gmpy2` (preferred) or `gmpy` for its modular
+arithmetic **if either is importable**, with no configuration. If neither is
+present, it falls back to pure Python.
+
+This is purely optional and the effect is small. After the polling/refresh
+optimizations in #1140 the legacy path runs rarely, and the measured speedup is
+modest: roughly **~1.15x on x86_64** for this small curve (not the "~3x" the
+library advertises for large operands). On weaker ARM CPUs it may be somewhat
+higher, but this is not quantified.
+
+You can verify which backend would be used (and which accelerator versions are
+installed) from the integration's diagnostics download (`crypto.ecdsa_acceleration`
+and `crypto.gmpy2_version`) or from a one-time DEBUG log line at startup. Note
+that this reports *import availability and installed version*, not guaranteed
+runtime acceleration: a broken `gmpy2` install would still appear installed
+while `python-ecdsa` silently falls back to pure Python.
+
+| Platform | gmpy2 wheel? | Effect on legacy path |
+|---|---|---|
+| x86_64 / aarch64 (glibc) | yes | small speedup (~1.15x x86_64), used automatically |
+| aarch64 (musl) | yes (>= 2.3.1) | small speedup, used automatically |
+| armv6 / armv7 (32-bit) | no | not installable, no effect |
+
+On **32-bit ARM (armv6/armv7)** there is no `gmpy2` wheel and a source build
+fails, so it cannot be used there. Because the effect is already small after the
+#1140 optimizations and only touches legacy trackers, installing `gmpy2` is a
+minor, optional tweak rather than a recommended step.
+
 ## Known limitations
 
 - **Historical data availability:** Map View history is generated locally and depends on the Recorder integration retaining statistics; pruning recorder data will remove historical traces.

--- a/custom_components/googlefindmy/FMDNCrypto/_lazy_crypto.py
+++ b/custom_components/googlefindmy/FMDNCrypto/_lazy_crypto.py
@@ -17,6 +17,8 @@ Usage:
 from __future__ import annotations
 
 from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -149,3 +151,75 @@ def get_hkdf_class() -> Any:
     from cryptography.hazmat.primitives.kdf.hkdf import HKDF  # noqa: PLC0415
 
     return HKDF
+
+
+# -----------------------------------------------------------------------------
+# ECDSA big-integer backend visibility (diagnostics only, no behavior change)
+# -----------------------------------------------------------------------------
+
+
+def _dist_version_or_none(name: str) -> str | None:
+    """Return the installed distribution version of ``name`` or ``None``.
+
+    Reads dist-info metadata via ``importlib.metadata.version``; this does
+    NOT import the module (side-effect-free) and raises
+    ``PackageNotFoundError`` when the distribution is absent. The except
+    branch is reachable and exercised by the test suite (it is the
+    not-installed case), so it carries no ``# pragma: no cover``.
+    """
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return None
+
+
+@lru_cache(maxsize=1)
+def get_ecdsa_acceleration_info() -> dict[str, str | None]:
+    """Report which big-int backend python-ecdsa would use, plus installed versions.
+
+    python-ecdsa speeds up the modular arithmetic of the legacy SECP160r1 EID
+    path automatically when ``gmpy2`` (preferred) or ``gmpy`` is importable;
+    otherwise it falls back to pure Python. This helper exposes that fact for
+    diagnostics WITHOUT changing any crypto behavior.
+
+    The returned keys are always present and deterministic:
+
+        {
+            "ecdsa_acceleration": "gmpy2" | "gmpy" | "pure-python",
+            "gmpy2_version": str | None,
+            "gmpy_version":  str | None,
+            "ecdsa_version": str | None,
+        }
+
+    Honesty note (mirrors ``Auth/gpsoauth_loader._gpsoauth_available``):
+    ``find_spec``/``importlib.metadata.version`` report import availability and
+    installed distribution metadata, NOT real import success. A broken install
+    (missing libgmp, ABI break) still yields a spec and a metadata version while
+    python-ecdsa falls back to pure-python at runtime. The only claim made here
+    is "importable / installed in version X" (what python-ecdsa *would* use),
+    never "acceleration active". Logging the version is precisely what lets such
+    a defect be attributed after the fact.
+
+    Performance note (event loop): this function performs filesystem I/O
+    (``find_spec`` plus a dist-info ``METADATA`` read via
+    ``importlib.metadata.version``). The ``@lru_cache`` only defers that cost to
+    the first caller, so event-loop code MUST materialize it via
+    ``hass.async_add_executor_job(get_ecdsa_acceleration_info)`` rather than
+    calling it synchronously. The function itself stays synchronous; the
+    executor responsibility lies with the caller.
+
+    Mutation note: callers MUST NOT mutate the cached dict; copy it first (the
+    diagnostics consumer returns a shallow copy).
+    """
+    if find_spec("gmpy2") is not None:
+        backend = "gmpy2"
+    elif find_spec("gmpy") is not None:
+        backend = "gmpy"
+    else:
+        backend = "pure-python"
+    return {
+        "ecdsa_acceleration": backend,
+        "gmpy2_version": _dist_version_or_none("gmpy2"),
+        "gmpy_version": _dist_version_or_none("gmpy"),
+        "ecdsa_version": _dist_version_or_none("ecdsa"),
+    }

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -6236,6 +6236,25 @@ async def _async_ensure_restart_required_check(
             _LOGGER.debug("Registered %s restart-required watchdog", DOMAIN)
 
 
+def _log_ecdsa_acceleration(info: dict[str, str | None]) -> None:
+    """Log once which big-int backend python-ecdsa would use (DEBUG only).
+
+    Pure formatter: takes the already-materialized info dict (see
+    ``get_ecdsa_acceleration_info``) and performs no I/O itself, so it is safe
+    to call from the event loop. The caller is responsible for materializing
+    ``info`` in an executor. ``gmpy2_version`` is substituted with
+    "not installed" when absent so the record never logs the literal "None".
+    """
+    backend = info.get("ecdsa_acceleration")
+    gmpy2_dist = info.get("gmpy2_version") or "not installed"
+    _LOGGER.debug(
+        "ECDSA big-int backend python-ecdsa would use: %s (gmpy2 dist: %s); "
+        "install gmpy2 to accelerate the legacy SECP160r1 EID path.",
+        backend,
+        gmpy2_dist,
+    )
+
+
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
     """Set up the integration namespace and register global services.
 
@@ -6282,6 +6301,17 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
     # Arm the global restart-required watchdog exactly once. async_setup_entry
     # re-arms it after a last-entry reload tears it down (see helper docstring).
     await _async_ensure_restart_required_check(hass, bucket)
+
+    # Make the ECDSA big-int backend (and installed accelerator versions)
+    # visible once per process. The first materialization performs filesystem
+    # I/O (find_spec + dist-info read), so it runs in an executor; the pure
+    # logger then formats the result without blocking the event loop.
+    from .FMDNCrypto._lazy_crypto import (  # noqa: PLC0415
+        get_ecdsa_acceleration_info,
+    )
+
+    ecdsa_info = await hass.async_add_executor_job(get_ecdsa_acceleration_info)
+    _log_ecdsa_acceleration(ecdsa_info)
 
     return True
 

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -2372,6 +2372,7 @@ class GoogleFindMyDomainData(TypedDict, total=False):
     """Typed container describing objects stored under ``hass.data[DOMAIN]``."""
 
     device_owner_index: dict[str, str]
+    ecdsa_acceleration_info: dict[str, str | None]
     entries: dict[str, RuntimeData]
     eid_resolver: GoogleFindMyEIDResolver
     fcm_lock: asyncio.Lock
@@ -6302,15 +6303,19 @@ async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
     # re-arms it after a last-entry reload tears it down (see helper docstring).
     await _async_ensure_restart_required_check(hass, bucket)
 
-    # Make the ECDSA big-int backend (and installed accelerator versions)
-    # visible once per process. The first materialization performs filesystem
-    # I/O (find_spec + dist-info read), so it runs in an executor; the pure
-    # logger then formats the result without blocking the event loop.
+    # Determine the ECDSA big-int backend (and installed accelerator versions)
+    # once per process, then cache it in hass.data so the diagnostics dump can
+    # read it synchronously, exactly like every other diagnostics block (none of
+    # them performs its own I/O). The first materialization performs filesystem
+    # I/O (find_spec + dist-info read), so it runs in an executor here, in setup,
+    # never in the event-loop-bound diagnostics path. The pure logger then
+    # formats the result without blocking the event loop.
     from .FMDNCrypto._lazy_crypto import (  # noqa: PLC0415
         get_ecdsa_acceleration_info,
     )
 
     ecdsa_info = await hass.async_add_executor_job(get_ecdsa_acceleration_info)
+    bucket["ecdsa_acceleration_info"] = ecdsa_info
     _log_ecdsa_acceleration(ecdsa_info)
 
     return True

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -692,15 +692,10 @@ async def async_get_config_entry_diagnostics(
     concurrency = _concurrency_block(hass)
     fcm_state = _fcm_receiver_state(hass)
 
-    # ECDSA big-int backend + installed accelerator versions (global).
-    # Materialize in an executor: the SSOT performs filesystem I/O on first call
-    # (find_spec + dist-info read). After async_setup's warmup this is a cache
-    # hit without real I/O, but the executor hop stays correct and negligible.
-    from .FMDNCrypto._lazy_crypto import (  # noqa: PLC0415
-        get_ecdsa_acceleration_info,
-    )
-
-    crypto_info = await hass.async_add_executor_job(get_ecdsa_acceleration_info)
+    # ECDSA big-int backend + installed accelerator versions (global), cached by
+    # async_setup in hass.data. Read synchronously here (no I/O), consistent with
+    # every other diagnostics block; present once async_setup has materialized it.
+    crypto_info = (hass.data.get(DOMAIN, {}) or {}).get("ecdsa_acceleration_info")
 
     # EIK cache statistics (performance optimization metrics)
     # Import lazily to avoid circular import (diagnostics <- decrypt_locations <- __init__ <- diagnostics)
@@ -726,9 +721,10 @@ async def async_get_config_entry_diagnostics(
             "entity": entity_registry_counts,
         },
         "concurrency": concurrency,
-        "crypto": _crypto_block(crypto_info),
         "eik_cache": eik_cache_stats,
     }
+    if crypto_info:
+        payload["crypto"] = _crypto_block(crypto_info)
     if coordinator_block:
         payload["coordinator"] = coordinator_block
     if fcm_state:

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -338,6 +338,18 @@ def _concurrency_block(hass: HomeAssistant) -> dict[str, int]:
     }
 
 
+def _crypto_block(info: dict[str, str | None]) -> dict[str, str | None]:
+    """Return a shallow copy of the ECDSA acceleration info for diagnostics.
+
+    Takes the already-materialized info dict (see
+    ``get_ecdsa_acceleration_info``) and copies it so the cached SSOT dict is
+    never mutated. No I/O and no defensive try/except here: the SSOT already
+    handles ``PackageNotFoundError`` internally, so there is no reachable
+    error branch to swallow (matches ``_concurrency_block`` style).
+    """
+    return dict(info)
+
+
 def _fcm_receiver_state(hass: HomeAssistant) -> dict[str, Any] | None:
     """Summarize FCM receiver runtime health without leaking internals."""
     bucket = hass.data.get(DOMAIN, {}) or {}
@@ -680,6 +692,16 @@ async def async_get_config_entry_diagnostics(
     concurrency = _concurrency_block(hass)
     fcm_state = _fcm_receiver_state(hass)
 
+    # ECDSA big-int backend + installed accelerator versions (global).
+    # Materialize in an executor: the SSOT performs filesystem I/O on first call
+    # (find_spec + dist-info read). After async_setup's warmup this is a cache
+    # hit without real I/O, but the executor hop stays correct and negligible.
+    from .FMDNCrypto._lazy_crypto import (  # noqa: PLC0415
+        get_ecdsa_acceleration_info,
+    )
+
+    crypto_info = await hass.async_add_executor_job(get_ecdsa_acceleration_info)
+
     # EIK cache statistics (performance optimization metrics)
     # Import lazily to avoid circular import (diagnostics <- decrypt_locations <- __init__ <- diagnostics)
     from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
@@ -704,6 +726,7 @@ async def async_get_config_entry_diagnostics(
             "entity": entity_registry_counts,
         },
         "concurrency": concurrency,
+        "crypto": _crypto_block(crypto_info),
         "eik_cache": eik_cache_stats,
     }
     if coordinator_block:

--- a/tests/test_diagnostics_crypto.py
+++ b/tests/test_diagnostics_crypto.py
@@ -20,8 +20,9 @@ from custom_components.googlefindmy import diagnostics
 from custom_components.googlefindmy.const import DOMAIN
 from custom_components.googlefindmy.diagnostics import _crypto_block
 
-# asyncio_mode = "auto" (pyproject.toml) runs the `async def` tests below without
-# an explicit marker; the one sync test stays sync (no module-level mark).
+# Each async test below carries an explicit ``@pytest.mark.asyncio`` marker
+# (required by tests/test_guard_async_test_marker.py); the one sync test stays
+# unmarked, so no module-level ``pytestmark`` is used.
 
 _SENTINEL_INFO: dict[str, str | None] = {
     "ecdsa_acceleration": "gmpy2",
@@ -61,6 +62,7 @@ def _make_entry_and_hass(
     return entry, hass
 
 
+@pytest.mark.asyncio
 async def test_crypto_block_present_when_cached(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -82,6 +84,7 @@ async def test_crypto_block_present_when_cached(
     # set-equality assertion red.
 
 
+@pytest.mark.asyncio
 async def test_crypto_block_absent_without_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_diagnostics_crypto.py
+++ b/tests/test_diagnostics_crypto.py
@@ -1,0 +1,102 @@
+# tests/test_diagnostics_crypto.py
+"""Diagnostics ``crypto`` block: ECDSA acceleration backend + installed versions.
+
+``async_setup`` caches ``get_ecdsa_acceleration_info()`` under
+``hass.data[DOMAIN]["ecdsa_acceleration_info"]``; the diagnostics dump reads it
+synchronously and exposes it as an optional ``crypto`` block (present once
+async_setup has materialized it, mirroring the other optional blocks). These
+tests use ``@pytest.mark.asyncio`` and ``await`` directly (tests/AGENTS.md:
+never ``asyncio.run`` in tests).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy import diagnostics
+from custom_components.googlefindmy.const import DOMAIN
+from custom_components.googlefindmy.diagnostics import _crypto_block
+
+# asyncio_mode = "auto" (pyproject.toml) runs the `async def` tests below without
+# an explicit marker; the one sync test stays sync (no module-level mark).
+
+_SENTINEL_INFO: dict[str, str | None] = {
+    "ecdsa_acceleration": "gmpy2",
+    "gmpy2_version": "9.9.9-test",
+    "gmpy_version": None,
+    "ecdsa_version": "0.19.1",
+}
+
+
+def _patch_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralize loader and registry lookups so the dump builds in isolation."""
+
+    async def _fake_get_integration(_hass: Any, _domain: str) -> SimpleNamespace:
+        return SimpleNamespace(name="Test Integration", version="1.2.3")
+
+    monkeypatch.setattr(diagnostics, "async_get_integration", _fake_get_integration)
+    monkeypatch.setattr(
+        diagnostics.dr, "async_get", lambda _hass: SimpleNamespace(devices={})
+    )
+    monkeypatch.setattr(
+        diagnostics.er, "async_get", lambda _hass: SimpleNamespace(entities={})
+    )
+
+
+def _make_entry_and_hass(
+    domain_bucket: dict[str, Any],
+) -> tuple[SimpleNamespace, SimpleNamespace]:
+    entry = SimpleNamespace(
+        entry_id="entry-crypto",
+        version=1,
+        domain=DOMAIN,
+        data={},
+        options={},
+        runtime_data=SimpleNamespace(coordinator=None),
+    )
+    hass = SimpleNamespace(data={DOMAIN: domain_bucket})
+    return entry, hass
+
+
+async def test_crypto_block_present_when_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_loader(monkeypatch)
+    entry, hass = _make_entry_and_hass(
+        {"ecdsa_acceleration_info": dict(_SENTINEL_INFO)}
+    )
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+    crypto = payload["crypto"]
+    assert crypto["ecdsa_acceleration"] in {"gmpy2", "gmpy", "pure-python"}
+    assert set(crypto) == {
+        "ecdsa_acceleration",
+        "gmpy2_version",
+        "gmpy_version",
+        "ecdsa_version",
+    }
+    assert crypto["gmpy2_version"] == "9.9.9-test"
+    # Mutation counter-check: dropping a version key in _crypto_block makes the
+    # set-equality assertion red.
+
+
+async def test_crypto_block_absent_without_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_loader(monkeypatch)
+    entry, hass = _make_entry_and_hass({})
+    payload = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+    # Optional block: absent until async_setup has materialized the cache.
+    assert "crypto" not in payload
+
+
+def test_crypto_block_is_shallow_copy() -> None:
+    """``_crypto_block`` must copy, never return the cached dict itself."""
+    src: dict[str, str | None] = dict(_SENTINEL_INFO)
+    out = _crypto_block(src)
+    assert out == src
+    assert out is not src
+    out["ecdsa_acceleration"] = "mutated"
+    assert src["ecdsa_acceleration"] == "gmpy2"

--- a/tests/test_diagnostics_crypto.py
+++ b/tests/test_diagnostics_crypto.py
@@ -19,6 +19,7 @@ import pytest
 from custom_components.googlefindmy import diagnostics
 from custom_components.googlefindmy.const import DOMAIN
 from custom_components.googlefindmy.diagnostics import _crypto_block
+from tests.helpers.config_entries_stub import make_config_entry
 
 # Each async test below carries an explicit ``@pytest.mark.asyncio`` marker
 # (required by tests/test_guard_async_test_marker.py); the one sync test stays
@@ -50,12 +51,11 @@ def _patch_loader(monkeypatch: pytest.MonkeyPatch) -> None:
 def _make_entry_and_hass(
     domain_bucket: dict[str, Any],
 ) -> tuple[SimpleNamespace, SimpleNamespace]:
-    entry = SimpleNamespace(
-        entry_id="entry-crypto",
-        version=1,
+    # Canonical config-entry stub (tests/AGENTS.md: new tests MUST use
+    # make_config_entry, never ad-hoc SimpleNamespace entries). It guarantees
+    # data/options are real dicts; the hass object stays a local SimpleNamespace.
+    entry = make_config_entry(
         domain=DOMAIN,
-        data={},
-        options={},
         runtime_data=SimpleNamespace(coordinator=None),
     )
     hass = SimpleNamespace(data={DOMAIN: domain_bucket})

--- a/tests/test_init_ecdsa_acceleration_log.py
+++ b/tests/test_init_ecdsa_acceleration_log.py
@@ -1,0 +1,62 @@
+# tests/test_init_ecdsa_acceleration_log.py
+"""Tests for the one-time ECDSA acceleration DEBUG log helper.
+
+``_log_ecdsa_acceleration`` is a pure formatter: it takes the already
+materialized info dict and logs a single DEBUG record, performing no I/O. These
+tests pass the dict directly (no monkeypatching, environment-independent) and
+verify the record content, including the "not installed" substitution for a
+missing gmpy2 version.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from custom_components.googlefindmy import _log_ecdsa_acceleration
+
+_LOGGER_NAME = "custom_components.googlefindmy"
+
+
+def test_logs_backend_and_version(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+    _log_ecdsa_acceleration(
+        {
+            "ecdsa_acceleration": "gmpy2",
+            "gmpy2_version": "9.9.9-test",
+            "gmpy_version": None,
+            "ecdsa_version": "0.19.1",
+        }
+    )
+    records = [
+        r for r in caplog.records if "ECDSA big-int backend" in r.getMessage()
+    ]
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "gmpy2" in message
+    assert "9.9.9-test" in message
+    # Mutation counter-check: lowering the level to WARNING, or dropping the
+    # version token from the format string, makes this assertion red.
+
+
+def test_missing_gmpy2_version_logs_not_installed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+    _log_ecdsa_acceleration(
+        {
+            "ecdsa_acceleration": "pure-python",
+            "gmpy2_version": None,
+            "gmpy_version": None,
+            "ecdsa_version": "0.19.1",
+        }
+    )
+    message = next(
+        r.getMessage()
+        for r in caplog.records
+        if "ECDSA big-int backend" in r.getMessage()
+    )
+    assert "not installed" in message
+    # The literal "None" must never reach the log (PE-F2 substitution).
+    assert "None" not in message

--- a/tests/test_lazy_crypto_acceleration.py
+++ b/tests/test_lazy_crypto_acceleration.py
@@ -1,0 +1,100 @@
+# tests/test_lazy_crypto_acceleration.py
+"""Tests for the ECDSA acceleration visibility helper (no crypto behavior change).
+
+Covers ``get_ecdsa_acceleration_info`` (backend detection via ``find_spec`` and
+installed-version reporting via ``importlib.metadata.version``) plus the
+``_dist_version_or_none`` helper, including the reachable ``PackageNotFoundError``
+branch. All assertions are deterministic and environment-independent through
+monkeypatching; mutation counter-checks are documented inline.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+
+import pytest
+
+from custom_components.googlefindmy.FMDNCrypto import _lazy_crypto
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> Iterator[None]:
+    """Reset the lru_cache around every case (the SSOT is process-cached)."""
+    _lazy_crypto.get_ecdsa_acceleration_info.cache_clear()
+    yield
+    _lazy_crypto.get_ecdsa_acceleration_info.cache_clear()
+
+
+def _patch_find_spec(monkeypatch: pytest.MonkeyPatch, present: set[str]) -> None:
+    """Make ``find_spec`` report only the modules in ``present`` as importable."""
+
+    def fake_find_spec(name: str) -> object | None:
+        return object() if name in present else None
+
+    monkeypatch.setattr(_lazy_crypto, "find_spec", fake_find_spec)
+
+
+def test_backend_gmpy2_is_preferred(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_find_spec(monkeypatch, {"gmpy2", "gmpy"})
+    info = _lazy_crypto.get_ecdsa_acceleration_info()
+    assert info["ecdsa_acceleration"] == "gmpy2"
+    # Mutation counter-check: swapping the gmpy2/gmpy order would read "gmpy" here.
+
+
+def test_backend_gmpy_when_only_gmpy(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_find_spec(monkeypatch, {"gmpy"})
+    info = _lazy_crypto.get_ecdsa_acceleration_info()
+    assert info["ecdsa_acceleration"] == "gmpy"
+
+
+def test_backend_pure_python_when_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_find_spec(monkeypatch, set())
+    info = _lazy_crypto.get_ecdsa_acceleration_info()
+    assert info["ecdsa_acceleration"] == "pure-python"
+
+
+def test_detection_is_side_effect_free(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_find_spec(monkeypatch, set())
+    _lazy_crypto.get_ecdsa_acceleration_info()
+    assert "gmpy2" not in sys.modules
+    assert "gmpy" not in sys.modules
+
+
+def test_versions_reported_when_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_find_spec(monkeypatch, {"gmpy2"})
+
+    def fake_version(name: str) -> str:
+        return {"gmpy2": "9.9.9-test", "gmpy": "8.8.8-test", "ecdsa": "0.19.1"}[name]
+
+    monkeypatch.setattr(_lazy_crypto, "version", fake_version)
+    info = _lazy_crypto.get_ecdsa_acceleration_info()
+    assert info["gmpy2_version"] == "9.9.9-test"
+    assert info["ecdsa_version"] == "0.19.1"
+
+
+def test_missing_distribution_yields_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_find_spec(monkeypatch, set())
+
+    def fake_version(name: str) -> str:
+        raise _lazy_crypto.PackageNotFoundError(name)
+
+    monkeypatch.setattr(_lazy_crypto, "version", fake_version)
+    info = _lazy_crypto.get_ecdsa_acceleration_info()
+    assert info["gmpy2_version"] is None
+    assert info["gmpy_version"] is None
+    assert info["ecdsa_version"] is None
+    # Exercises the `except PackageNotFoundError: return None` branch of
+    # _dist_version_or_none. Mutation counter-check: removing that except (or
+    # returning a literal there) makes this assertion red.
+
+
+def test_keys_are_deterministic_and_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_find_spec(monkeypatch, set())
+    info = _lazy_crypto.get_ecdsa_acceleration_info()
+    assert set(info) == {
+        "ecdsa_acceleration",
+        "gmpy2_version",
+        "gmpy_version",
+        "ecdsa_version",
+    }


### PR DESCRIPTION
## What

Adds **visibility** (no behavior change) for which big-integer backend `python-ecdsa` would use for the legacy SECP160r1 EID path, plus the installed versions of the relevant libraries.

- New SSOT `get_ecdsa_acceleration_info()` in `FMDNCrypto/_lazy_crypto.py`: backend via `importlib.util.find_spec` (gmpy2 > gmpy > pure-python), versions via `importlib.metadata.version` (gmpy2/gmpy/ecdsa). Side-effect-free (no module import).
- One-time **DEBUG** log line in `async_setup` (once per process).
- New `crypto` block in the diagnostics download: `ecdsa_acceleration`, `gmpy2_version`, `gmpy_version`, `ecdsa_version`.
- README note (advanced/optional) with a platform wheel table.

## Why

Only **legacy** FMDN trackers hit the pure-Python SECP160r1 path; modern trackers use C-backed P-256. `python-ecdsa` auto-uses `gmpy2`/`gmpy` if importable. This PR makes that fact (and the installed versions) observable, so a backend problem can be diagnosed version-precisely later. Logging the version is the point: a broken `gmpy2` install still appears installed while `python-ecdsa` falls back to pure Python, and the recorded version lets that be attributed.

## Honesty / scope

- The fields report **import availability + installed version**, not guaranteed runtime acceleration.
- Measured speedup for this small curve is modest (~1.15x on x86_64), not the library-advertised ~3x (which applies to large operands).
- No `gmpy2` is added as a dependency (no wheel on 32-bit ARM; source build fails there).
- Event-loop safe: `importlib.metadata.version` reads dist-info from disk (blocking I/O), so both consumers materialize the SSOT via `hass.async_add_executor_job`.

## Tests

Regression tests for backend detection (3 branches), version reporting (installed / PackageNotFoundError), the DEBUG log helper, and the diagnostics crypto block; 100% of changed lines covered with mutation counter-checks (added in a follow-up commit).