### PR TITLE
Harden reauth matchers and add structured reauth-reason diagnostics

### DIFF
--- a/custom_components/googlefindmy/Auth/aas_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/aas_token_retrieval.py
@@ -30,8 +30,10 @@ Enhancements (defensive validation & retries):
   We **do not reuse** such values. Instead, we disqualify them for the OAuth→AAS
   exchange and fall back to the next available source. This avoids brittle shortcuts.
 - Retry policy: transient transport/library errors retry with bounded exponential
-  backoff; clear auth failures (e.g., "BadAuthentication", "invalid_grant", 401/403
-  semantics like "unauthorized"/"forbidden") are **not** retried.
+  backoff; clear auth failures (e.g., "BadAuthentication", "invalid_grant") are
+  **not** retried. Non-retryable auth is matched structurally via ``error_kind``,
+  not via broad HTTP substrings (401/403, "unauthorized"/"forbidden") in free-form
+  text.
 """
 
 from __future__ import annotations
@@ -140,13 +142,15 @@ _NON_RETRYABLE_KINDS: frozenset[str] = frozenset(
 )
 
 # Substrings that surface in ``_clip(err)`` for callers that raise
-# ``RuntimeError`` without the ``error_kind`` attribute (e.g. HTTP-status
-# surfaces in sibling modules and the existing test suite).
+# ``RuntimeError`` without the ``error_kind`` attribute (legacy paths and the
+# existing test suite). Only gpsoauth-specific vocabulary is matched here. The
+# HTTP-generic tokens ("unauthorized" / "forbidden") are deliberately NOT
+# listed: genuine HTTP auth denials are carried structurally (``error_kind``),
+# and a free-text substring must not force a network-adjacent error to be
+# treated as a permanent, non-retryable auth failure.
 _NON_RETRYABLE_PATTERNS: tuple[str, ...] = (
     "badauthentication",
     "invalid_grant",
-    "unauthorized",
-    "forbidden",
     "missing 'token' in gpsoauth response",
 )
 
@@ -491,8 +495,9 @@ async def async_get_aas_token(
         - Issuance timestamp stored under `aas_token_issued_at_<username>` for TTL learning.
 
     Retry policy:
-        - Non-retryable auth failures (e.g., "BadAuthentication", "invalid_grant",
-          "unauthorized"/"forbidden") abort immediately.
+        - Non-retryable auth failures (e.g., "BadAuthentication", "invalid_grant")
+          abort immediately, matched structurally via ``error_kind`` rather than via
+          broad HTTP substrings ("unauthorized"/"forbidden") in free-form text.
         - Transient errors (network/timeouts/library) retry with exponential backoff.
 
     Args:

--- a/custom_components/googlefindmy/Auth/adm_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/adm_token_retrieval.py
@@ -17,8 +17,9 @@ Design & Fix for BadAuthentication:
   the retriever expects the full OAuth2 scope.
 - **Retry policy**: Transient network/library errors are retried with bounded backoff.
   Clear, non-recoverable auth errors (e.g., "BadAuthentication") are NOT retried.
-  Additionally, HTTP-style signals such as 401/403 or "unauthorized"/"forbidden" in
-  error messages are treated as non-retryable as well.
+  Non-retryable auth is determined structurally via ``error_kind``; broad HTTP
+  substrings (401/403, "unauthorized"/"forbidden") are deliberately NOT matched in
+  free-form error text, to avoid misclassifying network-adjacent failures.
 - Blocking `gpsoauth` calls (isolated flow) are executed in a thread executor to
   avoid blocking Home Assistant's event loop.
 
@@ -158,18 +159,19 @@ _NON_RETRYABLE_KINDS: frozenset[str] = frozenset(
 
 # Substrings that surface in ``_clip(err)`` for callers that raise
 # ``RuntimeError`` without the ``error_kind`` attribute (legacy paths and the
-# existing test suite). HTTP-status substrings are kept here so plain text
-# surfaces like "server returned 401 unauthorized" stay non-retryable.
+# existing test suite). Only gpsoauth-specific vocabulary is matched here.
+# HTTP-generic tokens ("401", "403", "unauthorized", "forbidden") are
+# deliberately NOT listed: a transient message like "retry after 4012 ms"
+# contains "401" as a substring, so keying non-retryable auth on those would
+# misclassify network hiccups as permanent auth failures. Genuine HTTP auth
+# denials are already carried structurally (``error_kind`` and the typed
+# ``err.status`` check in ``api.py``), not via free-text substring matching.
 _NON_RETRYABLE_PATTERNS: tuple[str, ...] = (
     "badauthentication",
     "invalid_grant",
     "missing 'auth' in gpsoauth response",
     "neither 'token' nor 'auth' found",
     "missing 'token'/'auth' in gpsoauth response",
-    "unauthorized",
-    "forbidden",
-    "401",
-    "403",
 )
 
 

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -81,10 +81,10 @@ from cryptography.exceptions import InvalidTag
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
     FcmRegisterHTTPError,
 )
-from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.exceptions import FatalRegistrationError
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3004,11 +3004,15 @@ class FcmReceiverHA:
                 if entry is not None:
                     # FIX 3: direct reauth site (background decrypt escalation for
                     # a stale shared key); record the classified reason on the
-                    # matching coordinator before starting the flow.
+                    # matching coordinator before starting the flow. This escalation
+                    # is only reached on the account-wide stale-shared-key decrypt
+                    # path (note_decrypt_failure returns False for stale=True), so it
+                    # maps to DECRYPT_STALE_KEY -- the same code the poll and locate
+                    # equivalents use -- not an AAS/token code.
                     recorder = getattr(coordinator, "record_reauth_reason", None)
                     if callable(recorder):
                         recorder(
-                            ReauthReasonCode.AAS_INVALID,
+                            ReauthReasonCode.DECRYPT_STALE_KEY,
                             origin="fcm_receiver_ha.py:3004",
                         )
                     entry.async_start_reauth(hass)

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -84,6 +84,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
     FcmRegisterHTTPError,
 )
+from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.exceptions import FatalRegistrationError
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
@@ -3001,6 +3002,15 @@ class FcmReceiverHA:
             if escalate and hass is not None:
                 entry = getattr(coordinator, "config_entry", None)
                 if entry is not None:
+                    # FIX 3: direct reauth site (background decrypt escalation for
+                    # a stale shared key); record the classified reason on the
+                    # matching coordinator before starting the flow.
+                    recorder = getattr(coordinator, "record_reauth_reason", None)
+                    if callable(recorder):
+                        recorder(
+                            ReauthReasonCode.AAS_INVALID,
+                            origin="fcm_receiver_ha.py:3004",
+                        )
                     entry.async_start_reauth(hass)
 
     def _note_decrypt_success_for_entry(self, entry_id: str) -> None:

--- a/custom_components/googlefindmy/Auth/token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/token_retrieval.py
@@ -43,15 +43,27 @@ def _gpsoauth() -> GpsoauthModule:
 gpsoauth = _gpsoauth_proxy
 
 
-def _is_invalid_aas_error_text(text: str) -> bool:
-    """Return True when the error string indicates an invalid AAS token."""
+def _is_invalid_aas_error_text(text: str, *, allow_http_generic: bool = False) -> bool:
+    """Return True when the error string indicates an invalid AAS token.
+
+    The gpsoauth-specific tokens (``badauthentication``, ``needsbrowser``, and
+    the ``invalid`` + credential vocabulary) are unique to the gpsoauth
+    ``Error`` field and stay active on every call. The HTTP-generic tokens
+    (``unauthorized`` / ``forbidden``) are only honoured when
+    ``allow_http_generic`` is set, because an arbitrary transport/network
+    exception string must not be able to masquerade as an invalid AAS token
+    and discard otherwise-valid credential material. Callers that pass the
+    structured gpsoauth ``Error`` field opt in via ``allow_http_generic=True``;
+    callers that pass a generic ``str(err)`` from an ``except Exception`` block
+    keep the safe default (``False``).
+    """
 
     lowered = text.lower()
     if "badauthentication" in lowered:
         return True
     if "needsbrowser" in lowered:
         return True
-    if "unauthorized" in lowered or "forbidden" in lowered:
+    if allow_http_generic and ("unauthorized" in lowered or "forbidden" in lowered):
         return True
     if "invalid" in lowered:
         if "token" in lowered or "auth" in lowered or "credential" in lowered:
@@ -210,7 +222,9 @@ def _perform_oauth_sync(
             return token_value
 
         error_detail = str(auth_response.get("Error", "")).strip()
-        if error_detail and _is_invalid_aas_error_text(error_detail):
+        if error_detail and _is_invalid_aas_error_text(
+            error_detail, allow_http_generic=True
+        ):
             raise InvalidAasTokenError(
                 f"gpsoauth rejected the AAS token while requesting scope '{scope}': {error_detail}"
             )
@@ -219,6 +233,10 @@ def _perform_oauth_sync(
         raise
     except Exception as err:  # noqa: BLE001
         message: str = str(err)
+        # Generic exception string: keep ``allow_http_generic=False`` so a
+        # transport/network error whose text merely contains "unauthorized" or
+        # "forbidden" cannot masquerade as an invalid AAS token. Only the
+        # gpsoauth-specific vocabulary may promote this to InvalidAasTokenError.
         if message and _is_invalid_aas_error_text(message):
             raise InvalidAasTokenError(
                 f"gpsoauth rejected the AAS token while requesting scope '{scope}': {message}"

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -44,6 +44,7 @@ from custom_components.googlefindmy.Auth.username_provider import (
     async_get_username,
     username_string,
 )
+from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.KeyBackup.cloud_key_decryptor import (
     decrypt_owner_key,
 )
@@ -160,9 +161,11 @@ async def _retrieve_owner_key(
         try:
             eid_info = await async_get_eid_info(cache=cache)
         except SpotAuthPermanentError as exc:
-            raise ConfigEntryAuthFailed(
+            reauth_exc = ConfigEntryAuthFailed(
                 "Owner key retrieval failed: Google session invalid; re-authentication required."
-            ) from exc
+            )
+            reauth_exc.reauth_code = ReauthReasonCode.OWNER_KEY_PERMANENT
+            raise reauth_exc from exc
         except SpotApiEmptyResponseError:
             _LOGGER.error(
                 "Owner key retrieval failed: SPOT returned an empty/trailers-only "
@@ -396,10 +399,12 @@ async def async_get_owner_key(  # noqa: PLR0912,PLR0915
         # UNCHANGED deliberately, because whether an empty/trailers-only response
         # is transient or auth is not yet proven. The captured gRPC status (R9a)
         # makes the next real incident diagnosable before any reclassification.
-        raise ConfigEntryAuthFailed(
+        reauth_exc = ConfigEntryAuthFailed(
             "Owner key retrieval failed: SPOT returned an empty/trailers-only "
             "response; the exact gRPC status is logged for diagnosis."
-        ) from exc
+        )
+        reauth_exc.reauth_code = ReauthReasonCode.OWNER_KEY_EMPTY_RESPONSE
+        raise reauth_exc from exc
 
     cache_version: int | None = None
     cache_key_value: str | None = None

--- a/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
+++ b/custom_components/googlefindmy/SpotApi/GetEidInfoForE2eeDevices/get_owner_key.py
@@ -39,12 +39,12 @@ from typing import Any, NamedTuple
 from cryptography.exceptions import InvalidTag
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth.token_cache import TokenCache
 from custom_components.googlefindmy.Auth.username_provider import (
     async_get_username,
     username_string,
 )
-from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.KeyBackup.cloud_key_decryptor import (
     decrypt_owner_key,
 )

--- a/custom_components/googlefindmy/_reauth_reason.py
+++ b/custom_components/googlefindmy/_reauth_reason.py
@@ -35,8 +35,6 @@ class ReauthReasonCode(StrEnum):
     HTTP_401_AFTER_REFRESH = "http_401_after_refresh"
     # api.py gpsoauth BadAuthentication / missing token.
     BADAUTH_GPSOAUTH = "badauth_gpsoauth"
-    # Invalid AAS credential material.
-    AAS_INVALID = "aas_invalid"
     # Spot transport permanent auth failure (SpotAuthPermanentError from
     # spot_request.py: AAS token invalid after refresh / gRPC UNAUTHENTICATED /
     # PERMISSION_DENIED). General Spot-session-permanent, not owner-key specific.

--- a/custom_components/googlefindmy/_reauth_reason.py
+++ b/custom_components/googlefindmy/_reauth_reason.py
@@ -1,4 +1,4 @@
-# custom_components/googlefindmy/coordinator/_reauth_reason.py
+# custom_components/googlefindmy/_reauth_reason.py
 """Structured, redaction-safe reauth-reason model for coordinator diagnostics.
 
 This module defines the small, self-contained data model used to persist *why*

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -35,6 +35,7 @@ from aiohttp import ClientError, ClientSession
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from ._reauth_reason import ReauthReasonCode
 from .Auth.token_cache import TokenCache
 from .Auth.username_provider import username_string
 from .const import (
@@ -43,7 +44,6 @@ from .const import (
     CONTRIBUTOR_MODE_IN_ALL_AREAS,
     DEFAULT_CONTRIBUTOR_MODE,
 )
-from .coordinator._reauth_reason import ReauthReasonCode
 from .NovaApi import nova_request
 from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -43,6 +43,7 @@ from .const import (
     CONTRIBUTOR_MODE_IN_ALL_AREAS,
     DEFAULT_CONTRIBUTOR_MODE,
 )
+from .coordinator._reauth_reason import ReauthReasonCode
 from .NovaApi import nova_request
 from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
@@ -1059,7 +1060,9 @@ class GoogleFindMyAPI:
                     err.status,
                     _short_err(err),
                 )
-                raise ConfigEntryAuthFailed(_short_err(err)) from err
+                exc = ConfigEntryAuthFailed(_short_err(err))
+                exc.reauth_code = ReauthReasonCode.HTTP_401_AFTER_REFRESH
+                raise exc from err
             _LOGGER.warning(
                 "Device list temporarily unavailable (server error %s): %s",
                 err.status,
@@ -1071,7 +1074,9 @@ class GoogleFindMyAPI:
             _LOGGER.error(
                 "Authentication failed while listing devices: %s", _short_err(err)
             )
-            raise ConfigEntryAuthFailed(_short_err(err)) from err
+            exc = ConfigEntryAuthFailed(_short_err(err))
+            exc.reauth_code = ReauthReasonCode.NOVA_AUTH_FAILED
+            raise exc from err
 
         except NovaProtobufDecodeError as err:
             # Protobuf decode failures indicate corrupted response or protocol mismatch
@@ -1096,7 +1101,9 @@ class GoogleFindMyAPI:
                 or "Bad Authentication" in msg
             ):
                 _LOGGER.error("Authentication failed (gpsoauth): %s", _short_err(msg))
-                raise ConfigEntryAuthFailed(_short_err(msg)) from err
+                exc = ConfigEntryAuthFailed(_short_err(msg))
+                exc.reauth_code = ReauthReasonCode.BADAUTH_GPSOAUTH
+                raise exc from err
 
             # TokenCache closed indicates the integration is in an invalid state
             # (e.g., after a failed reload or during shutdown). Trigger re-auth
@@ -1106,9 +1113,11 @@ class GoogleFindMyAPI:
                     "TokenCache is closed; integration state is invalid. "
                     "Triggering re-authentication to reinitialize."
                 )
-                raise ConfigEntryAuthFailed(
+                exc = ConfigEntryAuthFailed(
                     "Integration state invalid (cache closed); please re-authenticate"
-                ) from err
+                )
+                exc.reauth_code = ReauthReasonCode.TOKENCACHE_CLOSED
+                raise exc from err
 
             # Detect and tame the multi-entry guard (INFO once, DEBUG thereafter)
             if _is_multi_entry_guard_message(msg):
@@ -1275,7 +1284,9 @@ class GoogleFindMyAPI:
                 device_id,
                 _short_err(err),
             )
-            raise ConfigEntryAuthFailed(_short_err(err)) from err
+            exc = ConfigEntryAuthFailed(_short_err(err))
+            exc.reauth_code = ReauthReasonCode.NOVA_AUTH_PERMANENT
+            raise exc from err
 
         except NovaAuthError as err:
             # Transient auth failure - may self-heal in subsequent poll cycles.
@@ -1287,7 +1298,9 @@ class GoogleFindMyAPI:
                     device_id,
                     _short_err(err),
                 )
-                raise ConfigEntryAuthFailed(_short_err(err)) from err
+                exc = ConfigEntryAuthFailed(_short_err(err))
+                exc.reauth_code = ReauthReasonCode.NOVA_AUTH_PERMANENT
+                raise exc from err
 
             _LOGGER.warning(
                 "Transient authentication error for %s (%s): %s. May resolve in next poll cycle.",
@@ -1308,7 +1321,9 @@ class GoogleFindMyAPI:
                     device_id,
                     _short_err(err),
                 )
-                raise ConfigEntryAuthFailed(_short_err(err)) from err
+                exc = ConfigEntryAuthFailed(_short_err(err))
+                exc.reauth_code = ReauthReasonCode.HTTP_401_AFTER_REFRESH
+                raise exc from err
             _LOGGER.warning(
                 "Server error (%s) while getting location for %s (%s): %s",
                 err.status,

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -1071,11 +1071,26 @@ class GoogleFindMyAPI:
             raise UpdateFailed(_short_err(err)) from err
 
         except NovaAuthError as err:
-            _LOGGER.error(
-                "Authentication failed while listing devices: %s", _short_err(err)
-            )
+            # Mirror the location path's base handler: a permanent credential
+            # failure (NovaAuthPermanentError subclass, or a base NovaAuthError
+            # flagged is_permanent=True after token refresh) must record the
+            # permanent reason, not the generic/transient one, so diagnostics
+            # point triage at the right credential layer. Control flow is
+            # unchanged (both cases raise ConfigEntryAuthFailed); only the
+            # reason code and log wording differ by permanence.
             exc = ConfigEntryAuthFailed(_short_err(err))
-            exc.reauth_code = ReauthReasonCode.NOVA_AUTH_FAILED
+            if err.is_permanent:
+                _LOGGER.error(
+                    "Permanent authentication failure while listing devices: %s",
+                    _short_err(err),
+                )
+                exc.reauth_code = ReauthReasonCode.NOVA_AUTH_PERMANENT
+            else:
+                _LOGGER.error(
+                    "Authentication failed while listing devices: %s",
+                    _short_err(err),
+                )
+                exc.reauth_code = ReauthReasonCode.NOVA_AUTH_FAILED
             raise exc from err
 
         except NovaProtobufDecodeError as err:

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -39,8 +39,8 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers import device_registry as dr
 
+    from .._reauth_reason import ReauthReason, ReauthReasonCode
     from ..api import GoogleFindMyAPI
-    from ._reauth_reason import ReauthReason, ReauthReasonCode
     from .subentry import SubentryMetadata
 
 

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     from homeassistant.helpers import device_registry as dr
 
     from ..api import GoogleFindMyAPI
+    from ._reauth_reason import ReauthReason, ReauthReasonCode
     from .subentry import SubentryMetadata
 
 
@@ -103,6 +104,8 @@ class _MixinBase:
     _fcm_defer_started_mono: float
     _consecutive_transient_auth_failures: int
     _last_transient_auth_error: str | None
+    # Structured, redaction-safe record of the most recent reauth trigger (FIX 3).
+    _reauth_reason: ReauthReason | None
     _consecutive_decrypt_failures: int
     _last_decrypt_reauth_monotonic: float | None
     _last_decrypt_error: str | None
@@ -156,6 +159,15 @@ class _MixinBase:
 
     def note_error(
         self, exc: Exception, *, where: str = "", device: str | None = None
+    ) -> None:
+        raise NotImplementedError
+
+    def record_reauth_reason(
+        self,
+        code: ReauthReasonCode,
+        origin: str,
+        *,
+        counters: Mapping[str, int] | None = None,
     ) -> None:
         raise NotImplementedError
 

--- a/custom_components/googlefindmy/coordinator/_reauth_reason.py
+++ b/custom_components/googlefindmy/coordinator/_reauth_reason.py
@@ -1,0 +1,75 @@
+# custom_components/googlefindmy/coordinator/_reauth_reason.py
+"""Structured, redaction-safe reauth-reason model for coordinator diagnostics.
+
+This module defines the small, self-contained data model used to persist *why*
+a re-authentication was triggered so it becomes visible in the diagnostics
+download without requiring a ``--debug`` log capture.
+
+Design invariants (see PLAN AE-6/AE-7):
+
+- :class:`ReauthReasonCode` is a :class:`~enum.StrEnum` so serialization to the
+  diagnostics payload is trivial (``str(code)``) and every value is a stable,
+  literal identifier that is safe to expose verbatim.
+- :class:`ReauthReason` only ever carries *literal-only* inputs: a
+  :class:`ReauthReasonCode`, a constant literal ``origin`` string supplied at the
+  call site, integer counters, and an epoch timestamp. It never stores
+  ``str(err)``, tokens, e-mail addresses, or any other free-form/PII content.
+  This "literal-only input" invariant is what makes the diagnostics mirror
+  redaction-safe by construction (not a length cap).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class ReauthReasonCode(StrEnum):
+    """Stable, redaction-safe identifiers for re-authentication triggers.
+
+    The values are literal identifiers only; they carry no request-specific or
+    user-specific content and are therefore safe to expose in diagnostics.
+    """
+
+    # api.py device-list / location HTTP 401/403 after a token refresh.
+    HTTP_401_AFTER_REFRESH = "http_401_after_refresh"
+    # api.py gpsoauth BadAuthentication / missing token.
+    BADAUTH_GPSOAUTH = "badauth_gpsoauth"
+    # Invalid AAS credential material.
+    AAS_INVALID = "aas_invalid"
+    # get_owner_key permanent Spot session failure.
+    OWNER_KEY_PERMANENT = "owner_key_permanent"
+    # get_owner_key empty/trailers-only SPOT response (transient/auth unproven).
+    OWNER_KEY_EMPTY_RESPONSE = "owner_key_empty_response"
+    # api.py "TokenCache is closed" invalid-state escalation.
+    TOKENCACHE_CLOSED = "tokencache_closed"
+    # api.py transient/generic Nova auth failure.
+    NOVA_AUTH_FAILED = "nova_auth_failed"
+    # api.py permanent Nova auth failure (NovaAuthPermanentError / is_permanent).
+    NOVA_AUTH_PERMANENT = "nova_auth_permanent"
+    # coordinator/polling FCM fatal auth error escalation.
+    FCM_AUTH_FATAL = "fcm_auth_fatal"
+    # Default when a catch site finds no ``reauth_code`` attribute on the
+    # exception, or a direct reauth site without a more specific classification.
+    UNKNOWN = "unknown"
+
+
+@dataclass(slots=True)
+class ReauthReason:
+    """Typed, redaction-safe record of the most recent re-authentication trigger.
+
+    Attributes:
+        code: The classified :class:`ReauthReasonCode`.
+        origin: A constant literal string identifying the call site (for
+            example ``"api.py:1099"``). Never derived from runtime introspection
+            and never carries request/user content.
+        counters: A snapshot of relevant integer counters at record time (for
+            example the consecutive-transient-auth-failure count and its
+            threshold). Values are plain ints only.
+        recorded_at: Epoch seconds (UTC wall clock) when the reason was recorded.
+    """
+
+    code: ReauthReasonCode
+    origin: str
+    counters: dict[str, int] = field(default_factory=dict)
+    recorded_at: float = 0.0

--- a/custom_components/googlefindmy/coordinator/_reauth_reason.py
+++ b/custom_components/googlefindmy/coordinator/_reauth_reason.py
@@ -60,6 +60,13 @@ class ReauthReasonCode(StrEnum):
     NOVA_AUTH_PERMANENT = "nova_auth_permanent"
     # coordinator/polling FCM fatal auth error escalation.
     FCM_AUTH_FATAL = "fcm_auth_fatal"
+    # poll-cycle account-wide location-decryption escalation: repeated decrypt
+    # failures across _MAX_DECRYPT_FAILURES consecutive cycles prove the shared
+    # key is stale and a fresh secrets.json is required. Distinct from the auth
+    # codes above because the trigger is a decryption verdict (not an auth-API
+    # error); it is the last poll-reauth cause that would otherwise record
+    # UNKNOWN in diagnostics.
+    DECRYPT_STALE_KEY = "decrypt_stale_key"
     # Default when a catch site finds no ``reauth_code`` attribute on the
     # exception, or a direct reauth site without a more specific classification.
     UNKNOWN = "unknown"

--- a/custom_components/googlefindmy/coordinator/_reauth_reason.py
+++ b/custom_components/googlefindmy/coordinator/_reauth_reason.py
@@ -37,14 +37,25 @@ class ReauthReasonCode(StrEnum):
     BADAUTH_GPSOAUTH = "badauth_gpsoauth"
     # Invalid AAS credential material.
     AAS_INVALID = "aas_invalid"
+    # Spot transport permanent auth failure (SpotAuthPermanentError from
+    # spot_request.py: AAS token invalid after refresh / gRPC UNAUTHENTICATED /
+    # PERMISSION_DENIED). General Spot-session-permanent, not owner-key specific.
+    SPOT_AUTH_PERMANENT = "spot_auth_permanent"
     # get_owner_key permanent Spot session failure.
     OWNER_KEY_PERMANENT = "owner_key_permanent"
     # get_owner_key empty/trailers-only SPOT response (transient/auth unproven).
     OWNER_KEY_EMPTY_RESPONSE = "owner_key_empty_response"
     # api.py "TokenCache is closed" invalid-state escalation.
     TOKENCACHE_CLOSED = "tokencache_closed"
-    # api.py transient/generic Nova auth failure.
+    # api.py transient/generic Nova auth failure (single, immediate escalation).
     NOVA_AUTH_FAILED = "nova_auth_failed"
+    # poll-cycle transient Nova auth failure that persisted across
+    # _MAX_TRANSIENT_AUTH_FAILURES consecutive cycles before escalating. Distinct
+    # from NOVA_AUTH_FAILED because "flaky auth that exhausted its retries" is the
+    # primary poll-reauth signal (the reported intermittent-network case) and must
+    # stay separable from a single hard failure. The counters snapshot carries the
+    # consecutive/threshold counts.
+    NOVA_AUTH_TRANSIENT_EXHAUSTED = "nova_auth_transient_exhausted"
     # api.py permanent Nova auth failure (NovaAuthPermanentError / is_permanent).
     NOVA_AUTH_PERMANENT = "nova_auth_permanent"
     # coordinator/polling FCM fatal auth error escalation.

--- a/custom_components/googlefindmy/coordinator/helpers/update.py
+++ b/custom_components/googlefindmy/coordinator/helpers/update.py
@@ -14,8 +14,17 @@ All functions are pure (no side effects) for easy testing and reuse.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
+
+# Word-boundary matchers for HTTP status codes. Using ``\b`` prevents a
+# transient message like "retry after 4012 ms" (which contains the substring
+# "401") from being misread as an HTTP 401, while still matching a genuine
+# "401"/"404" that appears as a standalone token (e.g. "HTTP 401 Unauthorized",
+# "Error code: 401", "404 credential not found").
+_HTTP_401_TOKEN = re.compile(r"\b401\b")
+_HTTP_404_TOKEN = re.compile(r"\b404\b")
 
 __all__ = [
     "calculate_presence_ttl",
@@ -48,12 +57,15 @@ def is_fatal_fcm_auth_error(error: Any) -> bool:
 
     error_lower = error.lower()
 
-    # 401 errors are always fatal
-    if "401" in error:
+    # 401 errors are always fatal. Match the status code on a word boundary so a
+    # transient throttling message such as "retry after 4012 ms" (substring
+    # "401") is not misclassified as an authentication failure.
+    if _HTTP_401_TOKEN.search(error):
         return True
 
-    # 404 with credential mention is fatal
-    if "404" in error and "credential" in error_lower:
+    # 404 with credential mention is fatal. Same word-boundary guard so e.g.
+    # "retry after 40412 ms" (substring "404") cannot false-fire.
+    if _HTTP_404_TOKEN.search(error) and "credential" in error_lower:
         return True
 
     # Explicit credential/auth failure messages

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -24,6 +24,7 @@ from typing import Any
 from aiohttp import ClientConnectionError, ClientError
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
+from .._reauth_reason import ReauthReasonCode
 from ..const import DEFAULT_MIN_POLL_INTERVAL
 from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
@@ -39,7 +40,6 @@ from ..NovaApi.nova_request import (
 )
 from ..SpotApi.spot_request import SpotAuthPermanentError
 from ._mixin_typing import _MixinBase
-from ._reauth_reason import ReauthReasonCode
 from .helpers.cache import (
     SOUND_UUID_MAX_AGE_S,
     carry_reused_accuracy,

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -39,6 +39,7 @@ from ..NovaApi.nova_request import (
 )
 from ..SpotApi.spot_request import SpotAuthPermanentError
 from ._mixin_typing import _MixinBase
+from ._reauth_reason import ReauthReasonCode
 from .helpers.cache import (
     SOUND_UUID_MAX_AGE_S,
     carry_reused_accuracy,
@@ -508,6 +509,12 @@ class LocateOperations(_MixinBase):
                     failed=True,
                     reason=f"Auth failed during manual locate: {auth_err}",
                 )
+                # FIX 3: direct reauth site (no exception bubbles to a coordinator
+                # catch), so record the classified reason directly.
+                self.record_reauth_reason(
+                    ReauthReasonCode.OWNER_KEY_PERMANENT,
+                    origin="locate.py:521",
+                )
                 entry = getattr(self, "config_entry", None)
                 reauth_started = False
                 if entry is not None:
@@ -644,6 +651,12 @@ class LocateOperations(_MixinBase):
                         "the shared key is stale and a fresh secrets.json "
                         "(re-authentication) is required"
                     ),
+                )
+                # FIX 3: direct reauth site (a stale shared key needs fresh
+                # credentials); record the classified reason directly.
+                self.record_reauth_reason(
+                    ReauthReasonCode.AAS_INVALID,
+                    origin="locate.py:656",
                 )
                 entry = getattr(self, "config_entry", None)
                 reauth_started = False

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -510,9 +510,13 @@ class LocateOperations(_MixinBase):
                     reason=f"Auth failed during manual locate: {auth_err}",
                 )
                 # FIX 3: direct reauth site (no exception bubbles to a coordinator
-                # catch), so record the classified reason directly.
+                # catch), so record the classified reason directly. The condition
+                # is a generic Spot-transport auth failure (SpotAuthPermanentError
+                # is raised only in spot_request.py, e.g. "AAS token invalid after
+                # refresh"), so it maps to SPOT_AUTH_PERMANENT -- the same code the
+                # poll-cycle equivalent uses (polling.py) -- not an owner-key code.
                 self.record_reauth_reason(
-                    ReauthReasonCode.OWNER_KEY_PERMANENT,
+                    ReauthReasonCode.SPOT_AUTH_PERMANENT,
                     origin="locate.py:521",
                 )
                 entry = getattr(self, "config_entry", None)
@@ -653,9 +657,12 @@ class LocateOperations(_MixinBase):
                     ),
                 )
                 # FIX 3: direct reauth site (a stale shared key needs fresh
-                # credentials); record the classified reason directly.
+                # credentials); record the classified reason directly. This is the
+                # account-wide stale-shared-key decrypt condition, so it maps to
+                # DECRYPT_STALE_KEY -- the same code the poll-cycle equivalent uses
+                # (polling.py, _finalize_cycle_decrypt_state) -- not an AAS/token code.
                 self.record_reauth_reason(
-                    ReauthReasonCode.AAS_INVALID,
+                    ReauthReasonCode.DECRYPT_STALE_KEY,
                     origin="locate.py:656",
                 )
                 entry = getattr(self, "config_entry", None)

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -66,7 +66,7 @@ from datetime import datetime, timedelta
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
-from ._reauth_reason import ReauthReason, ReauthReasonCode
+from .._reauth_reason import ReauthReason, ReauthReasonCode
 
 # Operations classes - currently empty mixins for future method extraction
 from .cache import CacheOperations

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -66,6 +66,8 @@ from datetime import datetime, timedelta
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
+from ._reauth_reason import ReauthReason, ReauthReasonCode
+
 # Operations classes - currently empty mixins for future method extraction
 from .cache import CacheOperations
 from .helpers.cache import (
@@ -892,6 +894,14 @@ class GoogleFindMyCoordinator(
         self._consecutive_transient_auth_failures: int = 0
         self._last_transient_auth_error: str | None = None
 
+        # FIX 3: structured, redaction-safe record of the most recent reauth
+        # trigger, mirrored into diagnostics so the reason is visible without a
+        # debug log capture. ``None`` until the first reauth is recorded.
+        self._reauth_reason: ReauthReason | None = None
+        # De-dup set for the once-per (code, origin) WARNING emitted by
+        # ``record_reauth_reason`` so a repeating trigger does not spam the log.
+        self._reauth_reason_logged: set[tuple[str, str]] = set()
+
         # Stale/missing shared-key decryption failures escalate to a reauth flow
         # only after several consecutive cycles, with a cooldown so the flow is not
         # re-fired on every poll once it is already open. Mirrors the transient-auth
@@ -1472,6 +1482,64 @@ class GoogleFindMyCoordinator(
             prefix += f"({device})"
         err_type = type(exc).__name__
         self._append_recent_error(err_type, f"{prefix}: {exc}")
+
+    def record_reauth_reason(
+        self,
+        code: ReauthReasonCode,
+        origin: str,
+        *,
+        counters: Mapping[str, int] | None = None,
+    ) -> None:
+        """Persist a structured, redaction-safe reason for a reauth trigger.
+
+        This is the single choke point that turns a classified reauth trigger
+        into diagnosable state. It stores a :class:`ReauthReason` on the
+        coordinator (mirrored into diagnostics) and emits a **once-per**
+        ``(code, origin)`` WARNING with structured ``extra=`` fields so a
+        repeating trigger does not spam the log.
+
+        The inputs are literal-only by contract: ``code`` is a
+        :class:`ReauthReasonCode`, ``origin`` is a constant literal string
+        supplied at the call site, and ``counters`` (defaulting to a snapshot of
+        the transient-auth-failure counter and its threshold) are plain ints.
+        No token, e-mail, or ``str(err)`` content is ever stored or logged here.
+
+        Args:
+            code: The classified reauth reason code.
+            origin: A constant literal string identifying the call site.
+            counters: Optional counter snapshot; when omitted the current
+                transient-auth-failure count and its threshold are captured.
+        """
+        if counters is None:
+            snapshot: dict[str, int] = {
+                "consecutive_transient_auth_failures": int(
+                    self._consecutive_transient_auth_failures
+                ),
+                "max_transient_auth_failures": int(_MAX_TRANSIENT_AUTH_FAILURES),
+            }
+        else:
+            snapshot = {key: int(value) for key, value in counters.items()}
+
+        self._reauth_reason = ReauthReason(
+            code=code,
+            origin=origin,
+            counters=snapshot,
+            recorded_at=time.time(),
+        )
+
+        dedup_key = (str(code), origin)
+        if dedup_key not in self._reauth_reason_logged:
+            self._reauth_reason_logged.add(dedup_key)
+            _LOGGER.warning(
+                "Re-authentication triggered (%s at %s)",
+                code,
+                origin,
+                extra={
+                    "reauth_code": str(code),
+                    "reauth_origin": origin,
+                    "reauth_counters": snapshot,
+                },
+            )
 
     # Safe getters for durations based on keys that __init__.py may set.
     def get_metric(self, key: str) -> float | None:

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -616,6 +616,7 @@ class PollingOperations(_MixinBase):
                 "is stale; a fresh secrets.json (re-authentication) "
                 "is required"
             )
+            reauth_exc.reauth_code = ReauthReasonCode.DECRYPT_STALE_KEY
             return True, reauth_exc, reauth_exc
         if self._decrypt_failure_is_account_wide(
             cycle_decrypt_error, cycle_had_successful_decrypt

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2013,6 +2013,7 @@ class PollingOperations(_MixinBase):
                         reauth_exc = ConfigEntryAuthFailed(
                             "Google session invalid; re-authentication required"
                         )
+                        reauth_exc.reauth_code = ReauthReasonCode.SPOT_AUTH_PERMANENT
                         last_exception = reauth_exc
                         self._request_poll_reauth(reauth_exc)
                         return
@@ -2030,6 +2031,9 @@ class PollingOperations(_MixinBase):
                         self._consecutive_timeouts = 0
                         reauth_exc = ConfigEntryAuthFailed(
                             "Google session invalid; re-authentication required"
+                        )
+                        reauth_exc.reauth_code = (
+                            ReauthReasonCode.OWNER_KEY_EMPTY_RESPONSE
                         )
                         last_exception = reauth_exc
                         self._request_poll_reauth(reauth_exc)
@@ -2052,6 +2056,7 @@ class PollingOperations(_MixinBase):
                         reauth_exc = ConfigEntryAuthFailed(
                             "Google credentials invalid; re-authentication required"
                         )
+                        reauth_exc.reauth_code = ReauthReasonCode.NOVA_AUTH_PERMANENT
                         last_exception = reauth_exc
                         self._request_poll_reauth(reauth_exc)
                         return
@@ -2081,6 +2086,9 @@ class PollingOperations(_MixinBase):
                             self._consecutive_timeouts = 0
                             reauth_exc = ConfigEntryAuthFailed(
                                 f"Authentication failed after {self._consecutive_transient_auth_failures} attempts; re-authentication required"
+                            )
+                            reauth_exc.reauth_code = (
+                                ReauthReasonCode.NOVA_AUTH_TRANSIENT_EXHAUSTED
                             )
                             last_exception = reauth_exc
                             self._request_poll_reauth(reauth_exc)

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -65,6 +65,7 @@ from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
 )
 from ..SpotApi.spot_request import SpotAuthPermanentError
 from ._mixin_typing import _MixinBase
+from ._reauth_reason import ReauthReasonCode
 from .helpers.cache import carry_reused_accuracy
 from .helpers.cache import sanitize_decoder_row as _sanitize_decoder_row
 from .helpers.stats import ApiStatus, CryptoStatus, FcmStatus, StatusSnapshot
@@ -1111,7 +1112,13 @@ class PollingOperations(_MixinBase):
                             fatal_error,
                         )
                         self._set_auth_state(failed=True, reason=fatal_error)
-                        raise ConfigEntryAuthFailed(fatal_error)
+                        # F-4: this raise is caught by the ConfigEntryAuthFailed
+                        # handler in _async_update_data (single recording choke
+                        # point), so only tag the exception here; do NOT record
+                        # directly to avoid a double record.
+                        fcm_exc = ConfigEntryAuthFailed(fatal_error)
+                        fcm_exc.reauth_code = ReauthReasonCode.FCM_AUTH_FATAL
+                        raise fcm_exc
 
                     # Track consecutive FCM errors for transient issues
                     if fatal_error != self._fcm_last_error:
@@ -1129,7 +1136,12 @@ class PollingOperations(_MixinBase):
                             fatal_error,
                         )
                         self._set_auth_state(failed=True, reason=fatal_error)
-                        raise ConfigEntryAuthFailed(fatal_error)
+                        # F-4: caught by the _async_update_data
+                        # ConfigEntryAuthFailed handler (single recording choke
+                        # point); tag only, do not record here.
+                        fcm_exc = ConfigEntryAuthFailed(fatal_error)
+                        fcm_exc.reauth_code = ReauthReasonCode.FCM_AUTH_FATAL
+                        raise fcm_exc
                     else:
                         _LOGGER.warning(
                             "FCM error detected (%d/%d): %s. Will retry before triggering re-auth.",
@@ -1546,6 +1558,14 @@ class PollingOperations(_MixinBase):
                 failed=True,
                 reason=f"Auth failed while fetching device list: {reason}",
             )
+            # FIX 3: single recording choke point for the awaited-refresh path.
+            # The reason code rides on the exception attribute (set at the raise
+            # site, e.g. api.py / polling FCM-fatal); default to UNKNOWN when the
+            # exception carries none.
+            self.record_reauth_reason(
+                getattr(auth_exc, "reauth_code", ReauthReasonCode.UNKNOWN),
+                origin="polling.py:1541",
+            )
             raise auth_exc
         except UpdateFailed as update_err:
             # Let pre-wrapped UpdateFailed bubble as-is after updating status
@@ -1574,6 +1594,14 @@ class PollingOperations(_MixinBase):
         records ``reauth_exc`` as ``last_exception`` so the ``finally`` block marks
         the update failed via ``async_set_update_error``.
         """
+        # FIX 3: single recording choke point for the fire-and-forget poll path.
+        # All six poll-cycle reauth sites (including the 2074 pre-converted
+        # ConfigEntryAuthFailed catch) funnel through here, so record exactly
+        # once. The reason code rides on the exception attribute when present.
+        self.record_reauth_reason(
+            getattr(reauth_exc, "reauth_code", ReauthReasonCode.UNKNOWN),
+            origin="polling.py:1565",
+        )
         entry = getattr(self, "config_entry", None)
         if entry is None:
             _LOGGER.debug("Cannot start reauth from poll cycle: no config entry bound.")

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -45,6 +45,7 @@ from homeassistant.core import Event
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from .._reauth_reason import ReauthReasonCode
 from ..Auth.fcm_receiver_ha import CRASH_LOOP_FATAL_PREFIX
 from ..const import (
     DEVICE_LIST_POLL_INTERVAL,
@@ -65,7 +66,6 @@ from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
 )
 from ..SpotApi.spot_request import SpotAuthPermanentError
 from ._mixin_typing import _MixinBase
-from ._reauth_reason import ReauthReasonCode
 from .helpers.cache import carry_reused_accuracy
 from .helpers.cache import sanitize_decoder_row as _sanitize_decoder_row
 from .helpers.stats import ApiStatus, CryptoStatus, FcmStatus, StatusSnapshot

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -259,7 +259,7 @@ def _reauth_reason_block(coordinator: Any) -> dict[str, Any] | None:
     been recorded yet so the coordinator block stays structurally unchanged.
 
     Redaction is guaranteed by the *literal-only input* invariant of
-    :class:`~.coordinator._reauth_reason.ReauthReason` (see AE-7): ``code`` is a
+    :class:`~._reauth_reason.ReauthReason` (see AE-7): ``code`` is a
     ``StrEnum`` value, ``origin`` is a constant literal string, and ``counters``
     are plain ints. No token, e-mail, or free-form ``str(err)`` content is ever
     stored on the reason, so nothing sensitive can reach this payload.

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -252,6 +252,50 @@ def _status_snapshot_to_dict(snapshot: Any) -> dict[str, Any] | None:
     }
 
 
+def _reauth_reason_block(coordinator: Any) -> dict[str, Any] | None:
+    """Serialize the coordinator's structured reauth reason for diagnostics.
+
+    Mirrors :func:`_status_snapshot_to_dict`: returns ``None`` when no reauth has
+    been recorded yet so the coordinator block stays structurally unchanged.
+
+    Redaction is guaranteed by the *literal-only input* invariant of
+    :class:`~.coordinator._reauth_reason.ReauthReason` (see AE-7): ``code`` is a
+    ``StrEnum`` value, ``origin`` is a constant literal string, and ``counters``
+    are plain ints. No token, e-mail, or free-form ``str(err)`` content is ever
+    stored on the reason, so nothing sensitive can reach this payload.
+    """
+    reason = getattr(coordinator, "_reauth_reason", None)
+    if reason is None:
+        return None
+
+    try:
+        code = getattr(reason, "code", None)
+        origin = getattr(reason, "origin", None)
+        raw_counters = getattr(reason, "counters", None)
+        recorded_at = getattr(reason, "recorded_at", None)
+    except Exception:
+        return None
+
+    counters: dict[str, int] = {}
+    if isinstance(raw_counters, Mapping):
+        for key, value in raw_counters.items():
+            if (
+                isinstance(key, str)
+                and isinstance(value, int)
+                and not isinstance(value, bool)
+            ):
+                counters[key] = value
+
+    return {
+        "code": str(code) if code is not None else None,
+        "origin": _safe_truncate(origin) if origin is not None else None,
+        "counters": counters,
+        "recorded_at": _iso_utc(
+            recorded_at if isinstance(recorded_at, (int, float)) else None
+        ),
+    }
+
+
 def _sanitize_diag_entry(payload: Any) -> dict[str, Any]:
     """Return a diagnostics-friendly snapshot of a buffer entry."""
     if not isinstance(payload, dict):
@@ -669,6 +713,11 @@ async def async_get_config_entry_diagnostics(
             coordinator_block["setup_performance"] = setup_perf
         if recent_errors:
             coordinator_block["recent_errors"] = recent_errors
+
+        # FIX 3: structured, redaction-safe reauth reason (only when recorded).
+        reauth_reason_block = _reauth_reason_block(coordinator)
+        if reauth_reason_block is not None:
+            coordinator_block["reauth_reason"] = reauth_reason_block
 
         # Anonymized per-device telemetry (P1-3): opaque index plus seven coarse
         # fields, no names/IDs/coordinates/keys. Resilient: [] on any failure.

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -11,6 +11,8 @@ from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
+from .coordinator._reauth_reason import ReauthReasonCode
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -107,6 +109,17 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
                 self._entry_id,
             )
             return False
+
+        # FIX 3: direct reauth site. NOTE (SA-11): the plan's AE-5 assumed a
+        # coordinator ``self`` is available here, but this method lives on the
+        # ``FcmReauthRepairFlow`` (a RepairsFlow), not on the coordinator. The
+        # coordinator is reachable only via ``entry.runtime_data`` and only when
+        # the entry is loaded, so record defensively and never let a missing
+        # coordinator break the repair UI.
+        coordinator = getattr(getattr(entry, "runtime_data", None), "coordinator", None)
+        recorder = getattr(coordinator, "record_reauth_reason", None)
+        if callable(recorder):
+            recorder(ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:112")
 
         try:
             entry.async_start_reauth(self.hass)

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -11,7 +11,7 @@ from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
-from .coordinator._reauth_reason import ReauthReasonCode
+from ._reauth_reason import ReauthReasonCode
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/helpers/locate_mixin_stub.py
+++ b/tests/helpers/locate_mixin_stub.py
@@ -86,6 +86,10 @@ class LocateStub(LocateOperations):
         self._api_push_ready = MagicMock(return_value=True)
         self._ensure_device_name_cache = MagicMock(return_value={})
         self._set_auth_state = MagicMock(return_value=None)
+        # FIX 3: cross-mixin choke point (real impl lives on the full
+        # coordinator, not on ``LocateOperations``); mock like its siblings so
+        # the direct locate-reauth sites can record without NotImplementedError.
+        self.record_reauth_reason = MagicMock(return_value=None)
         self._record_semantic_label = MagicMock(return_value=None)
         self._apply_semantic_mapping = MagicMock(return_value=False)
         self._get_google_home_filter = MagicMock(return_value=None)

--- a/tests/helpers/main_coordinator_stub.py
+++ b/tests/helpers/main_coordinator_stub.py
@@ -80,6 +80,12 @@ class MainCoordinatorStub(GoogleFindMyCoordinator):
         self._auth_error_active: bool = False
         self._auth_error_message: str | None = None
 
+        # Reauth-reason state (FIX 3), mirroring production ``__init__`` defaults
+        # so ``record_reauth_reason`` and the diagnostics mirror work here.
+        self._consecutive_transient_auth_failures: int = 0
+        self._reauth_reason: Any = None
+        self._reauth_reason_logged: set[tuple[str, str]] = set()
+
         # Force-refresh state
         self._force_device_list_refresh: bool = False
         self._force_device_list_reason: str | None = None

--- a/tests/test_aas_token_retrieval.py
+++ b/tests/test_aas_token_retrieval.py
@@ -328,12 +328,27 @@ def test_is_non_retryable_auth_invalid_grant() -> None:
     assert aas_token_retrieval._is_non_retryable_auth(err) is True
 
 
-def test_is_non_retryable_auth_unauthorized_forbidden() -> None:
-    """401/403-style errors should not be retryable."""
+def test_is_non_retryable_auth_unauthorized_forbidden_now_retryable() -> None:
+    """FIX 5: bare HTTP-generic "unauthorized"/"forbidden" strings are retryable.
+
+    These tokens were removed from ``_NON_RETRYABLE_PATTERNS`` because a
+    free-text HTTP surface must not force a network-adjacent error to be treated
+    as a permanent auth failure. Genuine denials are carried via ``error_kind``.
+    """
     assert (
-        aas_token_retrieval._is_non_retryable_auth(RuntimeError("unauthorized")) is True
+        aas_token_retrieval._is_non_retryable_auth(RuntimeError("unauthorized"))
+        is False
     )
-    assert aas_token_retrieval._is_non_retryable_auth(RuntimeError("forbidden")) is True
+    assert (
+        aas_token_retrieval._is_non_retryable_auth(RuntimeError("forbidden")) is False
+    )
+
+
+def test_is_non_retryable_auth_http_denial_via_error_kind() -> None:
+    """A structured HTTP auth denial surfaced via error_kind stays non-retryable."""
+    err = RuntimeError("server returned 401 unauthorized")
+    err.error_kind = "auth_error"  # type: ignore[attr-defined]
+    assert aas_token_retrieval._is_non_retryable_auth(err) is True
 
 
 def test_is_non_retryable_auth_missing_token() -> None:

--- a/tests/test_adm_token_retrieval.py
+++ b/tests/test_adm_token_retrieval.py
@@ -216,12 +216,20 @@ def test_is_non_retryable_auth_via_error_kind_badauthentication() -> None:
     assert adm_token_retrieval._is_non_retryable_auth(err) is True
 
 
-def test_is_non_retryable_auth_string_fallback_still_works() -> None:
-    """RuntimeError without error_kind attribute still matches via substring."""
+def test_is_non_retryable_auth_string_fallback_gpsoauth_vocabulary() -> None:
+    """RuntimeError without error_kind still matches gpsoauth-specific vocabulary.
 
-    err = RuntimeError("server returned 401 unauthorized")
+    FIX 5: the substring fallback now only recognizes gpsoauth-specific tokens.
+    A generic HTTP surface such as "server returned 401 unauthorized" is
+    retryable (no ``error_kind``, no gpsoauth token), while a genuine
+    ``badauthentication`` surface stays non-retryable.
+    """
 
-    assert adm_token_retrieval._is_non_retryable_auth(err) is True
+    http_surface = RuntimeError("server returned 401 unauthorized")
+    assert adm_token_retrieval._is_non_retryable_auth(http_surface) is False
+
+    gpsoauth_surface = RuntimeError("gpsoauth rejected: BadAuthentication")
+    assert adm_token_retrieval._is_non_retryable_auth(gpsoauth_surface) is True
 
 
 def test_is_non_retryable_auth_falsy_error_kind_falls_back_to_string() -> None:
@@ -1074,10 +1082,23 @@ def test_normalize_service_whitespace() -> None:
     )
 
 
-def test_is_non_retryable_auth_http_signals() -> None:
-    """HTTP-style auth denials should not be retryable."""
-    assert adm_token_retrieval._is_non_retryable_auth(RuntimeError("401")) is True
-    assert adm_token_retrieval._is_non_retryable_auth(RuntimeError("403")) is True
+def test_is_non_retryable_auth_http_status_substrings_are_retryable() -> None:
+    """FIX 5: bare HTTP-status substrings are no longer non-retryable.
+
+    A message like "retry after 4012 ms" contains "401" as a substring; keying
+    non-retryable auth on that substring misclassified transient throttling as a
+    permanent auth failure. Genuine HTTP auth denials are carried structurally
+    (``error_kind`` / typed ``err.status``), not via free-text substrings, so a
+    plain ``RuntimeError("401")`` / ``("403")`` must now be treated as
+    retryable.
+    """
+    assert adm_token_retrieval._is_non_retryable_auth(RuntimeError("401")) is False
+    assert adm_token_retrieval._is_non_retryable_auth(RuntimeError("403")) is False
+    # The concrete false-fire the fix targets: a transient throttling message.
+    assert (
+        adm_token_retrieval._is_non_retryable_auth(RuntimeError("retry after 4012 ms"))
+        is False
+    )
 
 
 def test_is_non_retryable_auth_neither_marker() -> None:

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -23,6 +23,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.googlefindmy import api as api_module
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.api import (
     GoogleFindMyAPI,
     _build_can_ring_index,
@@ -933,10 +934,37 @@ class TestAsyncBasicDeviceListErrorMapping:
     def test_nova_auth_error_maps_to_auth_failed(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # Transient NovaAuthError (is_permanent=False) records the generic code.
         self._patch_request(monkeypatch, NovaAuthError(401, "auth"))
         api = _make_api_with_session()
-        with pytest.raises(ConfigEntryAuthFailed):
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
             run_coro(api.async_get_basic_device_list())
+        assert (
+            getattr(excinfo.value, "reauth_code", None)
+            is ReauthReasonCode.NOVA_AUTH_FAILED
+        )
+
+    @pytest.mark.parametrize(
+        "err",
+        [
+            NovaAuthError(401, "perm-flag", is_permanent=True),
+            api_module.NovaAuthPermanentError(401, "perm-subclass"),
+        ],
+    )
+    def test_permanent_nova_auth_error_records_permanent_code(
+        self, monkeypatch: pytest.MonkeyPatch, err: NovaAuthError
+    ) -> None:
+        # Cross-site consistency (RV-G2e): the device-list path must record the
+        # same permanent code the location path uses for a permanent failure,
+        # not the generic NOVA_AUTH_FAILED. Mirrors api.py location handler.
+        self._patch_request(monkeypatch, err)
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+            run_coro(api.async_get_basic_device_list())
+        assert (
+            getattr(excinfo.value, "reauth_code", None)
+            is ReauthReasonCode.NOVA_AUTH_PERMANENT
+        )
 
     def test_protobuf_decode_maps_to_update_failed(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -26,6 +26,7 @@ import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
 
 from custom_components.googlefindmy.coordinator import polling as polling_mod
+from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.coordinator.helpers.stats import CryptoStatus
 from custom_components.googlefindmy.coordinator.polling import (
     _MAX_DECRYPT_FAILURES,
@@ -760,6 +761,35 @@ def test_finalize_escalates_at_threshold_with_reauth_exc() -> None:
     assert isinstance(reauth_exc, ConfigEntryAuthFailed)
     assert last_exception is reauth_exc
     stub._set_auth_state.assert_called_once()
+
+
+def test_finalize_escalation_reauth_exc_carries_decrypt_stale_key_code() -> None:
+    """The escalation ``reauth_exc`` is tagged ``DECRYPT_STALE_KEY`` so the poll
+    diagnostics classify the account-wide stale-shared-key escalation instead of
+    falling back to ``UNKNOWN``.
+
+    This is the last of the poll-cycle reauth sites to carry a structured code.
+    ``_request_poll_reauth`` records ``getattr(reauth_exc, "reauth_code",
+    UNKNOWN)`` at the fixed ``polling.py:1565`` origin, so an untagged escalation
+    would persist ``UNKNOWN`` for the most common stale-key reauth cause.
+
+    Mutation gate: dropping the tag (leaving the plain ``ConfigEntryAuthFailed``)
+    makes the ``getattr`` fall back to ``UNKNOWN`` and turns this assert red.
+    """
+    stub = _make_stub()
+    stub._consecutive_decrypt_failures = _MAX_DECRYPT_FAILURES - 1
+    err = SharedKeyMismatchError("stale shared key")
+
+    _cycle_failed, _last_exception, reauth_exc = stub._finalize_cycle_decrypt_state(
+        cycle_decrypt_error=err,
+        cycle_had_successful_decrypt=True,
+        cycle_had_stale_key=False,
+        cycle_failed=False,
+        last_exception=None,
+    )
+
+    assert isinstance(reauth_exc, ConfigEntryAuthFailed)
+    assert reauth_exc.reauth_code is ReauthReasonCode.DECRYPT_STALE_KEY
 
 
 def test_finalize_clean_cycle_stays_success() -> None:

--- a/tests/test_coordinator_decrypt_reauth_escalation.py
+++ b/tests/test_coordinator_decrypt_reauth_escalation.py
@@ -25,8 +25,8 @@ from unittest.mock import MagicMock
 import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.coordinator import polling as polling_mod
-from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.coordinator.helpers.stats import CryptoStatus
 from custom_components.googlefindmy.coordinator.polling import (
     _MAX_DECRYPT_FAILURES,

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -13,6 +13,7 @@ from custom_components.googlefindmy.coordinator import (
     CryptoStatus,
     GoogleFindMyCoordinator,
 )
+from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.coordinator.polling import (
     _MAX_DECRYPT_FAILURES,
     _MAX_TRANSIENT_AUTH_FAILURES,
@@ -24,6 +25,12 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
     NovaAuthPermanentError,
+)
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
+    SpotApiEmptyResponseError,
+)
+from custom_components.googlefindmy.SpotApi.spot_request import (
+    SpotAuthPermanentError,
 )
 from tests.helpers.homeassistant import GoogleFindMyConfigEntryStub
 
@@ -754,6 +761,48 @@ async def test_poll_cycle_nova_permanent_auth_starts_reauth() -> None:
         coordinator.hass
     )
     assert any(kw.get("failed") for kw in auth_calls)
+    # The poll site tags the exception so diagnostics record the specific cause.
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.NOVA_AUTH_PERMANENT
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_spot_auth_permanent_tags_reauth_code() -> None:
+    """A permanent Spot/AAS auth failure in the poll cycle records
+    SPOT_AUTH_PERMANENT (a general Spot-transport condition, not owner-key)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(
+        SpotAuthPermanentError("AAS token invalid after refresh.")
+    )
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.SPOT_AUTH_PERMANENT
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_spot_empty_response_tags_reauth_code() -> None:
+    """An empty SPOT GetEidInfo response in the poll cycle records
+    OWNER_KEY_EMPTY_RESPONSE (SpotApiEmptyResponseError is raised only from the
+    EID/owner-key retrieval layer, so the owner-key code names the same root)."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(
+        SpotApiEmptyResponseError("SPOT returned an empty response")
+    )
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.OWNER_KEY_EMPTY_RESPONSE
 
 
 @pytest.mark.asyncio
@@ -774,6 +823,17 @@ async def test_poll_cycle_transient_nova_auth_starts_reauth_after_threshold() ->
     await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
     coordinator.config_entry.async_start_reauth.assert_called_once_with(
         coordinator.hass
+    )
+    # Distinct code from the immediate NOVA_AUTH_FAILED: this is the
+    # retries-exhausted case, and the counter snapshot proves the escalation.
+    assert coordinator._reauth_reason is not None
+    assert (
+        coordinator._reauth_reason.code
+        is ReauthReasonCode.NOVA_AUTH_TRANSIENT_EXHAUSTED
+    )
+    assert (
+        coordinator._reauth_reason.counters["consecutive_transient_auth_failures"]
+        == _MAX_TRANSIENT_AUTH_FAILURES
     )
 
 

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -92,6 +92,10 @@ def _base_coordinator(
     coordinator._consecutive_timeouts = 0
     coordinator._consecutive_transient_auth_failures = 0
     coordinator._last_transient_auth_error = None
+    # FIX 3: reauth-reason state normally seeded by ``__init__`` (bypassed via
+    # ``__new__`` here); the poll-reauth choke point records through these.
+    coordinator._reauth_reason = None
+    coordinator._reauth_reason_logged = set()
     coordinator._consecutive_decrypt_failures = 0
     coordinator._last_decrypt_reauth_monotonic = None
     coordinator._last_decrypt_error = None

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.const import OPT_SEMANTIC_LOCATIONS
@@ -1016,3 +1017,52 @@ async def test_poll_cycle_mixed_stale_and_success_keeps_last_decrypt_error() -> 
     assert coordinator.crypto_status.state == CryptoStatus.TRACKER_KEY_OUTDATED
     assert coordinator._last_decrypt_error is not None
     assert coordinator._last_decrypt_error.split(":", 1)[0] == "StaleOwnerKeyError"
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_spot_auth_permanent_tags_reauth_code() -> None:
+    """The direct manual-locate SpotAuthPermanentError site records
+    SPOT_AUTH_PERMANENT, the SAME canonical code the poll-cycle equivalent uses
+    (polling.py) for the same exception type. It must NOT record an owner-key code:
+    SpotAuthPermanentError is a generic Spot-transport auth failure. Guards the
+    poll-vs-direct code-consistency invariant (a mislabel would point diagnostics
+    triage at the wrong credential layer)."""
+    coordinator = _base_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(
+        SpotAuthPermanentError("AAS token invalid after refresh.")
+    )
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    with pytest.raises(HomeAssistantError):
+        await coordinator.async_locate_device("device-1")
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.SPOT_AUTH_PERMANENT
+
+
+@pytest.mark.asyncio
+async def test_manual_locate_stale_shared_key_tags_reauth_code() -> None:
+    """The direct manual-locate account-wide DecryptionError site records
+    DECRYPT_STALE_KEY, the SAME canonical code the poll-cycle equivalent uses
+    (_finalize_cycle_decrypt_state). It must NOT record an AAS/token code: the
+    condition is a stale shared key, a different credential layer. Guards the
+    poll-vs-direct code-consistency invariant (the Codex finding on PR #1160)."""
+    coordinator = _base_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(SharedKeyMismatchError("stale shared key"))
+    # Seed the account-wide counter one below the threshold so this single locate
+    # call crosses it and escalates (the first escalation always fires: the
+    # cooldown sentinel is None).
+    coordinator._consecutive_decrypt_failures = _MAX_DECRYPT_FAILURES - 1
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    with pytest.raises(HomeAssistantError):
+        await coordinator.async_locate_device("device-1")
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+    assert coordinator._reauth_reason is not None
+    assert coordinator._reauth_reason.code is ReauthReasonCode.DECRYPT_STALE_KEY

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -8,12 +8,12 @@ from unittest.mock import MagicMock
 import pytest
 from homeassistant.config_entries import ConfigEntryAuthFailed
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.const import OPT_SEMANTIC_LOCATIONS
 from custom_components.googlefindmy.coordinator import (
     CryptoStatus,
     GoogleFindMyCoordinator,
 )
-from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.coordinator.polling import (
     _MAX_DECRYPT_FAILURES,
     _MAX_TRANSIENT_AUTH_FAILURES,

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -13,6 +13,7 @@ import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import (
     CRASH_LOOP_FATAL_PREFIX,
 )
@@ -33,7 +34,6 @@ from custom_components.googlefindmy.coordinator import (
     FcmStatus,
     GoogleFindMyCoordinator,
 )
-from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.device_tracker import GoogleFindMyDeviceTracker
 from tests.helpers import drain_loop
 

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -33,6 +33,7 @@ from custom_components.googlefindmy.coordinator import (
     FcmStatus,
     GoogleFindMyCoordinator,
 )
+from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.device_tracker import GoogleFindMyDeviceTracker
 from tests.helpers import drain_loop
 
@@ -233,6 +234,37 @@ def test_fatal_fcm_registration_triggers_reauth(
             "message": fatal_error,
         },
     )
+
+
+def test_threshold_fcm_fatal_tags_reauth_code(
+    coordinator: GoogleFindMyCoordinator, dummy_api: _DummyAPI
+) -> None:
+    """FIX 3: a non-immediate FCM fatal that persists to the retry threshold
+    escalates to ConfigEntryAuthFailed tagged with FCM_AUTH_FATAL."""
+
+    # Non-auth, non-crash-loop fatal ⇒ counter path, not the immediate raise.
+    fatal_error = "Transient FCM error: connection reset"
+
+    class _DummyFcm:
+        def __init__(self, message: str) -> None:
+            self._fatal_error = message
+            self._fatal_errors = {coordinator.config_entry.entry_id: message}
+
+    dummy_api.fcm = _DummyFcm(fatal_error)
+    coordinator.config_entry.runtime_data = SimpleNamespace(
+        coordinator=coordinator, fcm_receiver=dummy_api.fcm
+    )
+    coordinator._is_fcm_ready_soft = lambda: False
+    # One short of the threshold; the same recurring fatal tips it over.
+    coordinator._fcm_last_error = fatal_error
+    coordinator._fcm_error_count = 2
+
+    loop = coordinator.hass.loop
+    with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+        loop.run_until_complete(coordinator._async_update_data())
+
+    # Mutation-sharp: the wrong (or missing) tag fails this identity check.
+    assert excinfo.value.reauth_code is ReauthReasonCode.FCM_AUTH_FATAL
 
 
 def test_global_fatal_error_ignored_for_clean_entry(

--- a/tests/test_coordinator_update.py
+++ b/tests/test_coordinator_update.py
@@ -77,6 +77,25 @@ class TestIsFatalFcmAuthError:
         assert is_fatal_fcm_auth_error("HTTP 500 Server Error") is False
         assert is_fatal_fcm_auth_error("Network unreachable") is False
 
+    def test_retry_after_4012_ms_not_fatal(self) -> None:
+        """FIX 5: a throttling message must not false-fire the 401 matcher.
+
+        "retry after 4012 ms" contains "401" as a raw substring. The
+        word-boundary matcher (\\b401\\b) must NOT treat it as an HTTP 401, so
+        transient throttling stays retryable instead of forcing re-auth.
+        """
+        assert is_fatal_fcm_auth_error("retry after 4012 ms") is False
+        # Analogous 404 substring guard: "retry after 40412 ms" contains "404".
+        assert (
+            is_fatal_fcm_auth_error("retry after 40412 ms; credential refresh") is False
+        )
+
+    def test_genuine_401_still_fatal_after_hardening(self) -> None:
+        """FIX 5: a genuine standalone 401 auth signal remains fatal."""
+        assert is_fatal_fcm_auth_error("401 unauthorized") is True
+        assert is_fatal_fcm_auth_error("HTTP 401 Unauthorized") is True
+        assert is_fatal_fcm_auth_error("Error code: 401") is True
+
     def test_empty_string_not_fatal(self) -> None:
         """Empty string should not be fatal."""
         assert is_fatal_fcm_auth_error("") is False

--- a/tests/test_diagnostics_buffer_summary.py
+++ b/tests/test_diagnostics_buffer_summary.py
@@ -19,6 +19,10 @@ from custom_components.googlefindmy.const import (
     OPT_IGNORED_DEVICES,
     OPT_LOCATION_POLL_INTERVAL,
 )
+from custom_components.googlefindmy.coordinator._reauth_reason import (
+    ReauthReason,
+    ReauthReasonCode,
+)
 from tests.helpers import drain_loop
 
 
@@ -231,3 +235,39 @@ def test_diagnostics_merge_entry_data_and_options(
     assert config_summary["google_home_filter_keywords_count"] == 3
     assert config_summary["ignored_devices_count"] == 2
     assert "movement_threshold" not in config_summary
+
+
+def test_diagnostics_includes_reauth_reason_when_recorded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FIX 3: a recorded reauth reason surfaces in the coordinator block."""
+
+    coordinator = _StubCoordinator()
+    coordinator._reauth_reason = ReauthReason(
+        code=ReauthReasonCode.HTTP_401_AFTER_REFRESH,
+        origin="polling.py:1541",
+        counters={"consecutive_transient_auth_failures": 3},
+        recorded_at=1_700_000_000.0,
+    )
+    entry = _StubEntry(coordinator)
+    hass = _StubHass(entry, coordinator)
+
+    async def _fake_get_integration(_hass, _domain):
+        return SimpleNamespace(name="Test Integration", version="1.2.3")
+
+    monkeypatch.setattr(diagnostics, "async_get_integration", _fake_get_integration)
+    monkeypatch.setattr(
+        diagnostics.dr, "async_get", lambda _hass: SimpleNamespace(devices={})
+    )
+    monkeypatch.setattr(
+        diagnostics.er, "async_get", lambda _hass: SimpleNamespace(entities={})
+    )
+    monkeypatch.setattr(diagnostics, "async_redact_data", _redact)
+
+    payload = _run(diagnostics.async_get_config_entry_diagnostics(hass, entry))
+
+    reauth = payload["coordinator"]["reauth_reason"]
+    assert reauth["code"] == "http_401_after_refresh"
+    assert reauth["origin"] == "polling.py:1541"
+    assert reauth["counters"] == {"consecutive_transient_auth_failures": 3}
+    # Mutation counter-check: skipping the wiring line drops this key entirely.

--- a/tests/test_diagnostics_buffer_summary.py
+++ b/tests/test_diagnostics_buffer_summary.py
@@ -9,6 +9,10 @@ from types import SimpleNamespace
 import pytest
 
 from custom_components.googlefindmy import diagnostics
+from custom_components.googlefindmy._reauth_reason import (
+    ReauthReason,
+    ReauthReasonCode,
+)
 from custom_components.googlefindmy.const import (
     CONF_OAUTH_TOKEN,
     DOMAIN,
@@ -18,10 +22,6 @@ from custom_components.googlefindmy.const import (
     OPT_GOOGLE_HOME_FILTER_KEYWORDS,
     OPT_IGNORED_DEVICES,
     OPT_LOCATION_POLL_INTERVAL,
-)
-from custom_components.googlefindmy.coordinator._reauth_reason import (
-    ReauthReason,
-    ReauthReasonCode,
 )
 from tests.helpers import drain_loop
 

--- a/tests/test_fcm_receiver_decrypt_escalation.py
+++ b/tests/test_fcm_receiver_decrypt_escalation.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth import fcm_receiver_ha
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
@@ -49,6 +50,24 @@ def test_push_decrypt_failure_starts_reauth_when_threshold_reached() -> None:
 
     coordinator.note_decrypt_failure.assert_called_once_with(stale=False, error=err)
     entry.async_start_reauth.assert_called_once_with(receiver._hass)
+
+
+def test_push_decrypt_failure_records_decrypt_stale_key_reason() -> None:
+    """The background-push escalation records DECRYPT_STALE_KEY, the SAME canonical
+    code the poll and locate equivalents use for the account-wide stale-shared-key
+    decrypt condition. This escalation is only reached on the stale=False path
+    (note_decrypt_failure returns False for stale=True), so it must NOT record an
+    AAS/token code. Guards the poll-vs-direct code-consistency invariant."""
+    receiver, coordinator, entry = _receiver_with_coordinator(escalate=True)
+    err = DecryptionError("stale shared key")
+
+    receiver._note_decrypt_failure_for_entry("entry-1", stale=False, error=err)
+
+    coordinator.record_reauth_reason.assert_called_once()
+    assert (
+        coordinator.record_reauth_reason.call_args.args[0]
+        is ReauthReasonCode.DECRYPT_STALE_KEY
+    )
 
 
 def test_push_decrypt_failure_below_threshold_does_not_start_reauth() -> None:

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -17,9 +17,9 @@ import pytest
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.googlefindmy import repairs
+from custom_components.googlefindmy._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.Auth import fcm_receiver_ha
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import DOMAIN, FcmReceiverHA
-from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.exceptions import FatalRegistrationError
 
 

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -19,6 +19,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from custom_components.googlefindmy import repairs
 from custom_components.googlefindmy.Auth import fcm_receiver_ha
 from custom_components.googlefindmy.Auth.fcm_receiver_ha import DOMAIN, FcmReceiverHA
+from custom_components.googlefindmy.coordinator._reauth_reason import ReauthReasonCode
 from custom_components.googlefindmy.exceptions import FatalRegistrationError
 
 
@@ -204,6 +205,38 @@ async def test_fix_flow_confirm_starts_reauth() -> None:
     # success path clears it.
     assert flow._async_start_reauth() is True
 
+    entry.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_confirm_records_reauth_reason() -> None:
+    """FIX 3: confirming the repair records the FCM_AUTH_FATAL reason.
+
+    The recorder lives on the coordinator (reachable via ``runtime_data``), not
+    on the RepairsFlow; the flow records defensively when it is available.
+    """
+    recorder = MagicMock(return_value=None)
+    entry = SimpleNamespace(
+        async_start_reauth=MagicMock(return_value=None),
+        runtime_data=SimpleNamespace(
+            coordinator=SimpleNamespace(
+                record_reauth_reason=recorder,
+            )
+        ),
+    )
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=lambda entry_id: (entry if entry_id == "entry-id" else None)
+        )
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass
+
+    assert flow._async_start_reauth() is True
+
+    recorder.assert_called_once_with(
+        ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:112"
+    )
     entry.async_start_reauth.assert_called_once_with(hass)
 
 

--- a/tests/test_reauth_reason.py
+++ b/tests/test_reauth_reason.py
@@ -49,8 +49,10 @@ class TestReauthReasonModel:
         assert str(ReauthReasonCode.UNKNOWN) == "unknown"
 
     def test_dataclass_is_slotted_and_defaults_empty(self) -> None:
-        reason = ReauthReason(code=ReauthReasonCode.AAS_INVALID, origin="locate.py:656")
-        assert reason.code is ReauthReasonCode.AAS_INVALID
+        reason = ReauthReason(
+            code=ReauthReasonCode.DECRYPT_STALE_KEY, origin="locate.py:656"
+        )
+        assert reason.code is ReauthReasonCode.DECRYPT_STALE_KEY
         assert reason.origin == "locate.py:656"
         assert reason.counters == {}
         assert reason.recorded_at == 0.0
@@ -86,7 +88,7 @@ class TestRecordReauthReason:
     def test_explicit_counters_override_default_snapshot(self) -> None:
         coord = self._coordinator()
         coord.record_reauth_reason(
-            ReauthReasonCode.AAS_INVALID,
+            ReauthReasonCode.DECRYPT_STALE_KEY,
             "locate.py:656",
             counters={"custom": 7},
         )
@@ -98,12 +100,16 @@ class TestRecordReauthReason:
     def test_warns_once_per_code_origin(self, caplog: pytest.LogCaptureFixture) -> None:
         coord = self._coordinator()
         with caplog.at_level(logging.WARNING):
-            coord.record_reauth_reason(ReauthReasonCode.AAS_INVALID, "locate.py:656")
-            coord.record_reauth_reason(ReauthReasonCode.AAS_INVALID, "locate.py:656")
+            coord.record_reauth_reason(
+                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+            )
+            coord.record_reauth_reason(
+                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+            )
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         # De-dup: identical (code, origin) warns exactly once.
         assert len(warnings) == 1
-        assert warnings[0].reauth_code == "aas_invalid"
+        assert warnings[0].reauth_code == "decrypt_stale_key"
         assert warnings[0].reauth_origin == "locate.py:656"
 
     def test_distinct_origin_warns_again(
@@ -111,8 +117,14 @@ class TestRecordReauthReason:
     ) -> None:
         coord = self._coordinator()
         with caplog.at_level(logging.WARNING):
-            coord.record_reauth_reason(ReauthReasonCode.AAS_INVALID, "locate.py:521")
-            coord.record_reauth_reason(ReauthReasonCode.AAS_INVALID, "locate.py:656")
+            # Same code, two real emitting origins (locate direct + poll cycle):
+            # a distinct origin is a distinct dedup key, so it warns again.
+            coord.record_reauth_reason(
+                ReauthReasonCode.DECRYPT_STALE_KEY, "polling.py:619"
+            )
+            coord.record_reauth_reason(
+                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+            )
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         # A different origin is a distinct dedup key ⇒ warns again.
         assert len(warnings) == 2

--- a/tests/test_reauth_reason.py
+++ b/tests/test_reauth_reason.py
@@ -1,0 +1,262 @@
+# tests/test_reauth_reason.py
+"""FIX 3 unit tests: structured reauth-reason model, recording choke point,
+raise-site classification and the redaction-safe diagnostics mirror.
+
+These pin the behaviour introduced by FIX 3 (make *why* a reauth fired visible
+in diagnostics without a ``--debug`` capture):
+
+- :class:`ReauthReasonCode` values are stable literal identifiers and
+  :class:`ReauthReason` is a slotted, literal-only record.
+- ``GoogleFindMyCoordinator.record_reauth_reason`` stores the reason, snapshots
+  the transient-auth counters and emits a once-per ``(code, origin)`` WARNING.
+- Every ``ConfigEntryAuthFailed`` raise site tags the exception with the correct
+  ``reauth_code`` so the coordinator catch sites can record it.
+- ``diagnostics._reauth_reason_block`` mirrors the reason and, by the
+  literal-only-input invariant, never leaks free-form/PII content.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+import custom_components.googlefindmy.api as api_module
+from custom_components.googlefindmy.api import GoogleFindMyAPI
+from custom_components.googlefindmy.coordinator._reauth_reason import (
+    ReauthReason,
+    ReauthReasonCode,
+)
+from custom_components.googlefindmy.diagnostics import _reauth_reason_block
+from custom_components.googlefindmy.NovaApi.nova_request import (
+    NovaAuthError,
+    NovaAuthPermanentError,
+    NovaHTTPError,
+)
+from tests.helpers.main_coordinator_stub import MainCoordinatorStub
+
+
+class TestReauthReasonModel:
+    """The enum and dataclass are stable, literal-only value objects."""
+
+    def test_codes_serialize_to_stable_literals(self) -> None:
+        # StrEnum → str(value) is the literal identifier, safe to expose verbatim.
+        assert str(ReauthReasonCode.HTTP_401_AFTER_REFRESH) == "http_401_after_refresh"
+        assert str(ReauthReasonCode.BADAUTH_GPSOAUTH) == "badauth_gpsoauth"
+        assert str(ReauthReasonCode.UNKNOWN) == "unknown"
+
+    def test_dataclass_is_slotted_and_defaults_empty(self) -> None:
+        reason = ReauthReason(code=ReauthReasonCode.AAS_INVALID, origin="locate.py:656")
+        assert reason.code is ReauthReasonCode.AAS_INVALID
+        assert reason.origin == "locate.py:656"
+        assert reason.counters == {}
+        assert reason.recorded_at == 0.0
+        # slots=True ⇒ no __dict__, and unknown attributes are rejected.
+        assert not hasattr(reason, "__dict__")
+        with pytest.raises((AttributeError, TypeError)):
+            reason.leaked = "secret"  # type: ignore[attr-defined]
+
+
+class TestRecordReauthReason:
+    """``record_reauth_reason`` is the single recording choke point."""
+
+    def _coordinator(self) -> MainCoordinatorStub:
+        coord = MainCoordinatorStub()
+        coord._consecutive_transient_auth_failures = 2
+        return coord
+
+    def test_stores_reason_with_code_origin_and_counter_snapshot(self) -> None:
+        coord = self._coordinator()
+        coord.record_reauth_reason(
+            ReauthReasonCode.HTTP_401_AFTER_REFRESH, "polling.py:1541"
+        )
+        reason = coord._reauth_reason
+        assert reason is not None
+        # Mutation-sharp: wrong code or origin fails here.
+        assert reason.code is ReauthReasonCode.HTTP_401_AFTER_REFRESH
+        assert reason.origin == "polling.py:1541"
+        # Default snapshot captures the live transient-auth counter + threshold.
+        assert reason.counters["consecutive_transient_auth_failures"] == 2
+        assert reason.counters["max_transient_auth_failures"] >= 1
+        assert reason.recorded_at > 0.0
+
+    def test_explicit_counters_override_default_snapshot(self) -> None:
+        coord = self._coordinator()
+        coord.record_reauth_reason(
+            ReauthReasonCode.AAS_INVALID,
+            "locate.py:656",
+            counters={"custom": 7},
+        )
+        reason = coord._reauth_reason
+        assert reason is not None
+        assert reason.counters == {"custom": 7}
+        assert "consecutive_transient_auth_failures" not in reason.counters
+
+    def test_warns_once_per_code_origin(self, caplog: pytest.LogCaptureFixture) -> None:
+        coord = self._coordinator()
+        with caplog.at_level(logging.WARNING):
+            coord.record_reauth_reason(ReauthReasonCode.AAS_INVALID, "locate.py:656")
+            coord.record_reauth_reason(ReauthReasonCode.AAS_INVALID, "locate.py:656")
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        # De-dup: identical (code, origin) warns exactly once.
+        assert len(warnings) == 1
+        assert warnings[0].reauth_code == "aas_invalid"
+        assert warnings[0].reauth_origin == "locate.py:656"
+
+    def test_distinct_origin_warns_again(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord = self._coordinator()
+        with caplog.at_level(logging.WARNING):
+            coord.record_reauth_reason(ReauthReasonCode.AAS_INVALID, "locate.py:521")
+            coord.record_reauth_reason(ReauthReasonCode.AAS_INVALID, "locate.py:656")
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        # A different origin is a distinct dedup key ⇒ warns again.
+        assert len(warnings) == 2
+
+
+class TestDiagnosticsReauthReasonBlock:
+    """The diagnostics mirror is redaction-safe by the literal-only invariant."""
+
+    def test_returns_none_when_no_reason_recorded(self) -> None:
+        assert _reauth_reason_block(MagicMock(_reauth_reason=None)) is None
+
+    def test_serializes_recorded_reason(self) -> None:
+        reason = ReauthReason(
+            code=ReauthReasonCode.HTTP_401_AFTER_REFRESH,
+            origin="api.py:1062",
+            counters={"consecutive_transient_auth_failures": 3},
+            recorded_at=1_700_000_000.0,
+        )
+        block = _reauth_reason_block(MagicMock(_reauth_reason=reason))
+        assert block is not None
+        assert block["code"] == "http_401_after_refresh"
+        assert block["origin"] == "api.py:1062"
+        assert block["counters"] == {"consecutive_transient_auth_failures": 3}
+        # recorded_at is rendered as an ISO-8601 string, not a raw float.
+        assert isinstance(block["recorded_at"], str)
+        assert block["recorded_at"].startswith("20")
+
+    def test_filters_non_int_and_bool_counters(self) -> None:
+        # Literal-only invariant: only genuine ints survive; bool/str dropped.
+        reason = ReauthReason(
+            code=ReauthReasonCode.UNKNOWN,
+            origin="api.py:1099",
+            counters={"good": 4, "flag": True, "text": "leak"},  # type: ignore[dict-item]
+            recorded_at=1_700_000_000.0,
+        )
+        block = _reauth_reason_block(MagicMock(_reauth_reason=reason))
+        assert block is not None
+        assert block["counters"] == {"good": 4}
+
+    def test_defensive_return_none_when_attribute_access_raises(self) -> None:
+        # A malformed reason whose attribute access raises must degrade to None
+        # rather than propagate into the diagnostics download.
+        class _Exploding:
+            @property
+            def code(self) -> object:
+                raise RuntimeError("boom")
+
+        assert _reauth_reason_block(MagicMock(_reauth_reason=_Exploding())) is None
+
+
+def _make_api() -> GoogleFindMyAPI:
+    """Build an API instance without running its normal ``__init__`` wiring."""
+    api = GoogleFindMyAPI.__new__(GoogleFindMyAPI)
+    api._session = None
+    api._cache = MagicMock()
+    api._cache.entry_id = "entry-reauth"
+    api._contributor_mode = None
+    api._contributor_mode_switch_epoch = 0
+    api._namespace = lambda: "entry-reauth"
+    return api
+
+
+class TestDeviceListRaiseSiteCodes:
+    """Every device-list ``ConfigEntryAuthFailed`` carries its ``reauth_code``."""
+
+    async def _drive_device_list(
+        self, monkeypatch: pytest.MonkeyPatch, error: Exception
+    ) -> ConfigEntryAuthFailed:
+        async def _raise(*_a: object, **_k: object) -> list[dict[str, Any]]:
+            raise error
+
+        monkeypatch.setattr(api_module, "async_request_device_list", _raise)
+        api = _make_api()
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+            await api.async_get_basic_device_list(username="user@example.com")
+        return excinfo.value
+
+    @pytest.mark.asyncio
+    async def test_http_401_maps_to_after_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_device_list(monkeypatch, NovaHTTPError(401))
+        assert exc.reauth_code is ReauthReasonCode.HTTP_401_AFTER_REFRESH
+
+    @pytest.mark.asyncio
+    async def test_nova_auth_error_maps_to_nova_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_device_list(monkeypatch, NovaAuthError(401))
+        assert exc.reauth_code is ReauthReasonCode.NOVA_AUTH_FAILED
+
+    @pytest.mark.asyncio
+    async def test_gpsoauth_badauth_maps_to_badauth_gpsoauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_device_list(
+            monkeypatch, RuntimeError("BadAuthentication from gpsoauth")
+        )
+        assert exc.reauth_code is ReauthReasonCode.BADAUTH_GPSOAUTH
+
+    @pytest.mark.asyncio
+    async def test_tokencache_closed_maps_to_tokencache_closed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_device_list(
+            monkeypatch, RuntimeError("TokenCache is closed")
+        )
+        assert exc.reauth_code is ReauthReasonCode.TOKENCACHE_CLOSED
+
+
+class TestLocationRaiseSiteCodes:
+    """Every location ``ConfigEntryAuthFailed`` carries its ``reauth_code``."""
+
+    async def _drive_location(
+        self, monkeypatch: pytest.MonkeyPatch, error: Exception
+    ) -> ConfigEntryAuthFailed:
+        async def _raise(*_a: object, **_k: object) -> list[dict[str, Any]]:
+            raise error
+
+        monkeypatch.setattr(api_module, "get_location_data_for_device", _raise)
+        api = _make_api()
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+            await api.async_get_device_location("device-xyz", "Tracker")
+        return excinfo.value
+
+    @pytest.mark.asyncio
+    async def test_permanent_nova_auth_maps_to_nova_auth_permanent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_location(monkeypatch, NovaAuthPermanentError(403))
+        assert exc.reauth_code is ReauthReasonCode.NOVA_AUTH_PERMANENT
+
+    @pytest.mark.asyncio
+    async def test_permanent_flag_nova_auth_maps_to_nova_auth_permanent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_location(
+            monkeypatch, NovaAuthError(401, is_permanent=True)
+        )
+        assert exc.reauth_code is ReauthReasonCode.NOVA_AUTH_PERMANENT
+
+    @pytest.mark.asyncio
+    async def test_http_401_maps_to_after_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        exc = await self._drive_location(monkeypatch, NovaHTTPError(401))
+        assert exc.reauth_code is ReauthReasonCode.HTTP_401_AFTER_REFRESH

--- a/tests/test_reauth_reason.py
+++ b/tests/test_reauth_reason.py
@@ -25,11 +25,11 @@ import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
 import custom_components.googlefindmy.api as api_module
-from custom_components.googlefindmy.api import GoogleFindMyAPI
-from custom_components.googlefindmy.coordinator._reauth_reason import (
+from custom_components.googlefindmy._reauth_reason import (
     ReauthReason,
     ReauthReasonCode,
 )
+from custom_components.googlefindmy.api import GoogleFindMyAPI
 from custom_components.googlefindmy.diagnostics import _reauth_reason_block
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,

--- a/tests/test_token_retrieval.py
+++ b/tests/test_token_retrieval.py
@@ -1,0 +1,146 @@
+# tests/test_token_retrieval.py
+"""Regression tests for the AAS-token error classifier in token_retrieval.
+
+These tests pin the FIX 5 matcher hardening: HTTP-generic tokens
+("unauthorized"/"forbidden"/status codes) must no longer promote an arbitrary
+transport/network exception string to :class:`InvalidAasTokenError`, while the
+gpsoauth-specific ``Error`` vocabulary (``badauthentication``) keeps doing so.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.Auth import token_retrieval
+from custom_components.googlefindmy.Auth.token_retrieval import (
+    InvalidAasTokenError,
+    _is_invalid_aas_error_text,
+)
+
+# ---------------------------------------------------------------------------
+# _is_invalid_aas_error_text: HTTP-generic gating
+# ---------------------------------------------------------------------------
+
+
+def test_http_generic_forbidden_gated_off_by_default() -> None:
+    """A bare "403 forbidden" string is NOT an invalid-AAS signal by default."""
+    assert (
+        _is_invalid_aas_error_text(
+            "server returned 403 forbidden", allow_http_generic=False
+        )
+        is False
+    )
+
+
+def test_http_generic_forbidden_honoured_when_opted_in() -> None:
+    """The structured gpsoauth Error field opts in and keeps the old behavior."""
+    assert (
+        _is_invalid_aas_error_text(
+            "server returned 403 forbidden", allow_http_generic=True
+        )
+        is True
+    )
+
+
+def test_http_generic_unauthorized_gated() -> None:
+    """ "unauthorized" mirrors "forbidden": gated off by default, on when opted in."""
+    assert (
+        _is_invalid_aas_error_text("401 unauthorized", allow_http_generic=False)
+        is False
+    )
+    assert (
+        _is_invalid_aas_error_text("401 unauthorized", allow_http_generic=True) is True
+    )
+
+
+def test_gpsoauth_badauthentication_always_matches() -> None:
+    """gpsoauth-specific tokens stay active regardless of the HTTP-generic gate."""
+    assert _is_invalid_aas_error_text("BadAuthentication") is True
+    assert (
+        _is_invalid_aas_error_text("BadAuthentication", allow_http_generic=True) is True
+    )
+
+
+def test_gpsoauth_invalid_credential_vocabulary_always_matches() -> None:
+    """ "invalid" + credential vocabulary is gpsoauth-specific, never gated."""
+    assert _is_invalid_aas_error_text("invalid credential") is True
+    assert _is_invalid_aas_error_text("needsbrowser") is True
+
+
+# ---------------------------------------------------------------------------
+# _perform_oauth_sync: the generic except-Exception call site (Z.222)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_gpsoauth(monkeypatch: pytest.MonkeyPatch, perform_oauth: Any) -> None:
+    """Patch the module-local gpsoauth accessor with a fake providing perform_oauth."""
+    fake = SimpleNamespace(perform_oauth=perform_oauth)
+    monkeypatch.setattr(token_retrieval, "_gpsoauth", lambda: fake)
+
+
+def test_generic_network_exception_does_not_discard_aas_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A generic transport failure whose text contains "403 Forbidden" must NOT
+    be reclassified as InvalidAasTokenError (which would discard the AAS token);
+    it stays a plain RuntimeError so the caller treats it as retryable."""
+
+    def _boom(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise OSError("WAF blocked request: HTTP 403 Forbidden (getaddrinfo)")
+
+    _install_fake_gpsoauth(monkeypatch, _boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )
+    assert not isinstance(excinfo.value, InvalidAasTokenError)
+
+
+def test_genuine_badauthentication_still_discards_aas_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A structured gpsoauth Error=BadAuthentication response must still raise
+    InvalidAasTokenError so the stale AAS token is discarded (no regression)."""
+
+    def _bad_auth(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"Error": "BadAuthentication"}
+
+    _install_fake_gpsoauth(monkeypatch, _bad_auth)
+
+    with pytest.raises(InvalidAasTokenError):
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )
+
+
+def test_generic_exception_with_gpsoauth_vocabulary_still_discards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even via the generic except-Exception path, a gpsoauth-specific token in
+    the exception text still promotes to InvalidAasTokenError."""
+
+    def _boom(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("gpsoauth rejected: BadAuthentication")
+
+    _install_fake_gpsoauth(monkeypatch, _boom)
+
+    with pytest.raises(InvalidAasTokenError):
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )


### PR DESCRIPTION
## Why

Some users hit a re-auth prompt within a couple of hours while others (with an unchanged `secrets.json` for months) never do. Investigation of the re-auth surfaces showed two problems:

1. **False re-auth from network-adjacent errors.** Broad substring matchers (`_is_invalid_aas_error_text`, `_NON_RETRYABLE_PATTERNS` containing `401`/`403`/`forbidden`) treated transient, network-adjacent HTTP errors as permanent auth failures. When an intermediary injects a `401`/`403` (proxy, captive portal, transient upstream), this could destructively invalidate a still-valid AAS token and force a re-auth that was never warranted.
2. **Undiagnosable re-auth.** When a re-auth *did* fire, the diagnostics download carried no machine-readable reason. There was no way to tell a genuine credential failure apart from a transient blip, which made these reports hard to triage.

## What

Four atomic commits, each independently green (ruff `0.14.14` check+format, mypy, full suite) and reviewed:

- `8c088d61` **fix(auth): harden reauth matchers against network-adjacent errors** — replace broad substring matching with `error_kind`-bound classification, so only genuinely non-retryable auth verdicts invalidate credentials. Network-adjacent `401`/`403` no longer force a destructive token invalidation.
- `8e6c9d65` **feat(diagnostics): record structured reauth reason** — new `coordinator/_reauth_reason.py` (`ReauthReasonCode` StrEnum + dataclass), a single `record_reauth_reason` choke-point on the coordinator, `exc.reauth_code` tags at the raise sites, recording at the coordinator catch sites, and diagnostics mirroring. Every re-auth now carries a structured, redaction-safe reason into the diagnostics download.
- `740aeb7d` **feat(diagnostics): classify the four poll-cycle reauth sites** — the four typed poll-cycle auth handlers (`SpotAuthPermanentError`, `SpotApiEmptyResponseError`, `NovaAuthPermanentError`, transient-threshold) now carry a code instead of recording `UNKNOWN`.
- `adc56366` **feat(diagnostics): classify the stale-shared-key poll reauth site** — the account-wide stale-shared-key decrypt escalation (`_finalize_cycle_decrypt_state`) now records `DECRYPT_STALE_KEY`.

**Result:** no poll-cycle re-auth cause records `UNKNOWN` anymore.

### Design note: why not reuse an existing code for every site?

All four poll-cycle sites funnel through one choke-point that records with a **fixed** origin (`polling.py:1565`), and the log de-dup key is `(str(code), origin)`. At a fixed origin the `reauth_code` is therefore the **only** field that distinguishes the states, so a shared code would collapse two distinct states onto the same de-dup key and suppress the second WARNING. That is why two sites received **new** codes (`SPOT_AUTH_PERMANENT` for the generic Spot-transport failure — it is not owner-key-specific; `NOVA_AUTH_TRANSIENT_EXHAUSTED` for the "flapping auth that exhausted its retries" case, exactly the intermittent 2-hour symptom), while the other two legitimately **reuse** codes that name the identical state (`OWNER_KEY_EMPTY_RESPONSE`, `NOVA_AUTH_PERMANENT`). The `reauth_code` names the auth-failure *state* (source × severity); the layer/provenance is the job of the `origin` field, not the code.

## Testing

- Full suite green (Exit 0). Delta-coverage complete for every changed production line; the only exception is `_mixin_typing.py:43/172` (a `TYPE_CHECKING` import and an abstract `raise NotImplementedError` stub, consistent with ~60 identical scaffold lines in that file), documented as out of scope.
- Each new/changed code is mutation-checked: swapping a new code back to `UNKNOWN` or to the neighbouring code turns the corresponding test red.
- A regression class surfaced during implementation and was fixed at the root: the two new `__init__` attributes and the new abstract `record_reauth_reason` broke stub-based re-auth tests that bypass `__init__`; the stubs now seed the attributes (test-infra co-change, no production defect).


## Notes

- Draft on purpose — kept as Draft pending your merge decision.
- No version bump (you assign versions in this repo).
