### PR TITLE
fix(const): drop non-finite ignored_at values instead of raising

### DIFF
--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -8,6 +8,7 @@ Keep comments and docstrings in English; user-facing strings belong in translati
 from __future__ import annotations
 
 import hashlib
+import math
 import time
 from collections.abc import Mapping, Sequence
 from typing import Final, Literal
@@ -290,6 +291,27 @@ def _coerce_aliases(value: object) -> list[str]:
     return []
 
 
+def _finite_int_or_none(value: object) -> int | None:
+    """Convert a finite ``int``/``float`` to ``int``; return ``None`` otherwise.
+
+    ``bool``, non-numeric types, and non-finite floats (``NaN``/``±inf``) all
+    yield ``None``. This exists because ``int(float("nan"))`` raises
+    ``ValueError`` and ``int(float("inf"))`` raises ``OverflowError`` -- either
+    would defeat the drop-invalid, never-raise contract of the coercer below
+    when a corrupt ``.storage`` edit or a direct-options writer stores such a
+    value. Guarding on ``math.isfinite`` keeps that coercer total.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return int(value)
+    return None
+
+
 def coerce_ignored_mapping(raw: object) -> tuple[IgnoredMapping, bool]:
     """Coerce various legacy shapes into v2 mapping.
     Accepted inputs:
@@ -346,8 +368,9 @@ def coerce_ignored_mapping(raw: object) -> tuple[IgnoredMapping, bool]:
                         name = name_value
                     aliases = _coerce_aliases(str_meta.get(_IGN_KEY_ALIASES))
                     ignored_value = str_meta.get(_IGN_KEY_IGNORED_AT)
-                    if isinstance(ignored_value, (int, float)):
-                        ignored_at = int(ignored_value)
+                    coerced_at = _finite_int_or_none(ignored_value)
+                    if coerced_at is not None:
+                        ignored_at = coerced_at
                     source_value = str_meta.get(_IGN_KEY_SOURCE)
                     if isinstance(source_value, str) and source_value:
                         source = source_value

--- a/tests/test_device_identifier_normalization.py
+++ b/tests/test_device_identifier_normalization.py
@@ -7,6 +7,7 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from homeassistant.config_entries import ConfigSubentry
 
 from custom_components.googlefindmy import (
@@ -20,6 +21,7 @@ from custom_components.googlefindmy.const import (
     OPT_OPTIONS_SCHEMA_VERSION,
     SUBENTRY_TYPE_TRACKER,
     TRACKER_SUBENTRY_KEY,
+    coerce_ignored_mapping,
 )
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from tests.helpers.config_flow import ConfigEntriesDomainUniqueIdLookupMixin
@@ -198,3 +200,36 @@ def test_migrate_entry_identifier_namespaces_updates_subentries() -> None:
     managed = manager.get(TRACKER_SUBENTRY_KEY)
     assert managed is not None
     assert tuple(managed.data.get("visible_device_ids", ())) == ("device-1",)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        float("nan"),  # int(nan) -> ValueError
+        float("inf"),  # int(inf) -> OverflowError
+        float("-inf"),  # int(-inf) -> OverflowError
+        True,  # bool is an int subclass; a truthy epoch of 1 is garbage
+    ],
+    ids=["nan", "inf", "-inf", "bool"],
+)
+def test_coerce_ignored_mapping_survives_invalid_ignored_at(bad_value: object) -> None:
+    """An invalid ``ignored_at`` is dropped to the default, never raised.
+
+    ``int()`` on a non-finite float raises (``ValueError``/``OverflowError``),
+    which would break the ignored-devices coercion on a corrupt ``.storage``
+    value; a ``bool`` would silently become the absurd epoch ``1``. Every one of
+    these must instead fall back to the finite default without raising.
+    """
+    result, _changed = coerce_ignored_mapping(
+        {"device-1": {"name": "Dev", "ignored_at": bad_value}}
+    )
+
+    assert "device-1" in result
+    metadata = result["device-1"]
+    assert metadata["name"] == "Dev"
+    # ignored_at fell back to the finite _now_epoch() default: a positive epoch,
+    # never NaN, never 0/None, and never the bool-derived 1 (a "return 0 instead
+    # of None" or dropped-guard helper mutation would leave a wrong value here).
+    ignored_at = metadata["ignored_at"]
+    assert isinstance(ignored_at, int)
+    assert ignored_at > 1


### PR DESCRIPTION
## What

Hardens `coerce_ignored_mapping` in `const.py` against non-finite floats (`NaN`/`±inf`) and `bool` in the stored `ignored_at` field.

`int(float("nan"))` raises `ValueError` and `int(float("inf"))` raises `OverflowError`. The coercer promises to *drop* invalid entries rather than raise, but the numeric branch was unguarded, so a corrupt `.storage` edit or a direct-options writer storing such a value would break the ignored-devices coercion.

## How

- New total helper `_finite_int_or_none(value)`: returns `None` for `bool`, non-numeric types, and non-finite floats; otherwise the truncated `int`.
- `ignored_at` conversion routed through the helper; invalid values fall back to the finite default instead of raising.
- Behaviour for valid finite values is unchanged (`int()` truncation preserved). Only intentional change: a `bool` `ignored_at` (previously accepted as the absurd epoch `1`/`0`) is now dropped to the default.

## Why standalone

This is a **feature-independent robustness fix** for the existing "Ignored devices" path. It was first spotted during review of #1157 (per-device poll interval), but applies to `origin/1.7` on its own: the branch already contains the unguarded `int(ignored_value)` conversion, without the per-device feature. Extracting it keeps the fix reviewable and mergeable regardless of #1157's fate.

## Tests

Parametrized regression test over `nan` / `inf` / `-inf` / `bool`, each verified mutation-sharp (removing the `isfinite` guard turns the non-finite cases red; removing the `bool` guard turns the bool case red).

## Verification

- `ruff check` + `ruff format --check` (CI-pinned 0.14.14 from `poetry.lock`): green
- `mypy` (strict): green
- Delta lines executed and asserted directly; full HA suite runs in CI.