### PR TITLE
fix(fcm): stop teardown race surfacing as 'Unknown error in listener'

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -396,7 +396,12 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
     # protobuf varint32 helpers
     async def _read_varint32(self) -> int:
         reader = self.reader
-        assert reader is not None, "StreamReader is not initialized"
+        if reader is None:
+            # Same class as the ``_send_msg`` writer guard: a read on a
+            # torn-down stream is a normal connection life-cycle event, not an
+            # invariant violation. Surface it as a ConnectionError the listener
+            # already handles gracefully rather than an "Unknown error" trace.
+            raise ConnectionError("StreamReader is not initialized")
         res = 0
         shift = 0
         while True:
@@ -434,13 +439,26 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         self._log_verbose("Sending packet to server: %s", self._msg_str(msg))
         buf = FcmPushClient._make_packet(msg, self.first_message)
         writer = self.writer
-        assert writer is not None, "StreamWriter is not initialized"
+        if writer is None:
+            # A send on a torn-down stream is a normal connection life-cycle
+            # event, not a programming-invariant violation: e.g. an in-flight
+            # heartbeat ack racing a concurrent stop()/teardown that already
+            # nulled ``self.writer`` in ``_do_writer_close``. Raise a
+            # ConnectionError so the listener's connection-error handling stops
+            # the worker cleanly, instead of an ``assert`` whose AssertionError
+            # falls through to the generic arm and surfaces as an alarming
+            # "Unknown error in listener" traceback for a benign shutdown.
+            raise ConnectionError("StreamWriter is not initialized")
         writer.write(buf)
         await writer.drain()
 
     async def _receive_msg(self) -> MessageProto | None:
         reader = self.reader
-        assert reader is not None, "StreamReader is not initialized"
+        if reader is None:
+            # Same class as the ``_send_msg`` writer guard (see there): a torn-
+            # down stream is a normal life-cycle event; raise ConnectionError so
+            # the listener stops cleanly instead of logging an "Unknown error".
+            raise ConnectionError("StreamReader is not initialized")
 
         if self.first_message:
             r = await reader.readexactly(2)

--- a/tests/test_fcmpushclient_teardown_stream_race.py
+++ b/tests/test_fcmpushclient_teardown_stream_race.py
@@ -1,0 +1,119 @@
+# tests/test_fcmpushclient_teardown_stream_race.py
+"""Regression suite for the shutdown-race stream guards in ``FcmPushClient``.
+
+When a manual quit (or any ``stop()``) tears the connection down,
+``_do_writer_close`` nulls ``self.writer`` while the listener task may still be
+processing an in-flight inbound heartbeat. The resulting
+``_handle_ping -> _send_msg`` then reads a ``None`` writer. The historic
+``assert writer is not None`` raised ``AssertionError``, which -- being an
+``Exception`` subclass -- fell through the listener's generic arm and surfaced
+as an alarming ``"Unknown error in listener: StreamWriter is not initialized"``
+traceback for a benign shutdown.
+
+The guards now raise ``ConnectionError`` instead, which the listener already
+treats as a normal life-cycle stop (``except (ConnectionError, ssl.SSLError)``).
+These tests pin that contract for the whole error class: the send guard
+(``_send_msg``) and both read guards (``_read_varint32`` / ``_receive_msg``).
+Same additive-composition discipline as ``fcm_handle_stub.FcmMessageSlim`` --
+the real unbound methods run without the heavy production constructor.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClient,
+    HeartbeatAck,
+)
+
+
+class _SendSlim:
+    """Binds the real async ``_send_msg`` with a controllable ``writer``."""
+
+    def __init__(self, writer: object) -> None:
+        self.logger = logging.getLogger(__name__ + "._SendSlim")
+        self.writer = writer
+        self.first_message = False
+
+    def _log_verbose(self, msg: str, *args: object) -> None:
+        self.logger.debug(msg, *args)
+
+    def _msg_str(self, msg: object) -> str:  # noqa: PLR6301 - bound stub
+        return "<msg>"
+
+    _send_msg = FcmPushClient._send_msg  # type: ignore[assignment]
+
+
+class _ReadSlim:
+    """Binds the real async read helpers with a controllable ``reader``."""
+
+    def __init__(self, reader: object) -> None:
+        self.logger = logging.getLogger(__name__ + "._ReadSlim")
+        self.reader = reader
+        self.first_message = False
+
+    def _log_warn_with_limit(self, msg: str, *args: object) -> None:
+        self.logger.warning(msg, *args)
+
+    _read_varint32 = FcmPushClient._read_varint32  # type: ignore[assignment]
+    _receive_msg = FcmPushClient._receive_msg  # type: ignore[assignment]
+
+
+@pytest.mark.asyncio
+async def test_send_on_torn_down_writer_raises_connection_error() -> None:
+    """``_send_msg`` with a nulled writer -> ConnectionError, NOT AssertionError.
+
+    This is the exact teardown race from the bug report: an in-flight heartbeat
+    ack after ``stop()`` nulled ``self.writer``. ConnectionError routes into the
+    listener's clean-stop arm; AssertionError would surface as "Unknown error".
+    """
+    client = _SendSlim(writer=None)
+
+    with pytest.raises(ConnectionError, match="StreamWriter is not initialized"):
+        await client._send_msg(HeartbeatAck())
+
+
+@pytest.mark.asyncio
+async def test_send_on_live_writer_writes_and_drains() -> None:
+    """Happy path: a live writer still receives the packet and is drained."""
+    writer = MagicMock()
+    writer.drain = AsyncMock()
+    client = _SendSlim(writer=writer)
+
+    await client._send_msg(HeartbeatAck())
+
+    writer.write.assert_called_once()
+    writer.drain.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_read_varint32_on_unconnected_reader_raises_connection_error() -> None:
+    """Class sibling: ``_read_varint32`` with a ``None`` reader -> ConnectionError.
+
+    Note ``_do_writer_close`` only nulls ``self.writer``, never ``self.reader``,
+    so this guard fires in the not-yet-connected state rather than the exact
+    writer teardown race. It is fixed for class consistency (same assert-on-
+    stream pattern) so no sibling can surface the "Unknown error" traceback.
+    """
+    client = _ReadSlim(reader=None)
+
+    with pytest.raises(ConnectionError, match="StreamReader is not initialized"):
+        await client._read_varint32()
+
+
+@pytest.mark.asyncio
+async def test_receive_msg_on_unconnected_reader_raises_connection_error() -> None:
+    """Class sibling: ``_receive_msg`` with a ``None`` reader -> ConnectionError.
+
+    Like ``_read_varint32`` above, the reader is never nulled during teardown;
+    this covers the not-yet-connected state and keeps the whole assert-on-stream
+    class consistent (ConnectionError, not AssertionError).
+    """
+    client = _ReadSlim(reader=None)
+
+    with pytest.raises(ConnectionError, match="StreamReader is not initialized"):
+        await client._receive_msg()


### PR DESCRIPTION
# Summary

A manual quit (or any `stop()`) can surface an alarming `Unknown error in listener: StreamWriter is not initialized` traceback to standalone CLI users, even though nothing actually went wrong. This is a benign FCM connection teardown race; this PR routes it into the existing clean worker-stop path.

- Type: fix
- Scope/Area: `Auth/firebase_messaging/fcmpushclient.py` (FCM push client)
- Linked issues: n/a (user-reported CLI traceback after idle + `q`)

## Motivation

On quit, `stop()` calls `_do_writer_close()`, which nulls `self.writer`. The listener task may still be handling an in-flight heartbeat ping at that moment: `_handle_ping -> _send_msg` then reads a `None` writer and trips `assert writer is not None`. Because `AssertionError` is an `Exception` subclass, it falls through the listener's generic arm and is logged as `Unknown error in listener: ...` with a full traceback for what is really a normal shutdown.

Reported traceback (standalone CLI, after long idle then `q`):

```
Unknown error in listener: StreamWriter is not initialized
  ... _handle_ping -> _send_msg
  AssertionError: StreamWriter is not initialized
```

---

## Change Log (human-readable)

- Replace three `assert <stream> is not None` guards with a clean `ConnectionError`:
  - `_send_msg` (writer) — the confirmed teardown race.
  - `_read_varint32` and `_receive_msg` (reader) — same error class, fixed for consistency (reader is not nulled during teardown, so these cover the not-yet-connected state).
- A send/receive on a torn-down stream is a normal connection life-cycle event, not a programming-invariant violation. The listener already catches `(ConnectionError, ssl.SSLError)` and stops the worker cleanly (`FCM stream ended; worker stopping.`), so the supervisor reconnects (or, on a CLI quit, it simply stops) without a scary traceback.
- Add `tests/test_fcmpushclient_teardown_stream_race.py`: pins `ConnectionError` (not `AssertionError`) for all three guards plus the live-writer happy path (write + drain).

## Verification

- `ruff check` + `ruff format --check`: clean (both files).
- `mypy` strict: clean.
- New tests: 4 passed; repo async/path guards green.
- FCM suite (`-k "fcm or push or listen"`, 396 tests): no regression.
- Mutation probe: reverting the writer guard to `assert` turns the send-race test red (`AssertionError`), confirming the test is sharp.
- Error-class sweep (SA-8): the three fixed sites are the only assert-on-stream guards in the whole `firebase_messaging` package.
- Independent adversarial diff review: PASS (verified listener routing via `issubclass`, no masking on the `_login` path).

## Notes

- No version bump (stays 1.7.8); the release version is the maintainer's call.
- Draft: further findings from the same session may be appended as additional commits before this is marked ready.
