### PR TITLE
test(cli): mark async tests in cli entry selection and shrink guard allowlist

### DIFF
--- a/tests/test_cli_entry_selection.py
+++ b/tests/test_cli_entry_selection.py
@@ -73,6 +73,7 @@ def test_resolve_cli_cache_multiple_entries_require_hint(
     assert "GOOGLEFINDMY_ENTRY_ID" in message
 
 
+@pytest.mark.asyncio
 async def test_cli_main_passes_selected_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     """CLI helper should forward the selected cache/namespace to API calls."""
 
@@ -168,6 +169,7 @@ class TestAsyncCliMainEntryResolution:
         monkeypatch.setattr(nbe_list_devices, "_resolve_cli_cache", _stub)
         return seen
 
+    @pytest.mark.asyncio
     async def test_explicit_empty_entry_id_is_not_overridden_by_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -180,6 +182,7 @@ class TestAsyncCliMainEntryResolution:
 
         assert seen["hint"] == ""
 
+    @pytest.mark.asyncio
     async def test_none_entry_id_falls_back_to_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -192,6 +195,7 @@ class TestAsyncCliMainEntryResolution:
 
         assert seen["hint"] == "from-env"
 
+    @pytest.mark.asyncio
     async def test_explicit_entry_id_wins_over_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_guard_async_test_marker.py
+++ b/tests/test_guard_async_test_marker.py
@@ -23,7 +23,6 @@ import pytest
 LEGACY_ALLOWLIST: set[str] = {
     "tests/test_aas_token_retrieval.py",
     "tests/test_api_location_selection.py",
-    "tests/test_cli_entry_selection.py",
     "tests/test_coordinator_locate_basics.py",
     "tests/test_coordinator_polling_basics.py",
     "tests/test_coordinator_polling_branches.py",


### PR DESCRIPTION
## Summary

Codex flagged that the async tests in `tests/test_cli_entry_selection.py` do not carry an explicit `@pytest.mark.asyncio` marker. This PR marks them and removes the file from the async-marker guard's legacy allowlist so the omission cannot recur.

## Why this matters

The repository's `tests/conftest.py` ships a fallback runner (`pytest_pyfunc_call`) for environments where `pytest-asyncio` is not installed. That fallback only drives coroutine tests that carry the asyncio marker. Without the marker, the affected entry-resolution regression tests would be collected but silently not executed on the fallback path, giving a false sense of coverage. The requirement is documented in `tests/AGENTS.md`, section "Async tests".

## Root cause (beyond the missing marker)

The file was listed in `LEGACY_ALLOWLIST` inside `tests/test_guard_async_test_marker.py`. The guard skips allowlisted files entirely, so when a new async test class was appended to this already-allowlisted file, the missing markers slipped past the guard unseen. This is the allowlist-append trap that `AGENTS.md` warns about: appending to an allowlisted file should be paired with shrinking the allowlist.

## Changes

Added
- (none)

Changed
- `tests/test_cli_entry_selection.py`: add an explicit `@pytest.mark.asyncio` decorator to all four async tests. Inline decorators are used rather than a module-level `pytestmark`, because the module mixes synchronous and asynchronous tests; a module-level marker would also tag the sync tests and emit "not an async function" warnings.
- `tests/test_guard_async_test_marker.py`: remove `tests/test_cli_entry_selection.py` from `LEGACY_ALLOWLIST`, so the guard now actively checks this file and blocks future unmarked async additions. Shrinking the list is explicitly welcomed by the guard's own comment.

## Tests

- `ruff check` on both files: clean.
- Guard test `test_async_tests_declare_asyncio_marker`: green.
- Target suite `tests/test_cli_entry_selection.py`: 6 passed, no warnings.
- Mutation cross-check: removing one decorator turns the guard red; restoring it turns it green again, confirming the guard now protects the file.

## Risk

Very low. Test-only change: four decorators and one removed allowlist line. No production code is touched. Behaviour of the tests is unchanged; only their execution guarantee on the fallback runner and the guard's coverage of the file improve.

## Notes

A broader follow-up remains possible and is intentionally not bundled here (one transformation per commit): the guard grants whole-file immunity for allowlisted files, so unmarked async appends to the remaining allowlisted files stay invisible. A stronger design would freeze offending lines rather than whole files. That is a separate, larger change to the guard and can be a follow-up PR.
