### PR TITLE
Classify typed gpsoauth AuthError structurally on both OAuth token paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=72 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=73 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/custom_components/googlefindmy/Auth/adm_token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/adm_token_retrieval.py
@@ -49,6 +49,7 @@ import logging
 import secrets
 import time
 from collections.abc import Awaitable, Callable, Mapping
+from types import ModuleType
 from typing import Any, cast
 
 # Prefer relative imports inside the package for robustness
@@ -56,6 +57,7 @@ from ..const import CONF_OAUTH_TOKEN, DATA_AAS_TOKEN, DATA_AUTH_METHOD
 from .aas_token_retrieval import async_get_aas_token  # entry-scoped AAS provider
 from .gpsoauth_loader import (
     GpsoauthModule,
+    load_gpsoauth_exceptions,
     require_gpsoauth,
 )
 from .gpsoauth_loader import (
@@ -70,6 +72,13 @@ from .token_retrieval import (
 from .username_provider import async_get_username, username_string
 
 _LOGGER = logging.getLogger(__name__)
+
+# Optional gpsoauth exceptions module (``None`` when the dependency is absent).
+# Mirrors ``aas_token_retrieval.gpsoauth_exceptions`` / ``token_retrieval`` so the
+# ADM OAuth path can classify a typed gpsoauth ``AuthError`` structurally (by
+# type) instead of relying on its (HTTP-generic) message text, which
+# ``_is_non_retryable_auth`` deliberately does not treat as non-retryable.
+gpsoauth_exceptions: ModuleType | None = load_gpsoauth_exceptions()
 
 # Constants for gpsoauth (kept for compatibility/reference)
 _CLIENT_SIG: str = "38918a453d07199354f8b19af05ec6562ced5788"
@@ -639,14 +648,34 @@ async def _perform_oauth_with_provided_aas(
     def _run() -> str:
         gpsoauth: GpsoauthModule = require_gpsoauth()
 
-        resp = gpsoauth.perform_oauth(
-            username,
-            aas_token,
-            android_id,
-            service="oauth2:https://www.googleapis.com/auth/android_device_manager",
-            app=_APP_ID,
-            client_sig=_CLIENT_SIG,
-        )
+        try:
+            resp = gpsoauth.perform_oauth(
+                username,
+                aas_token,
+                android_id,
+                service="oauth2:https://www.googleapis.com/auth/android_device_manager",
+                app=_APP_ID,
+                client_sig=_CLIENT_SIG,
+            )
+        except Exception as oauth_err:  # noqa: BLE001
+            # A typed gpsoauth ``AuthError`` is a definitive credential rejection,
+            # independent of its message text. gpsoauth may raise it instead of
+            # returning an ``Error`` dict, and its text can be HTTP-generic only
+            # (e.g. "HTTP 403 Forbidden"), which ``_is_non_retryable_auth``
+            # deliberately does not treat as non-retryable. Promote it to the
+            # structured ``error_kind="auth_error"`` channel (in
+            # ``_NON_RETRYABLE_KINDS``), mirroring the AAS exchange path and the
+            # dict-``Error`` branch below, so the retry loop stops instead of
+            # hammering a rejected AAS token.
+            if gpsoauth_exceptions is not None and isinstance(
+                oauth_err, gpsoauth_exceptions.AuthError
+            ):
+                auth_err = RuntimeError(
+                    "gpsoauth authentication failed (kind=auth_error)"
+                )
+                auth_err.error_kind = "auth_error"  # type: ignore[attr-defined]
+                raise auth_err from oauth_err
+            raise
         if not isinstance(resp, dict):
             # Never include the raw `resp` in logs/errors
             non_dict_err = RuntimeError(

--- a/custom_components/googlefindmy/Auth/token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/token_retrieval.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import secrets
 from collections.abc import Awaitable, Callable
+from types import ModuleType
 from typing import Any
 
 from custom_components.googlefindmy.Auth.aas_token_retrieval import (
@@ -21,6 +22,7 @@ from custom_components.googlefindmy.exceptions import MissingTokenCacheError
 
 from .gpsoauth_loader import (
     GpsoauthModule,
+    load_gpsoauth_exceptions,
     require_gpsoauth,
 )
 from .gpsoauth_loader import (
@@ -28,6 +30,13 @@ from .gpsoauth_loader import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Optional gpsoauth exceptions module (``None`` when the dependency is absent).
+# Mirrors ``aas_token_retrieval.gpsoauth_exceptions`` so both credential-exchange
+# paths can classify a genuine gpsoauth ``AuthError`` structurally (by type),
+# independent of its (possibly HTTP-generic) message text. Kept at module scope
+# so tests can monkeypatch it, exactly like the AAS exchange path.
+gpsoauth_exceptions: ModuleType | None = load_gpsoauth_exceptions()
 
 
 class InvalidAasTokenError(RuntimeError):
@@ -233,6 +242,20 @@ def _perform_oauth_sync(
         raise
     except Exception as err:  # noqa: BLE001
         message: str = str(err)
+        # A typed gpsoauth ``AuthError`` is a definitive credential rejection,
+        # independent of its message text. gpsoauth may raise it instead of
+        # returning an ``Error`` dict, and its text can be HTTP-generic only
+        # (e.g. "HTTP 403 Forbidden"), which the text matcher deliberately
+        # gates off (``allow_http_generic=False``). Classify it structurally,
+        # mirroring the AAS exchange path (``aas_token_retrieval`` treats
+        # ``gpsoauth.AuthError`` by type), so the rejected AAS token is
+        # invalidated/regenerated instead of being left in cache for a retry.
+        if gpsoauth_exceptions is not None and isinstance(
+            err, gpsoauth_exceptions.AuthError
+        ):
+            raise InvalidAasTokenError(
+                f"gpsoauth rejected the AAS token while requesting scope '{scope}': {message}"
+            ) from err
         # Generic exception string: keep ``allow_http_generic=False`` so a
         # transport/network error whose text merely contains "unauthorized" or
         # "forbidden" cannot masquerade as an invalid AAS token. Only the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,7 +368,10 @@ skip_covered = true
 # 1.7 fix series; the floor takes effect on the next pull request (a direct push
 # to 1.7 does not run the coverage gate, which is gated on pull_request and push
 # to main).
-fail_under = 72
+# Raised to 73 per maintainer request to lock in the coverage from the typed
+# gpsoauth AuthError classification tests; measured CI total is 73.26 %, so the
+# jitter margin is intentionally tightened to 0.26 Pp headroom here.
+fail_under = 73
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",

--- a/tests/test_adm_token_retrieval.py
+++ b/tests/test_adm_token_retrieval.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -2048,3 +2049,74 @@ def test_async_get_adm_token_isolated_without_cache_get(
     # Metadata should still be persisted
     assert "adm_token_issued_at_user@example.com" in persisted
     assert "adm_probe_startup_left_user@example.com" in persisted
+
+
+class _MockAuthError(Exception):
+    """Stand-in for ``gpsoauth.exceptions.AuthError`` (gpsoauth is absent in CI)."""
+
+
+@pytest.mark.asyncio
+async def test_isolated_oauth_typed_autherror_is_non_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typed gpsoauth AuthError raised by ``perform_oauth`` on the isolated ADM
+    path must be promoted to the structured ``error_kind='auth_error'`` channel so
+    the retry loop treats it as non-retryable, even when its text is only
+    HTTP-generic (which ``_is_non_retryable_auth`` deliberately ignores). Mirrors
+    the AAS exchange path and ``token_retrieval``; without the structural promotion
+    the rejected AAS token would be hammered in the retry loop."""
+
+    monkeypatch.setattr(
+        adm_token_retrieval,
+        "gpsoauth_exceptions",
+        SimpleNamespace(AuthError=_MockAuthError),
+    )
+
+    def _raise(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise _MockAuthError("HTTP 403 Forbidden")
+
+    monkeypatch.setattr(
+        adm_token_retrieval,
+        "require_gpsoauth",
+        lambda: SimpleNamespace(perform_oauth=_raise),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await adm_token_retrieval._perform_oauth_with_provided_aas(
+            "user@example.com",
+            "aas_et/fake",
+            android_id=0x1234,
+        )
+    # The typed AuthError is promoted to the structured auth_error channel ...
+    assert getattr(excinfo.value, "error_kind", "") == "auth_error"
+    # ... and is therefore classified non-retryable by the isolated retry loop.
+    assert adm_token_retrieval._is_non_retryable_auth(excinfo.value) is True
+
+
+@pytest.mark.asyncio
+async def test_isolated_oauth_typed_channel_absent_stays_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the gpsoauth exceptions module is unavailable, an HTTP-generic-only
+    failure keeps the safe default: no structural promotion, and
+    ``_is_non_retryable_auth`` stays False (retryable)."""
+
+    monkeypatch.setattr(adm_token_retrieval, "gpsoauth_exceptions", None)
+
+    def _raise(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("HTTP 403 Forbidden")
+
+    monkeypatch.setattr(
+        adm_token_retrieval,
+        "require_gpsoauth",
+        lambda: SimpleNamespace(perform_oauth=_raise),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await adm_token_retrieval._perform_oauth_with_provided_aas(
+            "user@example.com",
+            "aas_et/fake",
+            android_id=0x1234,
+        )
+    assert getattr(excinfo.value, "error_kind", "") != "auth_error"
+    assert adm_token_retrieval._is_non_retryable_auth(excinfo.value) is False

--- a/tests/test_token_retrieval.py
+++ b/tests/test_token_retrieval.py
@@ -144,3 +144,68 @@ def test_generic_exception_with_gpsoauth_vocabulary_still_discards(
             False,
             android_id=0x1234,
         )
+
+
+# ---------------------------------------------------------------------------
+# _perform_oauth_sync: typed gpsoauth.AuthError structural channel
+# ---------------------------------------------------------------------------
+
+
+class _MockAuthError(Exception):
+    """Stand-in for ``gpsoauth.exceptions.AuthError`` (gpsoauth is absent in CI)."""
+
+
+def test_typed_gpsoauth_autherror_http_only_discards_aas_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A typed gpsoauth AuthError with HTTP-generic-only text must discard the
+    AAS token. gpsoauth may raise its typed AuthError instead of returning an
+    Error dict; classifying it by type (mirroring the AAS exchange path) must
+    promote it to InvalidAasTokenError even though the text matcher gates the
+    HTTP-generic tokens off (``allow_http_generic=False``)."""
+
+    monkeypatch.setattr(
+        token_retrieval,
+        "gpsoauth_exceptions",
+        SimpleNamespace(AuthError=_MockAuthError),
+    )
+
+    def _typed_auth_error(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise _MockAuthError("HTTP 403 Forbidden")
+
+    _install_fake_gpsoauth(monkeypatch, _typed_auth_error)
+
+    with pytest.raises(InvalidAasTokenError):
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )
+
+
+def test_typed_channel_absent_http_only_stays_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the gpsoauth exceptions module is unavailable (dependency absent),
+    the typed channel is skipped and an HTTP-generic-only exception text keeps
+    the safe FIX-5 default: it stays a retryable RuntimeError and does not
+    masquerade as an invalid AAS token."""
+
+    monkeypatch.setattr(token_retrieval, "gpsoauth_exceptions", None)
+
+    def _http_only(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise RuntimeError("HTTP 403 Forbidden")
+
+    _install_fake_gpsoauth(monkeypatch, _http_only)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )
+    assert not isinstance(excinfo.value, InvalidAasTokenError)


### PR DESCRIPTION
## Problem

Codex flagged (on the upstream roll-up PR #199) that `token_retrieval._perform_oauth_sync` classifies a gpsoauth credential rejection **purely by text** (`_is_invalid_aas_error_text`, `allow_http_generic=False`). When `gpsoauth.perform_oauth` raises its **typed** `AuthError` instead of returning an `Error` dict, and that error's text is HTTP-generic only (e.g. `HTTP 403 Forbidden` / `Unauthorized`), the text matcher does not fire (those tokens are deliberately gated off). The definitive credential rejection is then wrapped as a retryable `RuntimeError`, so the ADM flow retries and leaves the rejected AAS token in cache instead of invalidating/regenerating it.

The sibling AAS-exchange path (`aas_token_retrieval._exchange_oauth_for_aas`) already treats `gpsoauth.AuthError` **structurally, by type**. This is a classification-channel asymmetry: one path classifies by type, the other by text, and hardening the text matcher (in the earlier FIX-5) dropped the typed cases the text channel used to catch.

## Fix

Mirror the AAS path's type-based channel on **both** `perform_oauth` callers (an exhaustive sweep found two, both fixed):

- **`token_retrieval._perform_oauth_sync`** — add a typed `isinstance(err, gpsoauth_exceptions.AuthError)` branch **before** the text check that raises `InvalidAasTokenError`, so the AAS token is invalidated/regenerated.
- **`adm_token_retrieval._perform_oauth_with_provided_aas`** — wrap `perform_oauth` and promote a typed `AuthError` to the structured `error_kind="auth_error"` channel (already in `_NON_RETRYABLE_KINDS`), so the isolated retry loop's `_is_non_retryable_auth` stops instead of hammering the rejected token.

Both branches sit before the text check and are guarded on the optional gpsoauth exceptions module (via `load_gpsoauth_exceptions()`), so they are a no-op on gpsoauth builds that do not expose a typed `AuthError`. Control flow is otherwise unchanged; transport/network errors are not `AuthError` subclasses and stay retryable.

## Tests

Four new mutation-sharp tests (two per path): typed `AuthError` with HTTP-only text is classified as the strict/non-retryable case; when the typed channel is absent (`gpsoauth_exceptions is None`) the safe text-based default is preserved. Full suite green, ruff/mypy clean, delta coverage complete.

## Notes

- No version bump.
- Targets `jleinenbach:1.7` so it flows into the upstream roll-up PR #199 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)