### PR TITLE
fix(auth): reconnect fresh FCM session before first locate

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3793,6 +3793,53 @@ class FcmReceiverHA:
                 self._first_locate_reconnect_done[entry_id] = fresh_pc
             return fresh_pc
 
+    async def _reconnect_and_refresh_token(
+        self, entry_id: str, previous_token: str, max_wait_s: float
+    ) -> str | None:
+        """Force the first-locate reconnect, then return the *live* entry token.
+
+        Fails closed (returns ``None``) when the replacement never reaches
+        STARTED, or when the entry has no FCM token after the reconnect.
+
+        The reconnect nudges a supervisor rebuild that may run a full
+        re-registration (``checkin_or_register`` / ``reregister_keeping_identity``)
+        and rotate the entry's FCM token after the caller captured
+        ``previous_token``.  Returning the stale token would send the locate to
+        the old registration while the live listener is subscribed with the new
+        one, reproducing the very timeout this fix heals (Codex #1150 follow-up).
+        Routing is re-pointed at the refreshed token only when it actually
+        rotated; the stale mapping for a dead registration is benign (it receives
+        no pushes) and is not eagerly purged here.
+        """
+        fresh_pc = await self._reconnect_for_first_locate(entry_id, max_wait_s)
+        if fresh_pc is None:
+            _LOGGER.warning(
+                "[entry=%s] Forced reconnect did not reach STARTED after %.1fs; "
+                "aborting manual locate registration (fail-closed)",
+                entry_id,
+                max_wait_s,
+            )
+            return None
+
+        refreshed = self.get_fcm_token(entry_id)
+        if not refreshed:
+            _LOGGER.warning(
+                "[entry=%s] FCM token unavailable after forced reconnect; "
+                "aborting manual locate registration (fail-closed)",
+                entry_id,
+            )
+            return None
+
+        if refreshed != previous_token:
+            _LOGGER.debug(
+                "[entry=%s] FCM token rotated during forced first-locate "
+                "reconnect; using the refreshed token for the locate",
+                entry_id,
+            )
+            self._update_token_routing(refreshed, {entry_id})
+            await self._persist_routing_token(entry_id, refreshed)
+        return refreshed
+
     async def async_register_for_location_updates(
         self, canonic_id: str, callback: Callable[[str, str], None]
     ) -> str | None:
@@ -3884,23 +3931,16 @@ class FcmReceiverHA:
                     # AP1 (first-locate-delivery fix): a fresh, not-yet-delivering
                     # session reached STARTED but empirically will not receive the
                     # very first locate push until it reconnects.  Force exactly
-                    # one cooperative reconnect, then fail closed if the
-                    # replacement never starts, like the gate above.  The
-                    # reconnect is serialised per entry so concurrent locates on
-                    # the same entry share one replacement instead of tearing
-                    # down each other's fresh session (Codex #1150 follow-up).
-                    fresh_pc = await self._reconnect_for_first_locate(
-                        entry_id, _MAX_READY_WAIT_S
+                    # one cooperative reconnect (serialised per entry so concurrent
+                    # locates on the same entry share one replacement instead of
+                    # tearing down each other's fresh session), then re-read the
+                    # token: the reconnect's supervisor rebuild may re-register and
+                    # rotate the entry's FCM token after it was captured above.
+                    # Fail closed if the replacement never starts or the token
+                    # vanished (Codex #1150 follow-ups).
+                    token = await self._reconnect_and_refresh_token(
+                        entry_id, token, _MAX_READY_WAIT_S
                     )
-                    if fresh_pc is None:
-                        _LOGGER.warning(
-                            "[entry=%s] Forced reconnect did not reach STARTED "
-                            "after %.1fs; aborting manual locate registration "
-                            "(fail-closed)",
-                            entry_id,
-                            _MAX_READY_WAIT_S,
-                        )
-                        token = None
 
             if token is not None:
                 _LOGGER.info(

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3627,27 +3627,36 @@ class FcmReceiverHA:
             waited += _POLL_INTERVAL_S
         return None
 
-    def _session_age_s(self) -> float | None:
-        """Age (seconds) of the most recent FCM session start, or ``None``.
+    def _session_age_s(self, pc: FcmPushClient[Any]) -> float | None:
+        """Age (seconds) since this client's STARTED transition, or ``None``.
 
-        ``last_start_monotonic`` is aggregate across entries (see its definition
-        near the top of this class).  For the single-entry CLI — the target of
-        the first-locate-delivery fix — it is exactly the one entry's session
-        age; under Home Assistant multi-entry it is approximate, which is why the
-        reconnect trigger is additionally gated on per-entry non-delivery (see
-        ``_needs_first_locate_reconnect``).
+        Anchored on the client's own ``_started_monotonic`` — stamped where the
+        library assigns ``run_state = STARTED`` — not the supervisor's
+        ``last_start_monotonic``, which is recorded *before* ``pc.start()`` and
+        before the listener reaches STARTED.  The readiness gate deliberately
+        allows a fresh MCS connection ~15-20s to reach STARTED; measuring the
+        churn window from the supervisor start would let a slow-but-fresh session
+        age past ``_CHURN_WINDOW_S`` before its first STARTED observation and skip
+        the very reconnect this heals (Codex #1150 follow-up).  Being per-client,
+        it is also exact under Home Assistant multi-entry — no aggregate blur.
+
+        Returns ``None`` until the client has reached STARTED at least once; the
+        manual-locate caller only consults this for an already-STARTED client, so
+        ``None`` there means "library without a STARTED stamp" and fails safe (no
+        reconnect).
         """
-        start = self.last_start_monotonic
-        if start <= 0:
+        started: float | None = getattr(pc, "_started_monotonic", None)
+        if started is None:
             return None
-        return max(time.monotonic() - start, 0.0)
+        return max(time.monotonic() - started, 0.0)
 
     def _needs_first_locate_reconnect(self, pc: FcmPushClient[Any]) -> bool:
         """True if a fresh, not-yet-delivering session should reconnect once.
 
         Trigger (T-A + per-entry sharpening): the session is *young*
-        (age < ``_CHURN_WINDOW_S``) **and** this client has not delivered any
-        data message since login.  Delivery is read from the library's
+        (STARTED age < ``_CHURN_WINDOW_S``, measured from this client's own
+        STARTED transition) **and** this client has not delivered any data
+        message since login.  Delivery is read from the library's
         ``persistent_ids`` list, which is reset to ``[]`` on each successful
         login and appended to only for a ``DataMessageStanza`` — so a non-empty
         list is a clean "has delivered" proof.  It deliberately does *not* use
@@ -3656,9 +3665,9 @@ class FcmReceiverHA:
         therefore never separate a broken fresh session (heartbeats, zero data)
         from a healthy one.  A healthy, already-delivering session (e.g. a
         long-running HA entry) is thus never torn down, independent of the
-        aggregate session age.
+        session age.
         """
-        age = self._session_age_s()
+        age = self._session_age_s(pc)
         if age is None or age >= _CHURN_WINDOW_S:
             return False
         delivered = bool(getattr(pc, "persistent_ids", None))
@@ -3677,7 +3686,7 @@ class FcmReceiverHA:
         it.  Part of the first-locate-delivery fix (#1148/#1149 family): STARTED
         is necessary but not sufficient for the first push to arrive.
         """
-        session_age = self._session_age_s()
+        session_age = self._session_age_s(stale_pc)
         _LOGGER.debug(
             "[entry=%s] Fresh FCM session (age=%.1fs) reached STARTED but has not "
             "delivered a data message yet; forcing one reconnect before the first "

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3208,8 +3208,13 @@ class FcmReceiverHA:
                 )
         self.creds[entry_id] = normalized if isinstance(normalized, dict) else None
 
-        # Update token routing from fresh creds if possible
-        token = self.get_fcm_token(entry_id)
+        # Update token routing from fresh creds if possible.  Read strictly
+        # entry-scoped: the creds for this entry were just written above, so
+        # ``get_fcm_token``'s cross-entry fallback could only route a *foreign*
+        # account's token under this entry when the update is tokenless -- the
+        # same leak class as the forced first-locate reconnect refresh (Codex
+        # #1150 follow-ups).  A tokenless update must route nothing here.
+        token = self._entry_scoped_fcm_token(entry_id)
         if token:
             self._update_token_routing(token, {entry_id})
             self._dispatch_to_hass_loop(
@@ -3492,6 +3497,33 @@ class FcmReceiverHA:
 
     # -------------------- Public token accessor --------------------
 
+    def _entry_scoped_fcm_token(self, entry_id: str) -> str | None:
+        """Return the FCM token that belongs strictly to ``entry_id``.
+
+        Reads the entry's persisted creds first, then the live client's
+        credentials.  Unlike :meth:`get_fcm_token`, this never falls back to
+        another entry's token, so a caller that requires per-entry correctness
+        (the forced first-locate reconnect in a multi-account setup) can fail
+        closed instead of routing a foreign account's token to the wrong entry.
+        """
+        creds = self.creds.get(entry_id)
+        if isinstance(creds, dict):
+            tok = (creds.get("fcm") or {}).get("registration", {}).get("token")
+            if isinstance(tok, str) and tok:
+                return tok
+        # Also try the current client's live creds if present
+        pc = self.pcs.get(entry_id)
+        if pc:
+            try:
+                c = getattr(pc, "credentials", None)
+                if isinstance(c, dict):
+                    tok = (c.get("fcm") or {}).get("registration", {}).get("token")
+                    if isinstance(tok, str) and tok:
+                        return tok
+            except Exception:
+                pass
+        return None
+
     def get_fcm_token(self, entry_id: str | None = None) -> str | None:
         """Return current FCM token (best-effort).
 
@@ -3502,22 +3534,9 @@ class FcmReceiverHA:
         target_entry = entry_id if entry_id is not None else self._default_entry_id
 
         if target_entry:
-            creds = self.creds.get(target_entry)
-            if isinstance(creds, dict):
-                tok = (creds.get("fcm") or {}).get("registration", {}).get("token")
-                if isinstance(tok, str) and tok:
-                    return tok
-            # Also try the current client's live creds if present
-            pc = self.pcs.get(target_entry)
-            if pc:
-                try:
-                    c = getattr(pc, "credentials", None)
-                    if isinstance(c, dict):
-                        tok = (c.get("fcm") or {}).get("registration", {}).get("token")
-                        if isinstance(tok, str) and tok:
-                            return tok
-                except Exception:
-                    pass
+            scoped = self._entry_scoped_fcm_token(target_entry)
+            if scoped:
+                return scoped
         # Fallback: first available token across entries
         for c in self.creds.values():
             if isinstance(c, dict):
@@ -3810,6 +3829,13 @@ class FcmReceiverHA:
         Routing is re-pointed at the refreshed token only when it actually
         rotated; the stale mapping for a dead registration is benign (it receives
         no pushes) and is not eagerly purged here.
+
+        The refreshed token is read strictly entry-scoped
+        (:meth:`_entry_scoped_fcm_token`, not :meth:`get_fcm_token`): in a
+        multi-account setup ``get_fcm_token``'s cross-entry fallback could return
+        another account's token when this entry is momentarily tokenless after the
+        rebuild, which would route a foreign token for this entry.  Failing closed
+        is correct there (Codex #1150 follow-up).
         """
         fresh_pc = await self._reconnect_for_first_locate(entry_id, max_wait_s)
         if fresh_pc is None:
@@ -3821,7 +3847,7 @@ class FcmReceiverHA:
             )
             return None
 
-        refreshed = self.get_fcm_token(entry_id)
+        refreshed = self._entry_scoped_fcm_token(entry_id)
         if not refreshed:
             _LOGGER.warning(
                 "[entry=%s] FCM token unavailable after forced reconnect; "

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -426,6 +426,22 @@ class FcmReceiverHA:
         self._entry_health: dict[str, bool] = {}
         self._entry_last_connected_wall: dict[str, float] = {}
 
+        # One-shot first-locate reconnect (#1150) serialization. Concurrent
+        # manual locates for different trackers on the *same* entry both enter
+        # the fresh/no-delivery reconnect branch; without coordination the
+        # second caller tears down the replacement client the first caller just
+        # waited for, so the first request hands its token to a listener that is
+        # already gone and times out (Codex #1150 follow-up). A per-entry lock
+        # serialises the decision and ``_first_locate_reconnect_done`` records
+        # the replacement we already reconnected to (by identity), so a
+        # concurrent or sequential second caller reuses it instead of forcing
+        # another reconnect. A genuinely new session generation (a different
+        # client object) is still allowed exactly one fresh reconnect. Not the
+        # global ``self._lock``: the reconnect awaits the supervisor rebuild,
+        # which itself takes ``self._lock``, so reusing it would deadlock.
+        self._first_locate_locks: dict[str, asyncio.Lock] = {}
+        self._first_locate_reconnect_done: dict[str, FcmPushClient[Any]] = {}
+
         # Active background tasks for exception tracking (P0 fix)
         self._active_tasks: set[asyncio.Task[Any]] = set()
 
@@ -3435,6 +3451,11 @@ class FcmReceiverHA:
     def _purge_entry_tokens(self, entry_id: str) -> None:
         """Remove all routing references and per-entry runtime state for an entry."""
         self._entry_last_activity_monotonic.pop(entry_id, None)
+        # First-locate reconnect serialization state (#1150 follow-up): drop the
+        # per-entry lock and the consumed-replacement record so a later reload
+        # under the same entry_id starts from a clean slate.
+        self._first_locate_locks.pop(entry_id, None)
+        self._first_locate_reconnect_done.pop(entry_id, None)
         # AP1 (finding 2a): fatal retry counters are only cleared on the success
         # path (registration ok), so they leak per teardown without this.
         self._fatal_retry_counts.pop(f"{entry_id}:auth", None)
@@ -3616,16 +3637,25 @@ class FcmReceiverHA:
         waited = 0.0
         while waited < max_wait_s:
             current_pc = self.pcs.get(entry_id, fallback_pc)
-            run_state = getattr(current_pc, "run_state", None)
-            if (
-                FcmPushClientRunState is not None
-                and run_state == FcmPushClientRunState.STARTED
-                and (exclude_pc is None or current_pc is not exclude_pc)
+            if self._is_started(current_pc) and (
+                exclude_pc is None or current_pc is not exclude_pc
             ):
                 return current_pc
             await asyncio.sleep(_POLL_INTERVAL_S)
             waited += _POLL_INTERVAL_S
         return None
+
+    def _is_started(self, pc: FcmPushClient[Any]) -> bool:
+        """True if *pc* is currently in the ``STARTED`` run state.
+
+        Single definition of "listening" shared by the readiness poll and the
+        first-locate reconnect short-circuits, so both fail closed on a client
+        that is not actually STARTED (e.g. a fresh, not-yet-started replacement
+        a concurrent supervisor swapped in).
+        """
+        if FcmPushClientRunState is None:
+            return False
+        return bool(getattr(pc, "run_state", None) == FcmPushClientRunState.STARTED)
 
     def _session_age_s(self, pc: FcmPushClient[Any]) -> float | None:
         """Age (seconds) since this client's STARTED transition, or ``None``.
@@ -3708,6 +3738,60 @@ class FcmReceiverHA:
         return await self._await_entry_started(
             entry_id, stale_pc, max_wait_s, exclude_pc=stale_pc
         )
+
+    def _get_first_locate_lock(self, entry_id: str) -> asyncio.Lock:
+        """Return the per-entry first-locate reconnect lock, creating it lazily.
+
+        Runs in the event loop with no ``await`` between the read and the
+        store, so the lazy creation is atomic against other callers.
+        """
+        lock = self._first_locate_locks.get(entry_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._first_locate_locks[entry_id] = lock
+        return lock
+
+    async def _reconnect_for_first_locate(
+        self, entry_id: str, max_wait_s: float
+    ) -> FcmPushClient[Any] | None:
+        """Serialise the one-shot first-locate reconnect for *entry_id*.
+
+        Concurrent manual locates for different trackers on the same entry must
+        not each tear down the fresh session (Codex #1150 follow-up): only the
+        first caller forces the single cooperative reconnect, and concurrent or
+        sequential callers await it and reuse the same replacement. The live
+        client is re-read under the per-entry lock because a concurrent caller
+        may already have replaced it. Returns the client to hand the locate to,
+        or ``None`` when no started client is available (the caller then fails
+        closed exactly like the readiness gate).
+        """
+        async with self._get_first_locate_lock(entry_id):
+            current = self.pcs.get(entry_id)
+            if current is None:
+                # The supervisor tore the client down; fail closed.
+                return None
+            reuse_current = (
+                # This exact replacement already had its one forced reconnect
+                # (a concurrent caller won the race), ...
+                self._first_locate_reconnect_done.get(entry_id) is current
+                # ... or another caller's reconnect already delivered / the
+                # session is no longer a fresh, undelivered one.
+                or not self._needs_first_locate_reconnect(current)
+            )
+            if reuse_current:
+                # Reuse the live client instead of forcing another reconnect,
+                # but only if it is actually STARTED. A concurrent supervisor
+                # swap may have installed a fresh, not-yet-started client here
+                # between the branch pre-check and this lock; handing the locate
+                # token to a non-listening client would reproduce the very
+                # timeout this heals, so fail closed like the readiness gate.
+                return current if self._is_started(current) else None
+            fresh_pc = await self._force_first_locate_reconnect(
+                entry_id, current, max_wait_s
+            )
+            if fresh_pc is not None:
+                self._first_locate_reconnect_done[entry_id] = fresh_pc
+            return fresh_pc
 
     async def async_register_for_location_updates(
         self, canonic_id: str, callback: Callable[[str, str], None]
@@ -3801,9 +3885,12 @@ class FcmReceiverHA:
                     # session reached STARTED but empirically will not receive the
                     # very first locate push until it reconnects.  Force exactly
                     # one cooperative reconnect, then fail closed if the
-                    # replacement never starts, like the gate above.
-                    fresh_pc = await self._force_first_locate_reconnect(
-                        entry_id, started_pc, _MAX_READY_WAIT_S
+                    # replacement never starts, like the gate above.  The
+                    # reconnect is serialised per entry so concurrent locates on
+                    # the same entry share one replacement instead of tearing
+                    # down each other's fresh session (Codex #1150 follow-up).
+                    fresh_pc = await self._reconnect_for_first_locate(
+                        entry_id, _MAX_READY_WAIT_S
                     )
                     if fresh_pc is None:
                         _LOGGER.warning(

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -276,6 +276,19 @@ _MAX_CONSECUTIVE_SHORT_RUNS = 10
 _SHORT_RUN_THRESHOLD_S = (
     30.0  # strictly < 30s between pc.start() and STOPPED = short run
 )
+# First-locate delivery reconnect (AP1): a brand-new MCS session can reach
+# ``STARTED`` yet never receive the very first locate push (``STARTED`` is
+# necessary but not sufficient for delivery; third of the #1148/#1149 family).
+# Only a full reconnect — a fresh session that subscribes *after* registration
+# completes — heals it.  This window bounds "how young a session still counts as
+# freshly registered / churning" for that one-shot decision.  It is deliberately
+# NOT the activity-health freshness window (``_activity_stale_after_s`` /
+# ``FCM_IDLE_RESET_AFTER_S`` = 90s, idle-reset semantics): it feeds no health
+# snapshot and no coordinator state, so it does not violate the Auth/AGENTS.md
+# "reuse the health helper, do not add parallel health windows" rule (whose
+# rationale is diagnostics/coordinator-state consistency, untouched here).
+_CHURN_WINDOW_S = 15.0
+
 _HTTP_UNAUTHORIZED = 401
 _HTTP_NOT_FOUND = 404
 
@@ -1218,11 +1231,8 @@ class FcmReceiverHA:
                     _on_creds_updated_entry,
                 )
                 pc = _FcmPushClientFactory(
-                    lambda payload,
-                    persistent_id,
-                    context,
-                    eid=entry_id: self._on_notification(
-                        eid, payload, persistent_id, context
+                    lambda payload, persistent_id, context, eid=entry_id: (
+                        self._on_notification(eid, payload, persistent_id, context)
                     ),
                     fcm_config,
                     creds,
@@ -3580,6 +3590,116 @@ class FcmReceiverHA:
 
         return self.get_fcm_token(entry_id)
 
+    async def _await_entry_started(
+        self,
+        entry_id: str,
+        fallback_pc: FcmPushClient[Any],
+        max_wait_s: float,
+        *,
+        exclude_pc: FcmPushClient[Any] | None = None,
+    ) -> FcmPushClient[Any] | None:
+        """Poll the live entry client until it reaches ``STARTED``.
+
+        Returns the ``STARTED`` client, or ``None`` if the budget expires.
+
+        Re-reads ``self.pcs[entry_id]`` on every poll (falling back to
+        ``fallback_pc`` only while the slot is momentarily empty) so a concurrent
+        supervisor restart that stops the captured client and swaps a replacement
+        into the slot is honored — the stale object may never transition while
+        the replacement reaches ``STARTED``.
+
+        ``exclude_pc`` (used after a forced reconnect) requires a *different*
+        instance to count, so a stale client that still lingers in ``STARTED`` is
+        not mistaken for the fresh replacement.
+        """
+        _POLL_INTERVAL_S = 0.3
+        waited = 0.0
+        while waited < max_wait_s:
+            current_pc = self.pcs.get(entry_id, fallback_pc)
+            run_state = getattr(current_pc, "run_state", None)
+            if (
+                FcmPushClientRunState is not None
+                and run_state == FcmPushClientRunState.STARTED
+                and (exclude_pc is None or current_pc is not exclude_pc)
+            ):
+                return current_pc
+            await asyncio.sleep(_POLL_INTERVAL_S)
+            waited += _POLL_INTERVAL_S
+        return None
+
+    def _session_age_s(self) -> float | None:
+        """Age (seconds) of the most recent FCM session start, or ``None``.
+
+        ``last_start_monotonic`` is aggregate across entries (see its definition
+        near the top of this class).  For the single-entry CLI — the target of
+        the first-locate-delivery fix — it is exactly the one entry's session
+        age; under Home Assistant multi-entry it is approximate, which is why the
+        reconnect trigger is additionally gated on per-entry non-delivery (see
+        ``_needs_first_locate_reconnect``).
+        """
+        start = self.last_start_monotonic
+        if start <= 0:
+            return None
+        return max(time.monotonic() - start, 0.0)
+
+    def _needs_first_locate_reconnect(self, pc: FcmPushClient[Any]) -> bool:
+        """True if a fresh, not-yet-delivering session should reconnect once.
+
+        Trigger (T-A + per-entry sharpening): the session is *young*
+        (age < ``_CHURN_WINDOW_S``) **and** this client has not delivered any
+        data message since login.  Delivery is read from the library's
+        ``persistent_ids`` list, which is reset to ``[]`` on each successful
+        login and appended to only for a ``DataMessageStanza`` — so a non-empty
+        list is a clean "has delivered" proof.  It deliberately does *not* use
+        the activity clock (``last_message_time`` / ``_entry_last_activity_
+        monotonic``), which a bare heartbeat ack also advances and which would
+        therefore never separate a broken fresh session (heartbeats, zero data)
+        from a healthy one.  A healthy, already-delivering session (e.g. a
+        long-running HA entry) is thus never torn down, independent of the
+        aggregate session age.
+        """
+        age = self._session_age_s()
+        if age is None or age >= _CHURN_WINDOW_S:
+            return False
+        delivered = bool(getattr(pc, "persistent_ids", None))
+        return not delivered
+
+    async def _force_first_locate_reconnect(
+        self, entry_id: str, stale_pc: FcmPushClient[Any], max_wait_s: float
+    ) -> FcmPushClient[Any] | None:
+        """Force one cooperative reconnect for a fresh, not-yet-delivering session.
+
+        Stops ``stale_pc``, nudges the supervisor to rebuild immediately, and
+        waits (``max_wait_s`` budget) for the *replacement* instance to reach
+        STARTED.  Returns the fresh client, or ``None`` if it never starts (the
+        caller then fails closed, exactly like the readiness gate).  The
+        supervisor owns the rebuild, so no new race surface is introduced against
+        it.  Part of the first-locate-delivery fix (#1148/#1149 family): STARTED
+        is necessary but not sufficient for the first push to arrive.
+        """
+        session_age = self._session_age_s()
+        _LOGGER.debug(
+            "[entry=%s] Fresh FCM session (age=%.1fs) reached STARTED but has not "
+            "delivered a data message yet; forcing one reconnect before the first "
+            "locate",
+            entry_id,
+            session_age if session_age is not None else -1.0,
+        )
+        try:
+            await stale_pc.stop()
+        except Exception as err:  # noqa: BLE001
+            # A stop() failure on an already-dying client is benign; the
+            # supervisor rebuild is driven by the nudge below.
+            _LOGGER.debug(
+                "[entry=%s] Forced-reconnect stop() raised (ignored): %s",
+                entry_id,
+                err,
+            )
+        self.nudge_retry(entry_id)
+        return await self._await_entry_started(
+            entry_id, stale_pc, max_wait_s, exclude_pc=stale_pc
+        )
+
     async def async_register_for_location_updates(
         self, canonic_id: str, callback: Callable[[str, str], None]
     ) -> str | None:
@@ -3649,27 +3769,10 @@ class FcmReceiverHA:
                     int(FCM_CONNECTION_RETRY_COUNT) * _PER_ATTEMPT_WAIT_S
                     + _READY_WAIT_MARGIN_S
                 )
-                _POLL_INTERVAL_S = 0.3
-                waited = 0.0
-                while waited < _MAX_READY_WAIT_S:
-                    # Re-read the live entry client each iteration.  A concurrent
-                    # supervisor restart can stop the captured ``pc`` and swap a
-                    # replacement into ``self.pcs[entry_id]`` on a transient
-                    # pre-start connection/login failure; that replacement may
-                    # reach STARTED while the stale object never does.  Polling
-                    # the current client (falling back to ``pc`` only while the
-                    # slot is momentarily empty) avoids a false fail-closed that
-                    # would abort a locate the replacement client could serve.
-                    current_pc = self.pcs.get(entry_id, pc)
-                    run_state = getattr(current_pc, "run_state", None)
-                    if (
-                        FcmPushClientRunState is not None
-                        and run_state == FcmPushClientRunState.STARTED
-                    ):
-                        break
-                    await asyncio.sleep(_POLL_INTERVAL_S)
-                    waited += _POLL_INTERVAL_S
-                else:
+                started_pc = await self._await_entry_started(
+                    entry_id, pc, _MAX_READY_WAIT_S
+                )
+                if started_pc is None:
                     # Fail closed: the client never started listening, so sending
                     # the location request would hand the token to a dead listener
                     # and the caller would block until an opaque 30s timeout.
@@ -3684,6 +3787,24 @@ class FcmReceiverHA:
                         _MAX_READY_WAIT_S,
                     )
                     token = None
+                elif self._needs_first_locate_reconnect(started_pc):
+                    # AP1 (first-locate-delivery fix): a fresh, not-yet-delivering
+                    # session reached STARTED but empirically will not receive the
+                    # very first locate push until it reconnects.  Force exactly
+                    # one cooperative reconnect, then fail closed if the
+                    # replacement never starts, like the gate above.
+                    fresh_pc = await self._force_first_locate_reconnect(
+                        entry_id, started_pc, _MAX_READY_WAIT_S
+                    )
+                    if fresh_pc is None:
+                        _LOGGER.warning(
+                            "[entry=%s] Forced reconnect did not reach STARTED "
+                            "after %.1fs; aborting manual locate registration "
+                            "(fail-closed)",
+                            entry_id,
+                            _MAX_READY_WAIT_S,
+                        )
+                        token = None
 
             if token is not None:
                 _LOGGER.info(

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -306,6 +306,13 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         self.last_message_time: float = 0.0
 
         self.run_state: FcmPushClientRunState = FcmPushClientRunState.CREATED
+        # Monotonic timestamp of this client's STARTED transition (set in
+        # ``_handle_message`` on a successful login, alongside ``persistent_ids``).
+        # Consumers measure "session age since STARTED" from this instead of the
+        # supervisor's pre-start timestamp, which is recorded before ``start()``
+        # and can trail the actual STARTED transition by the connection budget
+        # (~15-20s). ``None`` until the client first reaches STARTED.
+        self._started_monotonic: float | None = None
         self.tasks: list[asyncio.Task[None]] = []
         # Set by ``_listen`` when stored FCM key material is found to be
         # corrupt/undecodable. The supervisor reads this after the listener
@@ -829,6 +836,10 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             else:
                 self.logger.info("Successfully logged in to MCS endpoint")
                 self._reset_error_count(ErrorType.LOGIN)
+                # Stamp the STARTED-transition time *before* publishing the
+                # STARTED state so any observer that sees STARTED also sees the
+                # timestamp (single authoritative transition point, race-free).
+                self._started_monotonic = time.monotonic()
                 self.run_state = FcmPushClientRunState.STARTED
                 self.persistent_ids = []
                 # Refresh activity timestamp

--- a/tests/test_fcm_receiver_guard.py
+++ b/tests/test_fcm_receiver_guard.py
@@ -212,6 +212,51 @@ def test_multi_entry_buffers_prevent_global_cache_access(
     assert start_calls.count("entry-2") == 1
 
 
+def test_credentials_update_routes_only_own_entry_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tokenless creds update never routes another entry's token.
+
+    Regression (Codex #1150 follow-up, same leak class as the forced-reconnect
+    refresh): ``_on_credentials_updated_for_entry`` writes ``self.creds[entry_id]``
+    and then routes that entry's token.  Reading via ``get_fcm_token`` would fall
+    back to the first token across *all* entries, so a tokenless update for one
+    account while another account holds a token would route the foreign token
+    under the wrong entry.  The strict entry-scoped read must route nothing.
+    """
+    receiver = FcmReceiverHA()
+
+    # Another account already holds a token.
+    receiver.creds["entry-2"] = {"fcm": {"registration": {"token": "token-entry-2"}}}
+
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+    # Isolate the routing decision: swallow (and close) the dispatched coroutines
+    # and neutralise the fatal-error clear so no event loop is required.
+    monkeypatch.setattr(
+        receiver, "_dispatch_to_hass_loop", lambda coro, label=None: coro.close()
+    )
+    monkeypatch.setattr(
+        receiver, "_clear_fatal_error_for_entry", lambda eid, reason=None: None
+    )
+
+    # entry-1 receives a tokenless credentials update while entry-2 has a token.
+    receiver._on_credentials_updated_for_entry("entry-1", {"fcm": {}})
+
+    # The foreign account's token is never routed under entry-1; in fact nothing
+    # is routed, because entry-1 has no token of its own.
+    assert ("token-entry-2", {"entry-1"}) not in routed
+    assert routed == []
+
+    # A subsequent update *with* an own token routes exactly that token.
+    receiver._on_credentials_updated_for_entry(
+        "entry-1", {"fcm": {"registration": {"token": "token-entry-1"}}}
+    )
+    assert routed == [("token-entry-1", {"entry-1"})]
+
+
 def test_unregister_prunes_token_routing(monkeypatch: pytest.MonkeyPatch) -> None:
     """Removing a coordinator clears its tokens and blocks future fan-out."""
 

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -325,10 +325,19 @@ class _ReconnectPc:
     """Push client double exposing run_state, persistent_ids and async stop()."""
 
     def __init__(
-        self, run_state: object, persistent_ids: list[str] | None = None
+        self,
+        run_state: object,
+        persistent_ids: list[str] | None = None,
+        started_monotonic: float | None = None,
     ) -> None:
         self.run_state = run_state
         self.persistent_ids = list(persistent_ids or [])
+        # STARTED-transition anchor consumed by ``_session_age_s``. Defaults to
+        # "just reached STARTED" (young session) so the common case is terse;
+        # the established-session test passes an old timestamp explicitly.
+        self._started_monotonic = (
+            time.monotonic() if started_monotonic is None else started_monotonic
+        )
         self.stopped = False
 
     async def stop(self) -> None:
@@ -356,11 +365,11 @@ async def test_manual_locate_forces_reconnect_for_fresh_nondelivering_session(
     cache = DummyCache()
     _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
 
+    # Young session: the double defaults to a just-now STARTED stamp, so the
+    # per-client age gate (``_session_age_s``) is open (age ~0 < _CHURN_WINDOW_S).
     stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
     fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
     receiver.pcs[entry_id] = stale  # type: ignore[assignment]
-    # Young session (age ~0 < _CHURN_WINDOW_S) → age gate open.
-    receiver.last_start_monotonic = time.monotonic()
 
     nudged: list[str | None] = []
     monkeypatch.setattr(
@@ -400,10 +409,13 @@ async def test_manual_locate_no_reconnect_for_established_session(
     cache = DummyCache()
     _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
 
-    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    # Established session: STARTED well beyond _CHURN_WINDOW_S (per-client age).
+    stale = _ReconnectPc(
+        run_state=_RunState.STARTED,
+        persistent_ids=[],
+        started_monotonic=time.monotonic() - 100.0,
+    )
     receiver.pcs[entry_id] = stale  # type: ignore[assignment]
-    # Established session: age well beyond _CHURN_WINDOW_S.
-    receiver.last_start_monotonic = time.monotonic() - 100.0
 
     nudged: list[str | None] = []
     monkeypatch.setattr(
@@ -440,9 +452,9 @@ async def test_manual_locate_no_reconnect_when_already_delivered(
     cache = DummyCache()
     _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
 
+    # Young (default STARTED stamp) but already delivered (persistent_ids set).
     stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=["pid-1"])
     receiver.pcs[entry_id] = stale  # type: ignore[assignment]
-    receiver.last_start_monotonic = time.monotonic()  # young
 
     nudged: list[str | None] = []
     monkeypatch.setattr(
@@ -473,9 +485,9 @@ async def test_manual_locate_reconnect_fails_closed_when_replacement_never_start
     cache = DummyCache()
     _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
 
+    # Young (default STARTED stamp) and not delivered -> the trigger fires.
     stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
     receiver.pcs[entry_id] = stale  # type: ignore[assignment]
-    receiver.last_start_monotonic = time.monotonic()  # young → trigger fires
 
     monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
     # No replacement ever appears; the post-reconnect wait exhausts its budget.
@@ -560,3 +572,55 @@ async def test_force_reconnect_excludes_lingering_started_stale(
 
     assert result is None  # stale-but-STARTED must not be taken as the replacement
     assert stale.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_reconnect_for_slow_startup_fresh_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slow-startup fresh session: churn age is measured from STARTED, not supervisor start.
+
+    Codex #1150 follow-up: the supervisor records ``last_start_monotonic`` before
+    ``pc.start()``, and the readiness gate allows a fresh MCS connection ~15-20s
+    to reach STARTED.  A session that starts slowly (supervisor start long ago)
+    but has only *just* reached STARTED and delivered nothing is exactly the case
+    the reconnect must heal.  Anchoring the age on the client's own STARTED stamp
+    fires the reconnect here; the old anchor (``last_start_monotonic``, set far in
+    the past) would compute age >= _CHURN_WINDOW_S and wrongly skip it.  Setting a
+    stale ``last_start_monotonic`` proves the decision no longer depends on it.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    # Client only just reached STARTED (young), though the supervisor began the
+    # start long ago (slow connection budget consumed before STARTED).
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+    receiver.last_start_monotonic = time.monotonic() - 100.0  # stale supervisor stamp
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert stale.stopped is True  # reconnect fired despite the stale supervisor stamp
+    assert nudged == [entry_id]
+    assert receiver.pcs[entry_id] is fresh

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -624,3 +624,256 @@ async def test_manual_locate_reconnect_for_slow_startup_fresh_session(
     assert stale.stopped is True  # reconnect fired despite the stale supervisor stamp
     assert nudged == [entry_id]
     assert receiver.pcs[entry_id] is fresh
+
+
+# ---------------------------------------------------------------------------
+# First-locate reconnect serialization (Codex #1150 follow-up): concurrent or
+# sequential manual locates for different trackers on the SAME entry must share
+# a single reconnect instead of each tearing down the fresh session.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_reuses_replacement_on_sequential_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sequential second caller reuses the replacement instead of re-tearing.
+
+    After the first caller reconnects to ``fresh``, ``fresh`` is itself young
+    and has not delivered yet, so the naive age/no-delivery gate would fire
+    again and tear down the very replacement the first caller just built.  The
+    per-entry consumed-latch must make the second caller REUSE ``fresh``.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    first = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+    assert first is fresh
+    assert stale.stopped is True
+    assert nudged == [entry_id]
+
+    second = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+    assert second is fresh  # reused, not reconnected again
+    assert fresh.stopped is False  # replacement was NOT torn down
+    assert nudged == [entry_id]  # still exactly one reconnect
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_serialized_across_concurrent_callers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two concurrent callers on the same entry share one reconnect.
+
+    Regression (Codex #1150): without per-entry serialization the second caller
+    entered the reconnect branch independently and stopped the replacement the
+    first caller had just waited for, so the first request timed out.  The
+    per-entry lock must block the second caller until the first completes, after
+    which the consumed-latch makes it reuse the replacement.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    in_crit = asyncio.Event()
+    release = asyncio.Event()
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+
+    class _BarrierPc:
+        """Stale client whose stop() parks inside the critical section."""
+
+        def __init__(self) -> None:
+            self.run_state: object = _RunState.STARTED
+            self.persistent_ids: list[str] = []
+            self._started_monotonic = time.monotonic()
+            self.stopped = False
+
+        async def stop(self) -> None:
+            self.stopped = True
+            in_crit.set()  # first caller holds the per-entry lock now
+            await release.wait()  # park so the second caller can try to enter
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    stale = _BarrierPc()
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    task_a = asyncio.create_task(receiver._reconnect_for_first_locate(entry_id, 5.0))
+    await in_crit.wait()  # first caller is mid-reconnect, holding the lock
+    task_b = asyncio.create_task(receiver._reconnect_for_first_locate(entry_id, 5.0))
+    await asyncio.sleep(0)  # let the second caller run; it must block on the lock
+    # B has not completed: it is parked on the per-entry lock the first caller
+    # holds. (This alone is necessary, not sufficient -- the decisive proof of
+    # serialization is the single reconnect asserted via ``nudged`` below.)
+    assert not task_b.done()
+
+    release.set()  # let the first caller finish the single reconnect
+    result_a = await task_a
+    result_b = await task_b
+
+    assert result_a is fresh
+    assert result_b is fresh  # second caller reused the same replacement
+    assert fresh.stopped is False  # replacement never torn down
+    assert nudged == [entry_id]  # exactly one reconnect happened
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_relatches_for_new_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuinely new session generation is allowed its own single reconnect.
+
+    The consumed-latch is keyed by client identity, not by ``entry_id``: once
+    the supervisor rebuilds a brand-new young client (a different object), the
+    stored replacement no longer matches, so the next caller may reconnect once
+    more.  A key-based latch would wrongly suppress this.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    # State left by a prior reconnect: latch points at a now-superseded client,
+    # while the supervisor has installed a brand-new young session (new_pc).
+    old_fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver._first_locate_reconnect_done[entry_id] = old_fresh  # type: ignore[assignment]
+    new_pc = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    newest = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = new_pc  # type: ignore[assignment]
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is new_pc:
+            receiver.pcs[entry_id] = newest  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    result = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+
+    assert result is newest  # new generation got its own reconnect
+    assert new_pc.stopped is True
+    assert nudged == [entry_id]
+    assert receiver._first_locate_reconnect_done[entry_id] is newest
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_fails_closed_when_client_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No live client under the lock yields None (fail closed).
+
+    A concurrent supervisor teardown can pop the entry client between the
+    branch pre-check and the lock acquisition; the serialized decision must then
+    return None so the caller fails closed instead of dereferencing nothing.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    # self.pcs has no entry for entry_id -> current is None.
+    result = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+
+    assert result is None
+    assert nudged == []  # no reconnect attempted
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_uses_current_when_no_longer_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A client that has since delivered is used as-is, without a reconnect.
+
+    Between the cheap branch pre-check and acquiring the per-entry lock the
+    session may have delivered its first push (``persistent_ids`` filled).  The
+    authoritative re-check under the lock must then reuse it, never tear it down.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    delivered = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=["pid-1"])
+    receiver.pcs[entry_id] = delivered  # type: ignore[assignment]
+
+    result = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+
+    assert result is delivered  # reused as-is
+    assert delivered.stopped is False  # no reconnect
+    assert nudged == []
+
+
+@pytest.mark.asyncio
+async def test_first_locate_reconnect_fails_closed_on_unstarted_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-STARTED client reached via the reuse short-circuit fails closed.
+
+    Regression (Codex #1150 follow-up review): a concurrent supervisor swap can
+    install a fresh, not-yet-started client between the branch pre-check and the
+    per-entry lock. ``_needs_first_locate_reconnect`` is False for a never-
+    STARTED client (``_session_age_s`` is None), so the reuse path must NOT hand
+    this non-listening client back -- doing so reproduces the very locate
+    timeout the fix heals. It must fail closed instead, like the readiness gate.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    # Fresh, not-yet-started client swapped in under the lock: run_state is not
+    # STARTED and it never reached STARTED, so the reuse path selects it.
+    unstarted = _ReconnectPc(run_state="CONNECTING", persistent_ids=[])
+    unstarted._started_monotonic = None  # type: ignore[assignment]  # never STARTED
+    receiver.pcs[entry_id] = unstarted  # type: ignore[assignment]
+
+    result = await receiver._reconnect_for_first_locate(entry_id, 5.0)
+
+    assert result is None  # fail closed, not a non-listening client
+    assert unstarted.stopped is False  # untouched
+    assert nudged == []
+
+
+@pytest.mark.asyncio
+async def test_is_started_false_when_runstate_enum_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_is_started`` fails safe when the library run-state enum is unavailable."""
+    receiver = FcmReceiverHA()
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", None)
+
+    pc = _ReconnectPc(run_state="STARTED", persistent_ids=[])
+
+    assert receiver._is_started(pc) is False  # type: ignore[arg-type]

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -205,11 +205,13 @@ def _wire_manual_locate(
     monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure_client)
     monkeypatch.setattr(receiver, "_start_supervisor_for_entry", _start)
     monkeypatch.setattr(receiver, "_ensure_token_for_entry", _ensure_token)
-    # ``get_fcm_token`` reads live creds in production and, via
-    # ``_ensure_token_for_entry``, agrees with the token above.  Stub it to the
-    # same value so the post-reconnect token refresh sees an unchanged token by
-    # default; rotation tests override it explicitly.
-    monkeypatch.setattr(receiver, "get_fcm_token", lambda eid=None: "token-123")
+    # The post-reconnect refresh reads the token strictly entry-scoped via
+    # ``_entry_scoped_fcm_token`` (production seam), which via
+    # ``_ensure_token_for_entry`` agrees with the token above.  Stub it to the
+    # same value so the refresh sees an unchanged token by default; rotation and
+    # fail-closed tests override this seam explicitly.  The cross-entry scoping
+    # test deliberately leaves it unstubbed to exercise the real strict read.
+    monkeypatch.setattr(receiver, "_entry_scoped_fcm_token", lambda eid: "token-123")
     monkeypatch.setattr(receiver, "_update_token_routing", lambda tok, ids: None)
     monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
     monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
@@ -936,8 +938,8 @@ async def test_manual_locate_refreshes_rotated_token_after_reconnect(
     nudged = _wire_forced_reconnect(monkeypatch, receiver, entry_id)
 
     # The supervisor rebuild rotated the token: _ensure_token_for_entry captured
-    # "token-123", but get_fcm_token now reports the post-reconnect token.
-    monkeypatch.setattr(receiver, "get_fcm_token", lambda eid=None: "token-999")
+    # "token-123", but the entry-scoped read now reports the post-reconnect token.
+    monkeypatch.setattr(receiver, "_entry_scoped_fcm_token", lambda eid: "token-999")
     routed: list[tuple[str, set[str]]] = []
     monkeypatch.setattr(
         receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
@@ -978,7 +980,7 @@ async def test_manual_locate_fails_closed_when_token_missing_after_reconnect(
     _wire_forced_reconnect(monkeypatch, receiver, entry_id)
 
     # The re-registration during the rebuild left the entry without a token.
-    monkeypatch.setattr(receiver, "get_fcm_token", lambda eid=None: None)
+    monkeypatch.setattr(receiver, "_entry_scoped_fcm_token", lambda eid: None)
     routed: list[tuple[str, set[str]]] = []
     monkeypatch.setattr(
         receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
@@ -1014,8 +1016,8 @@ async def test_manual_locate_unchanged_token_skips_routing_churn(
     _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
     _wire_forced_reconnect(monkeypatch, receiver, entry_id)
 
-    # get_fcm_token still reports the captured token (no rotation).
-    monkeypatch.setattr(receiver, "get_fcm_token", lambda eid=None: "token-123")
+    # The entry-scoped read still reports the captured token (no rotation).
+    monkeypatch.setattr(receiver, "_entry_scoped_fcm_token", lambda eid: "token-123")
     routed: list[tuple[str, set[str]]] = []
     monkeypatch.setattr(
         receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
@@ -1032,3 +1034,135 @@ async def test_manual_locate_unchanged_token_skips_routing_churn(
     # Only the pre-reconnect path routed the captured token once; the refresh
     # added nothing because the token did not rotate (no churn).
     assert routed == [("token-123", {entry_id})]
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_refresh_stays_entry_scoped_across_accounts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multi-account: the post-reconnect refresh stays strictly entry-scoped.
+
+    Regression (Codex #1150 follow-up): ``get_fcm_token``'s cross-entry fallback
+    returns the first token across all accounts.  If the forced reconnect leaves
+    *this* entry momentarily tokenless while a *different* entry still holds a
+    token, reading via ``get_fcm_token`` would hand the foreign account's token to
+    this entry (routed and returned).  The refresh must read strictly entry-scoped
+    and fail closed instead.
+
+    Uses real creds and the real ``_entry_scoped_fcm_token`` (unstubbed), so a
+    revert to ``get_fcm_token`` turns this test red.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+
+    async def _ensure_client(eid: str, c: Any, generation: int | None = None) -> object:
+        return object()
+
+    async def _start(eid: str, c: Any) -> None:
+        return None
+
+    async def _ensure_token(eid: str) -> str:
+        return "token-123"
+
+    async def _persist(eid: str, tok: str) -> None:
+        return None
+
+    monkeypatch.setattr(
+        receiver, "_select_manual_locate_entry", lambda cid: (entry_id, cache)
+    )
+    monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure_client)
+    monkeypatch.setattr(receiver, "_start_supervisor_for_entry", _start)
+    monkeypatch.setattr(receiver, "_ensure_token_for_entry", _ensure_token)
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    # Real creds: this entry is tokenless after the rebuild, a *different* account
+    # still holds a token.  The strict entry-scoped read must not leak it.  The
+    # ``_entry_scoped_fcm_token`` seam is left unstubbed on purpose.
+    receiver.creds = {  # type: ignore[assignment]
+        entry_id: {},
+        "entry-2": {"fcm": {"registration": {"token": "other-account-token"}}},
+    }
+
+    # Force exactly one reconnect; the fresh replacement double carries no
+    # per-client credentials, so the strict read falls through to creds only.
+    _wire_forced_reconnect(monkeypatch, receiver, entry_id)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    # Fail closed: the foreign token is never returned to the caller ...
+    assert token is None
+    assert device_id not in receiver.location_update_callbacks
+    # ... and never routed for this entry (only the pre-reconnect path routed the
+    # captured token once; the foreign account's token must not appear at all).
+    assert ("other-account-token", {entry_id}) not in routed
+    assert routed == [("token-123", {entry_id})]
+
+
+def test_entry_scoped_fcm_token_never_leaks_across_entries() -> None:
+    """The strict entry-scoped read stays within its entry (no cross-entry fallback).
+
+    Directly pins the invariant that ``get_fcm_token`` and the post-reconnect token
+    refresh both rely on: read persisted creds, then the live client's credentials,
+    and fail closed with ``None`` when only *another* entry holds a token.
+    """
+    receiver = FcmReceiverHA()
+    receiver.creds = {  # type: ignore[assignment]
+        "entry-1": {"fcm": {"registration": {"token": "tok-1"}}},
+        "entry-2": {"fcm": {"registration": {"token": "tok-2"}}},
+    }
+    # Persisted-creds layer, strictly scoped (never entry-2's token for entry-1).
+    assert receiver._entry_scoped_fcm_token("entry-1") == "tok-1"
+    assert receiver._entry_scoped_fcm_token("entry-2") == "tok-2"
+
+    # No persisted creds for the entry, but a live client exposes credentials.
+    class _CredPc:
+        credentials = {"fcm": {"registration": {"token": "live-tok"}}}
+
+    receiver.creds = {  # type: ignore[assignment]
+        "entry-3": {},
+        "entry-2": {"fcm": {"registration": {"token": "tok-2"}}},
+    }
+    receiver.pcs["entry-3"] = _CredPc()  # type: ignore[assignment]
+    assert receiver._entry_scoped_fcm_token("entry-3") == "live-tok"
+
+    # A live client whose credentials access raises is swallowed (defensive path).
+    class _RaisingPc:
+        @property
+        def credentials(self) -> dict[str, Any]:
+            raise RuntimeError("creds unavailable")
+
+    receiver.creds = {  # type: ignore[assignment]
+        "entry-4": {},
+        "entry-2": {"fcm": {"registration": {"token": "tok-2"}}},
+    }
+    receiver.pcs["entry-4"] = _RaisingPc()  # type: ignore[assignment]
+    assert receiver._entry_scoped_fcm_token("entry-4") is None
+
+    # Live client exposes a credentials dict but with an empty token: fall through
+    # to None rather than leak another entry's token.
+    class _CredPcEmpty:
+        credentials = {"fcm": {"registration": {"token": ""}}}
+
+    receiver.creds = {  # type: ignore[assignment]
+        "entry-5": {},
+        "entry-2": {"fcm": {"registration": {"token": "tok-2"}}},
+    }
+    receiver.pcs["entry-5"] = _CredPcEmpty()  # type: ignore[assignment]
+    assert receiver._entry_scoped_fcm_token("entry-5") is None
+
+    # Entry is tokenless (no creds, no live client) while another entry has a
+    # token: must return None, never the foreign token.
+    receiver.pcs.pop("entry-4", None)
+    assert receiver._entry_scoped_fcm_token("entry-4") is None

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -311,3 +312,251 @@ async def test_manual_locate_reads_replacement_client_during_poll(
 
     assert token == "token-123"
     assert receiver.location_update_callbacks[device_id] is manual_callback
+
+
+# ---------------------------------------------------------------------------
+# First-locate delivery reconnect (AP1, T-A): a fresh session can reach STARTED
+# yet not deliver the first push until it reconnects.  The trigger fires only
+# for a *young* session that has *not yet delivered* a data message.
+# ---------------------------------------------------------------------------
+
+
+class _ReconnectPc:
+    """Push client double exposing run_state, persistent_ids and async stop()."""
+
+    def __init__(
+        self, run_state: object, persistent_ids: list[str] | None = None
+    ) -> None:
+        self.run_state = run_state
+        self.persistent_ids = list(persistent_ids or [])
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self.run_state = "STOPPED"
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_forces_reconnect_for_fresh_nondelivering_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Young + no delivery: force one reconnect and serve from the replacement.
+
+    Regression for the deterministic first-locate timeout after a fresh FCM
+    registration: the first client reaches STARTED but never receives the push,
+    and only a reconnect (a session that subscribes after registration) heals it.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+    # Young session (age ~0 < _CHURN_WINDOW_S) → age gate open.
+    receiver.last_start_monotonic = time.monotonic()
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    # The forced-reconnect wait swaps in the replacement on its first sleep,
+    # mirroring the supervisor rebuild.  The first readiness wait does not sleep
+    # (stale is already STARTED).
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert stale.stopped is True  # the reconnect actually happened
+    assert nudged == [entry_id]  # supervisor nudged to rebuild
+    assert receiver.pcs[entry_id] is fresh  # replacement client is live
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_no_reconnect_for_established_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Old session (age >= window): no reconnect, token returned unchanged."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+    # Established session: age well beyond _CHURN_WINDOW_S.
+    receiver.last_start_monotonic = time.monotonic() - 100.0
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert stale.stopped is False
+    assert nudged == []
+    assert receiver.pcs[entry_id] is stale
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_no_reconnect_when_already_delivered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Young but already-delivering session: the sharpening suppresses reconnect.
+
+    Protects a healthy HA multi-entry session that the aggregate age anchor might
+    otherwise mis-classify as young: a non-empty ``persistent_ids`` proves the
+    session already delivered a data message, so no needless reconnect fires.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=["pid-1"])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+    receiver.last_start_monotonic = time.monotonic()  # young
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    assert stale.stopped is False
+    assert nudged == []
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_reconnect_fails_closed_when_replacement_never_starts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Forced reconnect whose replacement never reaches STARTED fails closed."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+    receiver.last_start_monotonic = time.monotonic()  # young → trigger fires
+
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+    # No replacement ever appears; the post-reconnect wait exhausts its budget.
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token is None
+    assert device_id not in receiver.location_update_callbacks
+    assert stale.stopped is True  # reconnect was attempted before failing closed
+
+
+@pytest.mark.asyncio
+async def test_force_first_locate_reconnect_swallows_stop_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stop() error on the dying client is swallowed; the rebuild still runs."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    class _BoomPc(_ReconnectPc):
+        async def stop(self) -> None:
+            self.stopped = True
+            raise RuntimeError("boom")
+
+    stale = _BoomPc(run_state="STOPPED", persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    async def _swap(_seconds: float) -> None:
+        receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap)
+
+    result = await receiver._force_first_locate_reconnect(entry_id, stale, 5.0)  # type: ignore[arg-type]
+
+    assert result is fresh
+    assert stale.stopped is True
+    assert nudged == [entry_id]
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_excludes_lingering_started_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale client still STARTED after a failed stop() is not the replacement.
+
+    Hardens the ``exclude_pc`` guard: if ``stop()`` raised and the stale client
+    lingers in STARTED with no replacement swapped in, the post-reconnect wait
+    must reject the stale instance and let the budget expire (return ``None`` =
+    fail closed), rather than mistake the stale for the fresh client.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+
+    class _LingeringPc(_ReconnectPc):
+        async def stop(self) -> None:
+            # stop() fails and does NOT transition run_state: it lingers STARTED.
+            self.stopped = True
+            raise RuntimeError("stop failed; client lingers STARTED")
+
+    stale = _LingeringPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+    # No replacement is ever swapped in; the stale lingers in STARTED.
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    result = await receiver._force_first_locate_reconnect(entry_id, stale, 1.0)  # type: ignore[arg-type]
+
+    assert result is None  # stale-but-STARTED must not be taken as the replacement
+    assert stale.stopped is True

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -205,6 +205,11 @@ def _wire_manual_locate(
     monkeypatch.setattr(receiver, "_ensure_client_for_entry", _ensure_client)
     monkeypatch.setattr(receiver, "_start_supervisor_for_entry", _start)
     monkeypatch.setattr(receiver, "_ensure_token_for_entry", _ensure_token)
+    # ``get_fcm_token`` reads live creds in production and, via
+    # ``_ensure_token_for_entry``, agrees with the token above.  Stub it to the
+    # same value so the post-reconnect token refresh sees an unchanged token by
+    # default; rotation tests override it explicitly.
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda eid=None: "token-123")
     monkeypatch.setattr(receiver, "_update_token_routing", lambda tok, ids: None)
     monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
     monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
@@ -877,3 +882,153 @@ async def test_is_started_false_when_runstate_enum_unavailable(
     pc = _ReconnectPc(run_state="STARTED", persistent_ids=[])
 
     assert receiver._is_started(pc) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# First-locate reconnect: refresh the FCM token after the forced reconnect.
+# The reconnect drives a supervisor rebuild that may re-register and rotate the
+# entry token; returning the stale token would send the locate to the old
+# registration while the live listener is subscribed with the new one (Codex
+# #1150 follow-up).
+# ---------------------------------------------------------------------------
+
+
+def _wire_forced_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+    receiver: FcmReceiverHA,
+    entry_id: str,
+) -> list[str | None]:
+    """Set up a young, non-delivering session that forces exactly one reconnect."""
+
+    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    fresh = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=[])
+    receiver.pcs[entry_id] = stale  # type: ignore[assignment]
+
+    nudged: list[str | None] = []
+    monkeypatch.setattr(
+        receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
+    )
+
+    async def _swap_then_no_sleep(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap_then_no_sleep)
+    return nudged
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_refreshes_rotated_token_after_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rotated token: the refreshed token is returned and routing re-pointed.
+
+    Regression (Codex): the forced reconnect nudges a supervisor rebuild that can
+    re-register and rotate the entry FCM token after it was captured.  Returning
+    the stale token would hand the locate to the dead registration while the live
+    listener subscribes with the new one, reproducing the timeout.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+    nudged = _wire_forced_reconnect(monkeypatch, receiver, entry_id)
+
+    # The supervisor rebuild rotated the token: _ensure_token_for_entry captured
+    # "token-123", but get_fcm_token now reports the post-reconnect token.
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda eid=None: "token-999")
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+    persisted: list[tuple[str, str]] = []
+
+    async def _persist(eid: str, tok: str) -> None:
+        persisted.append((eid, tok))
+
+    monkeypatch.setattr(receiver, "_persist_routing_token", _persist)
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-999"  # the fresh token, not the stale "token-123"
+    assert nudged == [entry_id]  # the reconnect actually happened
+    # Routing/persist re-pointed at the rotated token (the pre-reconnect path
+    # also routes the captured token once; the refresh adds the new one).
+    assert ("token-999", {entry_id}) in routed
+    assert (entry_id, "token-999") in persisted
+    assert receiver.location_update_callbacks[device_id] is manual_callback
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_fails_closed_when_token_missing_after_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token gone after reconnect: fail closed (None) and leave no callback."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+    _wire_forced_reconnect(monkeypatch, receiver, entry_id)
+
+    # The re-registration during the rebuild left the entry without a token.
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda eid=None: None)
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token is None
+    assert device_id not in receiver.location_update_callbacks
+    # Fails closed before the rotation block: only the pre-reconnect path routed
+    # (the captured token once); a missing token is never routed.
+    assert routed == [("token-123", {entry_id})]
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_unchanged_token_skips_routing_churn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unrotated token: return it unchanged and do not re-point routing.
+
+    Pins the rotation guard: routing is touched only when the token actually
+    changed, so a no-op reconnect does not churn the token map.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-1"
+    device_id = "device-canonic"
+    cache = DummyCache()
+    _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
+    _wire_forced_reconnect(monkeypatch, receiver, entry_id)
+
+    # get_fcm_token still reports the captured token (no rotation).
+    monkeypatch.setattr(receiver, "get_fcm_token", lambda eid=None: "token-123")
+    routed: list[tuple[str, set[str]]] = []
+    monkeypatch.setattr(
+        receiver, "_update_token_routing", lambda tok, ids: routed.append((tok, ids))
+    )
+
+    def manual_callback(canonic: str, payload_hex: str) -> None:
+        return None
+
+    token = await receiver.async_register_for_location_updates(
+        device_id, manual_callback
+    )
+
+    assert token == "token-123"
+    # Only the pre-reconnect path routed the captured token once; the refresh
+    # added nothing because the token did not rotate (no churn).
+    assert routed == [("token-123", {entry_id})]

--- a/tests/test_fcmpushclient_started_stamp.py
+++ b/tests/test_fcmpushclient_started_stamp.py
@@ -1,0 +1,52 @@
+# tests/test_fcmpushclient_started_stamp.py
+"""Login-success path stamps the per-client STARTED-transition timestamp.
+
+Covers the ``LoginResponse`` success branch of ``FcmPushClient._handle_message``
+(the ``_started_monotonic`` stamp added alongside ``run_state = STARTED`` and the
+``persistent_ids`` reset). The supervisor's first-locate reconnect measures
+"session age since STARTED" from this field instead of the pre-start supervisor
+timestamp, so the stamp must be set exactly when the client reaches STARTED.
+
+Additive-composition discipline (same as ``FcmMessageSlim`` / ``FcmHandleSlim``):
+the real unbound async ``_handle_message`` runs against a light container that
+mirrors only the attributes the login-success branch touches, without the heavy
+production constructor. A real ``LoginResponse()`` is used (not a namespace) so
+the production ``isinstance(msg, LoginResponse)`` dispatch is exercised for real.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    ErrorType,
+    FcmPushClientRunState,
+    LoginResponse,
+)
+from tests.helpers.fcm_handle_stub import FcmMessageSlim
+
+
+@pytest.mark.asyncio
+async def test_login_success_stamps_started_monotonic() -> None:
+    """A successful login sets ``_started_monotonic``, STARTED and resets ids."""
+    slim = FcmMessageSlim()
+    # Attributes the login-success branch reads/writes beyond the Close preamble.
+    slim._reset_error_count = Mock()  # type: ignore[attr-defined]
+    slim.run_state = FcmPushClientRunState.CREATED  # type: ignore[attr-defined]
+    slim.persistent_ids = ["stale-pid"]  # type: ignore[attr-defined]
+    slim._started_monotonic = None  # type: ignore[attr-defined]
+
+    await slim._handle_message(LoginResponse())  # type: ignore[arg-type]
+
+    # The STARTED-transition stamp is set (was None) -> a real float timestamp.
+    assert isinstance(slim._started_monotonic, float)  # type: ignore[attr-defined]
+    # And the accompanying STARTED state + persistent-ids reset happened.
+    assert slim.run_state == FcmPushClientRunState.STARTED  # type: ignore[attr-defined]
+    assert slim.persistent_ids == []  # type: ignore[attr-defined]
+    slim._reset_error_count.assert_called_once_with(ErrorType.LOGIN)  # type: ignore[attr-defined]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
# Summary
The first manual locate after a fresh FCM registration deterministically timed out. This forces exactly one cooperative reconnect before the first locate for a *young, not-yet-delivering* FCM session, which is the empirically confirmed healing action. Third of the #1148/#1149 family.

- Type: ☑ fix
- Scope/Area: auth (FCM receiver, manual locate)
- Linked issues: —

## Motivation
On the very first locate after a fresh registration, the MCS client reaches `run_state == STARTED` and heartbeats, but receives **zero** data messages, so the locate push never arrives and the caller blocks until a 30s timeout. Device-log evidence: the delivered position was `Last seen 14:45:53` — already available on Google's servers *before* the first request (14:48:32), so it is not "device out of range" or "timeout too short". A longer timeout would not help. The first live client received 0 data messages across 30s; only after it died (`WinError 64`) and the supervisor rebuilt a fresh client did the push arrive 0.5s later, with the *same* persisted token. `STARTED` is necessary but not sufficient for delivery.

---

## Change Log (human-readable)

**Core (`custom_components/googlefindmy/Auth/fcm_receiver_ha.py`):**
- After the readiness gate confirms `STARTED`, force **exactly one** cooperative reconnect before the first locate, but only when the session is **young** (aggregate start age < `_CHURN_WINDOW_S` = 15s) **and** has **not yet delivered** a data message.
- Delivery is proven via the library's `persistent_ids` (reset to `[]` on each successful login at `fcmpushclient.py:833`, appended to only for a `DataMessageStanza` at `:840`). The activity clock (`last_message_time` / `_entry_last_activity_monotonic`) is **deliberately not used**: `_handle_message` advances it for *every* message including a bare heartbeat ack (`:808`), so it can never separate a broken fresh session (heartbeats, zero data) from a healthy one.
- The reconnect stops the stale client, nudges the supervisor to rebuild, and waits (same budget as the readiness gate) for the *replacement* instance to reach `STARTED`; it **fails closed** if the replacement never starts. The supervisor owns the rebuild, so no new race surface is introduced.
- The readiness poll is extracted into `_await_entry_started` (behavior-preserving; adds an `exclude_pc` guard so a stale-but-lingering-`STARTED` client is not mistaken for the fresh replacement).

**Why a healthy Home Assistant session is never disrupted:** the trigger is gated on per-entry non-delivery. A long-running HA entry has either aged past 15s or has a non-empty `persistent_ids`, so it never reconnects. The single-entry CLI (the reproduction target) is exact because the aggregate `last_start_monotonic` equals that one entry's session age.

**Scope note (`_CHURN_WINDOW_S`):** it feeds no health snapshot and no coordinator state (a one-shot, local decision), so it does not conflict with the `Auth/AGENTS.md` "reuse the health helper, do not add parallel health windows" rule, whose rationale is diagnostics/coordinator-state consistency. It is distinct from the 90s idle-reset window.

## Tests
6 new cases in `tests/test_fcm_receiver_manual_locate.py`: fresh+non-delivering → reconnect and serve from replacement; established (old) session → no reconnect; young-but-already-delivered → no reconnect (sharpening); replacement-never-starts → fail closed; `stop()` error swallowed; lingering-`STARTED` stale excluded from the replacement wait. All assertions behavioral and mutation-sharp. The three pre-existing #1148 readiness-gate tests pass unchanged.

- ruff + ruff format + mypy-strict: clean
- 142 FCM/locate tests green; delta-coverage of the changed lines complete; mutation gegenprobe confirmed for the trigger, fail-closed, and the `exclude_pc` guard.
- No version bump (stays 1.7.8; release version is the maintainer's call).

## Not in scope / honest caveats
- **Live delivery is not verifiable in CI** (no real FCM backend). The tests assert instance-swap / token origin / fail-closed with stubs, not the actual Google push. The definitive acceptance test is a device run: `python main.py --debug`, pick a tracker; the fix is confirmed when no `not in STARTED` warning appears, the DEBUG log shows exactly one forced reconnect, and the location arrives on the **first** attempt. That run also tunes `_CHURN_WINDOW_S`.
- **Double registration** (a second `Registered with FCM` when the supervisor start-registration and the on-demand manual-locate registration collide) is **not** fixed here; the reconnect heals the symptom regardless, and a separate de-dup would add risk to the registration flow. Left as a follow-up.
- **Nudge timing:** the forced reconnect relies on `nudge_retry` for a *prompt* rebuild; a nudge that lands before the supervisor's `clear()` is lost (pre-existing level-triggered-event property), but the rebuild still occurs on the backoff timer within the wait budget, so it self-heals.
- Unrelated follow-ups: blocking `input()` in the async loop, the duplicate browser/PIN auth step.

This PR is intentionally opened as a **draft** pending the device `--debug` acceptance run.
