### PR TITLE
fix(cli): repair FCM readiness gate and add opt-in debug logging

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3652,7 +3652,16 @@ class FcmReceiverHA:
                 _POLL_INTERVAL_S = 0.3
                 waited = 0.0
                 while waited < _MAX_READY_WAIT_S:
-                    run_state = getattr(pc, "run_state", None)
+                    # Re-read the live entry client each iteration.  A concurrent
+                    # supervisor restart can stop the captured ``pc`` and swap a
+                    # replacement into ``self.pcs[entry_id]`` on a transient
+                    # pre-start connection/login failure; that replacement may
+                    # reach STARTED while the stale object never does.  Polling
+                    # the current client (falling back to ``pc`` only while the
+                    # slot is momentarily empty) avoids a false fail-closed that
+                    # would abort a locate the replacement client could serve.
+                    current_pc = self.pcs.get(entry_id, pc)
+                    run_state = getattr(current_pc, "run_state", None)
                     if (
                         FcmPushClientRunState is not None
                         and run_state == FcmPushClientRunState.STARTED

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3634,7 +3634,21 @@ class FcmReceiverHA:
             # Google may arrive before the MCS connection is established.
             pc = self.pcs.get(entry_id)
             if pc is not None:
-                _MAX_READY_WAIT_S = 15.0
+                # Derive the readiness budget from the library's connection-retry
+                # count instead of a fixed 15.0s.  A brand-new FCM identity's
+                # first MCS connect can take the full retry budget
+                # (FCM_CONNECTION_RETRY_COUNT attempts, ~15-20s per the note near
+                # _listen()); a hard-coded 15.0s under-covered that window and let
+                # the gate expire before STARTED on the very first run.  Adding a
+                # small margin keeps a fresh registration from being abandoned
+                # prematurely, which is the root of the deterministic first-run
+                # locate timeout.
+                _PER_ATTEMPT_WAIT_S = 4.0
+                _READY_WAIT_MARGIN_S = 2.0
+                _MAX_READY_WAIT_S = (
+                    int(FCM_CONNECTION_RETRY_COUNT) * _PER_ATTEMPT_WAIT_S
+                    + _READY_WAIT_MARGIN_S
+                )
                 _POLL_INTERVAL_S = 0.3
                 waited = 0.0
                 while waited < _MAX_READY_WAIT_S:
@@ -3647,18 +3661,27 @@ class FcmReceiverHA:
                     await asyncio.sleep(_POLL_INTERVAL_S)
                     waited += _POLL_INTERVAL_S
                 else:
+                    # Fail closed: the client never started listening, so sending
+                    # the location request would hand the token to a dead listener
+                    # and the caller would block until an opaque 30s timeout.
+                    # Clearing the local token means the function returns None (the
+                    # sole caller, location_request.py, then reports a clear error
+                    # and returns early) and the finally block pops the manual-
+                    # locate callback so no stale registration leaks.
                     _LOGGER.warning(
                         "[entry=%s] FCM client not in STARTED state after %.1fs; "
-                        "location request may time out",
+                        "aborting manual locate registration (fail-closed)",
                         entry_id,
                         _MAX_READY_WAIT_S,
                     )
+                    token = None
 
-            _LOGGER.info(
-                "[entry=%s] Manual locate registration ready for %s",
-                entry_id,
-                canonic_id[:8],
-            )
+            if token is not None:
+                _LOGGER.info(
+                    "[entry=%s] Manual locate registration ready for %s",
+                    entry_id,
+                    canonic_id[:8],
+                )
             return token
         finally:
             if not token:

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -5,8 +5,8 @@
 """Standalone CLI entry point for GoogleFindMy functionality.
 
 Usage:
-    python -m custom_components.googlefindmy.main [--reauth] [--entry ENTRY_ID]
-    python custom_components/googlefindmy/main.py [--reauth] [--entry ENTRY_ID]
+    python -m custom_components.googlefindmy.main [--reauth] [--entry ENTRY_ID] [--debug]
+    python custom_components/googlefindmy/main.py [--reauth] [--entry ENTRY_ID] [--debug]
 
 Flags:
     --reauth   Force re-authentication by clearing cached tokens and running the
@@ -15,6 +15,10 @@ Flags:
     --entry    Target config entry ID.  Required when secrets.json contains caches
                for multiple HA config entries.  May also be set via the
                ``GOOGLEFINDMY_ENTRY_ID`` environment variable.
+    --debug    Enable verbose DEBUG logging for the bootstrap and FCM flow.  The
+               package configures no logging otherwise, so bootstrap/FCM diagnostics
+               are invisible without this flag.  May also be enabled via the
+               ``GOOGLEFINDMY_DEBUG`` environment variable.
 
 Run as a script, the module always runs the full token-bootstrap pipeline and
 writes ``secrets.json``, regardless of flat vs. repo directory layout.  When a
@@ -24,11 +28,17 @@ governs packaging (virtual package vs. real package), which is the one thing the
 directory name legitimately determines.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import types
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - import-time typing block
+    import argparse
+    from collections.abc import Mapping, Sequence
 
 _this_dir = Path(__file__).resolve().parent
 _standalone = not (
@@ -168,7 +178,7 @@ else:
                 fullname: str,
                 path: object,
                 target: object = None,
-            ) -> "importlib.machinery.ModuleSpec | None":
+            ) -> importlib.machinery.ModuleSpec | None:
                 if (
                     fullname == "homeassistant" or fullname.startswith("homeassistant.")
                 ) and fullname not in sys.modules:
@@ -839,17 +849,21 @@ async def _run_cli_bootstrap(file_cache: object, entry_id: str | None) -> None:
                 await fcm.async_stop()
 
 
-if __name__ == "__main__":
-    import argparse  # noqa: PLC0415
-    import asyncio  # noqa: PLC0415
+def _build_cli_parser() -> argparse.ArgumentParser:
+    """Build the standalone CLI argument parser.
 
-    _cli_parser = argparse.ArgumentParser(description="Google Find My Device CLI")
-    _cli_parser.add_argument(
+    Extracted from the ``__main__`` block so the flag surface (and therefore the
+    ``--help`` output) is unit-testable without spawning a subprocess.
+    """
+    import argparse  # noqa: PLC0415
+
+    parser = argparse.ArgumentParser(description="Google Find My Device CLI")
+    parser.add_argument(
         "--reauth",
         action="store_true",
         help="Force re-authentication by clearing cached tokens and running Chrome login",
     )
-    _cli_parser.add_argument(
+    parser.add_argument(
         "--entry",
         default=None,
         help=(
@@ -857,7 +871,53 @@ if __name__ == "__main__":
             "Required when secrets.json contains caches for multiple HA config entries."
         ),
     )
-    _cli_args = _cli_parser.parse_args()
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help=(
+            "Enable verbose DEBUG logging for the bootstrap and FCM flow. "
+            "Also enabled via the GOOGLEFINDMY_DEBUG environment variable."
+        ),
+    )
+    return parser
+
+
+def _configure_cli_logging(*, debug_flag: bool, env: Mapping[str, str]) -> None:
+    """Configure root logging for the standalone CLI.
+
+    The package never calls ``logging.basicConfig``; without it the root logger's
+    last-resort handler discards everything below WARNING, so every
+    ``_LOGGER.debug``/``info`` in the bootstrap and FCM path is invisible and the
+    first-run locate timeout cannot be diagnosed from a log.  DEBUG is enabled
+    when ``--debug`` is passed or ``GOOGLEFINDMY_DEBUG`` is truthy; otherwise the
+    default keeps normal runs at WARNING so the critical readiness warning still
+    surfaces without extra noise.
+
+    Must be called before the bootstrap so the auth and FCM steps emit under the
+    configured level.
+    """
+    import logging  # noqa: PLC0415
+
+    env_value = env.get("GOOGLEFINDMY_DEBUG", "").strip().lower()
+    debug_enabled = debug_flag or env_value not in ("", "0", "false", "no", "off")
+    logging.basicConfig(
+        level=logging.DEBUG if debug_enabled else logging.WARNING,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def _main(argv: Sequence[str] | None = None) -> None:
+    """Standalone CLI entry point.
+
+    Extracted from the ``__main__`` guard so flag parsing, logging setup, and the
+    bootstrap call order are unit-testable (the guard itself cannot be imported).
+    Logging is configured *before* ``_ensure_authenticated`` so the Chrome/FCM
+    diagnostics are captured from the very first step.
+    """
+    import asyncio  # noqa: PLC0415
+
+    args = _build_cli_parser().parse_args(argv)
+    _configure_cli_logging(debug_flag=args.debug, env=os.environ)
 
     # Always run the token-bootstrap pipeline, regardless of flat vs. repo
     # directory layout.  When a usable cache already exists, _ensure_authenticated
@@ -866,22 +926,26 @@ if __name__ == "__main__":
     # then a cache-signal check that was always empty for a fresh shell start),
     # both of which could dead-end a repo-layout start in an opaque
     # MissingTokenCacheError instead of bootstrapping.
-    if _cli_args.reauth:
+    if args.reauth:
         _clear_stale_tokens_for_reauth()
     _ensure_authenticated()
     # Resolve the effective entry id once (CLI > env > "") and use the SAME
     # value for both registration and hand-off, so the registry key and the
-    # lookup hint can never diverge.  Forwarding the raw _cli_args.entry instead
+    # lookup hint can never diverge.  Forwarding the raw args.entry instead
     # would re-trigger _async_cli_main's env fallback for an explicit
     # --entry "" (empty string is falsy), making _resolve_cli_cache reject the
     # env value as "Unknown entry_id" although the cache was registered under
     # "".  Codex reviews on 694f6883aa and 17669c7ff2.
-    _effective_entry_id = _resolve_effective_entry_id(
-        _cli_args.entry, os.environ.get("GOOGLEFINDMY_ENTRY_ID")
+    effective_entry_id = _resolve_effective_entry_id(
+        args.entry, os.environ.get("GOOGLEFINDMY_ENTRY_ID")
     )
-    _file_cache = _register_file_cache(_effective_entry_id)
+    file_cache = _register_file_cache(effective_entry_id)
 
     try:
-        asyncio.run(_run_cli_bootstrap(_file_cache, _effective_entry_id))
+        asyncio.run(_run_cli_bootstrap(file_cache, effective_entry_id))
     except KeyboardInterrupt:
         print("\nExiting.")
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -266,3 +266,48 @@ async def test_manual_locate_returns_token_when_started(
 
     assert token == "token-123"
     assert receiver.location_update_callbacks[device_id] is manual_callback
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_reads_replacement_client_during_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supervisor restart that swaps in a STARTED client mid-poll is honored.
+
+    Regression (Codex): the gate captured ``pc`` once before waiting.  When a
+    concurrent ``_start_supervisor_for_entry`` restart discards that client and
+    replaces ``self.pcs[entry_id]`` with a fresh one that reaches STARTED, the
+    stale object never transitions, so fail-closed used to abort a request the
+    replacement client could actually serve.  The loop must re-read the live
+    entry client during the poll.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    stale = _DummyPc(run_state="CONNECTING")
+    started = _DummyPc(run_state=_RunState.STARTED)
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    # Simulate a concurrent supervisor restart swapping the entry client in
+    # while the readiness gate is between polls (on the first ``await sleep``).
+    swapped = {"done": False}
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if not swapped["done"]:
+            receiver.pcs[entry_id] = started  # type: ignore[assignment]
+            swapped["done"] = True
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert receiver.location_update_callbacks[device_id] is manual_callback

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+from custom_components.googlefindmy.Auth import fcm_receiver_ha as fcm_mod
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
 
 
@@ -157,3 +158,111 @@ def test_process_background_update_uses_thread(
     assert receiver._pending_targets[key] == {"entry-1", "entry-2"}
     assert schedule_calls == [key]
     assert decode_calls == [("entry-1", "c0ffee")]
+
+
+# ---------------------------------------------------------------------------
+# Readiness gate: fail-closed when the FCM client never reaches STARTED
+# ---------------------------------------------------------------------------
+
+
+class _RunState:
+    """Minimal stand-in for FcmPushClientRunState (only STARTED is compared)."""
+
+    STARTED = "STARTED"
+
+
+class _DummyPc:
+    """Push client double exposing only the polled ``run_state`` attribute."""
+
+    def __init__(self, run_state: object) -> None:
+        self.run_state = run_state
+
+
+def _wire_manual_locate(
+    monkeypatch: pytest.MonkeyPatch,
+    receiver: FcmReceiverHA,
+    entry_id: str,
+    cache: DummyCache,
+) -> None:
+    """Stub every collaborator the readiness gate calls before the poll loop."""
+
+    async def _ensure_client(eid: str, c: Any, generation: int | None = None) -> object:
+        return object()
+
+    async def _start(eid: str, c: Any) -> None:
+        return None
+
+    async def _ensure_token(eid: str) -> str:
+        return "token-123"
+
+    async def _persist(eid: str, tok: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        receiver, "_select_manual_locate_entry", lambda cid: (entry_id, cache)
+    )
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure_client)
+    monkeypatch.setattr(receiver, "_start_supervisor_for_entry", _start)
+    monkeypatch.setattr(receiver, "_ensure_token_for_entry", _ensure_token)
+    monkeypatch.setattr(receiver, "_update_token_routing", lambda tok, ids: None)
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_fails_closed_when_never_started(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client that never reaches STARTED yields None and leaves no callback.
+
+    Regression for the deterministic first-run locate timeout: the gate used to
+    fall through to ``return token`` (fail-open), handing a token to a listener
+    that was not yet connected so the caller blocked until an opaque 30s timeout.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    receiver.pcs[entry_id] = _DummyPc(run_state="CONNECTING")  # type: ignore[assignment]
+
+    # Do not actually sleep through the readiness budget.
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token is None
+    assert device_id not in receiver.location_update_callbacks
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_returns_token_when_started(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HA happy path: STARTED within budget returns the token, keeps the callback."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    receiver.pcs[entry_id] = _DummyPc(run_state=_RunState.STARTED)  # type: ignore[assignment]
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert receiver.location_update_callbacks[device_id] is manual_callback

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,8 @@ it simply imports ``list_devices`` from ``nbe_list_devices`` and calls it.
 
 from __future__ import annotations
 
+import argparse
+import logging
 import subprocess
 import sys
 from unittest import mock
@@ -106,6 +108,9 @@ class TestDunderMain:
         )
         assert "--reauth" in result.stdout, (
             f"--reauth missing from --help output:\n{result.stdout}"
+        )
+        assert "--debug" in result.stdout, (
+            f"--debug missing from --help output:\n{result.stdout}"
         )
 
     def test_dunder_main_accepts_entry_flag(self) -> None:
@@ -899,3 +904,161 @@ class TestPasteRoundTrip:
         assert cache.saved[f"shared_key_{username}"] == "ddeeff"
         # The top-level field itself is preserved verbatim.
         assert cache.saved["owner_key"] == owner_hex
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point: parser surface, logging configuration, and call order
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCliParser:
+    """_build_cli_parser() exposes every documented flag."""
+
+    def test_help_lists_all_flags(self) -> None:
+        from custom_components.googlefindmy import main as cli_main
+
+        help_text = cli_main._build_cli_parser().format_help()
+        assert "--reauth" in help_text
+        assert "--entry" in help_text
+        assert "--debug" in help_text
+
+    def test_debug_defaults_to_false(self) -> None:
+        from custom_components.googlefindmy import main as cli_main
+
+        args = cli_main._build_cli_parser().parse_args([])
+        assert args.debug is False
+
+    def test_debug_flag_parses_true(self) -> None:
+        from custom_components.googlefindmy import main as cli_main
+
+        args = cli_main._build_cli_parser().parse_args(["--debug"])
+        assert args.debug is True
+
+
+class TestConfigureCliLogging:
+    """_configure_cli_logging() maps flag/env onto the basicConfig level."""
+
+    @staticmethod
+    def _captured_level(
+        monkeypatch: pytest.MonkeyPatch, *, debug_flag: bool, env: dict[str, str]
+    ) -> int:
+        from custom_components.googlefindmy import main as cli_main
+
+        captured: dict[str, object] = {}
+
+        def fake_basic_config(**kwargs: object) -> None:
+            # basicConfig is a no-op once pytest installed root handlers, so we
+            # assert on the requested level instead of the effective root level.
+            captured.update(kwargs)
+
+        monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+        cli_main._configure_cli_logging(debug_flag=debug_flag, env=env)
+        level = captured["level"]
+        assert isinstance(level, int)
+        return level
+
+    def test_flag_enables_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert (
+            self._captured_level(monkeypatch, debug_flag=True, env={}) == logging.DEBUG
+        )
+
+    def test_env_truthy_enables_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert (
+            self._captured_level(
+                monkeypatch, debug_flag=False, env={"GOOGLEFINDMY_DEBUG": "1"}
+            )
+            == logging.DEBUG
+        )
+
+    def test_env_falsy_stays_at_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # "0" must be treated as disabled, not merely "present" (mutation guard).
+        assert (
+            self._captured_level(
+                monkeypatch, debug_flag=False, env={"GOOGLEFINDMY_DEBUG": "0"}
+            )
+            == logging.WARNING
+        )
+
+    def test_default_is_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert (
+            self._captured_level(monkeypatch, debug_flag=False, env={})
+            == logging.WARNING
+        )
+
+
+class TestCliMainCallOrder:
+    """_main() configures logging before authentication and bootstrap."""
+
+    def _run_main(self, monkeypatch: pytest.MonkeyPatch, *, reauth: bool) -> mock.Mock:
+        import asyncio
+
+        from custom_components.googlefindmy import main as cli_main
+
+        manager = mock.Mock()
+        namespace = argparse.Namespace(debug=True, reauth=reauth, entry=None)
+        fake_parser = mock.Mock()
+        fake_parser.parse_args.return_value = namespace
+
+        monkeypatch.setattr(cli_main, "_build_cli_parser", lambda: fake_parser)
+        monkeypatch.setattr(cli_main, "_configure_cli_logging", manager.configure)
+        monkeypatch.setattr(cli_main, "_clear_stale_tokens_for_reauth", manager.clear)
+        monkeypatch.setattr(cli_main, "_ensure_authenticated", manager.auth)
+        monkeypatch.setattr(
+            cli_main, "_resolve_effective_entry_id", lambda *a: "entry-x"
+        )
+        monkeypatch.setattr(cli_main, "_register_file_cache", lambda entry: object())
+        # Mock the coroutine factory too so no un-awaited coroutine is created
+        # (asyncio.run is mocked, so a real coroutine would leak a warning).
+        monkeypatch.setattr(cli_main, "_run_cli_bootstrap", manager.bootstrap)
+        monkeypatch.setattr(asyncio, "run", manager.run)
+
+        cli_main._main([])
+        return manager
+
+    def test_logging_configured_before_auth_and_bootstrap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager = self._run_main(monkeypatch, reauth=False)
+        call_names = [call[0] for call in manager.mock_calls]
+
+        assert "configure" in call_names, call_names
+        assert call_names.index("configure") < call_names.index("auth")
+        assert call_names.index("auth") < call_names.index("run")
+        # reauth was False, so the stale-token clear must NOT run.
+        assert "clear" not in call_names
+
+    def test_logging_receives_debug_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        manager = self._run_main(monkeypatch, reauth=False)
+        manager.configure.assert_called_once_with(debug_flag=True, env=mock.ANY)
+
+    def test_reauth_clears_before_auth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        manager = self._run_main(monkeypatch, reauth=True)
+        call_names = [call[0] for call in manager.mock_calls]
+        assert call_names.index("clear") < call_names.index("auth")
+
+    def test_keyboard_interrupt_prints_exiting(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A Ctrl-C during the bootstrap is caught and reported, not propagated."""
+        import asyncio
+
+        from custom_components.googlefindmy import main as cli_main
+
+        namespace = argparse.Namespace(debug=False, reauth=False, entry=None)
+        fake_parser = mock.Mock()
+        fake_parser.parse_args.return_value = namespace
+
+        monkeypatch.setattr(cli_main, "_build_cli_parser", lambda: fake_parser)
+        monkeypatch.setattr(cli_main, "_configure_cli_logging", lambda **kwargs: None)
+        monkeypatch.setattr(cli_main, "_ensure_authenticated", lambda: None)
+        monkeypatch.setattr(cli_main, "_resolve_effective_entry_id", lambda *a: "")
+        monkeypatch.setattr(cli_main, "_register_file_cache", lambda entry: object())
+        monkeypatch.setattr(cli_main, "_run_cli_bootstrap", lambda *a: None)
+
+        def _raise(_coro: object) -> None:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(asyncio, "run", _raise)
+
+        cli_main._main([])
+        assert "Exiting." in capsys.readouterr().out


### PR DESCRIPTION
# Summary

Fixes the deterministic **first-run locate timeout** in the standalone CLI: the first location request after a fresh authentication always times out, while a `quit` + restart always succeeds. Two independent defects in the manual-locate path cause it, and a third gap (no logging at all) made it undiagnosable.

- Type: ☑ fix
- Scope/Area: cli / Auth (FCM manual-locate readiness)
- Linked issues: —

## Motivation

The manual-locate readiness gate in `Auth/fcm_receiver_ha.py::async_register_for_location_updates` waits only `_MAX_READY_WAIT_S = 15.0s` for the FCM client to reach `STARTED`, but the library's own connect-retry budget (`FCM_CONNECTION_RETRY_COUNT = 5`) is documented as "~15-20s". On a fresh FCM identity the first MCS connect is slower, so the gate expires **and then returns the token anyway (fail-open)** — the location request is sent to a listener that is not yet connected, and the 30s wait in `location_request.py` is guaranteed to expire. On restart the identity is already propagated, `STARTED` is reached under budget, and it works every time.

This was undiagnosable because the package configured **no logging**, so the decisive `FCM client not in STARTED state after 15.0s` warning was invisible.

---

## Change Log (human-readable)

**AP1 — Opt-in CLI logging (this commit):**
- New `--debug` flag (shown in `--help`) and `GOOGLEFINDMY_DEBUG` env toggle enabling DEBUG logging.
- Logging is configured *before* the auth/FCM bootstrap so those steps are observable; default stays WARNING so the critical readiness warning surfaces without extra noise.
- Extracted `_build_cli_parser()`, `_configure_cli_logging()`, `_main()` for unit-testability; docstring Usage/Flags synced.

**AP2 — Readiness-gate fix (follow-up commit on this branch):**
- Derive the readiness budget from `FCM_CONNECTION_RETRY_COUNT` (covering the documented ~15-20s window) instead of the too-short hard-coded 15s.
- Turn the gate **fail-closed**: on non-ready, return `None` (the sole caller already logs an explicit error and returns `[]`) instead of handing a token to a dead listener; clean up the manual-locate callback to avoid a leak.

## Testing

- `ruff check` / `ruff format --check`: clean
- `mypy --strict`: clean
- `pytest tests/test_main.py`: 44 passed (new: parser surface, logging-level logic incl. falsy-env guard, logging-before-auth call order, KeyboardInterrupt path)
- Delta coverage of changed lines in `main.py`: 100% (TYPE_CHECKING block excluded per repo convention)

## Notes / Negative protocol

- No version bump (release versioning is owner-decided).
- The real Google backend propagation of a brand-new FCM registration is not locally observable (no Google account / live tags); AP2 fixes the statically-provable gate defect independent of that. Windows WinError path not exercised (no Windows runner).
