### PR TITLE
Bump version to 1.7.9 and clarify own-report-mismatch message

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -1947,8 +1947,9 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
             )
 
     # Diff-Review #1 / Codex (PR #1153): the device HAS its own encrypted reports
-    # and EVERY one failed authentication (no own-report success), so the cached
-    # identity key no longer matches THIS device's server reports -- distinct from
+    # and EVERY one failed authentication (no own-report success), so THIS
+    # device's server-side own reports predate the cached identity key (they were
+    # encrypted under a previous key) -- distinct from
     # foreign/crowdsourced failures (which legitimately fail with other accounts'
     # keys and must NOT escalate). Raise the dedicated OwnReportIdentityMismatchError
     # so the escalation machinery (coordinator poll/locate handlers and the FCM push
@@ -1977,8 +1978,10 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         )
         if not has_network_fix:
             raise OwnReportIdentityMismatchError(
-                "All own-report decryptions failed; the cached identity key no "
-                "longer matches the server reports."
+                "All own-report decryptions failed: the server-side own reports "
+                "predate the current identity key (they were encrypted under a "
+                "previous key, so the current key cannot read them). This clears "
+                "once the device uploads a fresh report."
             )
 
     if not wrapped:

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -26,7 +26,7 @@ CONFIG_ENTRY_VERSION: int = 2
 # cross-reference, so the manifest side is anchored in this directory's AGENTS.md
 # ("Version bump touches three files"). pyproject.toml carries the reverse reference
 # in a TOML comment.
-INTEGRATION_VERSION: str = "1.7.8"
+INTEGRATION_VERSION: str = "1.7.9"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.8"
+  "version": "1.7.9"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "googlefindmy-ha"
 # [tool.semantic_release] version_toml below); on release branches it MUST be
 # bumped by hand alongside the other two. Canonical anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
-version = "1.7.8"
+version = "1.7.9"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -330,8 +330,10 @@ def test_resolve_mixed_cycle_sibling_success_blocks_spurious_reauth(
     # subclass here (NOT a plain DecryptionError), which is the only class the
     # sibling-success downgrade applies to.
     err = OwnReportIdentityMismatchError(
-        "All own-report decryptions failed; the cached identity key no longer "
-        "matches the server reports."
+        "All own-report decryptions failed: the server-side own reports predate "
+        "the current identity key (they were encrypted under a previous key, so "
+        "the current key cannot read them). This clears once the device uploads "
+        "a fresh report."
     )
 
     with caplog.at_level(logging.WARNING):

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -443,13 +443,13 @@ async def test_all_own_reports_failing_auth_raises_decryption_error(
 ) -> None:
     """T-D1: every own report fails authentication → OwnReportIdentityMismatchError.
 
-    Device-local signal: the cached identity key no longer matches THIS device's own
-    server reports (e.g. a phone powered off for days), so the function must raise
-    the dedicated subclass instead of silently returning empty (which the
-    coordinator would never surface). The coordinator downgrades it to a warning
-    only when a sibling proves the account keys healthy; on its own it still
-    escalates. Asserting the concrete subclass locks in the contract the
-    coordinator's sibling-success gate keys off.
+    Device-local signal: THIS device's own server reports predate the cached
+    identity key (e.g. a phone powered off for days, or freshly re-paired), so
+    the function must raise the dedicated subclass instead of silently returning
+    empty (which the coordinator would never surface). The coordinator downgrades
+    it to a warning only when a sibling proves the account keys healthy; on its
+    own it still escalates. Asserting the concrete subclass locks in the contract
+    the coordinator's sibling-success gate keys off.
     """
 
     base_now = 1_700_000_000.0

--- a/tests/test_location_request_decrypt_log_severity.py
+++ b/tests/test_location_request_decrypt_log_severity.py
@@ -75,8 +75,10 @@ def _patch_callback_imports(
         # Per-device decrypt/key failure -> warning (the offline-phone case).
         (
             DecryptionError(
-                "All own-report decryptions failed; the cached identity key no "
-                "longer matches the server reports."
+                "All own-report decryptions failed: the server-side own reports "
+                "predate the current identity key (they were encrypted under a "
+                "previous key, so the current key cannot read them). This clears "
+                "once the device uploads a fresh report."
             ),
             logging.WARNING,
         ),


### PR DESCRIPTION
## Summary

Two atomic commits, prepared on top of the merged `#1153` (network-location preservation) state.

**Commit 1 — `chore(release): bump integration version to 1.7.9`**
Bumps the version triple from `1.7.8` to `1.7.9`:
- `custom_components/googlefindmy/const.py` (`INTEGRATION_VERSION`)
- `custom_components/googlefindmy/manifest.json` (`version`)
- `pyproject.toml` (`version`)

These are the three canonical version locations (no other `1.7.8` occurrence exists in the repo; `hacs.json` and the README carry no integration version).

**Commit 2 — `fix(decrypt): clarify own-report-mismatch message framing`**
The `OwnReportIdentityMismatchError` message previously read *"the cached identity key no longer matches the server reports"*, which wrongly implies the cached key is broken. In this state the derived identity key is **current and valid** (its derivation succeeded and `StaleOwnerKeyError` — the owner-key-version check that runs earlier — did not fire). What is actually out of date are the **server-side own reports**, encrypted under a *previous* identity key after a device re-pair/rotation. The new wording reverses the blame direction and tells the user the condition self-heals once the device uploads a fresh report:

> All own-report decryptions failed: the server-side own reports predate the current identity key (they were encrypted under a previous key, so the current key cannot read them). This clears once the device uploads a fresh report.

## Behaviour

Wording-only. No production code branches on the message text (the account-wide classification uses `isinstance`, not the string). The message string is a single SSOT consumed by three log lines (`polling.py`, `location_request.py`). The two test payloads that reproduce the message and the T-D1 docstring/comment are updated for fidelity; none assert on the text (they check log level, object identity, and counters), so behaviour is unchanged.

## Verification

- `ruff check` + `ruff format --check`: clean on all changed files.
- `mypy` on `decrypt_locations.py`: clean.
- Affected tests (`test_coordinator_decrypt_reauth_escalation.py`, `test_decrypt_locations.py`, `test_location_request_decrypt_log_severity.py`): pass.
- Class sweep: the old phrasing *"cached identity key no longer matches"* no longer occurs anywhere in the repo.
- Independent adversarial diff review: PASS, no MAJOR/MINOR findings.

Draft until CI is green.