### PR TITLE
fix(auth): classify transient GCM check-in exhaustion, preserve identity

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -94,6 +94,23 @@ class FcmRegisterHTTPError(RuntimeError):
 _FATAL_HTTP_STATUSES = (HTTPStatus.UNAUTHORIZED, HTTPStatus.NOT_FOUND)
 
 
+class FcmCheckinTransientError(RuntimeError):
+    """Raised when GCM check-in exhausts its retry budget on pure network errors.
+
+    Distinguishes a *transient* transport failure (DNS timeout, connection
+    reset — the endpoint was never reached at the HTTP layer) from an
+    authoritative empty/non-OK response. Returning ``None`` for both cases made
+    callers treat a temporary network outage as an invalid identity and rotate a
+    working android_id/key material via a full ``register()``. By raising a
+    distinct ``RuntimeError`` subclass instead, callers preserve the device
+    identity and let the supervisor retry later, mirroring the
+    ``FcmRegisterHTTPError`` split for fatal HTTP statuses. Inherits from
+    ``RuntimeError`` so the supervisor's existing transient/retry classification
+    (``isinstance(err, (TimeoutError, RuntimeError))``) applies without a
+    dedicated branch.
+    """
+
+
 _SHA1_HEX_LENGTH = 40
 
 
@@ -298,6 +315,11 @@ class FcmRegister:
 
         max_attempts = 8
         content: bytes | None = None
+        # Distinguish a pure transport-layer exhaustion (the endpoint was never
+        # reached at the HTTP layer) from an authoritative empty/non-OK
+        # response, so callers can preserve identity on transient outages.
+        saw_http_response = False
+        last_transient_exc: Exception | None = None
 
         for attempt in range(1, max_attempts + 1):
             try:
@@ -308,6 +330,14 @@ class FcmRegister:
                     timeout=self.CLIENT_TIMEOUT,
                 ) as resp:
                     status = resp.status
+                    # Reached the endpoint at the HTTP layer: any later
+                    # exhaustion is authoritative, not a transport outage, so we
+                    # defer to the register() fallback rather than raising a
+                    # transient. Deliberately conservative: a mid-body read
+                    # failure after a 200 status line is also treated as
+                    # authoritative (errs toward re-register, never toward
+                    # blocking a genuinely revoked identity).
+                    saw_http_response = True
                     if status == HTTPStatus.OK:
                         content = await resp.read()
                         break
@@ -337,6 +367,7 @@ class FcmRegister:
                 # into the generic transient-retry loop below.
                 raise
             except Exception as e:
+                last_transient_exc = e
                 _logger.warning(
                     "GCM check-in error (attempt %d/%d) at url=%s: %s",
                     attempt,
@@ -352,6 +383,21 @@ class FcmRegister:
                 await asyncio.sleep(delay)
 
         if not content:
+            if not saw_http_response and last_transient_exc is not None:
+                # Pure transport failure (e.g. DNS timeout): the endpoint was
+                # never reached, so the existing identity is almost certainly
+                # still valid. Surface as transient so callers keep it instead
+                # of rotating android_id/keys via a full register().
+                _logger.error(
+                    "Unable to check-in to GCM after %d attempts (url=%s): "
+                    "transient network failure, preserving identity",
+                    max_attempts,
+                    GCM_CHECKIN_URL,
+                )
+                raise FcmCheckinTransientError(
+                    "GCM check-in exhausted after "
+                    f"{max_attempts} transient network failures"
+                ) from last_transient_exc
             _logger.error(
                 "Unable to check-in to GCM after %d attempts (url=%s)",
                 max_attempts,
@@ -888,6 +934,12 @@ class FcmRegister:
                 )
                 if gcm_response:
                     return self.credentials
+            except FcmCheckinTransientError:
+                # Transport-level check-in outage (e.g. DNS timeout): the
+                # existing identity is almost certainly still valid. Propagate
+                # so the supervisor retries later instead of discarding a
+                # working android_id/keys via a full register().
+                raise
             except Exception as e:
                 _logger.warning(
                     "Existing credentials check-in failed; re-registering",
@@ -937,6 +989,11 @@ class FcmRegister:
         # Step 1: Check-in with existing device identity
         try:
             gcm_response = await self.gcm_check_in(android_id, security_token)
+        except FcmCheckinTransientError:
+            # Transport-level check-in outage (e.g. DNS timeout): keep the
+            # existing GCM identity and let the supervisor retry later, rather
+            # than rotating a working android_id/keys via a full register().
+            raise
         except Exception as e:
             _logger.debug("Check-in exception detail", exc_info=e)
             return await self._fallback_full_register(

--- a/tests/test_fcm_register.py
+++ b/tests/test_fcm_register.py
@@ -16,6 +16,7 @@ from custom_components.googlefindmy.Auth.firebase_messaging.const import (
     GCM_SERVER_KEY_B64,
 )
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
+    FcmCheckinTransientError,
     FcmRegister,
     FcmRegisterConfig,
     FcmRegisterHTTPError,
@@ -819,3 +820,156 @@ async def test_gcm_register_classifier_independent_of_logger_output(
     # Defense is independent of logger output: the silenced logger
     # captured nothing, yet the classifier still surfaced the fatal.
     assert "status=404" not in caplog.text
+
+
+# --------------------------------------------------------------------------
+# gcm_check_in transient-vs-permanent taxonomy (FcmCheckinTransientError)
+# --------------------------------------------------------------------------
+
+
+class _RaisingCheckinResponse:
+    """Async CM whose ``__aenter__`` raises a transport error (HTTP never reached)."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def __aenter__(self) -> _RaisingCheckinResponse:
+        raise self._exc
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+
+class _SequencedCheckinSession:
+    """Session stub yielding transport failures and/or HTTP responses in order.
+
+    Each configured item is either an ``Exception`` (simulating a transport-layer
+    failure such as a DNS timeout, so the endpoint is never reached) or a
+    ``_FakeResponse`` (the server answered at the HTTP layer).
+    """
+
+    def __init__(self, items: list[Exception | _FakeResponse]) -> None:
+        self._items = items
+        self.calls = 0
+
+    def post(self, **_kwargs: Any) -> _RaisingCheckinResponse | _FakeResponse:
+        self.calls += 1
+        if not self._items:
+            raise AssertionError("No more check-in items configured")
+        item = self._items.pop(0)
+        if isinstance(item, Exception):
+            return _RaisingCheckinResponse(item)
+        return item
+
+
+def _checkin_config() -> FcmRegisterConfig:
+    return FcmRegisterConfig(
+        project_id="proj",
+        app_id="app",
+        api_key="key",
+        messaging_sender_id="1234567890123",
+        bundle_id="bundle",
+    )
+
+
+async def _fast_sleep(_: float) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_gcm_check_in_transient_exhaustion_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pure transport exhaustion (endpoint never reached) raises transient, not None."""
+    session = _SequencedCheckinSession([TimeoutError("DNS timeout")] * 8)
+    register = FcmRegister(_checkin_config(), http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    with pytest.raises(FcmCheckinTransientError):
+        await register.gcm_check_in(1, 2)
+    assert session.calls == 8  # full retry budget consumed
+
+
+@pytest.mark.asyncio
+async def test_gcm_check_in_authoritative_non_ok_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated non-OK HTTP responses (server reachable) still return None."""
+    session = _SequencedCheckinSession(
+        [_FakeResponse(500, "err", {"Content-Type": "text/plain"}) for _ in range(8)]
+    )
+    register = FcmRegister(_checkin_config(), http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    result = await register.gcm_check_in(1, 2)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_gcm_check_in_mixed_reached_server_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transport blip followed by non-OK HTTP is authoritative, not transient.
+
+    Guards the ``saw_http_response`` discriminator: once the endpoint answered at
+    the HTTP layer, exhaustion must return ``None`` (defer to the register
+    fallback), even though a transport exception was seen earlier.
+    """
+    session = _SequencedCheckinSession(
+        [TimeoutError("DNS blip"), TimeoutError("DNS blip")]
+        + [_FakeResponse(500, "err", {"Content-Type": "text/plain"}) for _ in range(6)]
+    )
+    register = FcmRegister(_checkin_config(), http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    result = await register.gcm_check_in(1, 2)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_reregister_keeping_identity_preserves_on_transient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient check-in outage propagates without rotating the device identity."""
+    session = _SequencedCheckinSession([TimeoutError("DNS timeout")] * 8)
+    creds = {"gcm": {"android_id": 1, "security_token": 2}}
+    register = FcmRegister(_checkin_config(), creds, http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    register_called = False
+
+    async def _spy_register() -> Any:
+        nonlocal register_called
+        register_called = True
+        return None
+
+    monkeypatch.setattr(register, "register", _spy_register)
+
+    with pytest.raises(FcmCheckinTransientError):
+        await register.reregister_keeping_identity()
+    assert register_called is False  # no full register() -> identity kept
+    assert register.credentials == creds
+
+
+@pytest.mark.asyncio
+async def test_checkin_or_register_preserves_on_transient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient check-in outage propagates instead of falling through to register()."""
+    session = _SequencedCheckinSession([TimeoutError("DNS timeout")] * 8)
+    creds = {"gcm": {"android_id": 1, "security_token": 2}}
+    register = FcmRegister(_checkin_config(), creds, http_client_session=session)
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    register_called = False
+
+    async def _spy_register() -> Any:
+        nonlocal register_called
+        register_called = True
+        return None
+
+    monkeypatch.setattr(register, "register", _spy_register)
+
+    with pytest.raises(FcmCheckinTransientError):
+        await register.checkin_or_register()
+    assert register_called is False


### PR DESCRIPTION
## Problem

A transient network failure during GCM check-in (e.g. `Cannot connect to host android.clients.google.com:443 ssl:default [Timeout while contacting DNS servers]`, seen in the wild at `fcmregister.py:340`) was collapsed into `None` by `gcm_check_in()`, indistinguishable from an authoritative empty response.

Both callers treated that `None` as a broken identity:
- `reregister_keeping_identity` → `_fallback_full_register(...)` → full `register()`
- `checkin_or_register` → fall-through to `register()`

So after the 8-attempt retry budget, a purely transient DNS outage **discarded a working GCM device identity + FCM key material and rotated it**. Worse, if the outage was still ongoing, the follow-up `register()` failed too (`RuntimeError`) — old identity gone, no new one obtainable. A temporary network blip was amplified into identity loss.

The codebase already had the transient-vs-permanent distinction twice (`FcmRegisterHTTPError`/`_FATAL_HTTP_STATUSES` for 401/404; `CredentialDecryptionError` for a run of auth-tag failures). It was missing only on the network-exception path of `gcm_check_in`.

## Fix (V1: failure taxonomy at the boundary)

- New `FcmCheckinTransientError(RuntimeError)`, mirroring `FcmRegisterHTTPError`.
- `gcm_check_in` tracks whether the endpoint was ever reached at the HTTP layer (`saw_http_response`) and the last transport exception. On a **pure transport-layer exhaustion** it raises `FcmCheckinTransientError` instead of returning `None`; a reachable-but-non-OK/empty response still returns `None` (register fallback unchanged, conservative).
- Both callers add `except FcmCheckinTransientError: raise` before their generic `except`, mirroring the existing `except FcmRegisterHTTPError: raise`. Identity is preserved; the supervisor's existing `isinstance(err, (TimeoutError, RuntimeError))` classification in `_register_for_fcm_entry` routes it to transient/retry (no `_invalidate_fcm_tokens`, verified at the code). No auto-retry masking: the failure stays visible, the identity survives.

## Error-class sweep

The class "transient network error collapsed into `None`/`RuntimeError` at the check-in/register boundary and treated as authoritative invalidity" has three instances:

| Instance | Behavior | Action |
|---|---|---|
| `gcm_check_in` → `None` → identity rotation | actively harmful | **fixed** |
| `gcm_register` → `None` → caller raises `RuntimeError` | already fail-safe (supervisor retries, no rotation) | documented, not touched |
| `fcm_install_and_register` → `None` → caller raises `RuntimeError` | already fail-safe | documented, not touched |

Only instance 1 rotated identity. Instances 2/3 already surface as `RuntimeError` → transient/retry without rotation, so they are left as-is (minimal blast radius).

## Tests & verification

- 5 new tests (transient exhaustion raises; authoritative non-OK returns `None`; mixed transport-then-HTTP returns `None`; both callers preserve identity), all `async def` + `@pytest.mark.asyncio` (no `asyncio.run`).
- 23 module tests + full FCM/register suites green; ruff + format + mypy-strict clean.
- Two mutation counter-proofs sharp: reverting the transient raise → 3 red; dropping the `saw_http_response` guard → mixed test red.
- Delta-coverage complete for the changed lines.

## Known limitation (INFO, documented in code)

`saw_http_response` is set at the status line, so a mid-body read failure after a `200` is treated as authoritative (register fallback). This errs toward re-register, never toward blocking a genuinely revoked identity, and matches prior behavior. Called out in a code comment.

## Acceptance test

Device-bound: `python main.py --debug` under a real DNS outage (the bug only reproduces against the live Google backend). No version bump.