### PR TITLE
feat: per-device poll interval override (Direction A)

### DIFF
--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -97,11 +97,14 @@ from .const import (
     DEFAULT_SEMANTIC_DETECTION_RADIUS,
     DEFAULT_SHOW_LOCATION_AGE,
     DEFAULT_STALE_THRESHOLD,
+    DEVICE_POLL_INTERVAL_MAX_S,
+    DEVICE_POLL_INTERVAL_MIN_S,
     # Core domain & credential keys
     DOMAIN,
     OPT_CONTRIBUTOR_MODE,
     OPT_DELETE_CACHES_ON_REMOVE,
     OPT_DEVICE_POLL_DELAY,
+    OPT_DEVICE_POLL_INTERVAL,
     OPT_ENABLE_STATS_ENTITIES,
     OPT_IGNORED_DEVICES,
     # Options (non-secret runtime settings)
@@ -121,6 +124,7 @@ from .const import (
     TRACKER_FEATURE_PLATFORMS,
     TRACKER_SUBENTRY_KEY,
     TRACKER_SUBENTRY_TRANSLATION_KEY,
+    coerce_device_poll_interval_mapping,
     coerce_ignored_mapping,
     service_device_identifier,
 )
@@ -4743,6 +4747,7 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
 
         super().__init__(*args, **kwargs)
         self._semantic_location_editing: str | None = None
+        self._per_device_poll_editing: str | None = None
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -4752,6 +4757,7 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
             step_id="init",
             menu_options=[
                 "settings",
+                "per_device_poll",
                 "credentials",
                 "visibility",
                 "semantic_locations",
@@ -5673,6 +5679,126 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
             data_schema=schema,
             description_placeholders=_SUBENTRY_PLACEHOLDERS,
         )
+
+    # ---------- Per-device poll interval (Direction A: slower than cadence) ----
+    def _per_device_poll_intervals(self) -> dict[str, int]:
+        """Return the current, coerced per-device poll interval overrides."""
+        raw = self.config_entry.options.get(OPT_DEVICE_POLL_INTERVAL) or {}
+        return coerce_device_poll_interval_mapping(raw)
+
+    async def async_step_per_device_poll(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Pick a device whose per-device poll interval should be set or cleared.
+
+        Direction A only: a per-device value slows an individual device down
+        relative to the coordinator-wide cadence; a value below the cadence is
+        clamped by ``max(per_device_interval, effective_interval)`` at runtime.
+        """
+        device_choices = self._device_choice_map()
+        if not device_choices:
+            return self.async_abort(reason="no_devices")
+
+        current = self._per_device_poll_intervals()
+        if current:
+            display = "\n".join(
+                f"{device_choices.get(dev_id, dev_id)}: {seconds}s"
+                for dev_id, seconds in sorted(current.items())
+            )
+        else:
+            display = "None configured"
+
+        schema = vol.Schema(
+            {
+                vol.Required("device"): vol.In(
+                    {
+                        dev_id: f"{name} ({dev_id})"
+                        for dev_id, name in device_choices.items()
+                    }
+                )
+            }
+        )
+        placeholders = {"per_device_poll_intervals": display}
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="per_device_poll",
+                data_schema=schema,
+                description_placeholders=placeholders,
+            )
+
+        selected = str(user_input.get("device", ""))
+        if selected not in device_choices:
+            return self.async_show_form(
+                step_id="per_device_poll",
+                data_schema=schema,
+                errors={"device": "invalid_device"},
+                description_placeholders=placeholders,
+            )
+
+        self._per_device_poll_editing = selected
+        return await self.async_step_per_device_poll_set()
+
+    async def async_step_per_device_poll_set(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Set (or clear, by leaving it empty) the selected device's interval."""
+        device_id = self._per_device_poll_editing
+        device_choices = self._device_choice_map()
+        if not device_id or device_id not in device_choices:
+            # Selection was lost; return to the picker rather than guess.
+            return await self.async_step_per_device_poll()
+
+        current = self._per_device_poll_intervals()
+        placeholders = {
+            "device_name": f"{device_choices.get(device_id, device_id)} ({device_id})",
+            "min_seconds": str(DEVICE_POLL_INTERVAL_MIN_S),
+            "max_seconds": str(DEVICE_POLL_INTERVAL_MAX_S),
+        }
+        base_schema = vol.Schema(
+            {
+                vol.Optional("interval"): vol.All(
+                    vol.Coerce(int),
+                    vol.Range(
+                        min=DEVICE_POLL_INTERVAL_MIN_S,
+                        max=DEVICE_POLL_INTERVAL_MAX_S,
+                    ),
+                )
+            }
+        )
+        suggested: dict[str, Any] = {}
+        if device_id in current:
+            suggested["interval"] = current[device_id]
+        schema = self.add_suggested_values_to_schema(base_schema, suggested)
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="per_device_poll_set",
+                data_schema=schema,
+                description_placeholders=placeholders,
+            )
+
+        new_map = dict(current)
+        interval_value = user_input.get("interval")
+        if interval_value is not None:
+            new_map[device_id] = int(interval_value)
+        else:
+            # Empty submission clears the override for this device.
+            new_map.pop(device_id, None)
+
+        new_options = dict(self.config_entry.options)
+        new_options[OPT_DEVICE_POLL_INTERVAL] = coerce_device_poll_interval_mapping(
+            new_map
+        )
+        self._per_device_poll_editing = None
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry, options=new_options
+        )
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(self.config_entry.entry_id)
+        )
+        return await self.async_step_init()
 
     async def async_step_repairs(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -164,7 +164,9 @@ DEFAULT_MIN_POLL_INTERVAL: int = 60  # seconds; hard lower bound between cycles
 # cadence floor: a per-device value below it is clamped by
 # ``max(per_device_interval, effective_interval)`` and would be inert anyway.
 DEVICE_POLL_INTERVAL_MIN_S: int = DEFAULT_MIN_POLL_INTERVAL  # seconds
-DEVICE_POLL_INTERVAL_MAX_S: int = 3600  # seconds (1 hour), mirrors location_poll_interval
+DEVICE_POLL_INTERVAL_MAX_S: int = (
+    3600  # seconds (1 hour), mirrors location_poll_interval
+)
 
 # Manual locate policy (button/service)
 LOCATE_COOLDOWN_S: int = DEFAULT_MIN_POLL_INTERVAL

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -105,6 +105,12 @@ DATA_AUTH_METHOD: str = "auth_method"  # "secrets_json" | "individual_tokens"
 OPT_LOCATION_POLL_INTERVAL: str = "location_poll_interval"
 OPT_DEVICE_POLL_DELAY: str = "device_poll_delay"
 OPT_MIN_POLL_INTERVAL: str = "min_poll_interval"
+# Per-device poll interval override (Direction A only): mapping
+# {device_id: seconds}. A device polls no more often than
+# ``max(per_device_interval, effective_interval)``; values below the
+# coordinator-wide cadence are clamped, not silently honored. Managed by a
+# dedicated options flow (like OPT_IGNORED_DEVICES), not a raw scalar field.
+OPT_DEVICE_POLL_INTERVAL: str = "device_poll_interval"
 OPT_ALLOW_HISTORY_FALLBACK: str = "allow_history_fallback"
 OPT_ENABLE_STATS_ENTITIES: str = "enable_stats_entities"
 OPT_GOOGLE_HOME_FILTER_ENABLED: str = "google_home_filter_enabled"
@@ -123,6 +129,7 @@ OPT_STALE_THRESHOLD_ENABLED: str = "stale_threshold_enabled"
 OPTION_KEYS: tuple[str, ...] = (
     OPT_IGNORED_DEVICES,
     OPT_LOCATION_POLL_INTERVAL,
+    OPT_DEVICE_POLL_INTERVAL,
     OPT_DEVICE_POLL_DELAY,
     OPT_MIN_POLL_INTERVAL,
     OPT_ALLOW_HISTORY_FALLBACK,
@@ -152,6 +159,12 @@ DEVICE_LIST_POLL_INTERVAL: int = 300
 DEFAULT_LOCATION_POLL_INTERVAL: int = 300  # seconds; start a new polling cycle
 DEFAULT_DEVICE_POLL_DELAY: int = 5  # seconds; inter-device delay within one cycle
 DEFAULT_MIN_POLL_INTERVAL: int = 60  # seconds; hard lower bound between cycles
+
+# Per-device poll interval bounds (Direction A). The lower bound equals the
+# cadence floor: a per-device value below it is clamped by
+# ``max(per_device_interval, effective_interval)`` and would be inert anyway.
+DEVICE_POLL_INTERVAL_MIN_S: int = DEFAULT_MIN_POLL_INTERVAL  # seconds
+DEVICE_POLL_INTERVAL_MAX_S: int = 3600  # seconds (1 hour), mirrors location_poll_interval
 
 # Manual locate policy (button/service)
 LOCATE_COOLDOWN_S: int = DEFAULT_MIN_POLL_INTERVAL
@@ -249,6 +262,8 @@ DEFAULT_OPTIONS: dict[str, object] = {
     # Store ignored devices as mapping {device_id: {"name": str, "aliases": [str], "ignored_at": int, "source": str}}
     # Backwards-compatible: old list[str] or dict[str,str] is auto-migrated on first write.
     OPT_IGNORED_DEVICES: {},
+    # Empty mapping = no per-device override; every device uses the cadence.
+    OPT_DEVICE_POLL_INTERVAL: {},
     OPT_LOCATION_POLL_INTERVAL: DEFAULT_LOCATION_POLL_INTERVAL,
     OPT_DEVICE_POLL_DELAY: DEFAULT_DEVICE_POLL_DELAY,
     OPT_MIN_POLL_INTERVAL: DEFAULT_MIN_POLL_INTERVAL,
@@ -374,6 +389,50 @@ def ignored_choices_for_ui(
     }
 
 
+DevicePollIntervalMapping = dict[str, int]
+
+
+def coerce_device_poll_interval_mapping(raw: object) -> DevicePollIntervalMapping:
+    """Coerce arbitrary stored input into a clean ``{device_id: seconds}`` map.
+
+    Defensive against hand-edited or legacy option values: only string keys
+    with integer-coercible values are kept, and each value is clamped to
+    ``DEVICE_POLL_INTERVAL_MIN_S..DEVICE_POLL_INTERVAL_MAX_S``. Invalid entries
+    are dropped rather than raising, so a corrupt option can never break the
+    poll loop. There is no legacy schema to migrate (new key), so no
+    ``changed`` flag is returned.
+
+    Args:
+        raw: The stored option value (expected mapping, but any type tolerated).
+
+    Returns:
+        A new mapping of device id to a bounded integer interval in seconds.
+    """
+    out: DevicePollIntervalMapping = {}
+    if not isinstance(raw, Mapping):
+        return out
+    for dev_id, value in raw.items():
+        if not isinstance(dev_id, str) or not dev_id:
+            continue
+        # Accept int/float/str-of-int; reject bool (bool is an int subclass).
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            seconds = int(value)
+        elif isinstance(value, str):
+            try:
+                seconds = int(value.strip())
+            except (TypeError, ValueError):
+                continue
+        else:
+            continue
+        seconds = max(
+            DEVICE_POLL_INTERVAL_MIN_S, min(DEVICE_POLL_INTERVAL_MAX_S, seconds)
+        )
+        out[dev_id] = seconds
+    return out
+
+
 # --------------------------------------------------------------------------------------
 # CONFIG_FIELDS — server-side validation contract for config/options flows
 # --------------------------------------------------------------------------------------
@@ -421,6 +480,9 @@ CONFIG_FIELDS: dict[str, dict[str, object]] = {
     },
     # OPT_IGNORED_DEVICES is intentionally omitted: it is managed by a dedicated
     # visibility flow and not edited as a raw field (list of ids).
+    # OPT_DEVICE_POLL_INTERVAL is likewise omitted: it is a mapping
+    # {device_id: seconds} managed by a dedicated per-device options flow, where
+    # each value is range-validated (DEVICE_POLL_INTERVAL_MIN_S..MAX_S).
 }
 
 # --------------------------------------------------------------------------------------
@@ -611,6 +673,7 @@ __all__ = [
     "DATA_AUTH_METHOD",
     "OPT_IGNORED_DEVICES",
     "OPT_LOCATION_POLL_INTERVAL",
+    "OPT_DEVICE_POLL_INTERVAL",
     "OPT_DEVICE_POLL_DELAY",
     "OPT_MIN_POLL_INTERVAL",
     "OPT_ALLOW_HISTORY_FALLBACK",
@@ -628,6 +691,8 @@ __all__ = [
     "DEFAULT_LOCATION_POLL_INTERVAL",
     "DEFAULT_DEVICE_POLL_DELAY",
     "DEFAULT_MIN_POLL_INTERVAL",
+    "DEVICE_POLL_INTERVAL_MIN_S",
+    "DEVICE_POLL_INTERVAL_MAX_S",
     "LOCATE_COOLDOWN_S",
     "DEFAULT_ALLOW_HISTORY_FALLBACK",
     "DEFAULT_ENABLE_STATS_ENTITIES",
@@ -680,6 +745,7 @@ __all__ = [
     "STORAGE_VERSION",
     "coerce_ignored_mapping",
     "ignored_choices_for_ui",
+    "coerce_device_poll_interval_mapping",
     "WEEK_SECONDS",
     "map_token_secret_seed",
     "map_token_hex_digest",

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -8,6 +8,7 @@ Keep comments and docstrings in English; user-facing strings belong in translati
 from __future__ import annotations
 
 import hashlib
+import math
 import time
 from collections.abc import Mapping, Sequence
 from typing import Final, Literal
@@ -307,6 +308,27 @@ def _coerce_aliases(value: object) -> list[str]:
     return []
 
 
+def _finite_int_or_none(value: object) -> int | None:
+    """Convert a finite ``int``/``float`` to ``int``; return ``None`` otherwise.
+
+    ``bool``, non-numeric types, and non-finite floats (``NaN``/``±inf``) all
+    yield ``None``. This exists because ``int(float("nan"))`` raises
+    ``ValueError`` and ``int(float("inf"))`` raises ``OverflowError`` -- either
+    would defeat the drop-invalid, never-raise contract of the coercers below
+    when a corrupt ``.storage`` edit or a direct-options writer stores such a
+    value. Guarding on ``math.isfinite`` keeps those coercers total.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return int(value)
+    return None
+
+
 def coerce_ignored_mapping(raw: object) -> tuple[IgnoredMapping, bool]:
     """Coerce various legacy shapes into v2 mapping.
     Accepted inputs:
@@ -363,8 +385,9 @@ def coerce_ignored_mapping(raw: object) -> tuple[IgnoredMapping, bool]:
                         name = name_value
                     aliases = _coerce_aliases(str_meta.get(_IGN_KEY_ALIASES))
                     ignored_value = str_meta.get(_IGN_KEY_IGNORED_AT)
-                    if isinstance(ignored_value, (int, float)):
-                        ignored_at = int(ignored_value)
+                    coerced_at = _finite_int_or_none(ignored_value)
+                    if coerced_at is not None:
+                        ignored_at = coerced_at
                     source_value = str_meta.get(_IGN_KEY_SOURCE)
                     if isinstance(source_value, str) and source_value:
                         source = source_value
@@ -416,11 +439,13 @@ def coerce_device_poll_interval_mapping(raw: object) -> DevicePollIntervalMappin
     for dev_id, value in raw.items():
         if not isinstance(dev_id, str) or not dev_id:
             continue
-        # Accept int/float/str-of-int; reject bool (bool is an int subclass).
-        if isinstance(value, bool):
-            continue
+        # Accept int/float/str-of-int; reject bool (bool is an int subclass)
+        # and non-finite floats (NaN/inf would raise on int() below).
         if isinstance(value, (int, float)):
-            seconds = int(value)
+            coerced = _finite_int_or_none(value)
+            if coerced is None:
+                continue
+            seconds = coerced
         elif isinstance(value, str):
             try:
                 seconds = int(value.strip())

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -79,6 +79,7 @@ class _MixinBase:
     _device_action_locks: dict[str, asyncio.Lock]
     _sound_request_uuids: dict[str, str]
     _device_poll_cooldown_until: dict[str, float]
+    _device_last_poll_mono: dict[str, float]
     _enabled_poll_device_ids: set[str]
     _devices_with_entry: set[str]
     _identity_key_to_devices: dict[bytes, set[str]]
@@ -170,6 +171,9 @@ class _MixinBase:
 
     def _get_ignored_set(self) -> set[str]:
         raise NotImplementedError
+
+    def _get_device_poll_interval_map(self) -> dict[str, int]:
+        raise NotImplementedError  # pragma: no cover - abstract mixin stub
 
     def _get_google_home_filter(self) -> Any:
         raise NotImplementedError

--- a/custom_components/googlefindmy/coordinator/helpers/update.py
+++ b/custom_components/googlefindmy/coordinator/helpers/update.py
@@ -19,6 +19,7 @@ from typing import Any
 
 __all__ = [
     "calculate_presence_ttl",
+    "device_due_by_interval",
     "filter_and_dedupe_devices",
     "is_fatal_fcm_auth_error",
     "is_poll_cycle_due",
@@ -251,3 +252,45 @@ def is_poll_cycle_due(
         return True
 
     return False
+
+
+def device_due_by_interval(
+    now_mono: float,
+    last_poll_mono: float,
+    per_device_interval: float,
+    effective_interval: float,
+) -> bool:
+    """Decide whether a single device is due under its per-device interval.
+
+    Direction A only: a device may be polled *less* often than the
+    coordinator-wide cadence, never more. The effective floor is therefore
+    ``max(per_device_interval, effective_interval)`` so a configured value
+    below the cadence is clamped, not honored. A device with no override
+    (``per_device_interval <= 0``) reduces to the cadence floor and thus always
+    passes once the global gate has admitted the cycle.
+
+    This predicate is a pure function of monotonic timestamps and never
+    mutates the stamp; the caller stamps ``last_poll_mono`` only at the real
+    poll end for devices that actually ran (so a device the global gate never
+    started does not have its floor advanced).
+
+    Args:
+        now_mono: Current monotonic clock reading in seconds.
+        last_poll_mono: Monotonic timestamp of this device's last real poll
+            (``0.0`` when never polled, which makes the device due).
+        per_device_interval: Configured per-device interval in seconds
+            (``0.0`` or negative means "no override").
+        effective_interval: Coordinator-wide cadence floor in seconds.
+
+    Returns:
+        True if the device's own interval has elapsed and it should stay in the
+        poll set; False if it should be skipped this cycle.
+    """
+    # Never polled (absent stamp passed as 0.0, or any non-positive sentinel):
+    # always due. Comparing (now_mono - 0.0) >= floor would otherwise wrongly
+    # skip a never-polled device shortly after boot, when monotonic uptime is
+    # still below the interval (anti-starvation).
+    if last_poll_mono <= 0.0:
+        return True
+    floor = max(per_device_interval, effective_interval)
+    return (now_mono - last_poll_mono) >= floor

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -151,9 +151,11 @@ from ..const import (
     # Required symbols provided by const.py (5.1-A)
     EVENT_AUTH_ERROR,
     EVENT_AUTH_OK,
+    OPT_DEVICE_POLL_INTERVAL,
     OPT_IGNORED_DEVICES,
     OPT_SEMANTIC_LOCATIONS,
     UPDATE_INTERVAL,
+    coerce_device_poll_interval_mapping,
     coerce_ignored_mapping,
 )
 from ..ha_typing import DataUpdateCoordinator
@@ -786,6 +788,11 @@ class GoogleFindMyCoordinator(
 
         # Per-device poll cooldowns after owner/crowdsourced reports.
         self._device_poll_cooldown_until: dict[str, float] = {}
+        # Per-device last real-poll monotonic stamp, keyed by device id. Written
+        # only at the real poll end (mirrors _last_poll_mono) for devices that
+        # actually ran a cycle; read by the per-device interval filter. Absent
+        # key => never polled => device is due.
+        self._device_last_poll_mono: dict[str, float] = {}
         # Per-device interval history for predictive polling
         self._device_interval_history: dict[str, list[float]] = {}
 
@@ -1440,6 +1447,30 @@ class GoogleFindMyCoordinator(
     def is_ignored(self, device_id: str) -> bool:
         """Return True if the device is currently ignored by user choice."""
         return device_id in self._get_ignored_set()
+
+    def _get_device_poll_interval_map(self) -> dict[str, int]:
+        """Return the per-device poll interval overrides (options-first).
+
+        Resolved live from ``config_entry.options`` on each read (like
+        ``_get_ignored_set``) so an options reload propagates without a
+        coordinator restart. Values are coerced and clamped to
+        ``DEVICE_POLL_INTERVAL_MIN_S..MAX_S``; an empty or missing mapping means
+        every device follows the coordinator-wide cadence.
+
+        Returns:
+            Mapping of device id to a bounded per-device interval in seconds.
+        """
+        try:
+            entry = self.config_entry
+            if entry is not None:
+                raw = entry.options.get(
+                    OPT_DEVICE_POLL_INTERVAL,
+                    DEFAULT_OPTIONS.get(OPT_DEVICE_POLL_INTERVAL, {}),
+                )
+                return coerce_device_poll_interval_mapping(raw)
+        except Exception:  # defensive: never break polling on a bad option
+            pass
+        return {}
 
     # ---------------------------- Metrics & errors helpers ------------------
     def safe_update_metric(self, key: str, value: float) -> None:

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -73,6 +73,9 @@ from .helpers.update import (
     calculate_presence_ttl as _calculate_presence_ttl_impl,
 )
 from .helpers.update import (
+    device_due_by_interval as _device_due_by_interval_impl,
+)
+from .helpers.update import (
     filter_and_dedupe_devices as _filter_and_dedupe_impl,
 )
 from .helpers.update import (
@@ -1429,6 +1432,25 @@ class PollingOperations(_MixinBase):
                     if now_mono >= self._device_poll_cooldown_until.get(d["id"], 0.0)
                 ]
 
+            # Apply per-device poll intervals (Direction A: a device may poll
+            # less often than the cadence, never more). Additive filter: a
+            # device is dropped from this cycle while its own interval (floored
+            # at effective_interval) has not elapsed since its last real poll.
+            # Reads _device_last_poll_mono only; the stamp is written at the
+            # real poll end so a globally-gated-out device keeps its floor.
+            per_device_interval = self._get_device_poll_interval_map()
+            if per_device_interval and devices_to_poll:
+                devices_to_poll = [
+                    d
+                    for d in devices_to_poll
+                    if _device_due_by_interval_impl(
+                        now_mono,
+                        self._device_last_poll_mono.get(d["id"], 0.0),
+                        float(per_device_interval.get(d["id"], 0)),
+                        effective_interval,
+                    )
+                ]
+
             # Cold start detection: force immediate poll on first install when devices have no location data
             is_cold_start = bool(
                 self._last_poll_mono == 0.0
@@ -2191,7 +2213,17 @@ class PollingOperations(_MixinBase):
                         self.min_poll_interval,
                     )
                     self._schedule_short_retry(self.min_poll_interval)
-                self._last_poll_mono = time.monotonic()
+                cycle_end_mono = time.monotonic()
+                self._last_poll_mono = cycle_end_mono
+                # Stamp the per-device interval floor at the same instant as the
+                # global baseline, for exactly the devices this cycle ran. The
+                # per-device filter reads (never writes) this map, so a device
+                # the global gate never started keeps its earlier stamp and
+                # stays due; only really-polled devices advance their floor.
+                for _polled in devices:
+                    _polled_id = _polled.get("id")
+                    if isinstance(_polled_id, str) and _polled_id:
+                        self._device_last_poll_mono[_polled_id] = cycle_end_mono
                 self._is_polling = False
                 self.safe_update_metric("last_poll_end_mono", time.monotonic())
                 if cycle_failed:

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1669,6 +1669,15 @@ class PollingOperations(_MixinBase):
 
             last_exception: Exception | None = None
             _any_device_got_data = False
+            # IDs of devices that actually entered the per-device request path
+            # this cycle. The finally-block per-device stamp must advance the
+            # poll floor only for these. The finally runs on every exit,
+            # including an early return/raise/cancel from mid-loop (reauth
+            # handlers, cancellation), so stamping the full scheduled batch
+            # would mark devices the loop never reached as freshly polled and
+            # suppress their next update for a full per-device interval without
+            # any real poll having happened.
+            attempted_ids: set[str] = set()
             try:
                 cycle_failed = False
                 # First account-wide decryption error seen this cycle (None == the
@@ -1694,6 +1703,11 @@ class PollingOperations(_MixinBase):
                 cycle_had_successful_decrypt = False
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
+                    # Mark attempted at iteration entry (before the request), so
+                    # a device whose poll raises is still stamped, but devices
+                    # after an early loop exit are not (see attempted_ids above).
+                    if isinstance(dev_id, str) and dev_id:
+                        attempted_ids.add(dev_id)
                     dev_name = dev.get("name", dev_id)
                     _LOGGER.debug(
                         "Sequential poll: requesting location for %s (%d/%d)",
@@ -2216,14 +2230,13 @@ class PollingOperations(_MixinBase):
                 cycle_end_mono = time.monotonic()
                 self._last_poll_mono = cycle_end_mono
                 # Stamp the per-device interval floor at the same instant as the
-                # global baseline, for exactly the devices this cycle ran. The
-                # per-device filter reads (never writes) this map, so a device
-                # the global gate never started keeps its earlier stamp and
-                # stays due; only really-polled devices advance their floor.
-                for _polled in devices:
-                    _polled_id = _polled.get("id")
-                    if isinstance(_polled_id, str) and _polled_id:
-                        self._device_last_poll_mono[_polled_id] = cycle_end_mono
+                # global baseline, for exactly the devices this cycle actually
+                # attempted. The per-device filter reads (never writes) this
+                # map, so a device the loop never reached (early return/raise/
+                # cancel) keeps its earlier stamp and stays due; only devices
+                # that entered the request path advance their floor.
+                for _polled_id in attempted_ids:
+                    self._device_last_poll_mono[_polled_id] = cycle_end_mono
                 self._is_polling = False
                 self.safe_update_metric("last_poll_end_mono", time.monotonic())
                 if cycle_failed:

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Update credentials",
           "settings": "Modify settings",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Device visibility",
           "semantic_locations": "Semantic locations",
           "repairs": "Subentry repairs"
@@ -277,6 +278,20 @@
           "subentry": "Restored devices join the feature group you choose. See [Subentries and feature groups]({subentries_docs_url}) for assignment guidance."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Subentry Repairs",
         "description": "Choose a repair action for your feature groups.",
@@ -315,10 +330,12 @@
       "duplicate_name": "Semantic name already exists. Choose a different name.",
       "duplicate_semantic_location": "Semantic name already exists. Choose a different name.",
       "unknown": "Unexpected error occurred.",
-      "invalid_subentry": "Choose a valid feature group."
+      "invalid_subentry": "Choose a valid feature group.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguration successful.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "There are no ignored devices to restore.",
       "no_semantic_locations": "No semantic locations are configured.",
       "repairs_no_subentries": "There are no subentries to repair.",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Anmeldedaten aktualisieren",
           "settings": "Einstellungen ändern",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Gerätesichtbarkeit",
           "semantic_locations": "Semantische Orte",
           "repairs": "Reparaturen für Funktionsgruppen"
@@ -277,6 +278,20 @@
           "subentry": "Wiederhergestellte Geräte werden der gewählten Funktionsgruppe zugeordnet. Hinweise finden Sie im Abschnitt [Subeinträge und Funktionsgruppen]({subentries_docs_url})."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Reparaturen für Funktionsgruppen",
         "description": "Wähle eine Reparaturaktion für deine Funktionsgruppen.",
@@ -315,10 +330,12 @@
       "duplicate_name": "Der semantische Name ist bereits vorhanden. Wähle einen anderen Namen.",
       "duplicate_semantic_location": "Der semantische Name ist bereits vorhanden. Wähle einen anderen Namen.",
       "unknown": "Unerwarteter Fehler.",
-      "invalid_subentry": "Wähle eine gültige Funktionsgruppe."
+      "invalid_subentry": "Wähle eine gültige Funktionsgruppe.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Neukonfiguration erfolgreich.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "Es gibt keine ignorierten Geräte, die wiederhergestellt werden können.",
       "no_semantic_locations": "Es sind keine semantischen Orte konfiguriert.",
       "repairs_no_subentries": "Es sind keine Funktionsgruppen zur Reparatur vorhanden.",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Update credentials",
           "settings": "Modify settings",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Device visibility",
           "semantic_locations": "Semantic locations",
           "repairs": "Subentry repairs"
@@ -277,6 +278,20 @@
           "subentry": "Restored devices join the feature group you choose. See [Subentries and feature groups]({subentries_docs_url}) for assignment guidance."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Subentry Repairs",
         "description": "Choose a repair action for your feature groups.",
@@ -315,10 +330,12 @@
       "duplicate_name": "Semantic name already exists. Choose a different name.",
       "duplicate_semantic_location": "Semantic name already exists. Choose a different name.",
       "unknown": "Unexpected error occurred.",
-      "invalid_subentry": "Choose a valid feature group."
+      "invalid_subentry": "Choose a valid feature group.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguration successful.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "There are no ignored devices to restore.",
       "no_semantic_locations": "No semantic locations are configured.",
       "repairs_no_subentries": "There are no subentries to repair.",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Actualizar credenciales",
           "settings": "Modificar ajustes",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Visibilidad de dispositivos",
           "semantic_locations": "Ubicaciones semánticas",
           "repairs": "Reparaciones de grupos de funciones"
@@ -277,6 +278,20 @@
           "subentry": "Los dispositivos restaurados se asignan al grupo de funciones elegido. Consulta [Subentradas y grupos de funciones]({subentries_docs_url}) para obtener orientación."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Reparaciones de grupos de funciones",
         "description": "Elige una acción de reparación para tus grupos de funciones.",
@@ -315,10 +330,12 @@
       "duplicate_name": "El nombre semántico ya existe. Elige un nombre diferente.",
       "duplicate_semantic_location": "El nombre semántico ya existe. Elige un nombre diferente.",
       "unknown": "Error inesperado.",
-      "invalid_subentry": "Elige un grupo de funciones válido."
+      "invalid_subentry": "Elige un grupo de funciones válido.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguración correcta.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "No hay dispositivos ignorados para restaurar.",
       "no_semantic_locations": "No hay ubicaciones semánticas configuradas.",
       "repairs_no_subentries": "No hay grupos de funciones que reparar.",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Mettre à jour les identifiants",
           "settings": "Modifier les paramètres",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Visibilité des appareils",
           "semantic_locations": "Emplacements sémantiques",
           "repairs": "Réparations des groupes de fonctionnalités"
@@ -277,6 +278,20 @@
           "subentry": "Les appareils restaurés sont associés au groupe de fonctionnalités choisi. Consultez [Sous-entrées et groupes de fonctionnalités]({subentries_docs_url}) pour obtenir des conseils."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Réparations des groupes de fonctionnalités",
         "description": "Choisissez une action de réparation pour vos groupes de fonctionnalités.",
@@ -315,10 +330,12 @@
       "duplicate_name": "Le nom sémantique existe déjà. Choisissez un autre nom.",
       "duplicate_semantic_location": "Le nom sémantique existe déjà. Choisissez un autre nom.",
       "unknown": "Erreur inattendue.",
-      "invalid_subentry": "Choisissez un groupe de fonctionnalités valide."
+      "invalid_subentry": "Choisissez un groupe de fonctionnalités valide.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguration réussie.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "Aucun appareil ignoré à restaurer.",
       "no_semantic_locations": "Aucun emplacement sémantique n’est configuré.",
       "repairs_no_subentries": "Aucun groupe de fonctionnalités à réparer.",

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "עדכון אישורים",
           "settings": "שינוי הגדרות",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "נראות התקנים",
           "semantic_locations": "מיקומים סמנטיים",
           "repairs": "תיקוני תת-רשומות"
@@ -277,6 +278,20 @@
           "subentry": "התקנים משוחזרים מצטרפים לקבוצת התכונות שתבחר. יש לעיין ב[תת-רשומות וקבוצות תכונות]({subentries_docs_url}) להנחיות שיוך."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "תיקוני תת-רשומות",
         "description": "יש לבחור פעולת תיקון עבור קבוצות התכונות שלך.",
@@ -315,10 +330,12 @@
       "duplicate_name": "השם הסמנטי כבר קיים. יש לבחור שם אחר.",
       "duplicate_semantic_location": "השם הסמנטי כבר קיים. יש לבחור שם אחר.",
       "unknown": "אירעה שגיאה בלתי צפויה.",
-      "invalid_subentry": "יש לבחור קבוצת תכונות תקינה."
+      "invalid_subentry": "יש לבחור קבוצת תכונות תקינה.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "הגדרה מחדש הצליחה.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "אין התקנים מוסתרים לשחזור.",
       "no_semantic_locations": "לא מוגדרים מיקומים סמנטיים.",
       "repairs_no_subentries": "אין תת-רשומות לתיקון.",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Aggiorna credenziali",
           "settings": "Modifica impostazioni",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Visibilità dei dispositivi",
           "semantic_locations": "Posizioni semantiche",
           "repairs": "Riparazioni dei gruppi di funzionalità"
@@ -277,6 +278,20 @@
           "subentry": "I dispositivi ripristinati vengono assegnati al gruppo di funzionalità scelto. Consulta [Sotto-voci e gruppi di funzionalità]({subentries_docs_url}) per ulteriori indicazioni."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Riparazioni dei gruppi di funzionalità",
         "description": "Scegli un'azione di riparazione per i tuoi gruppi di funzionalità.",
@@ -315,10 +330,12 @@
       "duplicate_name": "Il nome semantico esiste già. Scegli un nome diverso.",
       "duplicate_semantic_location": "Il nome semantico esiste già. Scegli un nome diverso.",
       "unknown": "Errore imprevisto.",
-      "invalid_subentry": "Scegli un gruppo di funzionalità valido."
+      "invalid_subentry": "Scegli un gruppo di funzionalità valido.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Riconfigurazione riuscita.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "Non ci sono dispositivi ignorati da ripristinare.",
       "no_semantic_locations": "Non sono configurate posizioni semantiche.",
       "repairs_no_subentries": "Non ci sono gruppi di funzionalità da riparare.",

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Inloggegevens bijwerken",
           "settings": "Instellingen wijzigen",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Apparaatzichtbaarheid",
           "semantic_locations": "Semantische locaties",
           "repairs": "Subentry-reparaties"
@@ -277,6 +278,20 @@
           "subentry": "Herstelde apparaten worden toegevoegd aan de functiegroep die je kiest. Zie [Subentries en functiegroepen]({subentries_docs_url}) voor toewijzingsadvies."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Subentry-reparaties",
         "description": "Kies een reparatieactie voor je functiegroepen.",
@@ -315,10 +330,12 @@
       "duplicate_name": "Semantische naam bestaat al. Kies een andere naam.",
       "duplicate_semantic_location": "Semantische naam bestaat al. Kies een andere naam.",
       "unknown": "Er is een onverwachte fout opgetreden.",
-      "invalid_subentry": "Kies een geldige functiegroep."
+      "invalid_subentry": "Kies een geldige functiegroep.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Herconfiguratie geslaagd.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "Er zijn geen genegeerde apparaten om te herstellen.",
       "no_semantic_locations": "Er zijn geen semantische locaties geconfigureerd.",
       "repairs_no_subentries": "Er zijn geen subentries om te repareren.",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Zaktualizuj poświadczenia",
           "settings": "Zmień ustawienia",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Widoczność urządzeń",
           "semantic_locations": "Lokalizacje semantyczne",
           "repairs": "Naprawy grup funkcji"
@@ -277,6 +278,20 @@
           "subentry": "Przywrócone urządzenia zostaną przypisane do wybranej grupy funkcji. Wskazówki znajdziesz w sekcji [Podpozycje i grupy funkcji]({subentries_docs_url})."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Naprawy grup funkcji",
         "description": "Wybierz działanie naprawcze dla swoich grup funkcji.",
@@ -315,10 +330,12 @@
       "duplicate_name": "Nazwa semantyczna już istnieje. Wybierz inną nazwę.",
       "duplicate_semantic_location": "Nazwa semantyczna już istnieje. Wybierz inną nazwę.",
       "unknown": "Wystąpił nieoczekiwany błąd.",
-      "invalid_subentry": "Wybierz prawidłową grupę funkcji."
+      "invalid_subentry": "Wybierz prawidłową grupę funkcji.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Ponowna konfiguracja zakończona pomyślnie.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "Brak ignorowanych urządzeń do przywrócenia.",
       "no_semantic_locations": "Nie skonfigurowano lokalizacji semantycznych.",
       "repairs_no_subentries": "Brak grup funkcji do naprawy.",

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Atualizar credenciais",
           "settings": "Modificar configurações",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Visibilidade dos dispositivos",
           "semantic_locations": "Localizações semânticas",
           "repairs": "Reparos de subentrada"
@@ -277,6 +278,20 @@
           "subentry": "Os dispositivos restaurados ingressam no grupo de recursos que você escolher. Consulte [Subentradas e grupos de recursos]({subentries_docs_url}) para orientações."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Reparos de subentrada",
         "description": "Escolha uma ação de reparo para seus grupos de recursos.",
@@ -315,10 +330,12 @@
       "duplicate_name": "O nome semântico já existe. Escolha um nome diferente.",
       "duplicate_semantic_location": "O nome semântico já existe. Escolha um nome diferente.",
       "unknown": "Ocorreu um erro inesperado.",
-      "invalid_subentry": "Escolha um grupo de recursos válido."
+      "invalid_subentry": "Escolha um grupo de recursos válido.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguração bem-sucedida.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "Não há dispositivos ignorados para restaurar.",
       "no_semantic_locations": "Não há localizações semânticas configuradas.",
       "repairs_no_subentries": "Não há subentradas para reparar.",

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -154,6 +154,7 @@
         "menu_options": {
           "credentials": "Atualizar credenciais",
           "settings": "Modificar configurações",
+          "per_device_poll": "Per-device poll intervals",
           "visibility": "Visibilidade do dispositivo",
           "semantic_locations": "Localizações semânticas",
           "repairs": "Reparos de subentrada"
@@ -277,6 +278,20 @@
           "subentry": "Os dispositivos restaurados ingressam no grupo de recursos que você escolher. Consulte [Subentradas e grupos de recursos]({subentries_docs_url}) para orientações."
         }
       },
+      "per_device_poll": {
+        "title": "Per-device poll intervals",
+        "description": "Poll an individual device less often than the global cadence (for example a rarely moving tracker). A per-device value below the global interval has no effect and is clamped. Pick a device to set or clear its interval.\n\nCurrent overrides:\n{per_device_poll_intervals}",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "per_device_poll_set": {
+        "title": "Set poll interval",
+        "description": "Poll interval in seconds for {device_name}. Allowed range {min_seconds}-{max_seconds} seconds. Leave the field empty to remove the override and follow the global cadence.",
+        "data": {
+          "interval": "Poll interval (s)"
+        }
+      },
       "repairs": {
         "title": "Reparos de subentrada",
         "description": "Escolha uma ação de reparo para seus grupos de recursos.",
@@ -315,10 +330,12 @@
       "duplicate_name": "O nome semântico já existe. Escolha um nome diferente.",
       "duplicate_semantic_location": "O nome semântico já existe. Escolha um nome diferente.",
       "unknown": "Ocorreu um erro inesperado.",
-      "invalid_subentry": "Escolha um grupo de recursos válido."
+      "invalid_subentry": "Escolha um grupo de recursos válido.",
+      "invalid_device": "Selected device is not available."
     },
     "abort": {
       "reconfigure_successful": "Reconfiguração bem-sucedida.",
+      "no_devices": "No devices are available to configure yet.",
       "no_ignored_devices": "Não há dispositivos ignorados para restaurar.",
       "no_semantic_locations": "Não estão configuradas localizações semânticas.",
       "repairs_no_subentries": "Não há subentradas para reparar.",

--- a/tests/test_coordinator_per_device_poll_interval.py
+++ b/tests/test_coordinator_per_device_poll_interval.py
@@ -398,6 +398,24 @@ def test_coerce_non_mapping_returns_empty() -> None:
     assert coerce_device_poll_interval_mapping(None) == {}
 
 
+def test_coerce_drops_non_finite_floats() -> None:
+    """NaN and +/-inf are dropped, never raised (Codex #1157 hardening).
+
+    ``int(float("nan"))`` raises ValueError and ``int(float("inf"))`` raises
+    OverflowError. A corrupt ``.storage`` edit or a direct-options writer could
+    store such a value; the coercer must honour its drop-invalid contract so one
+    bad entry cannot disable every valid override or break the options screen.
+    """
+    raw = {
+        "dev-ok": 300,
+        "dev-nan": float("nan"),
+        "dev-inf": float("inf"),
+        "dev-ninf": float("-inf"),
+    }
+    result = coerce_device_poll_interval_mapping(raw)
+    assert result == {"dev-ok": 300}
+
+
 # --------------------------------------------------------------------------
 # Coordinator live options resolution (_get_device_poll_interval_map)
 # --------------------------------------------------------------------------

--- a/tests/test_coordinator_per_device_poll_interval.py
+++ b/tests/test_coordinator_per_device_poll_interval.py
@@ -33,6 +33,9 @@ from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from custom_components.googlefindmy.coordinator.helpers.update import (
     device_due_by_interval,
 )
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
+    SpotApiEmptyResponseError,
+)
 from tests.helpers.config_entries_stub import make_config_entry
 
 
@@ -87,6 +90,25 @@ class _EmptyResultAPI:
     """API stub that returns an empty result so the real cycle reaches its end."""
 
     async def async_get_device_location(self, _dev_id: str, _dev_name: str):
+        return []
+
+
+class _RaiseOnDeviceAPI:
+    """API stub that raises on a target device to force an early loop exit.
+
+    ``SpotApiEmptyResponseError`` escalates to reauth inside the device loop and
+    returns immediately, so any device scheduled after the target is never
+    reached this cycle.
+    """
+
+    def __init__(self, raise_on: str) -> None:
+        self._raise_on = raise_on
+        self.calls: list[str] = []
+
+    async def async_get_device_location(self, dev_id: str, _dev_name: str):
+        self.calls.append(dev_id)
+        if dev_id == self._raise_on:
+            raise SpotApiEmptyResponseError("forced early exit")
         return []
 
 
@@ -364,6 +386,49 @@ async def test_stamp_not_written_when_global_gate_skips_cycle(
     coordinator._last_poll_mono = time.monotonic() - coordinator.min_poll_interval
     await _run_cycle_and_capture(coordinator)
     assert "dev-a" not in coordinator._device_last_poll_mono
+
+
+@pytest.mark.asyncio
+async def test_stamp_skips_devices_not_reached_on_early_exit(
+    coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An early mid-loop exit must not stamp devices the loop never reached.
+
+    The cycle exits via reauth on ``dev-b``; ``dev-c`` is scheduled after it and
+    is never polled. Its per-device floor must stay unstamped so it remains due,
+    while the attempted devices (``dev-a``, ``dev-b``) advance their floor.
+    """
+
+    api = _RaiseOnDeviceAPI(raise_on="dev-b")
+    coordinator.api = api
+    coordinator.config_entry = make_config_entry(
+        entry_id="entry-id", options={}, data={}, title="Test Entry"
+    )
+    coordinator._get_google_home_filter = lambda: None
+    coordinator._is_fcm_ready_soft = lambda: True
+    coordinator._get_ignored_set = set
+    coordinator._last_device_list = [{"id": "dev-a"}, {"id": "dev-b"}, {"id": "dev-c"}]
+    coordinator.data = []
+    coordinator.last_update_success = True
+    coordinator.last_exception = None
+    coordinator.async_set_update_error = lambda _exc: None
+    coordinator.async_set_updated_data = lambda _data: None
+    monkeypatch.setattr(coordinator, "_request_poll_reauth", lambda *_a, **_k: None)
+    monkeypatch.setattr(coordinator, "_set_auth_state", lambda *_a, **_k: None)
+
+    devices = [
+        {"id": "dev-a", "name": "A"},
+        {"id": "dev-b", "name": "B"},
+        {"id": "dev-c", "name": "C"},
+    ]
+    await coordinator._async_start_poll_cycle(devices, force=True)
+
+    # dev-c was never reached (loop returned on dev-b): it must stay unstamped.
+    assert "dev-c" not in coordinator._device_last_poll_mono
+    assert api.calls == ["dev-a", "dev-b"]
+    # Devices that actually entered the request path advanced their floor.
+    assert "dev-a" in coordinator._device_last_poll_mono
+    assert "dev-b" in coordinator._device_last_poll_mono
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_coordinator_per_device_poll_interval.py
+++ b/tests/test_coordinator_per_device_poll_interval.py
@@ -142,9 +142,7 @@ def _patch_side_effects(
     monkeypatch.setattr(
         coordinator, "_ensure_registry_for_devices", lambda *_a, **_k: 0
     )
-    monkeypatch.setattr(
-        coordinator, "_refresh_subentry_index", lambda *_a, **_k: None
-    )
+    monkeypatch.setattr(coordinator, "_refresh_subentry_index", lambda *_a, **_k: None)
     monkeypatch.setattr(
         coordinator,
         "_async_build_device_snapshot_with_fallbacks",
@@ -168,7 +166,9 @@ async def _run_cycle_and_capture(
 
     await coordinator._async_update_data()
     poll_tasks = [
-        task for task, name in coordinator.hass.created if name == f"{DOMAIN}.poll_cycle"
+        task
+        for task, name in coordinator.hass.created
+        if name == f"{DOMAIN}.poll_cycle"
     ]
     for task in poll_tasks:
         await asyncio.wait_for(task, timeout=1)

--- a/tests/test_coordinator_per_device_poll_interval.py
+++ b/tests/test_coordinator_per_device_poll_interval.py
@@ -1,0 +1,435 @@
+# tests/test_coordinator_per_device_poll_interval.py
+"""Tests for the per-device ``location_poll_interval`` feature (Direction A only).
+
+Direction A lets a user poll an individual device *less* often than the
+coordinator-wide cadence. The effective per-device floor is
+``max(per_device_interval, effective_interval)`` so a configured value below
+the coordinator cadence is clamped rather than silently ignored. The global
+poll gate (``is_poll_cycle_due``) and ``_last_poll_mono`` stay untouched.
+
+The characterization tests in this module pin today's ``devices_to_poll``
+behavior *before* the feature exists, so a later regression in the additive
+filter is caught.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from collections.abc import Coroutine
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.googlefindmy.const import (
+    DEVICE_POLL_INTERVAL_MAX_S,
+    DEVICE_POLL_INTERVAL_MIN_S,
+    DOMAIN,
+    coerce_device_poll_interval_mapping,
+)
+from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+from custom_components.googlefindmy.coordinator.helpers.update import (
+    device_due_by_interval,
+)
+from tests.helpers.config_entries_stub import make_config_entry
+
+
+class _DummyCache:
+    """Minimal cache stub satisfying the coordinator constructor."""
+
+    async def async_get_cached_value(self, _key: str) -> None:
+        return None
+
+    async def async_set_cached_value(self, _key: str, _value: object) -> None:
+        return None
+
+
+class _DummyBus:
+    """Provide async_listen placeholder used by the coordinator."""
+
+    def async_listen(self, *_args, **_kwargs):
+        return lambda: None
+
+
+class _DummyHass:
+    """Lightweight Home Assistant stub capturing created tasks."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.loop = loop
+        self.bus = _DummyBus()
+        self.data: dict[str, dict] = {DOMAIN: {}}
+        self.created: list[tuple[asyncio.Task[object], str | None]] = []
+
+    def async_create_task(
+        self,
+        coro: asyncio.Future | Coroutine[object, object, object],
+        *,
+        name: str | None = None,
+    ) -> asyncio.Task:
+        task = self.loop.create_task(coro, name=name)
+        self.created.append((task, name))
+        return task
+
+
+class _DummyAPI:
+    """No-op API placeholder injected into the coordinator."""
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    def is_push_ready(self) -> bool:
+        return True
+
+
+class _EmptyResultAPI:
+    """API stub that returns an empty result so the real cycle reaches its end."""
+
+    async def async_get_device_location(self, _dev_id: str, _dev_name: str):
+        return []
+
+
+@pytest.fixture
+async def coordinator(monkeypatch: pytest.MonkeyPatch):
+    """Instantiate a coordinator with patched dependencies for polling tests."""
+
+    loop = asyncio.get_running_loop()
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.GoogleFindMyCoordinator._async_load_stats",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.main.GoogleFindMyAPI",
+        lambda *args, **kwargs: _DummyAPI(),
+    )
+
+    hass = _DummyHass(loop)
+    coord = GoogleFindMyCoordinator(
+        hass,
+        cache=_DummyCache(),
+        location_poll_interval=200,
+        min_poll_interval=60,
+    )
+    coord.async_set_updated_data = lambda _data: None
+
+    yield coord
+    await asyncio.sleep(0)
+
+
+def _prime_devices(
+    coordinator: GoogleFindMyCoordinator, device_ids: list[str], wall_now: float
+) -> None:
+    """Seed cached device list, location data and overdue histories."""
+
+    coordinator._last_device_list = [{"id": dev_id} for dev_id in device_ids]
+    coordinator._last_list_poll_mono = time.monotonic()
+    for dev_id in device_ids:
+        coordinator._device_location_data[dev_id] = {"last_seen": wall_now}
+        coordinator._device_update_history[dev_id] = deque(
+            [wall_now - 900, wall_now - 600, wall_now - 350],
+            maxlen=4,
+        )
+
+
+def _patch_side_effects(
+    coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neutralize registry/snapshot side effects irrelevant to poll selection."""
+
+    monkeypatch.setattr(coordinator, "_ensure_service_device_exists", lambda: None)
+    monkeypatch.setattr(
+        coordinator, "_ensure_registry_for_devices", lambda *_a, **_k: 0
+    )
+    monkeypatch.setattr(
+        coordinator, "_refresh_subentry_index", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(
+        coordinator,
+        "_async_build_device_snapshot_with_fallbacks",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(coordinator, "_store_subentry_snapshots", lambda _snap: None)
+
+
+async def _run_cycle_and_capture(
+    coordinator: GoogleFindMyCoordinator,
+) -> list[str]:
+    """Drive one update cycle and return the ids passed to the poll cycle."""
+
+    captured: list[str] = []
+
+    async def _poll_cycle(devices, *, force=False):
+        captured.extend(dev["id"] for dev in devices)
+
+    coordinator._async_start_poll_cycle = _poll_cycle
+    coordinator._schedule_short_retry = lambda *_a, **_k: None
+
+    await coordinator._async_update_data()
+    poll_tasks = [
+        task for task, name in coordinator.hass.created if name == f"{DOMAIN}.poll_cycle"
+    ]
+    for task in poll_tasks:
+        await asyncio.wait_for(task, timeout=1)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_characterization_all_devices_polled_without_per_device_interval(
+    coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Characterization: with no per-device interval set, every enabled device polls.
+
+    Pins today's ``devices_to_poll`` behavior before the additive filter exists:
+    an empty per-device cooldown and no per-device interval means all non-ignored
+    devices participate in the cycle.
+    """
+
+    wall_now = time.time()
+    _prime_devices(coordinator, ["dev-a", "dev-b"], wall_now)
+    effective_interval = max(
+        coordinator.location_poll_interval, coordinator.min_poll_interval
+    )
+    coordinator._last_poll_mono = time.monotonic() - effective_interval
+    _patch_side_effects(coordinator, monkeypatch)
+
+    captured = await _run_cycle_and_capture(coordinator)
+
+    assert sorted(captured) == ["dev-a", "dev-b"]
+
+
+@pytest.mark.asyncio
+async def test_characterization_is_poll_cycle_due_unaffected(
+    coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression guard: the global poll gate stays interval-only, not per-device.
+
+    ``is_poll_cycle_due`` must remain a pure function of the coordinator-wide
+    cadence. This pins that a cycle below the cadence floor schedules no poll,
+    independent of any per-device interval configuration.
+    """
+
+    wall_now = time.time()
+    _prime_devices(coordinator, ["dev-a"], wall_now)
+    # elapsed == min_poll_interval < effective_interval → below cadence floor.
+    coordinator._last_poll_mono = time.monotonic() - coordinator.min_poll_interval
+    _patch_side_effects(coordinator, monkeypatch)
+
+    captured = await _run_cycle_and_capture(coordinator)
+
+    assert captured == []
+
+
+# --------------------------------------------------------------------------
+# Pure predicate unit tests (device_due_by_interval)
+# --------------------------------------------------------------------------
+
+
+def test_predicate_never_polled_is_due() -> None:
+    """A device never polled (stamp 0.0) is due regardless of its interval."""
+    assert device_due_by_interval(
+        now_mono=1000.0,
+        last_poll_mono=0.0,
+        per_device_interval=3600.0,
+        effective_interval=200.0,
+    )
+
+
+def test_predicate_below_own_interval_is_not_due() -> None:
+    """Within its own (larger-than-cadence) interval the device is skipped."""
+    # floor = max(600, 200) = 600; elapsed = 100 < 600 → not due.
+    assert not device_due_by_interval(
+        now_mono=1100.0,
+        last_poll_mono=1000.0,
+        per_device_interval=600.0,
+        effective_interval=200.0,
+    )
+
+
+def test_predicate_past_own_interval_is_due() -> None:
+    """Past its own interval the device becomes due again."""
+    # floor = 600; elapsed = 700 >= 600 → due.
+    assert device_due_by_interval(
+        now_mono=1700.0,
+        last_poll_mono=1000.0,
+        per_device_interval=600.0,
+        effective_interval=200.0,
+    )
+
+
+def test_predicate_clamps_below_cadence_floor() -> None:
+    """A per-device value below the cadence is clamped to effective_interval.
+
+    Discriminates the ``max(...)`` clamp: a naive floor of the raw 100 s value
+    would call the device due at elapsed 150 s, but the cadence floor of 200 s
+    must dominate, so it is NOT due.
+    """
+    assert not device_due_by_interval(
+        now_mono=1150.0,
+        last_poll_mono=1000.0,
+        per_device_interval=100.0,
+        effective_interval=200.0,
+    )
+    # And once the cadence floor itself elapses, it is due.
+    assert device_due_by_interval(
+        now_mono=1200.0,
+        last_poll_mono=1000.0,
+        per_device_interval=100.0,
+        effective_interval=200.0,
+    )
+
+
+# --------------------------------------------------------------------------
+# Coordinator-level filter + stamp behavior
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_filter_skips_device_within_its_interval(
+    coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A device recently polled and set to a long interval is dropped this cycle.
+
+    The fast device (no override) still polls; the slow device (3600 s override,
+    stamped as just polled) is filtered out even though the global cycle is due.
+    """
+
+    wall_now = time.time()
+    _prime_devices(coordinator, ["dev-fast", "dev-slow"], wall_now)
+    effective_interval = max(
+        coordinator.location_poll_interval, coordinator.min_poll_interval
+    )
+    coordinator._last_poll_mono = time.monotonic() - effective_interval
+    # Slow device was just polled and wants a long interval.
+    coordinator._device_last_poll_mono["dev-slow"] = time.monotonic()
+    monkeypatch.setattr(
+        coordinator, "_get_device_poll_interval_map", lambda: {"dev-slow": 3600}
+    )
+    _patch_side_effects(coordinator, monkeypatch)
+
+    captured = await _run_cycle_and_capture(coordinator)
+
+    assert captured == ["dev-fast"]
+
+
+@pytest.mark.asyncio
+async def test_stamp_written_at_real_poll_end_for_polled_devices(
+    coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A device that runs the real cycle gets its per-device stamp advanced.
+
+    Drives the real ``_async_start_poll_cycle`` (empty-result API) so the stamp
+    in the ``finally`` block executes at the same instant as ``_last_poll_mono``.
+    """
+
+    coordinator.api = _EmptyResultAPI()
+    coordinator.config_entry = make_config_entry(
+        entry_id="entry-id", options={}, data={}, title="Test Entry"
+    )
+    coordinator._get_google_home_filter = lambda: None
+    coordinator._is_fcm_ready_soft = lambda: True
+    coordinator._get_ignored_set = set
+    coordinator._last_device_list = [{"id": "dev-a"}]
+    coordinator.data = []
+    coordinator.last_update_success = True
+    coordinator.last_exception = None
+    coordinator.async_set_update_error = lambda _exc: None
+    coordinator.async_set_updated_data = lambda _data: None
+
+    devices = [{"id": "dev-a", "name": "A"}]
+    before = time.monotonic()
+    await coordinator._async_start_poll_cycle(devices, force=True)
+
+    assert coordinator._device_last_poll_mono.get("dev-a", 0.0) >= before
+    # Symmetry: the global baseline advanced at the same point.
+    assert coordinator._last_poll_mono >= before
+
+
+@pytest.mark.asyncio
+async def test_stamp_not_written_when_global_gate_skips_cycle(
+    coordinator: GoogleFindMyCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A device the global gate never started keeps its (absent) stamp.
+
+    Below the cadence floor no poll cycle runs, so ``_device_last_poll_mono``
+    stays empty and the device remains due next time.
+    """
+
+    wall_now = time.time()
+    _prime_devices(coordinator, ["dev-a"], wall_now)
+    _patch_side_effects(coordinator, monkeypatch)
+
+    # Below the cadence floor: no poll runs, so no stamp is written.
+    coordinator._last_poll_mono = time.monotonic() - coordinator.min_poll_interval
+    await _run_cycle_and_capture(coordinator)
+    assert "dev-a" not in coordinator._device_last_poll_mono
+
+
+# --------------------------------------------------------------------------
+# Coercion
+# --------------------------------------------------------------------------
+
+
+def test_coerce_drops_invalid_and_clamps() -> None:
+    """Coercion keeps valid entries, clamps to bounds, drops junk."""
+    raw = {
+        "dev-ok": 600,
+        "dev-str": "900",
+        "dev-low": 10,  # below min → clamped up
+        "dev-high": 99999,  # above max → clamped down
+        "dev-bool": True,  # bool rejected
+        "dev-none": None,  # non-numeric rejected
+        123: 600,  # non-str key rejected
+        "dev-bad": "abc",  # unparsable string rejected
+    }
+    result = coerce_device_poll_interval_mapping(raw)
+    assert result == {
+        "dev-ok": 600,
+        "dev-str": 900,
+        "dev-low": DEVICE_POLL_INTERVAL_MIN_S,
+        "dev-high": DEVICE_POLL_INTERVAL_MAX_S,
+    }
+
+
+def test_coerce_non_mapping_returns_empty() -> None:
+    """A non-mapping stored value coerces to an empty map (never raises)."""
+    assert coerce_device_poll_interval_mapping(["dev-a", "dev-b"]) == {}
+    assert coerce_device_poll_interval_mapping(None) == {}
+
+
+# --------------------------------------------------------------------------
+# Coordinator live options resolution (_get_device_poll_interval_map)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_option_resolution_reads_and_coerces(
+    coordinator: GoogleFindMyCoordinator,
+) -> None:
+    """The map is resolved live from ``entry.options`` and coerced/clamped."""
+    from custom_components.googlefindmy.const import OPT_DEVICE_POLL_INTERVAL
+
+    coordinator.config_entry = SimpleNamespace(
+        options={OPT_DEVICE_POLL_INTERVAL: {"dev-a": 600, "dev-low": 10}}
+    )
+    resolved = coordinator._get_device_poll_interval_map()
+    assert resolved == {"dev-a": 600, "dev-low": DEVICE_POLL_INTERVAL_MIN_S}
+
+    # An options reload propagates without restart (live read).
+    coordinator.config_entry.options = {OPT_DEVICE_POLL_INTERVAL: {"dev-a": 1200}}
+    assert coordinator._get_device_poll_interval_map() == {"dev-a": 1200}
+
+
+@pytest.mark.asyncio
+async def test_live_option_resolution_defensive_on_bad_entry(
+    coordinator: GoogleFindMyCoordinator,
+) -> None:
+    """A raising options access never breaks polling; returns an empty map."""
+
+    class _BadOptions:
+        def get(self, _key, _default=None):
+            raise RuntimeError("boom")
+
+    coordinator.config_entry = SimpleNamespace(options=_BadOptions())
+    assert coordinator._get_device_poll_interval_map() == {}

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -83,6 +83,7 @@ def _base_coordinator(
     coordinator._set_auth_state = lambda **_kwargs: None
     coordinator._device_location_data = {}
     coordinator._device_poll_cooldown_until = {}
+    coordinator._device_last_poll_mono = {}
     coordinator._present_last_seen = {}
     coordinator._locate_inflight = set()
     coordinator._locate_cooldown_until = {}
@@ -217,6 +218,7 @@ def _push_coordinator(options: dict[str, Any]) -> GoogleFindMyCoordinator:
     coordinator._device_name_cache = {}
     coordinator._device_update_history = {}
     coordinator._device_poll_cooldown_until = {}
+    coordinator._device_last_poll_mono = {}
     coordinator._present_last_seen = {}
     coordinator._semantic_label_cache = {}
     return coordinator

--- a/tests/test_device_identifier_normalization.py
+++ b/tests/test_device_identifier_normalization.py
@@ -20,6 +20,7 @@ from custom_components.googlefindmy.const import (
     OPT_OPTIONS_SCHEMA_VERSION,
     SUBENTRY_TYPE_TRACKER,
     TRACKER_SUBENTRY_KEY,
+    coerce_ignored_mapping,
 )
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from tests.helpers.config_flow import ConfigEntriesDomainUniqueIdLookupMixin
@@ -198,3 +199,25 @@ def test_migrate_entry_identifier_namespaces_updates_subentries() -> None:
     managed = manager.get(TRACKER_SUBENTRY_KEY)
     assert managed is not None
     assert tuple(managed.data.get("visible_device_ids", ())) == ("device-1",)
+
+
+def test_coerce_ignored_mapping_survives_non_finite_ignored_at() -> None:
+    """A NaN/inf ``ignored_at`` is dropped to the default, never raised.
+
+    Same class as the per-device coercer hardening (Codex #1157): ``int()`` on a
+    non-finite float raises, which would break the ignored-devices coercion on a
+    corrupt ``.storage`` value. The entry must survive with a fallback timestamp.
+    """
+    result, _changed = coerce_ignored_mapping(
+        {"device-1": {"name": "Dev", "ignored_at": float("nan")}}
+    )
+
+    assert "device-1" in result
+    metadata = result["device-1"]
+    assert metadata["name"] == "Dev"
+    # ignored_at fell back to the finite _now_epoch() default: a positive epoch,
+    # never NaN and never 0/None (a "return 0 instead of None" helper mutation
+    # would leave ignored_at at the pre-set default, which is > 0).
+    ignored_at = metadata["ignored_at"]
+    assert isinstance(ignored_at, int)
+    assert ignored_at > 0

--- a/tests/test_options_flow_per_device_poll.py
+++ b/tests/test_options_flow_per_device_poll.py
@@ -1,0 +1,206 @@
+# tests/test_options_flow_per_device_poll.py
+"""Options-flow tests for the per-device poll interval feature (Direction A).
+
+Cover the two-step management flow: pick a device (labelled by name), then set
+or clear its interval. Mirrors the semantic-locations options-flow scaffold.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from homeassistant.helpers import frame
+
+from custom_components.googlefindmy import config_flow
+from custom_components.googlefindmy.const import (
+    DEVICE_POLL_INTERVAL_MAX_S,
+    DEVICE_POLL_INTERVAL_MIN_S,
+    OPT_DEVICE_POLL_INTERVAL,
+)
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.config_flow import prepare_flow_hass_config_entries
+
+
+class _RecordingConfigEntries:
+    """Record options updates and reloads for verification."""
+
+    def __init__(self, entry: SimpleNamespace) -> None:
+        self._entry = entry
+        self.updated_options: list[dict[str, Any]] = []
+        self.reloaded: list[str] = []
+
+    def async_get_entry(self, entry_id: str) -> SimpleNamespace | None:
+        return self._entry if entry_id == self._entry.entry_id else None
+
+    def async_update_entry(
+        self, entry: SimpleNamespace, *, options: dict[str, Any] | None = None
+    ) -> None:
+        assert entry is self._entry
+        if options is not None:
+            self.updated_options.append(options)
+            entry.options = options
+
+    async def async_reload(self, entry_id: str) -> None:
+        self.reloaded.append(entry_id)
+
+
+class _HassStub:
+    """Minimal Home Assistant stub for per-device poll options flows."""
+
+    def __init__(self, entry: SimpleNamespace) -> None:
+        self.config_entries = _RecordingConfigEntries(entry)
+        prepare_flow_hass_config_entries(
+            self, lambda: self.config_entries, frame_module=frame
+        )
+        self.config = SimpleNamespace(latitude=12.5, longitude=34.5)
+        self.data: dict[str, Any] = {}
+        self._tasks: list[asyncio.Task[Any]] = []
+
+    def async_create_task(
+        self, coro: Awaitable[Any], *, name: str | None = None
+    ) -> asyncio.Task[Any]:
+        task = asyncio.create_task(coro, name=name)
+        self._tasks.append(task)
+        return task
+
+    async def drain_tasks(self) -> None:
+        if self._tasks:
+            await asyncio.gather(*self._tasks)
+
+
+def _entry_with_devices(
+    devices: list[dict[str, str]], options: dict[str, Any] | None = None
+) -> SimpleNamespace:
+    """Build a config entry whose runtime coordinator exposes ``devices``."""
+    coordinator = SimpleNamespace(data=devices)
+    return make_config_entry(
+        entry_id="entry-per-device",
+        title="Per Device",
+        options=options or {},
+        runtime_data=SimpleNamespace(coordinator=coordinator),
+    )
+
+
+def _make_flow(entry: SimpleNamespace) -> tuple[Any, _HassStub]:
+    hass = _HassStub(entry)
+    flow = config_flow.OptionsFlowHandler()
+    flow.hass = hass  # type: ignore[assignment]
+    flow.config_entry = entry  # type: ignore[attr-defined]
+    return flow, hass
+
+
+@pytest.mark.asyncio
+async def test_menu_lists_per_device_poll() -> None:
+    """The options menu exposes the per-device poll entry."""
+    entry = _entry_with_devices([{"id": "dev-a", "name": "Phone"}])
+    flow, _hass = _make_flow(entry)
+
+    result = await flow.async_step_init()
+
+    assert result["type"] == "menu"
+    assert "per_device_poll" in result["menu_options"]
+
+
+@pytest.mark.asyncio
+async def test_no_devices_aborts() -> None:
+    """With no devices the flow aborts instead of showing an empty picker."""
+    entry = _entry_with_devices([])
+    flow, _hass = _make_flow(entry)
+
+    result = await flow.async_step_per_device_poll(None)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "no_devices"
+
+
+@pytest.mark.asyncio
+async def test_set_interval_persists_and_reloads() -> None:
+    """Selecting a device and submitting an interval stores and reloads it."""
+    entry = _entry_with_devices([{"id": "dev-a", "name": "Phone"}])
+    flow, hass = _make_flow(entry)
+
+    picker = await flow.async_step_per_device_poll(None)
+    assert picker["type"] == "form"
+    assert picker["step_id"] == "per_device_poll"
+
+    set_form = await flow.async_step_per_device_poll({"device": "dev-a"})
+    assert set_form["type"] == "form"
+    assert set_form["step_id"] == "per_device_poll_set"
+
+    result = await flow.async_step_per_device_poll_set({"interval": 600})
+    await hass.drain_tasks()
+
+    assert result["type"] == "menu"
+    assert hass.config_entries.updated_options[-1][OPT_DEVICE_POLL_INTERVAL] == {
+        "dev-a": 600
+    }
+    assert hass.config_entries.reloaded == [entry.entry_id]
+
+
+@pytest.mark.asyncio
+async def test_empty_submission_clears_override() -> None:
+    """Leaving the interval empty removes the device's override."""
+    entry = _entry_with_devices(
+        [{"id": "dev-a", "name": "Phone"}],
+        options={OPT_DEVICE_POLL_INTERVAL: {"dev-a": 600}},
+    )
+    flow, hass = _make_flow(entry)
+
+    await flow.async_step_per_device_poll({"device": "dev-a"})
+    result = await flow.async_step_per_device_poll_set({})
+    await hass.drain_tasks()
+
+    assert result["type"] == "menu"
+    assert hass.config_entries.updated_options[-1][OPT_DEVICE_POLL_INTERVAL] == {}
+
+
+@pytest.mark.asyncio
+async def test_invalid_device_shows_error() -> None:
+    """An unknown device id is rejected on the picker step."""
+    entry = _entry_with_devices([{"id": "dev-a", "name": "Phone"}])
+    flow, _hass = _make_flow(entry)
+
+    result = await flow.async_step_per_device_poll({"device": "ghost"})
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"device": "invalid_device"}
+
+
+@pytest.mark.asyncio
+async def test_set_step_without_selection_returns_to_picker() -> None:
+    """Entering the set step without a valid selection returns to the picker."""
+    entry = _entry_with_devices([{"id": "dev-a", "name": "Phone"}])
+    flow, _hass = _make_flow(entry)
+
+    result = await flow.async_step_per_device_poll_set(None)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "per_device_poll"
+
+
+@pytest.mark.asyncio
+async def test_set_form_prefills_and_bounds() -> None:
+    """The interval field is bounded and prefilled from the current override."""
+    entry = _entry_with_devices(
+        [{"id": "dev-a", "name": "Phone"}],
+        options={OPT_DEVICE_POLL_INTERVAL: {"dev-a": 900}},
+    )
+    flow, _hass = _make_flow(entry)
+
+    form = await flow.async_step_per_device_poll({"device": "dev-a"})
+
+    # Suggested (prefilled) value reflects the stored override.
+    markers = {marker.schema: marker for marker in form["data_schema"].schema}
+    assert "interval" in markers
+    suggested = markers["interval"].description
+    assert isinstance(suggested, dict)
+    assert suggested.get("suggested_value") == 900
+    # Out-of-range submissions are rejected by the schema validator.
+    with pytest.raises(Exception):
+        form["data_schema"]({"interval": DEVICE_POLL_INTERVAL_MIN_S - 1})
+    with pytest.raises(Exception):
+        form["data_schema"]({"interval": DEVICE_POLL_INTERVAL_MAX_S + 1})

--- a/tests/test_spot_grpc_client.py
+++ b/tests/test_spot_grpc_client.py
@@ -462,6 +462,7 @@ async def test_manual_locate_starts_reauth(monkeypatch: pytest.MonkeyPatch) -> N
     coordinator._locate_inflight = set()
     coordinator._locate_cooldown_until = {}
     coordinator._device_poll_cooldown_until = {}
+    coordinator._device_last_poll_mono = {}
     coordinator._device_location_data = {}
     coordinator.data = []
     coordinator.push_updated = lambda *_args, **_kwargs: None

--- a/tests/test_spot_grpc_resilience.py
+++ b/tests/test_spot_grpc_resilience.py
@@ -370,6 +370,7 @@ async def test_manual_locate_reports_reauth_status() -> None:
     coordinator._locate_inflight = set()
     coordinator._locate_cooldown_until = {}
     coordinator._device_poll_cooldown_until = {}
+    coordinator._device_last_poll_mono = {}
     coordinator._device_location_data = {}
     coordinator.data = []
     coordinator.async_set_updated_data = Mock()


### PR DESCRIPTION
## What

Adds an optional **per-device poll interval** override so a user can poll an individual device *less* often than the coordinator-wide `location_poll_interval` (e.g. a rarely moving tracker every 10 min while the rest keep the global cadence). Managed via a new options-flow screen: pick a device by name, then set or clear its interval.

## Scope: Direction A only (slower, never faster)

The effective per-device floor is `max(per_device_interval, effective_interval)`. A value **below** the coordinator cadence is clamped, not honored. Polling a device *more* often than the cadence (Direction B) is deliberately out of scope: it would require breaking the global cadence gate introduced in #1156 and could reintroduce over-polling. Values below the floor are inert anyway (no global wake-up faster than the cadence).

## How

- **`const.py`**: new mapping option `OPT_DEVICE_POLL_INTERVAL` (`{device_id: seconds}`, default `{}`), defensive `coerce_device_poll_interval_mapping` (drops junk, clamps), named bounds `DEVICE_POLL_INTERVAL_MIN_S..MAX_S` (no magic values). Omitted from `CONFIG_FIELDS` like `OPT_IGNORED_DEVICES` (mapping managed by a dedicated flow).
- **Coordinator**: pure predicate `device_due_by_interval` (floor + never-polled sentinel); additive filter in `devices_to_poll` right after the per-device cooldown filter; live resolution `_get_device_poll_interval_map` from `entry.options` (reload-safe, mirrors `_get_ignored_set`); per-device stamp `_device_last_poll_mono` written at the **real poll end**, symmetric with `_last_poll_mono`, only for devices that actually ran the cycle (filter reads, never writes). The global gate (`is_poll_cycle_due`, `_last_poll_mono`) is untouched.
- **Config flow**: two-step options screen (device select with names, then range-validated interval; empty clears the override) + strings.

## Tests

- Characterization of current `devices_to_poll` (pinned before the filter) and a global-gate regression guard.
- Pure-predicate unit tests incl. the `max(...)` clamp and the never-polled sentinel.
- Coordinator filter + stamp behavior (real poll cycle drives the stamp; global-gate-skip leaves the stamp untouched).
- Coercion (drop/clamp/reject) and live options resolution incl. the defensive path.
- Options flow: menu, `no_devices` abort, set/clear, invalid device, lost selection, bounds.
- Full suite green; delta coverage complete (line + branch); mutation-sharp on floor, sentinel, filter, stamp and coercion clamp.

## Reviewer notes

- Non-English translations are **English backfills** produced by `script/sync_translations.py` (community translation to follow; the sync helper preserves later translations).
- `_mixin_typing` abstract stub carries `# pragma: no cover`.
- An independent adversarial diff-review returned **PASS** (no blocker).
- Base `1.7`. **No version bump** (maintainer decides). Draft until an on-device acceptance test.