### PR TITLE
fix(cli): make owner-key pre-fetch non-fatal; bump to 1.7.8

### DIFF
--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -26,7 +26,7 @@ CONFIG_ENTRY_VERSION: int = 2
 # cross-reference, so the manifest side is anchored in this directory's AGENTS.md
 # ("Version bump touches three files"). pyproject.toml carries the reverse reference
 # in a TOML comment.
-INTEGRATION_VERSION: str = "1.7.7"
+INTEGRATION_VERSION: str = "1.7.8"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -588,33 +588,56 @@ async def _ensure_owner_key(cache: object) -> None:
 
 
 async def _ensure_vault_keys(cache: object) -> None:
-    """Eagerly obtain both vault keys, exiting cleanly on any vault failure.
+    """Eagerly obtain the vault keys with a per-key criticality boundary.
 
-    Wraps the eager shared-key and owner-key retrieval at the CLI terminal
-    point. The vault/login step can fail in several ways (``RuntimeError`` from
-    ``shared_key_retrieval``, ``ValueError`` from hex/base64 decoding, or
-    ``ConfigEntryAuthFailed`` from the SPOT auth path); rather than surfacing a
-    raw traceback, this prints an actionable message and exits with status 1.
-    ``except Exception`` deliberately does *not* catch ``KeyboardInterrupt``
-    (a ``BaseException``), so a user-initiated abort still propagates.
+    The two eager retrievals have opposite criticality contracts, so each gets
+    its own error boundary instead of a single shared ``try`` that flattens both
+    to "all or nothing":
+
+    * **Shared key** (``_ensure_shared_key``) is *essential* and browser/login
+      bound. Failure here is fatal: there is no usable bundle without it, so we
+      print an actionable sign-in hint and exit with status 1.
+    * **Owner key** (``_ensure_owner_key``) is *optional* and non-interactive (a
+      SPOT API call plus a decrypt, no browser). The runtime re-derives it
+      lazily on first use (``decrypt_locations``/``eid_resolver`` call
+      ``async_get_owner_key`` with a ``force_refresh`` fallback), so a failure
+      here still leaves a usable ``secrets.json``. We warn and continue rather
+      than aborting the whole run.
+
+    Both blocks catch only ``Exception``; ``KeyboardInterrupt`` (a
+    ``BaseException``) still propagates so a user-initiated abort is honoured.
 
     No tokens are deleted on failure: the AAS/oauth tokens are durable by design
     (``_FileCache._SOFT_INVALIDATE_KEYS``); removing them would force an
     expensive full OAuth login on the next run.
     """
+    # Shared key: essential and browser-bound. Failure is fatal.
     try:
         await _ensure_shared_key(cache)
-        await _ensure_owner_key(cache)
     except Exception:  # noqa: BLE001
         print(
             "\nError: vault key retrieval failed.\n"
-            "Could not obtain the encryption keys from Google's vault.\n"
+            "Could not obtain the encryption key from Google's vault.\n"
             "\n"
             "Please re-run the tool and complete the Google sign-in when the "
             "browser opens.\n",
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # Owner key: optional and non-interactive. The runtime re-derives it lazily,
+    # so a failure here is non-fatal -- warn and keep the usable secrets.json.
+    try:
+        await _ensure_owner_key(cache)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"\nNote: the owner key could not be pre-fetched "
+            f"({type(exc).__name__}).\n"
+            "This is non-fatal: the shared key alone is sufficient for the Home "
+            "Assistant integration, and the owner key is fetched automatically "
+            "on first use. The generated secrets.json is ready to use.\n",
+            file=sys.stderr,
+        )
 
 
 async def _clear_stale_adm_token(cache: object) -> None:

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.7"
+  "version": "1.7.8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "googlefindmy-ha"
 # [tool.semantic_release] version_toml below); on release branches it MUST be
 # bumped by hand alongside the other two. Canonical anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
-version = "1.7.7"
+version = "1.7.8"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -688,10 +688,13 @@ class TestVaultKeysCompleteness:
         assert cache.data["owner_key"] == "owner-hex"
 
     @pytest.mark.asyncio
-    async def test_owner_key_failure_keeps_tokens(
+    async def test_owner_key_failure_is_non_fatal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """An owner-key fetch failure exits cleanly and deletes no tokens."""
+        """An owner-key fetch failure is non-fatal: the run continues without a
+        ``SystemExit``, the shared key obtained beforehand survives, and the
+        durable tokens are left untouched (the owner key is re-derived lazily
+        at runtime, so secrets.json stays usable)."""
         from custom_components.googlefindmy import main as cli_main
 
         cache = _AsyncDictCache(
@@ -707,14 +710,42 @@ class TestVaultKeysCompleteness:
         monkeypatch.setattr(cli_main, "_ensure_shared_key", _set_shared)
         monkeypatch.setattr(cli_main, "_ensure_owner_key", _owner_boom)
 
-        with pytest.raises(SystemExit) as excinfo:
-            await cli_main._ensure_vault_keys(cache)
+        # No SystemExit: the owner-key boundary warns and continues.
+        await cli_main._ensure_vault_keys(cache)
 
-        assert excinfo.value.code == 1
         assert cache.data["oauth_token"] == "oauth"
         assert cache.data["aas_token"] == "aas"
-        # The shared key obtained before the failure also survives.
+        # The shared key obtained before the owner-key failure survives.
         assert cache.data["shared_key"] == "shared-hex"
+
+    @pytest.mark.asyncio
+    async def test_owner_key_failure_warns_with_exception_type(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The non-fatal owner-key note names the concrete exception type and
+        states that secrets.json is still usable (so the user is not misled into
+        a pointless re-login)."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache({"username": "u@example.com"})
+
+        async def _set_shared(_cache):  # type: ignore[no-untyped-def]
+            await _cache.set("shared_key", "shared-hex")
+
+        async def _owner_boom(_cache):  # type: ignore[no-untyped-def]
+            raise RuntimeError("SPOT failure")
+
+        monkeypatch.setattr(cli_main, "_ensure_shared_key", _set_shared)
+        monkeypatch.setattr(cli_main, "_ensure_owner_key", _owner_boom)
+
+        await cli_main._ensure_vault_keys(cache)
+
+        err = capsys.readouterr().err
+        assert "RuntimeError" in err
+        assert "non-fatal" in err
+        assert "secrets.json" in err
+        # The fatal shared-key wording must NOT appear on the owner-key path.
+        assert "vault key retrieval failed" not in err
 
 
 class TestPasteRoundTrip:


### PR DESCRIPTION
## What

Split the eager vault-key retrieval in the standalone CLI bootstrap into **two per-key error boundaries** and bump the integration version to **1.7.8**.

## Why

A CLI run (used to produce `secrets.json`) could complete every essential step — account detection, "Credentials saved", new `android_id`, shared-key retrieval ("Encryption key saved") — and then **abort at "Retrieving owner key..."** with a misleading `vault key retrieval failed` message that tells the user to re-run and complete a browser sign-in.

Root cause: `_ensure_vault_keys` wrapped **both** `_ensure_shared_key` and `_ensure_owner_key` in a single `try/except Exception → sys.exit(1)`. That flattens two steps with opposite criticality contracts into "all or nothing":

| Step | Contract | Correct failure handling |
|------|----------|--------------------------|
| `_ensure_shared_key` | essential, browser/login bound | fatal exit + sign-in hint |
| `_ensure_owner_key` | optional, non-interactive (SPOT API + decrypt) | warn and continue |

The owner key is re-derived lazily at runtime — `decrypt_locations` and `eid_resolver` call `async_get_owner_key(cache=...)` (with a `force_refresh=True` fallback) on first use — so a failed eager pre-fetch still leaves a usable `secrets.json`. The hard exit was therefore unnecessary, and the browser hint was wrong for the non-interactive owner-key path.

## Change

- `main.py`: `_ensure_vault_keys` now uses one boundary per key.
  - Shared key failure stays **fatal** (`sys.exit(1)`), keeping the `vault key retrieval failed` sign-in message.
  - Owner key failure is **non-fatal**: it prints a note naming the concrete exception type and stating that `secrets.json` is still usable, then continues.
  - Both blocks catch only `Exception`, so `KeyboardInterrupt` still propagates.
- Version bumped to `1.7.8` in `const.py`, `manifest.json`, `pyproject.toml` (the three canonical version files).

## Honest caveat

On the warn path the generated `secrets.json` is **functional but not bundle-complete**: the top-level `owner_key` (read by the paste/seeding import in `__init__.py`) is absent. This is harmless for the user's own HA instance (runtime fetches it), and only matters when handing the bundle to a third party — hence the note says "sufficient", not "complete".

## Tests

- Rewrote `TestVaultKeysCompleteness::test_owner_key_failure_*`: the owner-key failure path no longer raises `SystemExit`; the shared key and durable tokens survive; the stderr note names the exception type, says "non-fatal", mentions `secrets.json`, and does **not** print the fatal `vault key retrieval failed` wording.
- Existing shared-key-fatal and `KeyboardInterrupt`-propagation tests are unchanged and still pass.
- `tests/test_main.py`: 31 passed locally (Python 3.13). `ruff check`/`ruff format` clean. The changed `_ensure_vault_keys` branches are fully covered.

## Out of scope (deliberate exclusions)

- The repo-layout pitfall (running `main.py` from inside `custom_components/googlefindmy/` sets `_standalone=False` and silently skips the bootstrap) is a separate latent issue that does **not** explain this report; tracked separately.
- The Windows `OSError [WinError 6]` teardown tracebacks are known `undetected_chromedriver` GC noise, not an integration fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
