### PR TITLE
chore: bump version to 1.7.10

### DIFF
--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -27,7 +27,7 @@ CONFIG_ENTRY_VERSION: int = 2
 # cross-reference, so the manifest side is anchored in this directory's AGENTS.md
 # ("Version bump touches three files"). pyproject.toml carries the reverse reference
 # in a TOML comment.
-INTEGRATION_VERSION: str = "1.7.9"
+INTEGRATION_VERSION: str = "1.7.10"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.9"
+  "version": "1.7.10"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "googlefindmy-ha"
 # [tool.semantic_release] version_toml below); on release branches it MUST be
 # bumped by hand alongside the other two. Canonical anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
-version = "1.7.9"
+version = "1.7.10"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Version bump 1.7.9 → 1.7.10

Bumps the three canonical version anchors to `1.7.10`, covering the changes merged into `1.7` since the last bump (`1.7.9`, #1154):

- #1155 — network-location fix via crypto provenance
- #1156 — predictive-poll cadence respects `location_poll_interval` (stage 1)
- #1158 — drop non-finite `ignored_at` values instead of raising

### Files changed (version-only)
- `custom_components/googlefindmy/const.py` (`INTEGRATION_VERSION`)
- `custom_components/googlefindmy/manifest.json` (`version`)
- `pyproject.toml` (`version`)

No functional changes. The three anchors are kept in sync per the `custom_components/googlefindmy/AGENTS.md` convention ("Version bump touches three files"). The release tag `1.7.10b0` is already the latest on the release track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)