### PR TITLE
fix(decrypt): detect network fix by crypto provenance, not isOwnReport flag

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -1607,6 +1607,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                         accuracy=0,  # Internal placeholder, not for display
                         status=loc.status,
                         is_own_report=False,  # SEMANTIC is not an Owner-Report
+                        is_network_report=True,  # SEMANTIC hits are network-side, never own AES-GCM
                         name=loc.semanticLocation.locationName,
                     )
                 )
@@ -1703,6 +1704,11 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     accuracy=loc.geoLocation.accuracy,
                     status=loc.status,
                     is_own_report=enc.isOwnReport,
+                    # Cryptographic provenance from the decrypt path: an empty
+                    # publicKeyRandom is an own AES-GCM report; a non-empty one is a
+                    # foreign/crowdsourced ECDH report. This is authoritative even
+                    # when the server flags a crowdsourced report as isOwnReport=True.
+                    is_network_report=public_key_random != b"",
                     name="",
                 )
             )
@@ -1833,6 +1839,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "status": _status_name_safe(loc.status),
                     "status_code": int(loc.status),
                     "is_own_report": False,
+                    "is_network_report": loc.is_network_report,
                     "semantic_name": loc.name,
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
@@ -1888,6 +1895,7 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
                     "status": status_name,
                     "status_code": int(loc.status),
                     "is_own_report": loc.is_own_report,
+                    "is_network_report": loc.is_network_report,
                     "semantic_name": None,
                     "encrypted_identity_key": raw_encrypted_identity_key,
                     "owner_key_version": raw_owner_key_version,
@@ -1972,8 +1980,16 @@ async def async_decrypt_location_response_locations(  # noqa: PLR0912, PLR0915
         and _own_auth_failures >= _own_encrypted_report_count
         and not _own_report_success
     ):
+        # Detect the network fix by CRYPTOGRAPHIC PROVENANCE (decrypted via the
+        # foreign/ECDH path), NOT by the server-supplied ``is_own_report`` flag. This
+        # integration's own crowdsourced uploader stamps valid network reports with
+        # ``isOwnReport=True`` while carrying a non-empty publicKeyRandom
+        # (fmdn_finder/location_uploader.py), so keying off ``not is_own_report``
+        # would misclassify such a real fix as an own report, fire the raise, and
+        # discard the good coordinate. ``is_network_report`` is set from the actual
+        # decrypt branch and is immune to that flag.
         has_network_fix = any(
-            not record.get("is_own_report") and is_real_location_record(record)
+            record.get("is_network_report") and is_real_location_record(record)
             for record in structured
         )
         if not has_network_fix:

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypted_location.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypted_location.py
@@ -14,6 +14,7 @@ class WrappedLocation:
         accuracy: float,
         status: int,
         is_own_report: bool,
+        is_network_report: bool,
         name: str,
     ) -> None:
         if isinstance(decrypted_location, bytearray):
@@ -28,5 +29,12 @@ class WrappedLocation:
         self.status: int = status
         self.decrypted_location: bytes = decrypted_payload
         self.is_own_report: bool = is_own_report
+        # Cryptographic provenance: True when this report came from the FMDN
+        # network side (a foreign/crowdsourced ECDH report, or a SEMANTIC network
+        # hit) rather than one of THIS device's own AES-GCM server reports. This is
+        # the authoritative decrypt-path signal and, unlike the server-supplied
+        # ``is_own_report`` flag, is not spoofed to True by this integration's own
+        # crowdsourced uploader (fmdn_finder/location_uploader.py).
+        self.is_network_report: bool = is_network_report
         self.accuracy: float = accuracy
         self.name: str = name

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypted_location.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypted_location.py
@@ -28,7 +28,15 @@ class WrappedLocation:
         self.time: float = time
         self.status: int = status
         self.decrypted_location: bytes = decrypted_payload
-        self.is_own_report: bool = is_own_report
+        # Invariant: a network report is never an owner report. The server-supplied
+        # ``is_own_report`` flag is unreliable: this integration's own crowdsourced
+        # uploader (fmdn_finder/location_uploader.py:586) stamps network reports with
+        # ``isOwnReport=True`` while carrying a non-empty publicKeyRandom. Cryptographic
+        # provenance (``is_network_report``) is authoritative, so enforcing the
+        # mutual exclusion here keeps every downstream consumer that reads
+        # ``is_own_report`` as owner provenance (row_source_label, FCM crowd-source
+        # stats, map view, ranking) from misclassifying an admitted network fix.
+        self.is_own_report: bool = is_own_report and not is_network_report
         # Cryptographic provenance: True when this report came from the FMDN
         # network side (a foreign/crowdsourced ECDH report, or a SEMANTIC network
         # hit) rather than one of THIS device's own AES-GCM server reports. This is

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -12,6 +12,9 @@ from cryptography.exceptions import InvalidTag
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
     decrypt_locations,
 )
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypted_location import (
+    WrappedLocation,
+)
 from custom_components.googlefindmy.ProtoDecoders import Common_pb2, DeviceUpdate_pb2
 from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_owner_key import (
     OwnerKeyInfo,
@@ -681,6 +684,62 @@ async def test_stale_own_reports_with_crowdsourced_own_flag_preserve_network_loc
     )
 
     assert decrypt_locations.any_real_location_record(result)
+
+    # Downstream contract (Codex BSkando PR #197, follow-up): the admitted network
+    # fix must be normalized to ``is_own_report=False`` so consumers that read that
+    # flag as authoritative owner provenance (row_source_label,
+    # FCM crowd-source stats, map view, ranking) classify it as crowdsourced, not
+    # owner. Cryptographic provenance stays visible via ``is_network_report=True``.
+    # Dropping the ``and not is_network_report`` invariant in WrappedLocation makes
+    # ``is_own_report`` stay True here (mutation proof).
+    network_fixes = [
+        record
+        for record in result
+        if record.get("is_network_report")
+        and decrypt_locations.is_real_location_record(record)
+    ]
+    assert network_fixes, "expected the crowdsourced fix to survive as a record"
+    for record in network_fixes:
+        assert record["is_own_report"] is False
+        assert record["is_network_report"] is True
+
+
+async def test_wrapped_location_network_report_is_never_own_report() -> None:
+    """T-WL1: WrappedLocation enforces the network/own mutual-exclusion invariant.
+
+    A network/foreign report is never an owner report. The server-supplied
+    ``is_own_report`` flag is unreliable (this integration's own crowdsourced
+    uploader stamps ``isOwnReport=True`` on network reports), so the object keys
+    ownership off cryptographic provenance: whenever ``is_network_report`` is True,
+    ``is_own_report`` must be coerced to False. Genuine own reports
+    (``is_network_report`` False) keep their flag. Dropping the
+    ``and not is_network_report`` coercion makes the network case return True
+    (mutation proof).
+    """
+
+    network = WrappedLocation(
+        decrypted_location=b"",
+        time=0.0,
+        accuracy=5.0,
+        status=int(Common_pb2.Status.LAST_KNOWN),
+        is_own_report=True,
+        is_network_report=True,
+        name="",
+    )
+    assert network.is_own_report is False
+    assert network.is_network_report is True
+
+    own = WrappedLocation(
+        decrypted_location=b"",
+        time=0.0,
+        accuracy=5.0,
+        status=int(Common_pb2.Status.LAST_KNOWN),
+        is_own_report=True,
+        is_network_report=False,
+        name="",
+    )
+    assert own.is_own_report is True
+    assert own.is_network_report is False
 
 
 async def test_foreign_failures_with_own_success_do_not_escalate(

--- a/tests/test_decrypt_locations.py
+++ b/tests/test_decrypt_locations.py
@@ -617,6 +617,72 @@ async def test_stale_own_reports_with_undecodable_foreign_still_escalate(
         )
 
 
+async def test_stale_own_reports_with_crowdsourced_own_flag_preserve_network_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T-D1d: stale own reports + a valid network report carrying isOwnReport=True.
+
+    Codex (BSkando PR #197) counterpoint to T-D1b: this integration's own
+    crowdsourced uploader (``fmdn_finder/location_uploader.py``) stamps network
+    reports with ``isOwnReport=True`` while still carrying a non-empty
+    ``publicKeyRandom`` (the foreign/ECDH crypto path). Keying the network-fix
+    suppression off the server-supplied ``is_own_report`` flag would misclassify
+    such a valid crowdsourced fix as an own report, let the raise fire, and discard
+    the good coordinate. The suppression is therefore keyed off cryptographic
+    provenance (``is_network_report`` = decrypted via the foreign ECDH path), which
+    is immune to that flag. Reverting the predicate to ``not is_own_report`` makes
+    this test raise ``OwnReportIdentityMismatchError`` (mutation proof).
+    """
+
+    base_now = 1_700_000_850.0
+    monkeypatch.setattr(decrypt_locations.time, "time", lambda: base_now)
+    monkeypatch.setattr(decrypt_locations, "is_mcu_tracker", lambda *_a: False)
+
+    async def fake_identity_key(*_args: object, **_kwargs: object) -> list[bytes]:
+        return [b"\x42" * 32]
+
+    async def fake_offload_aes(*_args: object, **_kwargs: object) -> bytes:
+        raise InvalidTag
+
+    async def fake_offload_foreign(*_args: object, **_kwargs: object) -> bytes:
+        return _valid_location_bytes()
+
+    monkeypatch.setattr(
+        decrypt_locations, "async_retrieve_identity_key", fake_identity_key
+    )
+    monkeypatch.setattr(decrypt_locations, "_offload_decrypt_aes", fake_offload_aes)
+    monkeypatch.setattr(
+        decrypt_locations, "_offload_decrypt_foreign", fake_offload_foreign
+    )
+
+    update = DeviceUpdate_pb2.DeviceUpdate()
+    update.deviceMetadata.information.deviceRegistration.SetInParent()
+    _add_report(
+        update,
+        public_key_random=b"",
+        encrypted_location=b"own-stale",
+        is_own_report=True,
+        base_now=base_now,
+    )
+    # A valid crowdsourced network fix that (like this repo's uploader) carries the
+    # server flag isOwnReport=True together with a non-empty publicKeyRandom.
+    _add_report(
+        update,
+        public_key_random=b"\x40\x41\x42\x43",
+        encrypted_location=b"crowdsourced-ok",
+        is_own_report=True,
+        base_now=base_now,
+    )
+
+    # Must NOT raise: the foreign-decrypted coordinate is a real network fix despite
+    # the isOwnReport=True flag, so it is preserved instead of being discarded.
+    result = await decrypt_locations.async_decrypt_location_response_locations(
+        update, cache=object()
+    )
+
+    assert decrypt_locations.any_real_location_record(result)
+
+
 async def test_foreign_failures_with_own_success_do_not_escalate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes a Codex finding on BSkando PR #197 (reviewed commit `acb6eea564`) that had not surfaced on the jleinenbach fork: the stale-own-report escalation guard could discard a valid network coordinate.

The `has_network_fix` guard in `decrypt_locations.py` suppressed `OwnReportIdentityMismatchError` only when a real location record had `is_own_report=False` (the server-supplied flag). But this integration's own crowdsourced uploader (`fmdn_finder/location_uploader.py`) stamps valid network reports with `isOwnReport=True` while carrying a non-empty `publicKeyRandom` (the foreign/ECDH decrypt path). A mixed response with all own reports stale plus one such valid crowdsourced fix was therefore misclassified as "no network fix": the guard raised and discarded the good decrypted coordinate, and callers skipped the stale-own-report handling.

## Root cause

`is_own_report` is the *server's* ownership flag, not the crypto provenance. The decrypt loop already knows the authoritative provenance: an empty `publicKeyRandom` is an own AES-GCM report; a non-empty one is a foreign/crowdsourced ECDH report. Keying the network-fix detection off the server flag is unsound because our own uploader sets it to `True` on crowdsourced data.

## Change

- `WrappedLocation` gains an `is_network_report` field, set from the actual decrypt branch (`public_key_random != b""`), immune to the server flag.
- Both structured payloads carry `is_network_report`.
- The guard now counts a network fix when a real coordinate carries `is_network_report=True` instead of `not is_own_report`.
- `is_own_report` is left untouched (kept for display/fidelity).

## Change Log

- **Fixed:** valid crowdsourced/network fixes with `isOwnReport=True` are no longer discarded by the stale-own-report escalation; the good coordinate flows through.
- **Added:** regression test `T-D1d` (stale own reports + a valid foreign report carrying `isOwnReport=True` must not raise). Mutation-proof: reverting the predicate to `not is_own_report` makes it raise `OwnReportIdentityMismatchError`.
- **Compatibility:** additive payload key; no behavioural change to `is_own_report`. No version bump (already 1.7.9).

## Tests

- ruff check + format, mypy (strict): clean.
- Affected suites green (`test_decrypt_locations.py`, `test_coordinator_decrypt_reauth_escalation.py`, `test_decrypt_locations_log_severity.py`).
- Delta coverage: every changed production line executed.
- Independent adversarial diff review: PASS (class sweep confirmed the guard was the only unsound discriminator; both `WrappedLocation` callsites set the field; SEMANTIC rows stay guard-neutral because they carry no coordinate).

## Risk & Rollback

Low. Single-file logic change plus a dataclass field and one test. Rollback = revert the commit. The device-level acceptance test (fresh auth with a mixed stale-own + crowdsourced response) can only be reproduced against the live Google backend.

## Note for reviewers

Targets `1.7` so that, once merged, it automatically lands in the open cross-fork PR #197 on BSkando (`jleinenbach:1.7 -> BSkando:1.7`).
