### PR TITLE
fix(cli): cache-signal bootstrap + deterministic teardown (WinError 6, session leak)

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -279,9 +279,15 @@ async def _async_cli_main(
         entry_id: Optional config entry ID to scope the CLI session.
         session: Optional shared aiohttp session to avoid ephemeral per-request sessions.
     """
-    cache, namespace = _resolve_cli_cache(
-        entry_id or os.environ.get("GOOGLEFINDMY_ENTRY_ID")
-    )
+    # ``entry_id`` is the single source of truth when the caller supplied one.
+    # Use ``is not None`` (not ``or``) so an explicit empty string -- the
+    # documented "use the sole default cache" selector that ``--entry ""`` sets
+    # to defeat ``GOOGLEFINDMY_ENTRY_ID`` -- is honoured verbatim instead of
+    # silently falling through to the env var (which would then look up an
+    # unregistered id and raise "Unknown entry_id"). The env fallback only
+    # applies when the caller passed nothing at all (``None``).
+    hint = entry_id if entry_id is not None else os.environ.get("GOOGLEFINDMY_ENTRY_ID")
+    cache, namespace = _resolve_cli_cache(hint)
 
     print("Loading...")
     result_hex = await async_request_device_list(
@@ -401,7 +407,9 @@ if __name__ == "__main__":
     # for testing or manual device registration.
     try:
         args = _parse_cli_args()
-        entry_hint = args.entry or os.environ.get("GOOGLEFINDMY_ENTRY_ID")
-        asyncio.run(_async_cli_main(entry_hint))
+        # Forward the raw --entry value (None when unset). _async_cli_main is
+        # the single resolver: it applies the GOOGLEFINDMY_ENTRY_ID fallback
+        # only for None, so an explicit --entry "" is honoured here too.
+        asyncio.run(_async_cli_main(args.entry))
     except KeyboardInterrupt:
         print("\nExiting.")

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -87,11 +87,54 @@ def _load_uc() -> Any:
 _UC_CACHE = SimpleNamespace(module=None)
 
 
+def _neutralize_uc_finalizer(module: Any) -> None:
+    """Silence undetected_chromedriver's ``Chrome.__del__`` re-quit.
+
+    uc's ``Chrome.__del__`` calls ``self.quit()`` during garbage collection,
+    which raises ``OSError [WinError 6] (The handle is invalid)`` on Windows
+    after our own ``safe_quit_driver`` has already torn the driver down — pure
+    teardown noise that alarms users reading the log.  Replacing ``__del__``
+    with a no-op removes that redundant re-quit.
+
+    This does NOT leak the chromedriver process: uc also registers
+    ``weakref.finalize(self, self._ensure_close, self)`` in ``__init__``, and
+    ``_ensure_close`` kills the service process independently of ``__del__``.
+    This integration owns the driver lifecycle exclusively via
+    ``create_driver``/``safe_quit_driver``, so suppressing the automatic
+    finalizer is safe and intentional.
+
+    Idempotent and guarded: only a real ``Chrome`` class that still defines its
+    own ``__del__`` is patched (the import-failure stub and an already-patched
+    module are skipped; a uc release without its own ``__del__`` is left
+    untouched rather than having one fabricated).
+    """
+    chrome = getattr(module, "Chrome", None)
+    if not isinstance(chrome, type):
+        return  # import stub (SimpleNamespace with a function), nothing to patch
+    if getattr(chrome, "_gfmy_del_neutralized", False):
+        return  # already patched in this process
+    if "__del__" not in chrome.__dict__:
+        return  # no own __del__ to suppress; do not fabricate one
+
+    def _no_op_del(self: Any) -> None:
+        return None
+
+    # ``chrome`` is narrowed to ``type`` by the isinstance guard above, which
+    # mypy treats as having no assignable ``__del__``/marker attributes. Assign
+    # through an ``Any`` alias so the dynamic class patch stays type-clean
+    # without resorting to ``setattr`` (which ruff B010 would flag).
+    chrome_cls: Any = chrome
+    chrome_cls.__del__ = _no_op_del
+    chrome_cls._gfmy_del_neutralized = True
+
+
 def _get_uc_module() -> Any:
     """Lazily import and cache ``undetected_chromedriver``."""
 
     if _UC_CACHE.module is None:
-        _UC_CACHE.module = cast(Any, _load_uc())
+        module = cast(Any, _load_uc())
+        _neutralize_uc_finalizer(module)
+        _UC_CACHE.module = module
 
     return _UC_CACHE.module
 

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -88,43 +88,55 @@ _UC_CACHE = SimpleNamespace(module=None)
 
 
 def _neutralize_uc_finalizer(module: Any) -> None:
-    """Silence undetected_chromedriver's ``Chrome.__del__`` re-quit.
+    """Silence undetected_chromedriver's ``Chrome.__del__`` re-quit noise.
 
-    uc's ``Chrome.__del__`` calls ``self.quit()`` during garbage collection,
-    which raises ``OSError [WinError 6] (The handle is invalid)`` on Windows
-    after our own ``safe_quit_driver`` has already torn the driver down — pure
-    teardown noise that alarms users reading the log.  Replacing ``__del__``
-    with a no-op removes that redundant re-quit.
+    uc's ``Chrome.__del__`` calls ``self.quit()`` during garbage collection.
+    After our own ``safe_quit_driver`` has already torn the driver down, that GC
+    re-quit raises ``OSError [WinError 6] (The handle is invalid)`` on Windows —
+    pure teardown noise that alarms users reading the log.
 
-    This does NOT leak the chromedriver process: uc also registers
-    ``weakref.finalize(self, self._ensure_close, self)`` in ``__init__``, and
-    ``_ensure_close`` kills the service process independently of ``__del__``.
-    This integration owns the driver lifecycle exclusively via
-    ``create_driver``/``safe_quit_driver``, so suppressing the automatic
-    finalizer is safe and intentional.
+    We do NOT replace ``__del__`` with a no-op: that would also disable uc's
+    cleanup of a *partially constructed* driver.  When ``uc.Chrome(...)`` raises
+    after the browser already launched (e.g. a Chrome/driver version mismatch),
+    the strategy helpers in this module never receive a ``driver`` object, so
+    their ``_quit_driver(driver)`` is a no-op and uc's own ``__del__`` is the
+    only thing that would kill the orphaned browser process and remove its temp
+    profile.  uc's ``weakref.finalize(self._ensure_close)`` reaper only kills the
+    chromedriver *service* process, not the browser or the temp dir, so a no-op
+    would leak both until interpreter exit.
+
+    Instead we wrap the original ``__del__`` so its cleanup still runs but any
+    exception it raises is swallowed.  This kills the redundant-quit noise
+    without weakening cleanup on failed constructions.
 
     Idempotent and guarded: only a real ``Chrome`` class that still defines its
-    own ``__del__`` is patched (the import-failure stub and an already-patched
+    own ``__del__`` is wrapped (the import-failure stub and an already-wrapped
     module are skipped; a uc release without its own ``__del__`` is left
     untouched rather than having one fabricated).
     """
     chrome = getattr(module, "Chrome", None)
     if not isinstance(chrome, type):
-        return  # import stub (SimpleNamespace with a function), nothing to patch
+        return  # import stub (SimpleNamespace with a function), nothing to wrap
     if getattr(chrome, "_gfmy_del_neutralized", False):
-        return  # already patched in this process
+        return  # already wrapped in this process
     if "__del__" not in chrome.__dict__:
-        return  # no own __del__ to suppress; do not fabricate one
+        return  # no own __del__ to wrap; do not fabricate one
 
-    def _no_op_del(self: Any) -> None:
-        return None
+    original_del = chrome.__dict__["__del__"]
+
+    def _quiet_del(self: Any) -> None:
+        # Preserve uc's cleanup (service + browser process + temp profile) for
+        # failed constructions; only swallow the redundant-quit error it raises
+        # after our safe_quit_driver has already torn the driver down.
+        with contextlib.suppress(Exception):
+            original_del(self)
 
     # ``chrome`` is narrowed to ``type`` by the isinstance guard above, which
     # mypy treats as having no assignable ``__del__``/marker attributes. Assign
     # through an ``Any`` alias so the dynamic class patch stays type-clean
     # without resorting to ``setattr`` (which ruff B010 would flag).
     chrome_cls: Any = chrome
-    chrome_cls.__del__ = _no_op_del
+    chrome_cls.__del__ = _quiet_del
     chrome_cls._gfmy_del_neutralized = True
 
 

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -10,16 +10,20 @@ Usage:
 
 Flags:
     --reauth   Force re-authentication by clearing cached tokens and running the
-               Chrome login flow.  Only active in standalone mode (flat directory
-               layout); in repo/HA layout the flag is currently a no-op and emits
-               a stderr warning.
+               Chrome login flow.  Honored in any directory layout; it always
+               forces a fresh token bootstrap.
     --entry    Target config entry ID.  Required when secrets.json contains caches
                for multiple HA config entries.  May also be set via the
                ``GOOGLEFINDMY_ENTRY_ID`` environment variable.
 
-The module selects between two code paths via ``_standalone``:
-    * standalone (flat directory):  runs the full token-bootstrap pipeline.
-    * non-standalone (HA repo layout): delegates to ``nbe_list_devices._async_cli_main``.
+The module decides between two code paths by the *cache signal* (whether a token
+cache is registered in this process), not by the directory layout:
+    * no registered cache (or ``--reauth``): runs the full token-bootstrap
+      pipeline and writes ``secrets.json``, regardless of flat vs. repo layout.
+    * a cache is already registered: delegates to
+      ``nbe_list_devices._async_cli_main`` (serve-only, no Chrome).
+``_standalone`` now only governs packaging (virtual package vs. real package),
+which is the one thing the directory name legitimately determines.
 """
 
 import os
@@ -794,6 +798,25 @@ def _resolve_effective_entry_id(cli_entry: str | None, env_entry: str | None) ->
     return ""
 
 
+def _should_serve_only(registered_entry_ids: list[str], reauth: bool) -> bool:
+    """Decide bootstrap vs. serve-only from the cache signal, not the layout.
+
+    Returns ``True`` when the CLI should serve an already-registered token cache
+    directly (no bootstrap, no Chrome).  Returns ``False`` when this invocation
+    must bootstrap ``secrets.json``.
+
+    The decision keys off the *cache signal* (whether a token cache is registered
+    in this process), not the directory layout: a registered cache means a usable
+    cache already exists, while an empty registry means the caller must bootstrap.
+    ``--reauth`` always forces a bootstrap (returns ``False``) so a fresh Chrome
+    login runs even if a cache happens to be present.
+
+    Extracted from the ``__main__`` block so the rule is unit-testable without
+    spawning a subprocess (mirrors ``_resolve_effective_entry_id``).
+    """
+    return bool(registered_entry_ids) and not reauth
+
+
 if __name__ == "__main__":
     import argparse  # noqa: PLC0415
     import asyncio  # noqa: PLC0415
@@ -818,7 +841,30 @@ if __name__ == "__main__":
     )
     _cli_args = _cli_parser.parse_args()
 
-    if _standalone:
+    # Decide bootstrap vs. serve-only by the *cache signal*, not by the directory
+    # layout.  A registered token cache means this process already holds a usable
+    # cache (embedded/advanced use): serve it directly.  No registered cache means
+    # this invocation must bootstrap secrets.json (open Chrome, exchange tokens),
+    # regardless of whether main.py sits in a flat or a repo directory.  --reauth
+    # always forces a bootstrap.  This decision previously keyed off _standalone
+    # (the directory name), which dead-ended a repo-layout shell start with no
+    # cache in an opaque MissingTokenCacheError instead of bootstrapping.
+    from custom_components.googlefindmy.Auth.token_cache import (  # noqa: E402, PLC0415
+        get_registered_entry_ids,
+    )
+
+    _serve_only = _should_serve_only(get_registered_entry_ids(), _cli_args.reauth)
+
+    if _serve_only:
+        # A token cache is already registered in this process: serve it without
+        # re-running the bootstrap or opening Chrome.  HA never executes main.py
+        # as __main__, so this path is for embedded/advanced callers only.
+        try:
+            asyncio.run(_async_cli_main(_cli_args.entry))
+        except KeyboardInterrupt:
+            print("\nExiting.")
+    else:
+        # Bootstrap path: provision secrets.json (token exchange + vault keys).
         if _cli_args.reauth:
             _clear_stale_tokens_for_reauth()
         _ensure_authenticated()
@@ -856,21 +902,5 @@ if __name__ == "__main__":
 
         try:
             asyncio.run(_cli_main())
-        except KeyboardInterrupt:
-            print("\nExiting.")
-    else:
-        # Repo/HA layout: --reauth is a standalone-only feature (see module
-        # docstring).  Warn explicitly instead of silently ignoring the flag.
-        if _cli_args.reauth:
-            print(
-                "warning: --reauth is only honored in standalone mode; ignoring.",
-                file=sys.stderr,
-            )
-        # Bypass list_devices() so we can forward --entry into _async_cli_main.
-        # list_devices() is a deliberately minimal upstream-API wrapper that
-        # takes no entry_id argument; extending its signature would change a
-        # public helper for a CLI-local concern.
-        try:
-            asyncio.run(_async_cli_main(_cli_args.entry))
         except KeyboardInterrupt:
             print("\nExiting.")

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -16,14 +16,12 @@ Flags:
                for multiple HA config entries.  May also be set via the
                ``GOOGLEFINDMY_ENTRY_ID`` environment variable.
 
-The module decides between two code paths by the *cache signal* (whether a token
-cache is registered in this process), not by the directory layout:
-    * no registered cache (or ``--reauth``): runs the full token-bootstrap
-      pipeline and writes ``secrets.json``, regardless of flat vs. repo layout.
-    * a cache is already registered: delegates to
-      ``nbe_list_devices._async_cli_main`` (serve-only, no Chrome).
-``_standalone`` now only governs packaging (virtual package vs. real package),
-which is the one thing the directory name legitimately determines.
+Run as a script, the module always runs the full token-bootstrap pipeline and
+writes ``secrets.json``, regardless of flat vs. repo directory layout.  When a
+usable cache already exists, ``_ensure_authenticated`` returns early so no Chrome
+login is launched; ``--reauth`` forces a fresh login.  ``_standalone`` only
+governs packaging (virtual package vs. real package), which is the one thing the
+directory name legitimately determines.
 """
 
 import os
@@ -798,25 +796,6 @@ def _resolve_effective_entry_id(cli_entry: str | None, env_entry: str | None) ->
     return ""
 
 
-def _should_serve_only(registered_entry_ids: list[str], reauth: bool) -> bool:
-    """Decide bootstrap vs. serve-only from the cache signal, not the layout.
-
-    Returns ``True`` when the CLI should serve an already-registered token cache
-    directly (no bootstrap, no Chrome).  Returns ``False`` when this invocation
-    must bootstrap ``secrets.json``.
-
-    The decision keys off the *cache signal* (whether a token cache is registered
-    in this process), not the directory layout: a registered cache means a usable
-    cache already exists, while an empty registry means the caller must bootstrap.
-    ``--reauth`` always forces a bootstrap (returns ``False``) so a fresh Chrome
-    login runs even if a cache happens to be present.
-
-    Extracted from the ``__main__`` block so the rule is unit-testable without
-    spawning a subprocess (mirrors ``_resolve_effective_entry_id``).
-    """
-    return bool(registered_entry_ids) and not reauth
-
-
 async def _run_cli_bootstrap(file_cache: object, entry_id: str | None) -> None:
     """Run the standalone token bootstrap, then hand off to the interactive CLI.
 
@@ -830,8 +809,7 @@ async def _run_cli_bootstrap(file_cache: object, entry_id: str | None) -> None:
     and the WinError-6 teardown noise on Windows.
 
     Extracted from the ``__main__`` block so the session lifecycle is testable
-    without spawning a subprocess (mirrors ``_resolve_effective_entry_id`` /
-    ``_should_serve_only``).
+    without spawning a subprocess (mirrors ``_resolve_effective_entry_id``).
     """
     import contextlib  # noqa: PLC0415
 
@@ -865,10 +843,6 @@ if __name__ == "__main__":
     import argparse  # noqa: PLC0415
     import asyncio  # noqa: PLC0415
 
-    from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import (  # noqa: E402, PLC0415
-        _async_cli_main,
-    )
-
     _cli_parser = argparse.ArgumentParser(description="Google Find My Device CLI")
     _cli_parser.add_argument(
         "--reauth",
@@ -885,43 +859,26 @@ if __name__ == "__main__":
     )
     _cli_args = _cli_parser.parse_args()
 
-    # Decide bootstrap vs. serve-only by the *cache signal*, not by the directory
-    # layout.  A registered token cache means this process already holds a usable
-    # cache (embedded/advanced use): serve it directly.  No registered cache means
-    # this invocation must bootstrap secrets.json (open Chrome, exchange tokens),
-    # regardless of whether main.py sits in a flat or a repo directory.  --reauth
-    # always forces a bootstrap.  This decision previously keyed off _standalone
-    # (the directory name), which dead-ended a repo-layout shell start with no
-    # cache in an opaque MissingTokenCacheError instead of bootstrapping.
-    from custom_components.googlefindmy.Auth.token_cache import (  # noqa: E402, PLC0415
-        get_registered_entry_ids,
+    # Always run the token-bootstrap pipeline, regardless of flat vs. repo
+    # directory layout.  When a usable cache already exists, _ensure_authenticated
+    # returns early so no Chrome login is launched; --reauth forces a fresh login.
+    # This replaces the earlier branch gates (first the _standalone directory name,
+    # then a cache-signal check that was always empty for a fresh shell start),
+    # both of which could dead-end a repo-layout start in an opaque
+    # MissingTokenCacheError instead of bootstrapping.
+    if _cli_args.reauth:
+        _clear_stale_tokens_for_reauth()
+    _ensure_authenticated()
+    # Resolve the effective entry id (CLI > env > ""). Without this,
+    # _async_cli_main forwards a non-empty hint that _resolve_cli_cache
+    # would reject as "Unknown entry_id" because the cache was only
+    # registered under "".  Codex review on 694f6883aa.
+    _effective_entry_id = _resolve_effective_entry_id(
+        _cli_args.entry, os.environ.get("GOOGLEFINDMY_ENTRY_ID")
     )
+    _file_cache = _register_file_cache(_effective_entry_id)
 
-    _serve_only = _should_serve_only(get_registered_entry_ids(), _cli_args.reauth)
-
-    if _serve_only:
-        # A token cache is already registered in this process: serve it without
-        # re-running the bootstrap or opening Chrome.  HA never executes main.py
-        # as __main__, so this path is for embedded/advanced callers only.
-        try:
-            asyncio.run(_async_cli_main(_cli_args.entry))
-        except KeyboardInterrupt:
-            print("\nExiting.")
-    else:
-        # Bootstrap path: provision secrets.json (token exchange + vault keys).
-        if _cli_args.reauth:
-            _clear_stale_tokens_for_reauth()
-        _ensure_authenticated()
-        # Resolve the effective entry id (CLI > env > ""). Without this,
-        # _async_cli_main forwards a non-empty hint that _resolve_cli_cache
-        # would reject as "Unknown entry_id" because the cache was only
-        # registered under "".  Codex review on 694f6883aa.
-        _effective_entry_id = _resolve_effective_entry_id(
-            _cli_args.entry, os.environ.get("GOOGLEFINDMY_ENTRY_ID")
-        )
-        _file_cache = _register_file_cache(_effective_entry_id)
-
-        try:
-            asyncio.run(_run_cli_bootstrap(_file_cache, _cli_args.entry))
-        except KeyboardInterrupt:
-            print("\nExiting.")
+    try:
+        asyncio.run(_run_cli_bootstrap(_file_cache, _cli_args.entry))
+    except KeyboardInterrupt:
+        print("\nExiting.")

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -869,16 +869,19 @@ if __name__ == "__main__":
     if _cli_args.reauth:
         _clear_stale_tokens_for_reauth()
     _ensure_authenticated()
-    # Resolve the effective entry id (CLI > env > ""). Without this,
-    # _async_cli_main forwards a non-empty hint that _resolve_cli_cache
-    # would reject as "Unknown entry_id" because the cache was only
-    # registered under "".  Codex review on 694f6883aa.
+    # Resolve the effective entry id once (CLI > env > "") and use the SAME
+    # value for both registration and hand-off, so the registry key and the
+    # lookup hint can never diverge.  Forwarding the raw _cli_args.entry instead
+    # would re-trigger _async_cli_main's env fallback for an explicit
+    # --entry "" (empty string is falsy), making _resolve_cli_cache reject the
+    # env value as "Unknown entry_id" although the cache was registered under
+    # "".  Codex reviews on 694f6883aa and 17669c7ff2.
     _effective_entry_id = _resolve_effective_entry_id(
         _cli_args.entry, os.environ.get("GOOGLEFINDMY_ENTRY_ID")
     )
     _file_cache = _register_file_cache(_effective_entry_id)
 
     try:
-        asyncio.run(_run_cli_bootstrap(_file_cache, _cli_args.entry))
+        asyncio.run(_run_cli_bootstrap(_file_cache, _effective_entry_id))
     except KeyboardInterrupt:
         print("\nExiting.")

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -817,6 +817,50 @@ def _should_serve_only(registered_entry_ids: list[str], reauth: bool) -> bool:
     return bool(registered_entry_ids) and not reauth
 
 
+async def _run_cli_bootstrap(file_cache: object, entry_id: str | None) -> None:
+    """Run the standalone token bootstrap, then hand off to the interactive CLI.
+
+    A single aiohttp session is shared across the whole flow and managed by
+    ``async with`` so it is closed deterministically on *every* exit path,
+    including the ``sys.exit(1)`` that ``_ensure_vault_keys`` raises on a fatal
+    shared-key failure: ``__aexit__`` runs for ``BaseException`` (``SystemExit``,
+    ``KeyboardInterrupt``) too.  Previously the session was created before the
+    ``try`` and closed only in a ``finally``, so any ``sys.exit`` from the eager
+    key-retrieval steps leaked it, producing 'Unclosed client session' warnings
+    and the WinError-6 teardown noise on Windows.
+
+    Extracted from the ``__main__`` block so the session lifecycle is testable
+    without spawning a subprocess (mirrors ``_resolve_effective_entry_id`` /
+    ``_should_serve_only``).
+    """
+    import contextlib  # noqa: PLC0415
+
+    import aiohttp  # noqa: PLC0415
+
+    from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import (  # noqa: PLC0415
+        _async_cli_main,
+    )
+
+    async with aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(limit=16, enable_cleanup_closed=True)
+    ) as session:
+        # Exchange the single-use OAuth cookie for an AAS master token BEFORE
+        # opening Chrome again for the shared key flow.  The OAuth cookie has a
+        # very short TTL and is invalidated once a new Chrome session is opened,
+        # so the exchange must happen immediately.
+        await _ensure_aas_token(file_cache)
+        # Eagerly obtain both vault keys (shared + owner); a vault failure exits
+        # cleanly without deleting the durable AAS/oauth tokens.
+        await _ensure_vault_keys(file_cache)
+        await _clear_stale_adm_token(file_cache)
+        fcm = await _setup_fcm_receiver(file_cache)
+        try:
+            await _async_cli_main(entry_id=entry_id, session=session)
+        finally:
+            with contextlib.suppress(Exception):
+                await fcm.async_stop()
+
+
 if __name__ == "__main__":
     import argparse  # noqa: PLC0415
     import asyncio  # noqa: PLC0415
@@ -877,30 +921,7 @@ if __name__ == "__main__":
         )
         _file_cache = _register_file_cache(_effective_entry_id)
 
-        async def _cli_main() -> None:
-            import aiohttp  # noqa: PLC0415
-
-            session = aiohttp.ClientSession(
-                connector=aiohttp.TCPConnector(limit=16, enable_cleanup_closed=True)
-            )
-            # Exchange the single-use OAuth cookie for an AAS master token
-            # BEFORE opening Chrome again for the shared key flow.  The OAuth
-            # cookie has a very short TTL and is invalidated once a new Chrome
-            # session is opened, so the exchange must happen immediately.
-            await _ensure_aas_token(_file_cache)
-            # Eagerly obtain both vault keys (shared + owner); a vault failure
-            # exits cleanly without deleting the durable AAS/oauth tokens.
-            await _ensure_vault_keys(_file_cache)
-            await _clear_stale_adm_token(_file_cache)
-            fcm = await _setup_fcm_receiver(_file_cache)
-            try:
-                await _async_cli_main(entry_id=_cli_args.entry, session=session)
-            finally:
-                with __import__("contextlib").suppress(Exception):
-                    await fcm.async_stop()
-                await session.close()
-
         try:
-            asyncio.run(_cli_main())
+            asyncio.run(_run_cli_bootstrap(_file_cache, _cli_args.entry))
         except KeyboardInterrupt:
             print("\nExiting.")

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -376,21 +376,36 @@ def test_get_uc_module_caches_loaded_module(
 # ---------------------------------------------------------------------------
 
 
-def test_neutralize_replaces_own_del_with_noop() -> None:
-    """A real Chrome class with its own ``__del__`` gets a no-op finalizer."""
-    quit_calls: list[str] = []
+def test_neutralize_preserves_original_cleanup() -> None:
+    """The wrapped __del__ still runs uc's cleanup (no leak on failed builds)."""
+    cleanup_calls: list[str] = []
 
     class _FakeChrome:
         def __del__(self) -> None:
-            quit_calls.append("re-quit")
+            cleanup_calls.append("cleanup")
 
     chrome_driver._neutralize_uc_finalizer(SimpleNamespace(Chrome=_FakeChrome))
 
     assert _FakeChrome._gfmy_del_neutralized is True
-    # The replaced __del__ is a no-op: invoking it explicitly does nothing.
+    # The wrapper delegates to the original __del__ instead of dropping it:
+    # this preserves browser/temp-profile cleanup for a partially built driver.
     inst = _FakeChrome.__new__(_FakeChrome)
     assert _FakeChrome.__del__(inst) is None
-    assert quit_calls == []
+    assert cleanup_calls == ["cleanup"]
+
+
+def test_neutralize_suppresses_del_errors() -> None:
+    """A WinError-6-style raise from uc's __del__ is swallowed, not propagated."""
+
+    class _FakeChrome:
+        def __del__(self) -> None:
+            raise OSError(6, "The handle is invalid")
+
+    chrome_driver._neutralize_uc_finalizer(SimpleNamespace(Chrome=_FakeChrome))
+
+    # Invoking the wrapped __del__ must not raise despite the original raising.
+    inst = _FakeChrome.__new__(_FakeChrome)
+    assert _FakeChrome.__del__(inst) is None
 
 
 def test_neutralize_skips_import_stub() -> None:
@@ -436,7 +451,7 @@ def test_get_uc_module_neutralizes_finalizer(monkeypatch: pytest.MonkeyPatch) ->
     """``_get_uc_module`` neutralizes the finalizer on the freshly loaded module."""
 
     class _FakeChrome:
-        def __del__(self) -> None:  # pragma: no cover - replaced by the no-op
+        def __del__(self) -> None:  # pragma: no cover - not invoked in this test
             return None
 
     fake_module = SimpleNamespace(Chrome=_FakeChrome, ChromeOptions=FakeChromeOptions)

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -372,6 +372,83 @@ def test_get_uc_module_caches_loaded_module(
 
 
 # ---------------------------------------------------------------------------
+# _neutralize_uc_finalizer (WinError 6 teardown noise)
+# ---------------------------------------------------------------------------
+
+
+def test_neutralize_replaces_own_del_with_noop() -> None:
+    """A real Chrome class with its own ``__del__`` gets a no-op finalizer."""
+    quit_calls: list[str] = []
+
+    class _FakeChrome:
+        def __del__(self) -> None:
+            quit_calls.append("re-quit")
+
+    chrome_driver._neutralize_uc_finalizer(SimpleNamespace(Chrome=_FakeChrome))
+
+    assert _FakeChrome._gfmy_del_neutralized is True
+    # The replaced __del__ is a no-op: invoking it explicitly does nothing.
+    inst = _FakeChrome.__new__(_FakeChrome)
+    assert _FakeChrome.__del__(inst) is None
+    assert quit_calls == []
+
+
+def test_neutralize_skips_import_stub() -> None:
+    """The import-failure stub exposes ``Chrome`` as a function, not a class."""
+
+    def _stub_chrome(*, options: object) -> object:  # pragma: no cover - shape only
+        return object()
+
+    # Must not raise and must not mark a plain function.
+    chrome_driver._neutralize_uc_finalizer(SimpleNamespace(Chrome=_stub_chrome))
+
+    assert not hasattr(_stub_chrome, "_gfmy_del_neutralized")
+
+
+def test_neutralize_is_idempotent() -> None:
+    """A second call does not re-wrap an already-neutralized class."""
+
+    class _FakeChrome:
+        def __del__(self) -> None:
+            return None
+
+    module = SimpleNamespace(Chrome=_FakeChrome)
+    chrome_driver._neutralize_uc_finalizer(module)
+    patched = _FakeChrome.__del__
+    chrome_driver._neutralize_uc_finalizer(module)
+
+    assert _FakeChrome.__del__ is patched
+
+
+def test_neutralize_leaves_class_without_own_del() -> None:
+    """A uc release without its own ``__del__`` is left untouched (none fabricated)."""
+
+    class _NoDel:
+        pass
+
+    chrome_driver._neutralize_uc_finalizer(SimpleNamespace(Chrome=_NoDel))
+
+    assert "__del__" not in _NoDel.__dict__
+    assert not hasattr(_NoDel, "_gfmy_del_neutralized")
+
+
+def test_get_uc_module_neutralizes_finalizer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_get_uc_module`` neutralizes the finalizer on the freshly loaded module."""
+
+    class _FakeChrome:
+        def __del__(self) -> None:  # pragma: no cover - replaced by the no-op
+            return None
+
+    fake_module = SimpleNamespace(Chrome=_FakeChrome, ChromeOptions=FakeChromeOptions)
+    chrome_driver._reset_uc_cache(None)
+    monkeypatch.setattr(chrome_driver, "_load_uc", lambda: fake_module)
+
+    chrome_driver._get_uc_module()
+
+    assert _FakeChrome._gfmy_del_neutralized is True
+
+
+# ---------------------------------------------------------------------------
 # get_chrome_version
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli_entry_selection.py
+++ b/tests/test_cli_entry_selection.py
@@ -139,3 +139,67 @@ async def test_cli_main_passes_selected_cache(monkeypatch: pytest.MonkeyPatch) -
     assert called["list_namespace"] == "entry-one"
     assert called["loc_cache"] is cache
     assert called["loc_namespace"] == "entry-one"
+
+
+class _StopAfterResolve(Exception):
+    """Sentinel raised from a stubbed _resolve_cli_cache to stop _async_cli_main."""
+
+
+class TestAsyncCliMainEntryResolution:
+    """The env fallback must apply only for an unspecified (None) entry id.
+
+    Regression for Codex review on 17669c7ff2: ``entry_id or env`` conflated an
+    explicit empty string (the documented "use the sole default cache" selector
+    that ``--entry ""`` sets to defeat ``GOOGLEFINDMY_ENTRY_ID``) with "not
+    supplied", so the env value overrode it and ``_resolve_cli_cache`` raised
+    ``Unknown entry_id``.  ``_async_cli_main`` now resolves with ``is not None``,
+    making it the single source of the env fallback.
+    """
+
+    @staticmethod
+    def _capture_hint(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+        """Stub _resolve_cli_cache to record its hint and short-circuit."""
+        seen: dict[str, Any] = {}
+
+        def _stub(hint: Any) -> tuple[Any, str]:
+            seen["hint"] = hint
+            raise _StopAfterResolve
+
+        monkeypatch.setattr(nbe_list_devices, "_resolve_cli_cache", _stub)
+        return seen
+
+    async def test_explicit_empty_entry_id_is_not_overridden_by_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--entry ""`` must win over GOOGLEFINDMY_ENTRY_ID (CLI > env)."""
+        monkeypatch.setenv("GOOGLEFINDMY_ENTRY_ID", "from-env")
+        seen = self._capture_hint(monkeypatch)
+
+        with pytest.raises(_StopAfterResolve):
+            await nbe_list_devices._async_cli_main("")
+
+        assert seen["hint"] == ""
+
+    async def test_none_entry_id_falls_back_to_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unspecified (None) entry id still uses the env var."""
+        monkeypatch.setenv("GOOGLEFINDMY_ENTRY_ID", "from-env")
+        seen = self._capture_hint(monkeypatch)
+
+        with pytest.raises(_StopAfterResolve):
+            await nbe_list_devices._async_cli_main(None)
+
+        assert seen["hint"] == "from-env"
+
+    async def test_explicit_entry_id_wins_over_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-empty explicit entry id is used verbatim, ignoring env."""
+        monkeypatch.setenv("GOOGLEFINDMY_ENTRY_ID", "from-env")
+        seen = self._capture_hint(monkeypatch)
+
+        with pytest.raises(_StopAfterResolve):
+            await nbe_list_devices._async_cli_main("explicit")
+
+        assert seen["hint"] == "explicit"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -328,6 +328,117 @@ class TestShouldServeOnly:
         assert _should_serve_only([], reauth=True) is False
 
 
+class _TrackingSession:
+    """Fake ``aiohttp.ClientSession`` context manager that records closure.
+
+    ``__aexit__`` runs for ``BaseException`` (``SystemExit``) too, so a ``closed``
+    flag set to ``True`` after a vault ``sys.exit`` proves the session was not
+    leaked.  A list passed at construction time collects every instance so the
+    test can inspect the one the function created.
+    """
+
+    def __init__(
+        self, sink: list[_TrackingSession], *args: object, **kwargs: object
+    ) -> None:
+        self.closed = False
+        sink.append(self)
+
+    async def __aenter__(self) -> _TrackingSession:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        self.closed = True
+        return False  # do not suppress the propagating exception
+
+
+class TestRunCliBootstrapSessionLifecycle:
+    """`_run_cli_bootstrap` closes its aiohttp session on every exit path.
+
+    The session is opened with ``async with`` so ``__aexit__`` reaps it even when
+    ``_ensure_vault_keys`` raises ``SystemExit`` on a fatal shared-key failure.
+    A leaked session was the source of the 'Unclosed client session' / WinError-6
+    teardown noise.
+    """
+
+    @pytest.mark.asyncio
+    async def test_session_closed_on_vault_sys_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``sys.exit`` from the eager vault step still closes the session."""
+        import aiohttp
+
+        from custom_components.googlefindmy import main as cli_main
+
+        created: list[_TrackingSession] = []
+        monkeypatch.setattr(
+            aiohttp,
+            "ClientSession",
+            lambda *a, **k: _TrackingSession(created, *a, **k),
+        )
+        monkeypatch.setattr(aiohttp, "TCPConnector", lambda **k: object())
+
+        async def _ok(_cache: object) -> None:
+            return None
+
+        async def _vault_exit(_cache: object) -> None:
+            raise SystemExit(1)
+
+        monkeypatch.setattr(cli_main, "_ensure_aas_token", _ok)
+        monkeypatch.setattr(cli_main, "_ensure_vault_keys", _vault_exit)
+
+        with pytest.raises(SystemExit):
+            await cli_main._run_cli_bootstrap(object(), None)
+
+        assert created, "the function should have opened exactly one session"
+        assert created[0].closed is True
+
+    @pytest.mark.asyncio
+    async def test_session_and_fcm_closed_on_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On the happy path the session closes and the FCM receiver is stopped."""
+        import aiohttp
+
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.NovaApi.ListDevices import (
+            nbe_list_devices as nbe,
+        )
+
+        created: list[_TrackingSession] = []
+        monkeypatch.setattr(
+            aiohttp,
+            "ClientSession",
+            lambda *a, **k: _TrackingSession(created, *a, **k),
+        )
+        monkeypatch.setattr(aiohttp, "TCPConnector", lambda **k: object())
+
+        stopped: list[bool] = []
+
+        class _Fcm:
+            async def async_stop(self) -> None:
+                stopped.append(True)
+
+        async def _ok(_cache: object) -> None:
+            return None
+
+        async def _fcm(_cache: object) -> _Fcm:
+            return _Fcm()
+
+        async def _cli(*, entry_id: str | None, session: object) -> None:
+            return None
+
+        monkeypatch.setattr(cli_main, "_ensure_aas_token", _ok)
+        monkeypatch.setattr(cli_main, "_ensure_vault_keys", _ok)
+        monkeypatch.setattr(cli_main, "_clear_stale_adm_token", _ok)
+        monkeypatch.setattr(cli_main, "_setup_fcm_receiver", _fcm)
+        monkeypatch.setattr(nbe, "_async_cli_main", _cli)
+
+        await cli_main._run_cli_bootstrap(object(), "entry_x")
+
+        assert created and created[0].closed is True
+        assert stopped == [True]
+
+
 # ---------------------------------------------------------------------------
 # AP-B1: atomic JSON write + clean vault-failure exit
 # ---------------------------------------------------------------------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -293,41 +293,6 @@ class TestResolveEffectiveEntryId:
         assert _resolve_effective_entry_id("", "env_value") == ""
 
 
-class TestShouldServeOnly:
-    """Unit tests for the bootstrap-vs-serve cache-signal decision.
-
-    The CLI must decide whether to bootstrap ``secrets.json`` or serve an
-    already-registered cache based on the *cache signal* (a registered token
-    cache), not on the directory layout.  A repo-layout shell start with no
-    registered cache must bootstrap (return ``False``) instead of dead-ending
-    in ``MissingTokenCacheError``.
-    """
-
-    def test_no_cache_bootstraps(self) -> None:
-        """Empty registry → bootstrap (this is the repo-layout fix)."""
-        from custom_components.googlefindmy.main import _should_serve_only
-
-        assert _should_serve_only([], reauth=False) is False
-
-    def test_registered_cache_serves_only(self) -> None:
-        """A registered cache without --reauth → serve directly, no bootstrap."""
-        from custom_components.googlefindmy.main import _should_serve_only
-
-        assert _should_serve_only(["entry_a"], reauth=False) is True
-
-    def test_reauth_forces_bootstrap_even_with_cache(self) -> None:
-        """--reauth always bootstraps, even when a cache is registered."""
-        from custom_components.googlefindmy.main import _should_serve_only
-
-        assert _should_serve_only(["entry_a"], reauth=True) is False
-
-    def test_no_cache_with_reauth_bootstraps(self) -> None:
-        """No cache and --reauth both point to bootstrap."""
-        from custom_components.googlefindmy.main import _should_serve_only
-
-        assert _should_serve_only([], reauth=True) is False
-
-
 class _TrackingSession:
     """Fake ``aiohttp.ClientSession`` context manager that records closure.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -293,6 +293,41 @@ class TestResolveEffectiveEntryId:
         assert _resolve_effective_entry_id("", "env_value") == ""
 
 
+class TestShouldServeOnly:
+    """Unit tests for the bootstrap-vs-serve cache-signal decision.
+
+    The CLI must decide whether to bootstrap ``secrets.json`` or serve an
+    already-registered cache based on the *cache signal* (a registered token
+    cache), not on the directory layout.  A repo-layout shell start with no
+    registered cache must bootstrap (return ``False``) instead of dead-ending
+    in ``MissingTokenCacheError``.
+    """
+
+    def test_no_cache_bootstraps(self) -> None:
+        """Empty registry → bootstrap (this is the repo-layout fix)."""
+        from custom_components.googlefindmy.main import _should_serve_only
+
+        assert _should_serve_only([], reauth=False) is False
+
+    def test_registered_cache_serves_only(self) -> None:
+        """A registered cache without --reauth → serve directly, no bootstrap."""
+        from custom_components.googlefindmy.main import _should_serve_only
+
+        assert _should_serve_only(["entry_a"], reauth=False) is True
+
+    def test_reauth_forces_bootstrap_even_with_cache(self) -> None:
+        """--reauth always bootstraps, even when a cache is registered."""
+        from custom_components.googlefindmy.main import _should_serve_only
+
+        assert _should_serve_only(["entry_a"], reauth=True) is False
+
+    def test_no_cache_with_reauth_bootstraps(self) -> None:
+        """No cache and --reauth both point to bootstrap."""
+        from custom_components.googlefindmy.main import _should_serve_only
+
+        assert _should_serve_only([], reauth=True) is False
+
+
 # ---------------------------------------------------------------------------
 # AP-B1: atomic JSON write + clean vault-failure exit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the two CLI issues previously deferred as "out of scope" in #1146.
Three independent, individually revertible fixes, plus a follow-up cleanup
that drops the now-unreachable serve-only branch left over from F1.

- **F1 - CLI bootstrap no longer gated by the directory layout.**
  Running `main.py` from inside `custom_components/googlefindmy/` set
  `_standalone=False` and routed straight to `_async_cli_main`, which requires
  an already-registered token cache. On a plain shell start the registry is
  empty, so the CLI dead-ended in an opaque `MissingTokenCacheError` instead of
  provisioning `secrets.json`. Run as a script, `main.py` now always runs the
  token-bootstrap pipeline, regardless of flat vs. repo layout. When a usable
  cache already exists, `_ensure_authenticated` returns early so no Chrome login
  is launched; `--reauth` forces a fresh login. `_standalone` now only governs
  packaging. Users can run `main.py` directly from
  `custom_components/googlefindmy/` and get `secrets.json` without changing the
  directory structure. The running HA integration is untouched: HA never
  executes `main.py` as `__main__`.

- **F2a - deterministic aiohttp session teardown.** The shared `ClientSession`
  was created before the `try` and closed only in a `finally`, so a `sys.exit(1)`
  from the eager vault-key step leaked it ("Unclosed client session" warnings,
  contributing to the Windows teardown noise). It is now wrapped in `async with`,
  so `__aexit__` closes it on every exit path, including `SystemExit` /
  `KeyboardInterrupt`.

- **F2b - quiet undetected_chromedriver `Chrome.__del__` noise.** uc's
  `Chrome.__del__` calls `self.quit()` during GC, which raises
  `OSError [WinError 6]` on Windows after `safe_quit_driver` has already torn the
  driver down (pure teardown noise). When the uc module is first loaded, its
  `Chrome.__del__` is wrapped (once, idempotently, guarded) so the original
  cleanup still runs but the redundant re-quit error is swallowed via
  `contextlib.suppress(Exception)`; `KeyboardInterrupt`/`SystemExit` still
  propagate.

  This deliberately does **not** replace `__del__` with a no-op. A no-op would
  disable uc's cleanup of a *partially constructed* driver: when `uc.Chrome(...)`
  raises after the browser already launched (e.g. a Chrome/driver version
  mismatch), the strategy helpers never receive a `driver` object, so their
  `_quit_driver(driver)` is a no-op and uc's own `__del__` is the only path that
  kills the orphaned browser process and removes its temp profile. uc's
  `weakref.finalize(self._ensure_close)` reaper only kills the chromedriver
  *service* process, not the browser or the temp dir, so a no-op would leak both
  until interpreter exit (thanks @chatgpt-codex-connector for catching this).
  The wrapper preserves cleanup on failed constructions while still silencing the
  noise. Guarded as before (real `Chrome` class with its own `__del__` only;
  import stub, already-wrapped module, and a uc release without its own `__del__`
  are skipped).

- **Cleanup - drop the unreachable serve-only branch.** The `__main__` block
  briefly chose bootstrap vs. serve-only from the registered cache signal
  (`get_registered_entry_ids()`), but that registry is always empty at the
  decision point of a fresh `python main.py`: it is populated only by
  `async_setup_entry` (HA runtime, which never runs `main.py` as `__main__`) and
  by `_register_file_cache` (the bootstrap branch itself, after the decision).
  The serve-only branch was therefore dead code. The bootstrap now runs
  unconditionally; no capability is lost, since `_ensure_authenticated`
  early-returns for an existing cache.

- **Entry-id resolution - single source of truth.** `_async_cli_main`
  resolved its lookup hint with `entry_id or os.environ.get(...)`. Because an
  empty string is falsy, an explicit `--entry ""` (the documented way to defeat
  `GOOGLEFINDMY_ENTRY_ID` and select the sole default cache, CLI > env) fell
  through to the env value, so `_resolve_cli_cache` raised `Unknown entry_id`
  although the cache was registered under `""`. `_async_cli_main` now resolves
  with `is not None`, making it the single resolver: an explicit (possibly
  empty) value is honored verbatim, the env fallback applies only for an
  unsupplied (`None`) id. `main.py` forwards the already-resolved
  `_effective_entry_id` so the registry key and the lookup hint can never
  diverge, and the `python -m ...nbe_list_devices` entrypoint forwards the raw
  `--entry` value instead of re-applying the same falsy fallback. Regression
  tests `TestAsyncCliMainEntryResolution` cover all three cases (reverting to
  `or` turns the empty-string test red). Thanks @chatgpt-codex-connector for
  catching this.

## Behavior change (please note)

F1 changes what `python -m custom_components.googlefindmy.main` does when no
token cache is registered: it now runs the full bootstrap (opening Chrome for an
interactive login) instead of failing fast with `MissingTokenCacheError`. This is
the intended fix, but headless/CI/script callers that relied on the old fast
failure should be aware. `--reauth` is now honored in any layout (it always
forces a bootstrap), so the old repo-layout "ignored" warning is removed.

## Out of scope (intentional)

- **HA-stub decoupling for HA-less machines.** The HA import stubs
  (`main.py`) are still tied to the standalone branch. Any environment with an
  importable `homeassistant` (every real HA install, including the reporter's) is
  fully covered: the bootstrap pipeline imports the real `homeassistant` package.
  Only a machine that merely clones the repo without HA installed would also need
  the stubs in repo layout; that is a different user type and touches sensitive
  packaging code, so it is left as an optional follow-up rather than mixed into
  this behavior-changing PR.

## Tests

- `_run_cli_bootstrap`: session closed on vault `SystemExit`; session + FCM
  stopped on the happy path. (`async def` tests, no `asyncio.run`, per
  `tests/AGENTS.md`.)
- `_neutralize_uc_finalizer`: original-`__del__` delegation (cleanup preserved),
  error suppression (WinError-6-style raise swallowed), import-stub skip,
  idempotency, no-own-`__del__` skip, plus the `_get_uc_module` integration.
- `tests/test_main.py` (33) and `tests/test_chrome_driver.py` (98) green; ruff,
  `mypy --strict` and the strict-compliance test clean; `chrome_driver.py` at
  100% line/branch coverage.

## Version

No version bump in this PR. The version stays at 1.7.8; the maintainer
assigns release version numbers. A bump to 1.7.9 across the coupled triple
(`const.py`, `manifest.json`, `pyproject.toml`) can be applied at release time
if desired.


