### PR TITLE
fix(decrypt): stop stateless decrypt layer from advising re-auth on transient report failures

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -154,8 +154,12 @@ def invalidate_eik_cache_for_key(
 ) -> int:
     """Invalidate all cached EIK entries for a specific encrypted identity key.
 
-    Called when persistent MAC/InvalidTag failures indicate the cached decrypted
-    EIK is stale (e.g., after key rotation, re-pairing, or E2EE reset).
+    Called when every encrypted report in a poll cycle fails MAC/InvalidTag
+    authentication, which suggests the cached decrypted EIK is stale (e.g., after
+    key rotation, re-pairing, or E2EE reset). Whether the failure is actually
+    persistent is decided by the stateful callers (coordinator poll verdict / FCM
+    callback), not here: this helper only drops the cache so the next poll
+    re-derives the key.
 
     Returns:
         The number of entries removed.
@@ -169,7 +173,8 @@ def invalidate_eik_cache_for_key(
             removed += 1
     if removed:
         _LOGGER.info(
-            "Invalidated %d EIK cache entries (version=%s) due to persistent auth failures",
+            "Invalidated %d EIK cache entries (version=%s) after authentication "
+            "failures this cycle; the next poll re-derives the key",
             removed,
             owner_key_version,
         )
@@ -1708,11 +1713,17 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             _auth_failures += 1
             if public_key_random == b"":  # Own-report auth failure
                 _own_auth_failures += 1
-            _LOGGER.warning(
+            # Per-report detail diagnostics only: a single report failing to
+            # authenticate is not actionable on its own (a stale own report,
+            # an offline device, or a foreign/crowdsourced report keyed to
+            # another account all land here). The user-facing verdict and any
+            # reauth decision belong to the stateful, sibling-aware callers
+            # (coordinator poll verdict / FCM callback), so this stays DEBUG and
+            # carries no reauth advice.
+            _LOGGER.debug(
                 "Decryption auth failed (InvalidTag) for %s report "
                 "(time_offset=%s, key_len=%s, candidates=%d): "
-                "report could not be authenticated. "
-                "Try re-authenticating the account in the Google app.",
+                "report could not be authenticated.",
                 "own" if public_key_random == b"" else "foreign",
                 time_offset if public_key_random != b"" else "N/A",
                 len(active_identity_key) if active_identity_key else 0,
@@ -1727,7 +1738,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 _auth_failures += 1
                 if public_key_random == b"":  # Own-report auth failure
                     _own_auth_failures += 1
-                _LOGGER.warning(
+                # Same class as InvalidTag above (PyCryptodome AES-EAX raises
+                # ValueError("MAC check failed") on the same tag mismatch);
+                # per-report detail diagnostics, DEBUG, no reauth advice.
+                _LOGGER.debug(
                     "Decryption auth failed (MAC check) for %s report "
                     "(time_offset=%s, key_len=%s, candidates=%d): %s",
                     "own" if public_key_random == b"" else "foreign",
@@ -1766,20 +1780,27 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     ):
         owner_ver = getattr(encrypted_user_secrets, "ownerKeyVersion", 0)
         removed = invalidate_eik_cache_for_key(raw_encrypted_identity_key, owner_ver)
+        # This aggregate notice stays DEBUG and carries no reauth advice: this
+        # function is stateless per call (it sees a single poll cycle, often with
+        # just one report) and cannot judge whether the failure is persistent. The
+        # cache invalidation above is logged once at INFO; the sibling-aware,
+        # cross-cycle reauth verdict belongs to the coordinator
+        # (PollingOperations) and the FCM callback, which remain the user-facing
+        # owners of any WARNING/ERROR. The own-report mismatch is still surfaced
+        # via OwnReportIdentityMismatchError below, so the escalation machinery is
+        # untouched.
         if removed:
-            _LOGGER.warning(
-                "All %d encrypted location reports failed authentication. "
-                "Invalidated %d cached identity key(s) to force re-derivation "
-                "on next poll. If this persists, re-authenticate the account "
-                "or check if E2EE keys have been reset.",
+            _LOGGER.debug(
+                "All %d encrypted location reports failed authentication; "
+                "invalidated %d cached identity key(s) to force re-derivation "
+                "on the next poll.",
                 _auth_failures,
                 removed,
             )
         else:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "All %d encrypted location reports failed authentication "
-                "but no cached keys found to invalidate. The identity key "
-                "derivation may be failing. Re-authenticate the account.",
+                "but no cached keys were found to invalidate.",
                 _auth_failures,
             )
 

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -26,7 +26,7 @@ CONFIG_ENTRY_VERSION: int = 2
 # cross-reference, so the manifest side is anchored in this directory's AGENTS.md
 # ("Version bump touches three files"). pyproject.toml carries the reverse reference
 # in a TOML comment.
-INTEGRATION_VERSION: str = "1.7.6"
+INTEGRATION_VERSION: str = "1.7.7"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.6"
+  "version": "1.7.7"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "googlefindmy-ha"
 # [tool.semantic_release] version_toml below); on release branches it MUST be
 # bumped by hand alongside the other two. Canonical anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
-version = "1.7.6"
+version = "1.7.7"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_decrypt_locations_log_severity.py
+++ b/tests/test_decrypt_locations_log_severity.py
@@ -1,0 +1,181 @@
+# tests/test_decrypt_locations_log_severity.py
+"""Log severity of per-report decrypt-auth failures in ``decrypt_locations``.
+
+``async_decrypt_location_response_locations`` is stateless per call: it sees a
+single poll cycle (often just one report) and cannot judge whether an
+authentication failure is persistent. A single own-report ``InvalidTag`` is
+therefore detail diagnostics, logged at DEBUG, and must carry no
+``re-authenticate`` advice -- the sibling-aware, cross-cycle verdict belongs to
+the coordinator (``PollingOperations``) and the FCM callback, which stay the
+user-facing WARNING/ERROR owners. The functional contract is unchanged: the
+own-report mismatch is still surfaced via ``OwnReportIdentityMismatchError`` and
+the stale EIK cache is still invalidated.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    decrypt_locations,
+)
+from custom_components.googlefindmy.ProtoDecoders import Common_pb2, DeviceUpdate_pb2
+
+pytestmark = pytest.mark.asyncio
+
+_DECRYPT_LOGGER = decrypt_locations.__name__
+
+
+def _build_single_own_report_update() -> DeviceUpdate_pb2.DeviceUpdate:
+    """Build a DeviceUpdate carrying exactly one own (server-side) report.
+
+    A 32-byte ``encryptedIdentityKey`` is attached so the aggregate
+    invalidation branch is reached without triggering the 60-byte unwrap path.
+    """
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    registration = update.deviceMetadata.information.deviceRegistration
+    registration.encryptedUserSecrets.encryptedIdentityKey = b"\x11" * 32
+
+    reports = update.deviceMetadata.information.locationInformation.reports.recentLocationAndNetworkLocations
+    reports.recentLocationTimestamp.seconds = 1_700_000_000
+    recent = reports.recentLocation
+    recent.status = Common_pb2.Status.LAST_KNOWN
+    recent.geoLocation.accuracy = 5.0
+    encrypted_report = recent.geoLocation.encryptedReport
+    encrypted_report.publicKeyRandom = b""  # empty -> own report
+    encrypted_report.encryptedLocation = b"ciphertext"
+    encrypted_report.isOwnReport = True
+    return update
+
+
+async def test_single_own_report_invalidtag_logs_debug_without_reauth_advice(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One own-report ``InvalidTag`` is DEBUG-only and gives no reauth advice.
+
+    The aggregate "all reports failed authentication" notice must also be DEBUG
+    and free of ``re-authenticate``/``persistent`` wording, while the
+    ``OwnReportIdentityMismatchError`` escalation signal is still raised so the
+    coordinator/callback keep ownership of the user-facing verdict.
+    """
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag("authentication tag mismatch")
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload)
+
+    update = _build_single_own_report_update()
+
+    with caplog.at_level(logging.DEBUG, logger=_DECRYPT_LOGGER):
+        with pytest.raises(decrypt_locations.OwnReportIdentityMismatchError):
+            await decrypt_locations.async_decrypt_location_response_locations(
+                update, cache=object()
+            )
+
+    decrypt_records = [rec for rec in caplog.records if rec.name == _DECRYPT_LOGGER]
+
+    # The per-report InvalidTag notice exists and proves the failure path ran...
+    per_report = [
+        rec
+        for rec in decrypt_records
+        if "Decryption auth failed (InvalidTag)" in rec.message
+    ]
+    assert len(per_report) == 1
+    # ...at DEBUG, not WARNING (this is the behavior the change pins).
+    assert per_report[0].levelno == logging.DEBUG
+
+    # The aggregate "all reports failed authentication" notice is also DEBUG.
+    aggregate = [
+        rec
+        for rec in decrypt_records
+        if "encrypted location reports failed authentication" in rec.message
+    ]
+    assert len(aggregate) == 1
+    assert aggregate[0].levelno == logging.DEBUG
+
+    # No auth-failure record from this stateless layer may reach WARNING/ERROR;
+    # the user-facing verdict is owned by the coordinator/callback.
+    auth_records = per_report + aggregate
+    assert all(rec.levelno < logging.WARNING for rec in auth_records)
+
+    # The contradictory reauth advice is gone from every record of this layer.
+    joined = "\n".join(rec.getMessage() for rec in decrypt_records).lower()
+    assert "re-authenticat" not in joined
+    assert "try re-authenticating" not in joined
+
+
+async def test_aggregate_invalidation_notice_is_debug_and_not_persistent(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A stale EIK is still invalidated, but the notices are DEBUG/neutral.
+
+    With a primed EIK cache the ``removed > 0`` branch runs: the aggregate
+    "all reports failed" notice and the "Invalidated N EIK cache entries" INFO
+    must no longer claim the failure is ``persistent`` or advise reauth, while
+    the cache entries are still dropped to force a fresh derivation next poll.
+    """
+
+    raw_eik = b"\x11" * 32
+    owner_version = 0  # default ownerKeyVersion on the proto used below
+
+    # Prime the EIK cache via the real key mechanic so invalidate removes >0.
+    decrypt_locations._eik_cache.clear()
+    for do_flip in (False, True):
+        flipped = decrypt_locations.flip_bits(raw_eik, do_flip)
+        cache_key = decrypt_locations._get_eik_cache_key(
+            flipped, owner_version, do_flip
+        )
+        decrypt_locations._eik_cache[cache_key] = b"\x00" * 32
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag("authentication tag mismatch")
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload)
+
+    update = _build_single_own_report_update()
+
+    try:
+        with caplog.at_level(logging.DEBUG, logger=_DECRYPT_LOGGER):
+            with pytest.raises(decrypt_locations.OwnReportIdentityMismatchError):
+                await decrypt_locations.async_decrypt_location_response_locations(
+                    update, cache=object()
+                )
+    finally:
+        decrypt_locations._eik_cache.clear()
+
+    decrypt_records = [rec for rec in caplog.records if rec.name == _DECRYPT_LOGGER]
+
+    # The cache invalidation INFO ran (removed > 0 branch) with neutral wording.
+    invalidation = [rec for rec in decrypt_records if "Invalidated" in rec.message]
+    assert len(invalidation) == 1
+    assert invalidation[0].levelno == logging.INFO
+    assert "after authentication failures this cycle" in invalidation[0].getMessage()
+
+    # The aggregate notice ran on the removed>0 branch, at DEBUG.
+    aggregate = [
+        rec
+        for rec in decrypt_records
+        if "encrypted location reports failed authentication" in rec.message
+    ]
+    assert len(aggregate) == 1
+    assert aggregate[0].levelno == logging.DEBUG
+
+    joined = "\n".join(rec.getMessage() for rec in decrypt_records).lower()
+    assert "persistent" not in joined
+    assert "re-authenticat" not in joined


### PR DESCRIPTION
## What & why

A single transient Google server report failing AES-GCM authentication (own report, `InvalidTag`) produced a **five-line WARNING/INFO cascade** across three layers within one millisecond, with **two contradictory hints**: the per-report and aggregate lines in `decrypt_locations.py` advised *"re-authenticate the account"*, while the sibling-aware coordinator correctly concluded *"no re-authentication is required"*. On the next poll the device decrypted fine (observed: 169 successful vs. 1 failed decrypt for the same device that day).

Root cause: `decrypt_locations.async_decrypt_location_response_locations` is **stateless per call** — it sees a single poll cycle (often just one report) and cannot judge whether a failure is *persistent*. It nonetheless emitted a user-facing WARNING and a reauth recommendation. The cross-cycle, sibling-aware verdict belongs to the **stateful owners**: `coordinator/polling.py` (`PollingOperations`) and the FCM callback in `location_request.py`.

This is over-sensitivity in the logging layer, not a functional bug: the escalation decision was already correct (no spurious reauth, self-healed next cycle).

## Changes (`decrypt_locations.py` only)

- Per-report `InvalidTag` and MAC auth-failure logs: **WARNING → DEBUG**, reauth advice removed (per-report detail diagnostics, not actionable on their own — an offline device or a foreign/crowdsourced report keyed to another account legitimately lands here).
- Aggregate *"all reports failed authentication"* notice: **WARNING → DEBUG**, *"if this persists, re-authenticate"* advice removed.
- EIK cache-invalidation INFO line + its docstring: drop the **"persistent"** wording. The cache is still invalidated to force a fresh key derivation on the next poll.

## What is deliberately NOT changed

- `location_request.py` is **untouched**. Its per-device `Failed to process location data` WARNING is intentional (the callback has no cross-device view) and is pinned by `tests/test_location_request_decrypt_log_severity.py`. That test stays green here as a regression guard.
- `coordinator/polling.py` escalation path is untouched.
- Functional behavior unchanged: `OwnReportIdentityMismatchError` is still raised, and `invalidate_eik_cache_for_key` is still called.

## Tests

- New `tests/test_decrypt_locations_log_severity.py`: asserts the per-report and aggregate notices are DEBUG (not WARNING) and carry no `re-authenticate`/`persistent` wording, while `OwnReportIdentityMismatchError` is still raised. Covers **both** the `removed > 0` (primed EIK cache) and `removed == 0` invalidation branches.
- Mutation check: reverting the severity makes the new test fail (it reproduces the original two contradictory reauth lines).
- Regression: `test_location_request_decrypt_log_severity.py`, `test_decrypt_locations*.py`, `test_coordinator_decrypt_reauth_escalation.py`, `test_fcm_receiver_decrypt_escalation.py`, `test_stale_owner_key_wording.py` all green.
- `ruff check` clean, `mypy --strict` clean on the changed files.

## Version

Coupled triple bumped **1.7.6 → 1.7.7** (`manifest.json`, `const.py`, `pyproject.toml`); `poetry check --lock` passes (version bump is lock-neutral).