### PR TITLE
fix(coordinator): predictive poll respects location_poll_interval cadence (Stage 1)

### DIFF
--- a/custom_components/googlefindmy/coordinator/helpers/update.py
+++ b/custom_components/googlefindmy/coordinator/helpers/update.py
@@ -244,6 +244,9 @@ def is_poll_cycle_due(
     # Predictive due, but never below the chosen cadence. min_poll_interval
     # stays a pure API safety floor; effective_interval governs the cadence,
     # so predictive pre-fetch no longer pulls polling below effective_interval.
+    # hard_limit_passed is redundant while callers keep the invariant
+    # effective_interval >= min_poll_interval, but is retained so this pure
+    # function stays correct for any caller (do not "simplify" it away).
     if predictive_due and hard_limit_passed and elapsed >= effective_interval:
         return True
 

--- a/custom_components/googlefindmy/coordinator/helpers/update.py
+++ b/custom_components/googlefindmy/coordinator/helpers/update.py
@@ -217,7 +217,10 @@ def is_poll_cycle_due(
     Poll is due when:
     1. Cold start (first poll with no location data) - always due
     2. Elapsed time >= effective_interval AND not predictively blocked
-    3. Predictive due AND hard limit passed
+    3. Predictive due AND hard limit passed AND elapsed >= effective_interval
+       (min_poll_interval alone no longer triggers a poll below the chosen
+       cadence; effective_interval governs the cadence, min_poll_interval
+       stays a pure API safety floor)
 
     Args:
         elapsed: Time since last poll in seconds.
@@ -238,8 +241,10 @@ def is_poll_cycle_due(
     if elapsed >= effective_interval and not predictive_block:
         return True
 
-    # Predictive due with hard limit passed
-    if predictive_due and hard_limit_passed:
+    # Predictive due, but never below the chosen cadence. min_poll_interval
+    # stays a pure API safety floor; effective_interval governs the cadence,
+    # so predictive pre-fetch no longer pulls polling below effective_interval.
+    if predictive_due and hard_limit_passed and elapsed >= effective_interval:
         return True
 
     return False

--- a/tests/test_coordinator_predictive_polling.py
+++ b/tests/test_coordinator_predictive_polling.py
@@ -149,10 +149,17 @@ async def test_predictive_polling_defers_until_predicted_window(
 
 
 @pytest.mark.asyncio
-async def test_predictive_polling_triggers_overdue_poll(
+async def test_predictive_overdue_does_not_poll_below_cadence_floor(
     coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Overdue predictions trigger an immediate poll when limits allow."""
+    """An overdue prediction must not pull polling below the cadence floor.
+
+    Stage 1 makes ``effective_interval`` govern the cadence: predictive
+    pre-fetch no longer fires while ``elapsed < effective_interval``. Here
+    ``elapsed == min_poll_interval`` (the API safety floor) but stays below
+    ``effective_interval``, so no poll is scheduled even though the device's
+    prediction is overdue.
+    """
 
     wall_now = time.time()
     coordinator._device_update_history["dev-id"] = deque(
@@ -160,7 +167,73 @@ async def test_predictive_polling_triggers_overdue_poll(
         maxlen=4,
     )
     _prime_cached_devices(coordinator, wall_now)
+    # elapsed == min_poll_interval < effective_interval → below the cadence floor.
     coordinator._last_poll_mono = time.monotonic() - coordinator.min_poll_interval
+    baseline_polls = sum(
+        1 for _, name in coordinator.hass.created if name == f"{DOMAIN}.poll_cycle"
+    )
+
+    monkeypatch.setattr(coordinator, "_ensure_service_device_exists", lambda: None)
+    monkeypatch.setattr(
+        coordinator, "_ensure_registry_for_devices", lambda *_args, **_kwargs: 0
+    )
+    monkeypatch.setattr(
+        coordinator, "_refresh_subentry_index", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        coordinator,
+        "_async_build_device_snapshot_with_fallbacks",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(coordinator, "_store_subentry_snapshots", lambda _snap: None)
+
+    poll_cycle = AsyncMock(return_value=None)
+    coordinator._async_start_poll_cycle = poll_cycle
+
+    short_retries: list[float] = []
+    coordinator._schedule_short_retry = short_retries.append
+
+    await coordinator._async_update_data()
+    poll_tasks = [
+        task
+        for task, name in coordinator.hass.created
+        if name == f"{DOMAIN}.poll_cycle"
+    ]
+    # Below the cadence floor the overdue prediction is suppressed: no poll,
+    # and no short retry is scheduled (that only happens on predictive_block).
+    assert len(poll_tasks) == baseline_polls
+    assert not short_retries
+    assert poll_cycle.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_predictive_overdue_polls_at_cadence_floor(
+    coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An overdue prediction does not suppress the poll at the cadence floor.
+
+    Guard companion to the below-floor case: with ``elapsed >= effective_interval``
+    the regular cadence branch admits the poll, and this test proves the overdue
+    prediction (``predictive_due``) neither blocks it nor triggers a short retry.
+    The discriminating coverage of the new ``elapsed >= effective_interval`` term
+    on the predictive branch itself lives in the pure-function unit tests
+    (``test_coordinator_update.py``); at integration level ``predictive_block``
+    is not freely settable, so the cadence branch is the only realistic path.
+    Uses the same ``max(location_poll_interval, min_poll_interval)`` the
+    coordinator computes (no magic value).
+    """
+
+    wall_now = time.time()
+    coordinator._device_update_history["dev-id"] = deque(
+        [wall_now - 900, wall_now - 600, wall_now - 350],
+        maxlen=4,
+    )
+    _prime_cached_devices(coordinator, wall_now)
+    effective_interval = max(
+        coordinator.location_poll_interval, coordinator.min_poll_interval
+    )
+    # elapsed == effective_interval → the cadence floor is satisfied.
+    coordinator._last_poll_mono = time.monotonic() - effective_interval
     baseline_polls = sum(
         1 for _, name in coordinator.hass.created if name == f"{DOMAIN}.poll_cycle"
     )

--- a/tests/test_coordinator_update.py
+++ b/tests/test_coordinator_update.py
@@ -497,3 +497,52 @@ class TestIsPollCycleDue:
             is_cold_start=False,
         )
         assert result is False
+
+    def test_predictive_due_below_real_cadence_not_due(self) -> None:
+        """Cadence fix: predictive due below effective_interval must not poll.
+
+        Discriminating case for the Stage-1 fix using the reported real-world
+        cadence (effective_interval=241s). elapsed=100 is past the raw
+        min_poll_interval floor (hard_limit_passed=True) but below the chosen
+        cadence, so the poll must NOT fire. Reverting the fix
+        (dropping ``and elapsed >= effective_interval``) flips this to True,
+        which keeps the mutation gegenprobe sharp.
+        """
+        result = is_poll_cycle_due(
+            elapsed=100.0,
+            effective_interval=241.0,
+            predictive_block=False,
+            predictive_due=True,
+            hard_limit_passed=True,
+            is_cold_start=False,
+        )
+        assert result is False
+
+    def test_predictive_due_at_cadence_due_via_interval(self) -> None:
+        """At/above the cadence, the normal interval branch fires (branch 2)."""
+        result = is_poll_cycle_due(
+            elapsed=245.0,
+            effective_interval=241.0,
+            predictive_block=False,
+            predictive_due=True,
+            hard_limit_passed=True,
+            is_cold_start=False,
+        )
+        assert result is True
+
+    def test_predictive_due_past_cadence_due_when_blocked(self) -> None:
+        """Predictive branch 3 fires past cadence even when interval branch is blocked.
+
+        With predictive_block=True the normal interval branch (2) is skipped,
+        so this exercises the TRUE path of the new ``elapsed >= effective_interval``
+        term inside branch 3 (predictive due, past cadence -> poll).
+        """
+        result = is_poll_cycle_due(
+            elapsed=245.0,
+            effective_interval=241.0,
+            predictive_block=True,
+            predictive_due=True,
+            hard_limit_passed=True,
+            is_cold_start=False,
+        )
+        assert result is True

--- a/tests/test_coordinator_update.py
+++ b/tests/test_coordinator_update.py
@@ -420,8 +420,14 @@ class TestIsPollCycleDue:
         )
         assert result is False
 
-    def test_due_on_predictive_due_with_hard_limit(self) -> None:
-        """Should be due on predictive_due when hard limit passed."""
+    def test_not_due_on_predictive_due_below_cadence(self) -> None:
+        """Predictive due must not trigger below the chosen cadence.
+
+        Stage-1 cadence fix: min_poll_interval (reflected here by
+        hard_limit_passed=True) alone no longer pulls a poll below
+        effective_interval. Predictive pre-fetch only fires once
+        elapsed >= effective_interval.
+        """
         result = is_poll_cycle_due(
             elapsed=30.0,
             effective_interval=60.0,
@@ -430,7 +436,7 @@ class TestIsPollCycleDue:
             hard_limit_passed=True,
             is_cold_start=False,
         )
-        assert result is True
+        assert result is False
 
     def test_not_due_on_predictive_due_without_hard_limit(self) -> None:
         """Should not be due on predictive_due without hard limit."""

--- a/tests/test_coordinator_update.py
+++ b/tests/test_coordinator_update.py
@@ -546,3 +546,21 @@ class TestIsPollCycleDue:
             is_cold_start=False,
         )
         assert result is True
+
+    def test_hard_limit_gate_still_blocks_branch_three(self) -> None:
+        """hard_limit_passed must still gate branch 3, even past cadence.
+
+        Pins the retained ``hard_limit_passed`` term: with it False, branch 3
+        must not fire even though elapsed >= effective_interval and the interval
+        branch is blocked. Dropping ``hard_limit_passed`` from branch 3 flips
+        this to True, so the contract stays locked (caller-independence).
+        """
+        result = is_poll_cycle_due(
+            elapsed=245.0,
+            effective_interval=241.0,
+            predictive_block=True,
+            predictive_due=True,
+            hard_limit_passed=False,
+            is_cold_start=False,
+        )
+        assert result is False


### PR DESCRIPTION
## Problem

With `location_poll_interval` set to e.g. 241 s, the coordinator still polls the
worn phone every ~91–153 s (empirical, live log). The predictive branch of
`is_poll_cycle_due` only respected the raw `min_poll_interval` floor (default
60 s), so predictive pre-fetch pulled the effective cadence far below the
configured value. `min_poll_interval` is not exposed in the options UI, so users
cannot even work around it.

Root cause: `is_poll_cycle_due` branch 3 fired on `predictive_due and
hard_limit_passed`, where `hard_limit_passed` is `elapsed >= min_poll_interval`.
That let the predictive path trigger anywhere above 60 s, ignoring
`effective_interval = max(location_poll_interval, min_poll_interval)`.

## This PR (Stage 1 of 2)

One-line logic change in the pure decision function
`coordinator/helpers/update.py`:

```python
-    if predictive_due and hard_limit_passed:
+    if predictive_due and hard_limit_passed and elapsed >= effective_interval:
```

Now `effective_interval` governs the cadence and `min_poll_interval` becomes a
pure API safety floor. `polling.py` is not touched.

**Correctness:** `effective_interval >= min_poll_interval` always, and
`predictive_due`/`predictive_block` are mutually exclusive in the caller, so the
cadence is now guaranteed `>= effective_interval`, never faster. `polling.py`'s
`self.min_poll_interval` users are unchanged.

## Dual goal & the honest tradeoff

The goal is dual: (a) minimal server load / no over-polling, (b) maximum
freshness per device. **Stage 1 fully serves (a)** but temporarily disables the
adaptive predictive pre-fetch below the configured cadence for **all** devices,
so automatic freshness becomes a flat `location_poll_interval`. The manual
locate path (button/service) is not touched and keeps its own throttling
(in-flight guard + optimistic 60 s cooldown + success cooldown
`clamp(max(60, location_poll_interval), 60, 600)` + baseline reset), so
on-demand freshness is unaffected.

**Stage 2 (follow-up commits on this same PR)** restores goal (b) via a
per-device due-gate: a device is polled predictively only when *its own*
prediction is due, not the fastest neighbour's. That removes the fan-out
("thundering herd") root cause and re-enables adaptive per-device freshness.

## Behavior change note

One existing unit test encoded the old predictive-below-cadence behavior
(`test_due_on_predictive_due_with_hard_limit`) and is intentionally updated to
assert the new contract (renamed `test_not_due_on_predictive_due_below_cadence`).
This is the whole point of Stage 1.

## Tests

`custom_components/googlefindmy/coordinator/helpers/update.py`: **100 % line +
branch coverage** (61 stmts, 36 branches, 0 missing, 0 partial). New
discriminating regression tests at the reported real-world cadence
(effective_interval = 241 s); mutation gegenprobe verified (dropping the new
`elapsed >= effective_interval` term or `hard_limit_passed` each turns a test
red). `ruff` + `mypy` clean.

No version bump (maintainer-owned). PR stays **draft** until the on-device
acceptance test and Stage 2.
