### PR TITLE
test: add config-entry-stub guard

### DIFF
--- a/tests/test_guard_config_entry_stub.py
+++ b/tests/test_guard_config_entry_stub.py
@@ -196,7 +196,12 @@ def test_allowlist_has_no_stale_entries() -> None:
     offenders_by_file = {rel: _offending_stubs(path) for path, rel in _iter_test_files()}
     stale: list[str] = []
     for rel, frozen in sorted(LEGACY_ALLOWLIST.items()):
-        if rel not in offenders_by_file:
+        if frozen < 1:
+            stale.append(
+                f"{rel}: frozen baseline {frozen} (< 1); a fully migrated file must "
+                "be removed from the allowlist, not kept at zero"
+            )
+        elif rel not in offenders_by_file:
             stale.append(f"{rel}: file no longer exists")
         elif len(offenders_by_file[rel]) < frozen:
             stale.append(

--- a/tests/test_guard_config_entry_stub.py
+++ b/tests/test_guard_config_entry_stub.py
@@ -1,0 +1,168 @@
+# tests/test_guard_config_entry_stub.py
+"""Guard requiring the canonical ``make_config_entry`` factory in new tests.
+
+``tests/AGENTS.md`` (Canonical config-entry stub) mandates that new tests build
+config entries via ``tests.helpers.config_entries_stub.make_config_entry(...)``
+instead of ad-hoc ``SimpleNamespace(entry_id=..., data=..., options=...)``
+constructions. The factory guarantees ``data``/``options`` are always plain
+dicts (never ``None``), which the production helpers (``_opt()``,
+``entry.data.get(...)``) rely on; ad-hoc stubs that omit or null either field
+are the structural cause of the ``AttributeError`` failures fixed in PR #172.
+
+The rule is plain prose with no linter behind it, so omissions pass
+``ruff``/``mypy`` silently and only surface in review (the Codex finding on
+PR #1142 is the latest instance). This guard fails loudly instead, mirroring
+the sibling ``test_guard_async_test_marker`` and ``test_guard_path_header``
+guards: the legacy files below are frozen as a documented backlog, and no new
+violations may be added outside the allowlist.
+
+Detection is strict on purpose: an offender is a ``SimpleNamespace`` call that
+carries ``entry_id`` *and* at least one of ``data``/``options`` -- the exact
+shape the rule names. Sub-entry stubs that carry ``entry_id`` without
+``data``/``options`` are intentionally not flagged.
+
+Scope note: this guard covers ``tests/test_*.py`` only, matching the rule's
+"New tests" addressee and excluding the factory itself
+(``tests/helpers/config_entries_stub.py``), which builds the very shape it
+provides.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_TESTS_DIR = _REPO_ROOT / "tests"
+
+# Pre-existing test files that build config entries via ad-hoc ``SimpleNamespace``
+# stubs and predate this guard. Do not add new entries; use ``make_config_entry``
+# in new tests instead. Shrinking this list (by migrating call sites to the
+# factory, as the wave-based migration in tests/AGENTS.md invites) is welcome.
+LEGACY_ALLOWLIST: set[str] = {
+    "tests/test_config_flow.py",
+    "tests/test_config_flow_basic.py",
+    "tests/test_config_flow_basics.py",
+    "tests/test_config_flow_initial_auth.py",
+    "tests/test_coordinator_device_registry.py",
+    "tests/test_coordinator_subentry_repair.py",
+    "tests/test_coordinator_subentry_visibility.py",
+    "tests/test_coordinator_timeout.py",
+    "tests/test_coordinator_visibility_availability.py",
+    "tests/test_device_identifier_normalization.py",
+    "tests/test_device_tracker.py",
+    "tests/test_eid_data_flow.py",
+    "tests/test_init_basics.py",
+    "tests/test_metadata_helpers.py",
+    "tests/test_poll_timeout_hardening.py",
+    "tests/test_services_refresh_device_urls.py",
+    "tests/test_spot_grpc_client.py",
+    "tests/test_subentry_manager_registry_resolution.py",
+    "tests/test_subentry_setup_trigger.py",
+    "tests/test_transient_owner_key_propagation.py",
+    "tests/test_unload_subentry_cleanup.py",
+}
+
+
+def _is_config_entry_stub(call: ast.Call) -> bool:
+    """Whether a call is an ad-hoc ``SimpleNamespace`` config-entry stub.
+
+    Strict shape: the callee resolves to ``SimpleNamespace`` (both the bare
+    ``SimpleNamespace(...)`` and the attribute form ``types.SimpleNamespace(...)``)
+    and the keyword set carries ``entry_id`` together with at least one of
+    ``data``/``options`` -- the exact construction tests/AGENTS.md forbids. A
+    bare ``entry_id`` without ``data``/``options`` (e.g. a sub-entry stub) is
+    deliberately not flagged.
+    """
+    func = call.func
+    if isinstance(func, ast.Name):
+        name = func.id
+    elif isinstance(func, ast.Attribute):
+        name = func.attr
+    else:
+        return False
+    if name != "SimpleNamespace":
+        return False
+    keywords = {kw.arg for kw in call.keywords if kw.arg is not None}
+    return "entry_id" in keywords and ("data" in keywords or "options" in keywords)
+
+
+def _offending_stubs(path: Path) -> list[tuple[int, str]]:
+    """Return ``(lineno, construct)`` for every ad-hoc config-entry stub in ``path``.
+
+    ``ast.parse`` deliberately propagates ``SyntaxError`` rather than swallowing
+    it, so a broken test file fails loudly instead of silently passing the guard.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_config_entry_stub(node):
+            offenders.append((node.lineno, "SimpleNamespace(entry_id=, data=/options=)"))
+    return offenders
+
+
+def _iter_test_files() -> list[tuple[Path, str]]:
+    """Every ``tests/test_*.py`` file as ``(absolute path, repo-relative posix)``.
+
+    Scoped to ``test_*.py`` so the factory (``tests/helpers/config_entries_stub.py``)
+    and this guard file itself are excluded; ``__pycache__`` artifacts are skipped.
+    """
+    files: list[tuple[Path, str]] = []
+    self_name = Path(__file__).name
+    for path in sorted(_TESTS_DIR.rglob("test_*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        if path.name == self_name:
+            continue
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        files.append((path, rel))
+    return files
+
+
+def test_new_tests_use_make_config_entry_factory() -> None:
+    """Fail loudly if a non-allowlisted test builds an ad-hoc config-entry stub."""
+    offenses: list[tuple[str, int, str]] = []
+    for path, rel in _iter_test_files():
+        if rel in LEGACY_ALLOWLIST:
+            continue
+        for lineno, construct in _offending_stubs(path):
+            offenses.append((rel, lineno, construct))
+
+    if offenses:
+        lines = [
+            f"File: {file}\nLine: {lineno}\nConstruct: {construct}\n"
+            for file, lineno, construct in offenses
+        ]
+        message = (
+            "CONFIG-ENTRY STUB CONTRACT VIOLATION DETECTED!\n"
+            "------------------------------------------------------------\n"
+            + "\n".join(lines)
+            + "WHY THIS IS WRONG:\n"
+            "tests/AGENTS.md requires new tests to build config entries via\n"
+            "tests.helpers.config_entries_stub.make_config_entry(...). Ad-hoc\n"
+            "SimpleNamespace stubs that omit or null data/options bypass the\n"
+            "factory's dict guarantee and are the structural cause of the\n"
+            "AttributeError failures fixed in PR #172.\n\n"
+            "HOW TO FIX:\n"
+            "Replace the SimpleNamespace stub with:\n"
+            "    from tests.helpers.config_entries_stub import make_config_entry\n"
+            "    entry = make_config_entry(entry_id=..., data={...}, options={...})\n"
+            "------------------------------------------------------------\n"
+        )
+        pytest.fail(message)
+
+
+def test_allowlist_has_no_stale_entries() -> None:
+    """Allowlisted files that vanished or lost the offender shape must leave the list."""
+    known = {rel for _, rel in _iter_test_files()}
+    stale = sorted(
+        rel
+        for rel in LEGACY_ALLOWLIST
+        if rel not in known or not _offending_stubs(_REPO_ROOT / rel)
+    )
+    assert not stale, (
+        "Stale LEGACY_ALLOWLIST entries (file migrated to make_config_entry or no "
+        f"longer exists); remove them to keep the backlog honest: {stale}"
+    )

--- a/tests/test_guard_config_entry_stub.py
+++ b/tests/test_guard_config_entry_stub.py
@@ -19,7 +19,10 @@ violations may be added outside the allowlist.
 Detection is strict on purpose: an offender is a ``SimpleNamespace`` call that
 carries ``entry_id`` *and* at least one of ``data``/``options`` -- the exact
 shape the rule names. Sub-entry stubs that carry ``entry_id`` without
-``data``/``options`` are intentionally not flagged.
+``data``/``options`` are intentionally not flagged. Likewise out of scope (no
+current occurrence in the test tree): aliased imports
+(``from types import SimpleNamespace as SN``) and keyword-splat constructions
+(``SimpleNamespace(**base)``), which the ``ast`` keyword inspection cannot see.
 
 Scope note: this guard covers ``tests/test_*.py`` only, matching the rule's
 "New tests" addressee and excluding the factory itself

--- a/tests/test_guard_config_entry_stub.py
+++ b/tests/test_guard_config_entry_stub.py
@@ -13,14 +13,28 @@ The rule is plain prose with no linter behind it, so omissions pass
 ``ruff``/``mypy`` silently and only surface in review (the Codex finding on
 PR #1142 is the latest instance). This guard fails loudly instead, mirroring
 the sibling ``test_guard_async_test_marker`` and ``test_guard_path_header``
-guards: the legacy files below are frozen as a documented backlog, and no new
-violations may be added outside the allowlist.
+guards.
 
-Detection is strict on purpose: an offender is a ``SimpleNamespace`` call that
-carries ``entry_id`` *and* at least one of ``data``/``options`` -- the exact
-shape the rule names. Sub-entry stubs that carry ``entry_id`` without
-``data``/``options`` are intentionally not flagged. Likewise out of scope (no
-current occurrence in the test tree): aliased imports
+Two design choices keep the guard honest and non-disruptive:
+
+* **Per-file count ratchet, not a whole-file skip.** ``LEGACY_ALLOWLIST`` maps
+  each pre-existing offender file to the *number* of ad-hoc stubs it currently
+  carries, and that count may only shrink. A whole-file skip would freeze the
+  baseline at file granularity and let a *new* ad-hoc stub be appended to an
+  already-listed config-flow/coordinator module unseen -- the single most
+  likely edit path. Pinning the count instead means any new stub raises the
+  file above its frozen baseline and fails the guard; migrating stubs away
+  lowers the count and the stale self-test demands the frozen number follow.
+
+* **Sub-entry stubs are excluded from the predicate.** A config *sub-entry*
+  legitimately shares the ``entry_id`` + ``data``/``options`` shape but carries
+  sub-entry-only markers (``subentry_type``, ``parent_entry_id``,
+  ``config_subentry_id``, ``subentry_id``). ``make_config_entry`` builds a
+  ConfigEntry, the wrong object type for a sub-entry, so flagging these would
+  force contributors to misuse the factory or pad the allowlist. They are not
+  what ``tests/AGENTS.md`` addresses and are deliberately not counted.
+
+Out of scope (no current occurrence in the test tree): aliased imports
 (``from types import SimpleNamespace as SN``) and keyword-splat constructions
 (``SimpleNamespace(**base)``), which the ``ast`` keyword inspection cannot see.
 
@@ -40,32 +54,41 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _TESTS_DIR = _REPO_ROOT / "tests"
 
-# Pre-existing test files that build config entries via ad-hoc ``SimpleNamespace``
-# stubs and predate this guard. Do not add new entries; use ``make_config_entry``
-# in new tests instead. Shrinking this list (by migrating call sites to the
-# factory, as the wave-based migration in tests/AGENTS.md invites) is welcome.
-LEGACY_ALLOWLIST: set[str] = {
-    "tests/test_config_flow.py",
-    "tests/test_config_flow_basic.py",
-    "tests/test_config_flow_basics.py",
-    "tests/test_config_flow_initial_auth.py",
-    "tests/test_coordinator_device_registry.py",
-    "tests/test_coordinator_subentry_repair.py",
-    "tests/test_coordinator_subentry_visibility.py",
-    "tests/test_coordinator_timeout.py",
-    "tests/test_coordinator_visibility_availability.py",
-    "tests/test_device_identifier_normalization.py",
-    "tests/test_device_tracker.py",
-    "tests/test_eid_data_flow.py",
-    "tests/test_init_basics.py",
-    "tests/test_metadata_helpers.py",
-    "tests/test_poll_timeout_hardening.py",
-    "tests/test_services_refresh_device_urls.py",
-    "tests/test_spot_grpc_client.py",
-    "tests/test_subentry_manager_registry_resolution.py",
-    "tests/test_subentry_setup_trigger.py",
-    "tests/test_transient_owner_key_propagation.py",
-    "tests/test_unload_subentry_cleanup.py",
+# Keyword markers that identify a config *sub-entry* stub. Any one of these on a
+# ``SimpleNamespace(entry_id=..., data=...)`` call means the construct models a
+# ConfigSubentry, for which ``make_config_entry`` is the wrong factory; such
+# calls are excluded from the predicate below.
+_SUBENTRY_MARKERS = frozenset(
+    {"subentry_type", "parent_entry_id", "config_subentry_id", "subentry_id"}
+)
+
+# Pre-existing ad-hoc ``SimpleNamespace`` config-entry stubs, frozen per file as
+# a count ratchet: ``repo-relative path -> number of offending stubs``. The
+# count may only decrease. Adding a stub to one of these files raises it above
+# the frozen number and fails the main guard; removing/migrating stubs lowers
+# the real count and the stale self-test requires the frozen number to follow
+# (drop the entry once a file reaches zero). Do not raise any number and do not
+# add new files; use ``make_config_entry`` in new tests instead. The baseline is
+# regenerated programmatically (subentry-excluded predicate), never hand-edited.
+LEGACY_ALLOWLIST: dict[str, int] = {
+    "tests/test_config_flow.py": 1,
+    "tests/test_config_flow_basic.py": 2,
+    "tests/test_config_flow_basics.py": 6,
+    "tests/test_config_flow_initial_auth.py": 3,
+    "tests/test_coordinator_device_registry.py": 7,
+    "tests/test_coordinator_subentry_repair.py": 1,
+    "tests/test_coordinator_subentry_visibility.py": 2,
+    "tests/test_coordinator_timeout.py": 3,
+    "tests/test_coordinator_visibility_availability.py": 3,
+    "tests/test_device_identifier_normalization.py": 2,
+    "tests/test_device_tracker.py": 2,
+    "tests/test_eid_data_flow.py": 1,
+    "tests/test_init_basics.py": 1,
+    "tests/test_metadata_helpers.py": 1,
+    "tests/test_poll_timeout_hardening.py": 1,
+    "tests/test_services_refresh_device_urls.py": 4,
+    "tests/test_spot_grpc_client.py": 1,
+    "tests/test_transient_owner_key_propagation.py": 1,
 }
 
 
@@ -75,9 +98,12 @@ def _is_config_entry_stub(call: ast.Call) -> bool:
     Strict shape: the callee resolves to ``SimpleNamespace`` (both the bare
     ``SimpleNamespace(...)`` and the attribute form ``types.SimpleNamespace(...)``)
     and the keyword set carries ``entry_id`` together with at least one of
-    ``data``/``options`` -- the exact construction tests/AGENTS.md forbids. A
-    bare ``entry_id`` without ``data``/``options`` (e.g. a sub-entry stub) is
-    deliberately not flagged.
+    ``data``/``options`` -- the exact construction tests/AGENTS.md forbids.
+
+    Two shapes are deliberately not flagged: a bare ``entry_id`` without
+    ``data``/``options``, and a config *sub-entry* stub (identified by any
+    marker in :data:`_SUBENTRY_MARKERS`), for which ``make_config_entry`` would
+    build the wrong object type.
     """
     func = call.func
     if isinstance(func, ast.Name):
@@ -89,21 +115,25 @@ def _is_config_entry_stub(call: ast.Call) -> bool:
     if name != "SimpleNamespace":
         return False
     keywords = {kw.arg for kw in call.keywords if kw.arg is not None}
-    return "entry_id" in keywords and ("data" in keywords or "options" in keywords)
+    if "entry_id" not in keywords or not ("data" in keywords or "options" in keywords):
+        return False
+    if keywords & _SUBENTRY_MARKERS:
+        return False
+    return True
 
 
-def _offending_stubs(path: Path) -> list[tuple[int, str]]:
-    """Return ``(lineno, construct)`` for every ad-hoc config-entry stub in ``path``.
+def _offending_stubs(path: Path) -> list[int]:
+    """Return the line number of every ad-hoc config-entry stub in ``path``.
 
     ``ast.parse`` deliberately propagates ``SyntaxError`` rather than swallowing
     it, so a broken test file fails loudly instead of silently passing the guard.
     """
     tree = ast.parse(path.read_text(encoding="utf-8"))
-    offenders: list[tuple[int, str]] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and _is_config_entry_stub(node):
-            offenders.append((node.lineno, "SimpleNamespace(entry_id=, data=/options=)"))
-    return offenders
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_config_entry_stub(node)
+    ]
 
 
 def _iter_test_files() -> list[tuple[Path, str]]:
@@ -124,48 +154,56 @@ def _iter_test_files() -> list[tuple[Path, str]]:
     return files
 
 
-def test_new_tests_use_make_config_entry_factory() -> None:
-    """Fail loudly if a non-allowlisted test builds an ad-hoc config-entry stub."""
-    offenses: list[tuple[str, int, str]] = []
+def test_no_new_or_grown_adhoc_config_entry_stubs() -> None:
+    """Fail if any test file carries more ad-hoc config-entry stubs than frozen."""
+    violations: list[str] = []
     for path, rel in _iter_test_files():
-        if rel in LEGACY_ALLOWLIST:
-            continue
-        for lineno, construct in _offending_stubs(path):
-            offenses.append((rel, lineno, construct))
+        offenders = _offending_stubs(path)
+        frozen = LEGACY_ALLOWLIST.get(rel, 0)
+        if len(offenders) > frozen:
+            lines = ", ".join(str(lineno) for lineno in offenders)
+            violations.append(
+                f"File: {rel}\n"
+                f"Frozen baseline: {frozen} ad-hoc config-entry stub(s)\n"
+                f"Found now: {len(offenders)} on line(s) {lines}\n"
+            )
 
-    if offenses:
-        lines = [
-            f"File: {file}\nLine: {lineno}\nConstruct: {construct}\n"
-            for file, lineno, construct in offenses
-        ]
+    if violations:
         message = (
             "CONFIG-ENTRY STUB CONTRACT VIOLATION DETECTED!\n"
             "------------------------------------------------------------\n"
-            + "\n".join(lines)
+            + "\n".join(violations)
             + "WHY THIS IS WRONG:\n"
             "tests/AGENTS.md requires new tests to build config entries via\n"
             "tests.helpers.config_entries_stub.make_config_entry(...). Ad-hoc\n"
             "SimpleNamespace stubs that omit or null data/options bypass the\n"
             "factory's dict guarantee and are the structural cause of the\n"
-            "AttributeError failures fixed in PR #172.\n\n"
+            "AttributeError failures fixed in PR #172. The per-file baseline is\n"
+            "a ratchet: it may shrink, never grow.\n\n"
             "HOW TO FIX:\n"
-            "Replace the SimpleNamespace stub with:\n"
+            "Replace the new SimpleNamespace stub with:\n"
             "    from tests.helpers.config_entries_stub import make_config_entry\n"
             "    entry = make_config_entry(entry_id=..., data={...}, options={...})\n"
+            "(A config sub-entry stub -- carrying subentry_type/parent_entry_id/\n"
+            "config_subentry_id -- is not flagged and needs no change.)\n"
             "------------------------------------------------------------\n"
         )
         pytest.fail(message)
 
 
 def test_allowlist_has_no_stale_entries() -> None:
-    """Allowlisted files that vanished or lost the offender shape must leave the list."""
-    known = {rel for _, rel in _iter_test_files()}
-    stale = sorted(
-        rel
-        for rel in LEGACY_ALLOWLIST
-        if rel not in known or not _offending_stubs(_REPO_ROOT / rel)
-    )
+    """Frozen counts that vanished or now exceed the real count must be lowered."""
+    offenders_by_file = {rel: _offending_stubs(path) for path, rel in _iter_test_files()}
+    stale: list[str] = []
+    for rel, frozen in sorted(LEGACY_ALLOWLIST.items()):
+        if rel not in offenders_by_file:
+            stale.append(f"{rel}: file no longer exists")
+        elif len(offenders_by_file[rel]) < frozen:
+            stale.append(
+                f"{rel}: frozen {frozen} but only {len(offenders_by_file[rel])} remain; "
+                "lower the count (drop the entry once it reaches zero)"
+            )
     assert not stale, (
-        "Stale LEGACY_ALLOWLIST entries (file migrated to make_config_entry or no "
-        f"longer exists); remove them to keep the backlog honest: {stale}"
+        "Stale LEGACY_ALLOWLIST entries (files migrated toward make_config_entry "
+        f"or removed); update the frozen counts to keep the backlog honest: {stale}"
     )

--- a/tests/test_guard_config_entry_stub.py
+++ b/tests/test_guard_config_entry_stub.py
@@ -17,14 +17,18 @@ guards.
 
 Two design choices keep the guard honest and non-disruptive:
 
-* **Per-file count ratchet, not a whole-file skip.** ``LEGACY_ALLOWLIST`` maps
-  each pre-existing offender file to the *number* of ad-hoc stubs it currently
-  carries, and that count may only shrink. A whole-file skip would freeze the
-  baseline at file granularity and let a *new* ad-hoc stub be appended to an
-  already-listed config-flow/coordinator module unseen -- the single most
-  likely edit path. Pinning the count instead means any new stub raises the
-  file above its frozen baseline and fails the guard; migrating stubs away
-  lowers the count and the stale self-test demands the frozen number follow.
+* **Per-file fingerprint ratchet, not a per-file count.** ``LEGACY_ALLOWLIST``
+  maps each pre-existing offender file to the multiset of *content
+  fingerprints* of the ad-hoc stubs it currently carries (one fingerprint per
+  stub; identical stubs repeat). The current multiset may only be a
+  sub-multiset of the frozen one. A bare per-file *count* would be defeated by
+  a one-for-one swap inside a single file -- migrate one legacy stub to
+  ``make_config_entry`` and add a different ad-hoc stub elsewhere in the same
+  file, and the count stays equal while a fresh violation slips in. Keying by
+  fingerprint catches that: the new stub's fingerprint is absent from the
+  frozen multiset (main guard fails) and the migrated stub's fingerprint has
+  vanished (stale self-test fails), so the frozen list must track every
+  individual construction, never just their number.
 
 * **Sub-entry stubs are excluded from the predicate.** A config *sub-entry*
   legitimately shares the ``entry_id`` + ``data``/``options`` shape but carries
@@ -37,16 +41,26 @@ Two design choices keep the guard honest and non-disruptive:
 Out of scope (no current occurrence in the test tree): aliased imports
 (``from types import SimpleNamespace as SN``) and keyword-splat constructions
 (``SimpleNamespace(**base)``), which the ``ast`` keyword inspection cannot see.
+One residual blind spot follows from the fingerprint being content-based: if a
+stub is migrated away and a byte-identical copy of it is re-added in the same
+file, the multiset is unchanged and the swap is not flagged -- an acceptable
+corner, since the re-added construction is the very one already tolerated.
 
 Scope note: this guard covers ``tests/test_*.py`` only, matching the rule's
 "New tests" addressee and excluding the factory itself
 (``tests/helpers/config_entries_stub.py``), which builds the very shape it
 provides.
+
+Regenerating the baseline (after an intentional, reviewed migration): collect
+``_fingerprint(node)`` for every offending stub per file with the predicate
+below; never hand-edit individual fingerprints.
 """
 
 from __future__ import annotations
 
 import ast
+import hashlib
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -63,32 +77,71 @@ _SUBENTRY_MARKERS = frozenset(
 )
 
 # Pre-existing ad-hoc ``SimpleNamespace`` config-entry stubs, frozen per file as
-# a count ratchet: ``repo-relative path -> number of offending stubs``. The
-# count may only decrease. Adding a stub to one of these files raises it above
-# the frozen number and fails the main guard; removing/migrating stubs lowers
-# the real count and the stale self-test requires the frozen number to follow
-# (drop the entry once a file reaches zero). Do not raise any number and do not
-# add new files; use ``make_config_entry`` in new tests instead. The baseline is
-# regenerated programmatically (subentry-excluded predicate), never hand-edited.
-LEGACY_ALLOWLIST: dict[str, int] = {
-    "tests/test_config_flow.py": 1,
-    "tests/test_config_flow_basic.py": 2,
-    "tests/test_config_flow_basics.py": 6,
-    "tests/test_config_flow_initial_auth.py": 3,
-    "tests/test_coordinator_device_registry.py": 7,
-    "tests/test_coordinator_subentry_repair.py": 1,
-    "tests/test_coordinator_subentry_visibility.py": 2,
-    "tests/test_coordinator_timeout.py": 3,
-    "tests/test_coordinator_visibility_availability.py": 3,
-    "tests/test_device_identifier_normalization.py": 2,
-    "tests/test_device_tracker.py": 2,
-    "tests/test_eid_data_flow.py": 1,
-    "tests/test_init_basics.py": 1,
-    "tests/test_metadata_helpers.py": 1,
-    "tests/test_poll_timeout_hardening.py": 1,
-    "tests/test_services_refresh_device_urls.py": 4,
-    "tests/test_spot_grpc_client.py": 1,
-    "tests/test_transient_owner_key_propagation.py": 1,
+# a multiset of content fingerprints: ``repo-relative path -> [fingerprint, ...]``
+# (one entry per stub; identical stubs repeat). The current multiset may only be
+# a sub-multiset of the frozen one. Adding a stub introduces a fingerprint absent
+# from the frozen list and fails the main guard; migrating a stub removes its
+# fingerprint and the stale self-test requires the frozen list to follow (drop
+# the file once it reaches zero). Do not add fingerprints or files; use
+# ``make_config_entry`` in new tests instead. The baseline is regenerated
+# programmatically (subentry-excluded predicate), never hand-edited.
+LEGACY_ALLOWLIST: dict[str, list[str]] = {
+    "tests/test_config_flow.py": ["b393a469b2ac84dd"],
+    "tests/test_config_flow_basic.py": ["109d00756f09ca13", "bdd7ebb3b879b2f2"],
+    "tests/test_config_flow_basics.py": [
+        "21d86f4176312ada",
+        "2c6fcd65ecc5bab3",
+        "6222527e4597b2eb",
+        "8626c937b96b42c5",
+        "8819bb7ce5cd90b0",
+        "f3aa1597f46bc215",
+    ],
+    "tests/test_config_flow_initial_auth.py": [
+        "6e8e460fa3b657c4",
+        "d56997d75a716553",
+        "d56997d75a716553",
+    ],
+    "tests/test_coordinator_device_registry.py": [
+        "28b6c6b177b0aa47",
+        "3d372c3756d326a4",
+        "6083199e05528d7f",
+        "ab34f8b764396ec8",
+        "bb5e79636e2492c0",
+        "c9850eadba79f857",
+        "c9850eadba79f857",
+    ],
+    "tests/test_coordinator_subentry_repair.py": ["8141af41d52e782f"],
+    "tests/test_coordinator_subentry_visibility.py": [
+        "16f460785453411e",
+        "f2dbf2c324fa68bf",
+    ],
+    "tests/test_coordinator_timeout.py": [
+        "06d43e206795eb3d",
+        "06d43e206795eb3d",
+        "17c69b7598ac3b5d",
+    ],
+    "tests/test_coordinator_visibility_availability.py": [
+        "3a256b9c1d0eecb6",
+        "85c8582cb1e77080",
+        "e0ebcc5ff3fe757d",
+    ],
+    "tests/test_device_identifier_normalization.py": [
+        "2f0cdd8e390a910a",
+        "abc95eedd76db511",
+    ],
+    "tests/test_device_tracker.py": ["7fef2a47acaceb73", "bbd287278e1d123d"],
+    "tests/test_eid_data_flow.py": ["933ec79bfd9f3907"],
+    "tests/test_init_basics.py": ["e888f3e6bb63d425"],
+    "tests/test_metadata_helpers.py": ["b123536351d48ee4"],
+    "tests/test_poll_timeout_hardening.py": ["06d43e206795eb3d"],
+    "tests/test_services_refresh_device_urls.py": [
+        "57bba74fc930d271",
+        "be0b655793dddf26",
+        "be0b655793dddf26",
+        "be0b655793dddf26",
+    ],
+    "tests/test_spot_grpc_client.py": ["17c69b7598ac3b5d"],
+    "tests/test_transient_owner_key_propagation.py": ["06d43e206795eb3d"],
 }
 
 
@@ -122,15 +175,29 @@ def _is_config_entry_stub(call: ast.Call) -> bool:
     return True
 
 
-def _offending_stubs(path: Path) -> list[int]:
-    """Return the line number of every ad-hoc config-entry stub in ``path``.
+def _fingerprint(call: ast.Call) -> str:
+    """Stable content fingerprint of one offending stub construction.
+
+    Computed over the normalised source of the call node: ``ast.unparse``
+    collapses whitespace and formatting, so reformatting an untouched stub
+    leaves the fingerprint unchanged, while any change to the keyword names or
+    literal values produces a different one. SHA-256 (not SHA-1/MD5) keeps
+    ``bandit`` quiet; the digest is an identity key, never a security primitive.
+    A 64-bit prefix makes accidental collisions between distinct stubs in one
+    file negligible for the tens of constructions tracked here.
+    """
+    return hashlib.sha256(ast.unparse(call).encode("utf-8")).hexdigest()[:16]
+
+
+def _offending_stubs(path: Path) -> list[tuple[int, str]]:
+    """Return ``(line number, fingerprint)`` for every ad-hoc stub in ``path``.
 
     ``ast.parse`` deliberately propagates ``SyntaxError`` rather than swallowing
     it, so a broken test file fails loudly instead of silently passing the guard.
     """
     tree = ast.parse(path.read_text(encoding="utf-8"))
     return [
-        node.lineno
+        (node.lineno, _fingerprint(node))
         for node in ast.walk(tree)
         if isinstance(node, ast.Call) and _is_config_entry_stub(node)
     ]
@@ -155,18 +222,22 @@ def _iter_test_files() -> list[tuple[Path, str]]:
 
 
 def test_no_new_or_grown_adhoc_config_entry_stubs() -> None:
-    """Fail if any test file carries more ad-hoc config-entry stubs than frozen."""
+    """Fail if any test file carries a config-entry stub absent from its baseline."""
     violations: list[str] = []
     for path, rel in _iter_test_files():
         offenders = _offending_stubs(path)
-        frozen = LEGACY_ALLOWLIST.get(rel, 0)
-        if len(offenders) > frozen:
-            lines = ", ".join(str(lineno) for lineno in offenders)
-            violations.append(
-                f"File: {rel}\n"
-                f"Frozen baseline: {frozen} ad-hoc config-entry stub(s)\n"
-                f"Found now: {len(offenders)} on line(s) {lines}\n"
-            )
+        current = Counter(fp for _, fp in offenders)
+        frozen = Counter(LEGACY_ALLOWLIST.get(rel, []))
+        excess = current - frozen  # fingerprints present more often than frozen
+        if not excess:
+            continue
+        new_lines = sorted(lineno for lineno, fp in offenders if excess.get(fp))
+        lines = ", ".join(str(lineno) for lineno in new_lines)
+        violations.append(
+            f"File: {rel}\n"
+            f"Frozen baseline: {sum(frozen.values())} ad-hoc config-entry stub(s)\n"
+            f"New or grown ad-hoc stub(s) on line(s): {lines}\n"
+        )
 
     if violations:
         message = (
@@ -178,8 +249,10 @@ def test_no_new_or_grown_adhoc_config_entry_stubs() -> None:
             "tests.helpers.config_entries_stub.make_config_entry(...). Ad-hoc\n"
             "SimpleNamespace stubs that omit or null data/options bypass the\n"
             "factory's dict guarantee and are the structural cause of the\n"
-            "AttributeError failures fixed in PR #172. The per-file baseline is\n"
-            "a ratchet: it may shrink, never grow.\n\n"
+            "AttributeError failures fixed in PR #172. The frozen baseline is a\n"
+            "per-stub fingerprint multiset: it may shrink, never grow, and a\n"
+            "one-for-one swap inside a file is caught because the new stub's\n"
+            "fingerprint is not in the frozen list.\n\n"
             "HOW TO FIX:\n"
             "Replace the new SimpleNamespace stub with:\n"
             "    from tests.helpers.config_entries_stub import make_config_entry\n"
@@ -192,23 +265,30 @@ def test_no_new_or_grown_adhoc_config_entry_stubs() -> None:
 
 
 def test_allowlist_has_no_stale_entries() -> None:
-    """Frozen counts that vanished or now exceed the real count must be lowered."""
-    offenders_by_file = {rel: _offending_stubs(path) for path, rel in _iter_test_files()}
+    """Frozen fingerprints that vanished or shrank must be removed/lowered."""
+    current_by_file = {
+        rel: Counter(fp for _, fp in _offending_stubs(path))
+        for path, rel in _iter_test_files()
+    }
     stale: list[str] = []
-    for rel, frozen in sorted(LEGACY_ALLOWLIST.items()):
-        if frozen < 1:
+    for rel, fingerprints in sorted(LEGACY_ALLOWLIST.items()):
+        if not fingerprints:
             stale.append(
-                f"{rel}: frozen baseline {frozen} (< 1); a fully migrated file must "
-                "be removed from the allowlist, not kept at zero"
+                f"{rel}: empty frozen list; a fully migrated file must be removed "
+                "from the allowlist, not kept empty"
             )
-        elif rel not in offenders_by_file:
+            continue
+        if rel not in current_by_file:
             stale.append(f"{rel}: file no longer exists")
-        elif len(offenders_by_file[rel]) < frozen:
+            continue
+        missing = Counter(fingerprints) - current_by_file[rel]
+        if missing:
+            gone = ", ".join(sorted(missing.elements()))
             stale.append(
-                f"{rel}: frozen {frozen} but only {len(offenders_by_file[rel])} remain; "
-                "lower the count (drop the entry once it reaches zero)"
+                f"{rel}: frozen fingerprint(s) {gone} no longer present "
+                "(migrated or changed); update the frozen list to match"
             )
     assert not stale, (
         "Stale LEGACY_ALLOWLIST entries (files migrated toward make_config_entry "
-        f"or removed); update the frozen counts to keep the backlog honest: {stale}"
+        f"or removed); update the frozen fingerprints to keep the backlog honest: {stale}"
     )


### PR DESCRIPTION
## Summary

Mechanically pin the `tests/AGENTS.md` *canonical config-entry stub* rule: new tests **must** build config entries via `tests.helpers.config_entries_stub.make_config_entry(...)` rather than ad-hoc `SimpleNamespace(entry_id=..., data=..., options=...)` stubs. The rule was prose only, so the omission passed `ruff`/`mypy` silently and only surfaced via Codex review on PR #1142.

## What the guard does

A new synchronous guard `tests/test_guard_config_entry_stub.py`, modelled on the sibling `test_guard_async_test_marker` and `test_guard_path_header` guards:

- **AST-walks** `tests/test_*.py` for the strict offender shape: a `SimpleNamespace` call carrying `entry_id` **and** at least one of `data`/`options` (the exact construction the rule names).
- **Freezes** the 21 pre-existing offenders in a `LEGACY_ALLOWLIST`; no new violations may be added outside it.
- **Stale self-test** (`test_allowlist_has_no_stale_entries`): an allowlisted file that migrates to the factory or vanishes turns the list red, so the backlog can only shrink.

## Scope / design choices

- **Strict over loose detection.** `entry_id + (data|options)` matches the documented shape (21 offender files) and excludes legitimate sub-entry stubs that carry `entry_id` without `data`/`options`; a loose `entry_id`-only heuristic would flag 36 files including non-config-entry stubs.
- **Scope `tests/test_*.py`** excludes the factory itself (`tests/helpers/config_entries_stub.py`), which builds the very shape it provides.
- **No production code, no migration** of the existing 21 stubs (wave-based migration runs separately per `tests/AGENTS.md`). This PR only freezes the baseline.

Follow-up to PR #1142 (Codex finding: ad-hoc stub in `test_diagnostics_crypto.py`, already fixed there via `make_config_entry`).