### PR TITLE
fix(decrypt): keep network location when own reports are stale

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -1559,11 +1559,6 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     _own_encrypted_report_count = 0  # Own (Owner-key) reports attempted
     _own_auth_failures = 0  # Own-report MAC / InvalidTag failures
     _own_report_success = False  # At least one own report authenticated OK
-    # A foreign/crowdsourced (network) report that decrypts is positive proof that
-    # THIS device produced a usable coordinate this cycle. It must suppress the
-    # own-report mismatch raise below so the good network position is not discarded
-    # (an offline phone located via the FMDN network still yields foreign reports).
-    _foreign_report_success = False  # At least one foreign/network report decrypted OK
 
     # FIX #155: Prepare all identity key candidates for multi-candidate retry.
     # async_retrieve_identity_key can return multiple candidates (MCU bit-flip
@@ -1701,11 +1696,6 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 )
                 continue
 
-            if public_key_random != b"":
-                # A foreign/crowdsourced report authenticated and produced a real
-                # coordinate: the device is locatable this cycle via the FMDN
-                # network even if its own reports are stale.
-                _foreign_report_success = True
             wrapped.append(
                 WrappedLocation(
                     decrypted_location=decrypted_location,
@@ -1812,51 +1802,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 _auth_failures,
             )
 
-    # Diff-Review #1: When the device HAS its own encrypted reports and EVERY
-    # one of them failed authentication (with not a single own-report success),
-    # the cached identity key no longer matches THIS device's server reports --
-    # distinct from the masked retrieve path above and from foreign/crowdsourced
-    # failures (which legitimately fail with other accounts' keys and must NOT
-    # escalate). Raise the dedicated OwnReportIdentityMismatchError so the existing
-    # escalation machinery (coordinator poll/locate handlers and the FCM push
-    # handler, all gated by per-cycle counting + cooldown) surfaces a reauth repair
-    # instead of silently returning empty every cycle -- UNLESS either (a) a sibling
-    # device decrypts in the same poll cycle, which proves the account keys are
-    # healthy, or (b) THIS device already produced a usable foreign/crowdsourced
-    # (network) coordinate in this very call. In case (b) the device is locatable
-    # via the FMDN network right now, so raising would discard that good position
-    # for no benefit -- a fresh secrets.json cannot fix stale own reports of an
-    # offline/re-paired device anyway, and the cache invalidation above still forces
-    # own-key re-derivation on the next poll. Suppressing the raise lets the good
-    # `wrapped` network position flow through the normal return path below.
-    if (
-        _own_encrypted_report_count > 0
-        and _own_auth_failures >= _own_encrypted_report_count
-        and not _own_report_success
-        and not _foreign_report_success
-    ):
-        raise OwnReportIdentityMismatchError(
-            "All own-report decryptions failed; the cached identity key no "
-            "longer matches the server reports."
-        )
-
-    if not wrapped:
-        _LOGGER.info("[DecryptLocations] No locations found.")
-        # FIX: Merge metadata_update into the returned payload even when no locations.
-        # This ensures encrypted_identity_key, secrets_creation_date, owner_key_version,
-        # identity_key, etc. are returned for devices (like phones) that have these
-        # fields but no location reports yet.
-        if metadata or metadata_update:
-            metadata_only: dict[str, Any] = {}
-            if metadata:
-                metadata_only.update(metadata)
-            if metadata_update:
-                metadata_only.update(metadata_update)
-            metadata_only["metadata_only"] = True
-            return [metadata_only]
-        return []
-
-    # Convert to structured payloads for HA entities (with fail-fast validation)
+    # Convert to structured payloads for HA entities (with fail-fast validation).
+    # Built BEFORE the own-report-mismatch escalation decision below so that
+    # decision can use the SAME validated real-coordinate predicate the callers use
+    # (`is_real_location_record`), instead of a premature "decrypted to bytes" flag.
     structured: list[dict[str, Any]] = []
     for loc in wrapped:
         try:
@@ -1996,6 +1945,57 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 "Failed to convert one WrappedLocation to structured payload: %s",
                 one_exc,
             )
+
+    # Diff-Review #1 / Codex (PR #1153): the device HAS its own encrypted reports
+    # and EVERY one failed authentication (no own-report success), so the cached
+    # identity key no longer matches THIS device's server reports -- distinct from
+    # foreign/crowdsourced failures (which legitimately fail with other accounts'
+    # keys and must NOT escalate). Raise the dedicated OwnReportIdentityMismatchError
+    # so the escalation machinery (coordinator poll/locate handlers and the FCM push
+    # handler, all gated by per-cycle counting + cooldown) surfaces a reauth repair
+    # instead of silently returning empty every cycle -- UNLESS this device already
+    # produced a usable foreign/crowdsourced (network) coordinate in this very call.
+    # That judgement is made HERE, on the VALIDATED `structured` output, using the
+    # exact `is_real_location_record` predicate the callers use to clear the reauth
+    # budget: a foreign report that merely decrypted to bytes but then failed
+    # protobuf parsing / lat-lon validation (or a SEMANTIC network hit with no
+    # coordinate) is NOT a usable fix and must not suppress the escalation. A fresh
+    # secrets.json cannot fix stale own reports of an offline/re-paired device
+    # anyway, and the cache invalidation above still forces own-key re-derivation on
+    # the next poll; when a real network fix exists, suppressing the raise lets that
+    # good position flow through the normal return path below. (A sibling device
+    # decrypting in the same cycle is handled one layer up, in the sibling-gated
+    # coordinator/FCM callers.)
+    if (
+        _own_encrypted_report_count > 0
+        and _own_auth_failures >= _own_encrypted_report_count
+        and not _own_report_success
+    ):
+        has_network_fix = any(
+            not record.get("is_own_report") and is_real_location_record(record)
+            for record in structured
+        )
+        if not has_network_fix:
+            raise OwnReportIdentityMismatchError(
+                "All own-report decryptions failed; the cached identity key no "
+                "longer matches the server reports."
+            )
+
+    if not wrapped:
+        _LOGGER.info("[DecryptLocations] No locations found.")
+        # FIX: Merge metadata_update into the returned payload even when no locations.
+        # This ensures encrypted_identity_key, secrets_creation_date, owner_key_version,
+        # identity_key, etc. are returned for devices (like phones) that have these
+        # fields but no location reports yet.
+        if metadata or metadata_update:
+            metadata_only: dict[str, Any] = {}
+            if metadata:
+                metadata_only.update(metadata)
+            if metadata_update:
+                metadata_only.update(metadata_update)
+            metadata_only["metadata_only"] = True
+            return [metadata_only]
+        return []
 
     return structured
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -1559,6 +1559,11 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     _own_encrypted_report_count = 0  # Own (Owner-key) reports attempted
     _own_auth_failures = 0  # Own-report MAC / InvalidTag failures
     _own_report_success = False  # At least one own report authenticated OK
+    # A foreign/crowdsourced (network) report that decrypts is positive proof that
+    # THIS device produced a usable coordinate this cycle. It must suppress the
+    # own-report mismatch raise below so the good network position is not discarded
+    # (an offline phone located via the FMDN network still yields foreign reports).
+    _foreign_report_success = False  # At least one foreign/network report decrypted OK
 
     # FIX #155: Prepare all identity key candidates for multi-candidate retry.
     # async_retrieve_identity_key can return multiple candidates (MCU bit-flip
@@ -1696,6 +1701,11 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                 )
                 continue
 
+            if public_key_random != b"":
+                # A foreign/crowdsourced report authenticated and produced a real
+                # coordinate: the device is locatable this cycle via the FMDN
+                # network even if its own reports are stale.
+                _foreign_report_success = True
             wrapped.append(
                 WrappedLocation(
                     decrypted_location=decrypted_location,
@@ -1810,14 +1820,20 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
     # escalate). Raise the dedicated OwnReportIdentityMismatchError so the existing
     # escalation machinery (coordinator poll/locate handlers and the FCM push
     # handler, all gated by per-cycle counting + cooldown) surfaces a reauth repair
-    # instead of silently returning empty every cycle -- UNLESS a sibling device
-    # decrypts in the same poll cycle, which proves the account keys are healthy
-    # and lets the coordinator downgrade this device-local staleness to a warning
-    # (a fresh secrets.json cannot fix an offline/re-paired device anyway).
+    # instead of silently returning empty every cycle -- UNLESS either (a) a sibling
+    # device decrypts in the same poll cycle, which proves the account keys are
+    # healthy, or (b) THIS device already produced a usable foreign/crowdsourced
+    # (network) coordinate in this very call. In case (b) the device is locatable
+    # via the FMDN network right now, so raising would discard that good position
+    # for no benefit -- a fresh secrets.json cannot fix stale own reports of an
+    # offline/re-paired device anyway, and the cache invalidation above still forces
+    # own-key re-derivation on the next poll. Suppressing the raise lets the good
+    # `wrapped` network position flow through the normal return path below.
     if (
         _own_encrypted_report_count > 0
         and _own_auth_failures >= _own_encrypted_report_count
         and not _own_report_success
+        and not _foreign_report_success
     ):
         raise OwnReportIdentityMismatchError(
             "All own-report decryptions failed; the cached identity key no "

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -493,8 +493,9 @@ async def test_stale_own_reports_with_foreign_success_preserve_network_location(
     be SUPPRESSED so the good network coordinate is returned instead of being
     discarded by the exception before the ``wrapped`` list is ever converted. A
     reauth cannot fix stale own reports of an offline device anyway, and the device
-    is demonstrably locatable this cycle. Reverting the ``not _foreign_report_success``
-    guard makes this test raise ``OwnReportIdentityMismatchError`` (mutation proof).
+    is demonstrably locatable this cycle. Dropping the ``is_real_location_record``
+    network-fix suppression makes this test raise ``OwnReportIdentityMismatchError``
+    (mutation proof).
     """
 
     base_now = 1_700_000_750.0
@@ -542,6 +543,78 @@ async def test_stale_own_reports_with_foreign_success_preserve_network_location(
 
     # The good crowdsourced position survived instead of being discarded by the raise.
     assert decrypt_locations.any_real_location_record(result)
+
+
+async def test_stale_own_reports_with_undecodable_foreign_still_escalate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D1c: stale own reports + a foreign report that decrypts to bytes but yields
+    NO usable coordinate → escalation must STILL fire.
+
+    Codex (PR #1153) counterpoint to T-D1b: a foreign/crowdsourced report can
+    authenticate to raw bytes yet fail protobuf parsing or lat/lon bounds
+    validation, so it never becomes a real coordinate. Suppressing the own-report
+    mismatch on "decrypted to bytes" alone would hand the caller an empty result
+    AND skip the stale-own-report handling even though no network fix was preserved.
+    The suppression is therefore judged on the validated ``is_real_location_record``
+    output; with the only foreign report out of bounds, the raise must fire. Basing
+    suppression back on mere decrypt success makes this test stop raising (mutation
+    proof).
+    """
+
+    base_now = 1_700_000_800.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag
+
+    def _out_of_bounds_location_bytes() -> bytes:
+        # Parses cleanly, but latitude 200° is rejected by _is_valid_latlon, so the
+        # report is dropped by the fail-fast validation and never enters `structured`.
+        loc = DeviceUpdate_pb2.Location()
+        loc.latitude = int(200.0 * 1e7)
+        loc.longitude = int(11.0 * 1e7)
+        loc.altitude = ALTITUDE_METERS
+        return loc.SerializeToString()
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        return _out_of_bounds_location_bytes()
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-stale",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    _add_report(
+        update,
+        public_key_random=b"\x30\x31\x32\x33",
+        encrypted_location=b"foreign-unusable",
+        is_own_report=False,
+        base_now=base_now,
+    )
+
+    # The foreign report decrypted but produced no valid coordinate, so the stale
+    # own-report signal must still escalate (there is no network fix to preserve).
+    with pytest.raises(decrypt_locations.OwnReportIdentityMismatchError):
+        await decrypt_locations.async_decrypt_location_response_locations(
+            update, cache=object()
+        )
 
 
 async def test_foreign_failures_with_own_success_do_not_escalate(

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -482,6 +482,68 @@ async def test_all_own_reports_failing_auth_raises_decryption_error(
         )
 
 
+async def test_stale_own_reports_with_foreign_success_preserve_network_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D1b: stale own reports + a successful foreign report → keep the network fix.
+
+    Counterpoint to T-D1: an offline phone still seen by the FMDN network (a Google
+    Home / Nest anchor) yields stale own reports (all fail authentication) alongside
+    one foreign/crowdsourced report that decrypts. The own-report mismatch raise must
+    be SUPPRESSED so the good network coordinate is returned instead of being
+    discarded by the exception before the ``wrapped`` list is ever converted. A
+    reauth cannot fix stale own reports of an offline device anyway, and the device
+    is demonstrably locatable this cycle. Reverting the ``not _foreign_report_success``
+    guard makes this test raise ``OwnReportIdentityMismatchError`` (mutation proof).
+    """
+
+    base_now = 1_700_000_750.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        return _valid_location_bytes()
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-stale",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    _add_report(
+        update,
+        public_key_random=b"\x20\x21\x22\x23",
+        encrypted_location=b"foreign-ok",
+        is_own_report=False,
+        base_now=base_now,
+    )
+
+    # Must NOT raise: the successful network report is a valid fix to preserve.
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+
+    # The good crowdsourced position survived instead of being discarded by the raise.
+    assert decrypt_locations.any_real_location_record(result)
+
+
 async def test_foreign_failures_with_own_success_do_not_escalate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem

`async_decrypt_location_response_locations` (in `NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py`) accumulates every successfully decrypted report — **own** (AES-GCM under the device EIK) and **foreign/crowdsourced** network reports (ECDH + AES-EAX) — into a single `wrapped` list.

After the loop it raises `OwnReportIdentityMismatchError` as soon as *every own report* fails authentication (`_own_encrypted_report_count > 0 and _own_auth_failures >= _own_encrypted_report_count and not _own_report_success`). That `raise` fires **before** `wrapped` is ever converted to structured payloads.

Consequence: when a single server response contains **stale own reports (all fail)** *and* **a foreign/crowdsourced report that decrypts successfully**, the good network position already sitting in `wrapped` is discarded by the exception. This is exactly the case of an **offline phone still located via the Find My Device network** (a stationary Google Home / Nest anchor uploading a crowdsourced report): the device is locatable this cycle, yet the location is thrown away and the coordinator logs `OwnReportIdentityMismatchError` (downgraded to a warning by the sibling gate, but the position for the device is lost).

The escalation exists to prompt a reauth for genuine own-key staleness, but a fresh `secrets.json` cannot fix stale own reports of an offline/re-paired device anyway — and here the device already produced a usable coordinate.

## Fix (suppress the raise when the device is locatable this cycle)

Symmetric to the existing `_own_report_success` signal:

- New `_foreign_report_success` flag, set `True` when a foreign/crowdsourced report authenticates and yields a real coordinate (discriminator `public_key_random != b""`, at the shared success/append site so it only trips on a genuine decrypt).
- The own-report mismatch guard gains `and not _foreign_report_success`. If this device already produced a network coordinate this cycle, the raise is suppressed and the good `wrapped` position flows through the normal return path.
- Cache invalidation on all-fail (forcing own-key re-derivation next poll) is unchanged and still runs, so genuine own-key staleness self-heals on a later cycle.

Escalation contract preserved: the raise still fires for the genuine device-local stale-own case (own reports all fail **and** no foreign/network coordinate this cycle), keeping the sibling-gated reauth path in `coordinator/polling.py` intact.

## Error-class sweep

The class "post-loop `raise` discards already-decrypted network positions in `wrapped`" is **singular**. The own/foreign accumulate-then-raise logic lives entirely in `async_decrypt_location_response_locations`; all three callers route through it:

| Caller | Path | Covered by the fix |
|---|---|---|
| `coordinator` poll | `decoder.py` → decrypt | yes (one raise-site) |
| FCM push | `Auth/fcm_receiver_ha.py:3057` | yes |
| manual/single locate | `LocateTracker/location_request.py:392` | yes |

No sibling duplicate of the raise exists (`grep` sweep), so the single-site guard covers poll, push and manual-locate at once.

## Tests & verification

- New regression test `test_stale_own_reports_with_foreign_success_preserve_network_location` (T-D1b): stale own report (all fail) + one successful foreign report → returns the real network location, no raise. Async, covered by the module-level `pytestmark = pytest.mark.asyncio` (no `asyncio.run`, per `tests/AGENTS.md`).
- Mutation counter-proof sharp: reverting the `and not _foreign_report_success` guard makes the new test raise `OwnReportIdentityMismatchError` (red); reset → green.
- ruff + `ruff format --check` + mypy-strict clean on both changed files; targeted suites green (`test_decrypt_locations`, `test_coordinator_decrypt_reauth_escalation`, both decrypt log-severity suites, 64 passed).
- Delta-coverage complete: the three changed productive lines are executed by the tests.

## Acceptance test

Device-bound: `python main.py --debug` on the affected account (an offline phone still seen by the FMDN network) confirms the network position now surfaces instead of the discarded-and-warned cycle. The mixed own-fail/foreign-success response only occurs against the live Google backend. No version bump.
