### PR TITLE
Self-heal the FCM 'zombie' session via a liveness watchdog

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -119,9 +119,14 @@ try:
         FCM_ABORT_ON_SEQ_ERROR_COUNT,
         FCM_CLIENT_HEARTBEAT_INTERVAL_S,
         FCM_CONNECTION_RETRY_COUNT,
+        FCM_DATA_STARVATION_S,
         FCM_IDLE_RESET_AFTER_S,
         FCM_MONITOR_INTERVAL_S,
         FCM_SERVER_HEARTBEAT_INTERVAL_S,
+        FCM_ZOMBIE_CHECK_INTERVAL_S,
+        FCM_ZOMBIE_MAX_RECONNECTS,
+        FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S,
+        FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S,
         OPT_IGNORED_DEVICES,  # for ignore fallback via options
     )
 except ImportError:  # pragma: no cover
@@ -131,8 +136,39 @@ except ImportError:  # pragma: no cover
     FCM_CONNECTION_RETRY_COUNT = 5
     FCM_MONITOR_INTERVAL_S = 1
     FCM_ABORT_ON_SEQ_ERROR_COUNT = 3
+    FCM_DATA_STARVATION_S = 900
+    FCM_ZOMBIE_CHECK_INTERVAL_S = 30
+    FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S = 60
+    FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S = 900
+    FCM_ZOMBIE_MAX_RECONNECTS = 5
     DOMAIN = "googlefindmy"
     OPT_IGNORED_DEVICES = "ignored_devices"
+
+
+# Readiness budget (seconds) for a fresh FCM identity to reach the STARTED
+# state after a (re)connect.  Derived from the library's connection-retry
+# count rather than a fixed value: a brand-new identity's first MCS connect
+# can take the full retry budget (FCM_CONNECTION_RETRY_COUNT attempts at
+# ~_FCM_READY_WAIT_PER_ATTEMPT_S each) plus a small margin.  SINGLE SOURCE OF
+# TRUTH shared by the manual-/first-locate path and the zombie-starvation
+# watchdog so the two readiness budgets can never drift.  The watchdog in
+# particular must NOT wait the full FCM_DATA_STARVATION_S (900s) here: its
+# reconnect wrapper holds the shared per-entry first-locate lock while
+# waiting, so a 900s budget would block a concurrent manual locate on the
+# same entry for up to 15 minutes (Codex F1).  The 900s starvation threshold
+# still governs the *decision* to reconnect (``_is_data_starved``); only this
+# wait-for-STARTED budget is bounded by it.
+_FCM_READY_WAIT_PER_ATTEMPT_S: float = 4.0
+_FCM_READY_WAIT_MARGIN_S: float = 2.0
+
+
+def _max_ready_wait_s() -> float:
+    """Return the STARTED-readiness budget in seconds (see note above)."""
+    return (
+        int(FCM_CONNECTION_RETRY_COUNT) * _FCM_READY_WAIT_PER_ATTEMPT_S
+        + _FCM_READY_WAIT_MARGIN_S
+    )
+
 
 # Optional import of worker run-state enum (for robust state checks)
 if TYPE_CHECKING:
@@ -426,6 +462,33 @@ class FcmReceiverHA:
         self._activity_stale_after_s: float = float(FCM_IDLE_RESET_AFTER_S)
         self._entry_health: dict[str, bool] = {}
         self._entry_last_connected_wall: dict[str, float] = {}
+
+        # Data-starvation liveness watchdog (re-arming zombie self-heal).
+        #
+        # ``_entry_last_data_delivery_monotonic`` is a *separate* clock from the
+        # activity clock above: it advances ONLY on a real locate data delivery
+        # (the cb-hit branch of ``_handle_notification_async``), never on a bare
+        # heartbeat ack. This separation is the crux of the fix -- the activity
+        # clock is heartbeat-poisoned and therefore masks starvation, so the
+        # watchdog must not consult it for "data flowing". A missing entry means
+        # "no data delivered yet" (only starved once a locate has been sent).
+        self._entry_last_data_delivery_monotonic: dict[str, float] = {}
+        # ``_entry_last_locate_sent_monotonic`` records the last time a locate was
+        # dispatched for the entry (stamped in ``async_register_for_location_
+        # updates``). The predicate requires "at least one locate since the last
+        # delivery" so an empty account (no locates -> no expected delivery) is
+        # never mis-classified as a zombie.
+        self._entry_last_locate_sent_monotonic: dict[str, float] = {}
+        # Per-entry watchdog backoff state and throttle clock.
+        self._zombie_reconnect_attempts: dict[str, int] = {}
+        self._zombie_next_allowed_reconnect_monotonic: dict[str, float] = {}
+        self._zombie_next_eval_monotonic: dict[str, float] = {}
+        # Tracked in-flight watchdog reconnect tasks (one per entry). The reconnect
+        # runs in a SEPARATE task (never inline in the supervisor monitor loop,
+        # which would deadlock: ``_force_first_locate_reconnect`` awaits a fresh
+        # STARTED pc that only the supervisor's outer loop can build). Cancelled
+        # on teardown in ``_purge_entry_tokens``.
+        self._zombie_reconnect_tasks: dict[str, asyncio.Task[None]] = {}
 
         # One-shot first-locate reconnect (#1150) serialization. Concurrent
         # manual locates for different trackers on the *same* entry both enter
@@ -1689,6 +1752,19 @@ class FcmReceiverHA:
                         )
                         if not writes_suppressed:
                             self._update_entry_health(entry_id, healthy)
+                            # Data-starvation liveness watchdog (AP4). Evaluated
+                            # only when writes are not suppressed (never against a
+                            # superseded/tombstoned generation), and throttled to
+                            # FCM_ZOMBIE_CHECK_INTERVAL_S rather than every 1s
+                            # tick. Detection + scheduling only -- the reconnect
+                            # runs as its own task, so the loop is never blocked
+                            # (no ``break``, no inline ``await`` on the reconnect).
+                            next_eval = self._zombie_next_eval_monotonic.get(entry_id)
+                            if next_eval is None or monotonic_now >= next_eval:
+                                self._zombie_next_eval_monotonic[entry_id] = (
+                                    monotonic_now + FCM_ZOMBIE_CHECK_INTERVAL_S
+                                )
+                                self._maybe_reconnect_starved(entry_id, monotonic_now)
                         if state is None:
                             _LOGGER.info(
                                 "[entry=%s] FCM client state unknown; scheduling restart",
@@ -2512,6 +2588,10 @@ class FcmReceiverHA:
 
             cb = self.location_update_callbacks.get(canonic_id)
             if cb:
+                # Real locate data delivery: stamp the data-delivery clock for
+                # every routed target entry and clear any watchdog backoff state,
+                # since data is flowing again (re-arm on the next starvation).
+                self._stamp_data_delivery(target_entries)
                 self._log_push_received(canonic_id, target_entries, route_src, 1)
                 await self._run_callback_async(cb, canonic_id, hex_string)
                 return
@@ -2555,6 +2635,30 @@ class FcmReceiverHA:
             _LOGGER.exception("Failed to handle FCM notification safely")
 
     # -------------------- Routing helpers --------------------
+
+    def _stamp_data_delivery(self, target_entries: set[str] | None) -> None:
+        """Record a real locate data delivery for every routed target entry.
+
+        Called ONLY from the cb-hit branch of ``_handle_notification_async`` (a
+        genuine locate data message), never on heartbeat acks and never from
+        ``_log_push_received``. Token routing can fan out to several receiver
+        entries under multi-account setups, so all entries in ``target_entries``
+        are stamped; a ``None`` routing set (broadcast / unknown owner) is
+        conservatively left unstamped so it can never mask starvation on a
+        specific entry. Delivery also re-arms the watchdog by clearing any
+        backoff state (data is flowing again).
+        """
+        if not target_entries:
+            return
+        now = time.monotonic()
+        for eid in target_entries:
+            self._entry_last_data_delivery_monotonic[eid] = now
+            self._reset_zombie_backoff(eid)
+
+    def _reset_zombie_backoff(self, entry_id: str) -> None:
+        """Clear the watchdog backoff/count state for *entry_id* (re-arm)."""
+        self._zombie_reconnect_attempts.pop(entry_id, None)
+        self._zombie_next_allowed_reconnect_monotonic.pop(entry_id, None)
 
     def _extract_hex_payload(self, payload: Mapping[str, Any]) -> str | None:
         """Return the decoded hex payload or None when absent."""
@@ -3470,6 +3574,18 @@ class FcmReceiverHA:
     def _purge_entry_tokens(self, entry_id: str) -> None:
         """Remove all routing references and per-entry runtime state for an entry."""
         self._entry_last_activity_monotonic.pop(entry_id, None)
+        # Data-starvation watchdog state (LC-13): drop the data/locate clocks and
+        # the backoff/count/throttle records, and cancel any in-flight watchdog
+        # reconnect task so it cannot keep working against the torn-down ``pc``
+        # after the entry is purged.
+        self._entry_last_data_delivery_monotonic.pop(entry_id, None)
+        self._entry_last_locate_sent_monotonic.pop(entry_id, None)
+        self._zombie_reconnect_attempts.pop(entry_id, None)
+        self._zombie_next_allowed_reconnect_monotonic.pop(entry_id, None)
+        self._zombie_next_eval_monotonic.pop(entry_id, None)
+        zombie_task = self._zombie_reconnect_tasks.pop(entry_id, None)
+        if zombie_task is not None and not zombie_task.done():
+            zombie_task.cancel()
         # First-locate reconnect serialization state (#1150 follow-up): drop the
         # per-entry lock and the consumed-replacement record so a later reload
         # under the same entry_id starts from a clean slate.
@@ -3826,6 +3942,174 @@ class FcmReceiverHA:
                 self._first_locate_reconnect_done[entry_id] = fresh_pc
             return fresh_pc
 
+    # -------------------- Data-starvation liveness watchdog --------------------
+
+    def _is_data_starved(self, entry_id: str, now: float) -> bool:  # noqa: PLR0911
+        """True if *entry_id* is a data-starvation zombie at monotonic time *now*.
+
+        Pure and side-effect-free (no IO): safe to call every evaluation tick.
+        Returns True only when ALL hold:
+
+        * a live client exists and is ``STARTED`` (``_is_started``);
+        * the session is *established* (``age >= _CHURN_WINDOW_S``) -- a young
+          session is the one-shot first-locate reconnect's job, not the watchdog;
+        * the activity clock (K4) is *fresh* -- the heartbeat is alive, so this
+          is a "STARTED, heartbeating, but silent" zombie, not a dead socket
+          (that is the idle-reset's job);
+        * at least ``FCM_DATA_STARVATION_S`` elapsed since the last real data
+          delivery (a missing data clock counts as "never delivered", starved
+          only in combination with the locate-sent gate below); and
+        * a locate was sent for this entry AND it is at or after the last data
+          delivery (>= 1 locate since the last delivery) -- this is what rules
+          out an empty account with no pending locate.
+        """
+        pc = self.pcs.get(entry_id)
+        if pc is None or not self._is_started(pc):
+            return False
+        age = self._session_age_s(pc)
+        if age is None or age < _CHURN_WINDOW_S:
+            return False
+        last_activity = self._entry_last_activity_monotonic.get(entry_id)
+        stale_after = max(self._activity_stale_after_s, 0.0)
+        if last_activity is None:
+            return False
+        if stale_after > 0.0 and now - last_activity > stale_after:
+            # Heartbeat is not fresh: a dead session, not a data-starved zombie.
+            return False
+        last_locate = self._entry_last_locate_sent_monotonic.get(entry_id)
+        if last_locate is None:
+            # No locate ever dispatched for this entry: nothing to expect.
+            return False
+        last_delivery = self._entry_last_data_delivery_monotonic.get(entry_id)
+        if last_delivery is None:
+            # Never delivered, but a locate was sent: starved once the locate is
+            # old enough that a healthy session would have answered.
+            return now - last_locate >= FCM_DATA_STARVATION_S
+        if now - last_delivery < FCM_DATA_STARVATION_S:
+            return False
+        # Require >= 1 locate since the last delivery, else a quiet-but-healthy
+        # account (delivered, then no new locate) would look starved.
+        return last_locate >= last_delivery
+
+    async def _reconnect_for_starvation(self, entry_id: str, max_wait_s: float) -> None:
+        """Force one cooperative reconnect for a data-starved zombie session.
+
+        Runs in its OWN task (scheduled by ``_maybe_reconnect_starved``), never
+        inline in the supervisor monitor loop -- awaiting the reconnect there
+        would deadlock, because ``_force_first_locate_reconnect`` waits for a
+        fresh STARTED client that only the supervisor's outer loop can build.
+
+        Acquires the shared ``_get_first_locate_lock(entry_id)`` (serialises
+        against the first-/manual-locate reconnect so the same ``pc`` is never
+        torn down twice), re-reads the live client under the lock, and -- if it
+        is still a live STARTED session -- calls ``_force_first_locate_reconnect``
+        UNCONDITIONALLY. It deliberately does NOT go through
+        ``_reconnect_for_first_locate``: that method's reuse gate
+        (``not _needs_first_locate_reconnect(current)``) is always True for an
+        aged zombie (``_needs_first_locate_reconnect`` returns False once
+        ``age >= _CHURN_WINDOW_S``) and would return ``current`` WITHOUT
+        reconnecting. The backoff / count / one-in-flight guard has already made
+        the reconnect decision before this runs. ``_first_locate_reconnect_done``
+        is left untouched (that latch belongs to the first-locate path).
+        """
+        async with self._get_first_locate_lock(entry_id):
+            current = self.pcs.get(entry_id)
+            if current is None or not self._is_started(current):
+                # The supervisor tore the client down (or it is no longer
+                # STARTED) between scheduling and lock acquisition; nothing to do.
+                return
+            await self._force_first_locate_reconnect(entry_id, current, max_wait_s)
+
+    def _maybe_reconnect_starved(self, entry_id: str, now: float) -> None:
+        """Schedule a watchdog reconnect if *entry_id* is a starved zombie.
+
+        Called from the supervisor monitor loop (throttled to
+        ``FCM_ZOMBIE_CHECK_INTERVAL_S``). Detection + scheduling only: it never
+        awaits the reconnect (that runs as a separate task). Guards:
+
+        * predicate ``_is_data_starved`` must hold;
+        * the backoff window must be open
+          (``now >= _zombie_next_allowed_reconnect_monotonic``);
+        * the hard reconnect ceiling ``FCM_ZOMBIE_MAX_RECONNECTS`` must not be
+          reached; and
+        * no watchdog reconnect task may be in flight for this entry.
+
+        When all pass it schedules ``_reconnect_for_starvation`` via
+        ``hass.async_create_task`` and, only once that task is created, commits
+        the next (exponentially larger, capped) backoff window and the
+        incremented attempt count. If scheduling raises ``RuntimeError`` (event
+        loop closing during shutdown) it leaves all scheduler state untouched so
+        a later tick can retry, rather than spending an attempt with no task.
+        """
+        if self._hass is None:
+            return
+        existing = self._zombie_reconnect_tasks.get(entry_id)
+        if existing is not None and not existing.done():
+            return  # one-in-flight guard (b): a reconnect is already running.
+        if not self._is_data_starved(entry_id, now):
+            return
+        next_allowed = self._zombie_next_allowed_reconnect_monotonic.get(entry_id)
+        if next_allowed is not None and now < next_allowed:
+            return  # still inside the current backoff window.
+        attempts = self._zombie_reconnect_attempts.get(entry_id, 0)
+        if attempts >= FCM_ZOMBIE_MAX_RECONNECTS:
+            return  # hard ceiling reached for this starvation episode.
+        # Plan the next backoff window (exponential from BASE, doubled per
+        # attempt, capped) and record the attempt before scheduling.
+        backoff = min(
+            FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S * (2**attempts),
+            FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S,
+        )
+        # F1: bound the reconnect's wait-for-STARTED to the conservative
+        # readiness budget (~22s), NOT FCM_DATA_STARVATION_S (900s).
+        # ``_reconnect_for_starvation`` holds the shared per-entry first-locate
+        # lock while awaiting STARTED; a 900s budget would starve a concurrent
+        # manual locate on the same entry for up to 15 minutes.  The 900s
+        # starvation threshold still gates the reconnect *decision* above; only
+        # the STARTED-wait is capped here.  Shared SSOT with the native locate
+        # path via ``_max_ready_wait_s`` so the two budgets cannot drift.
+        max_wait_s = _max_ready_wait_s()
+        # F3: schedule the task FIRST and commit the backoff-window / attempt
+        # counter only once it is guaranteed created.  During HA shutdown the
+        # event loop is closing and ``async_create_task`` raises ``RuntimeError``
+        # (same failure mode guarded at the direct-schedule paths above); if the
+        # counter were bumped before that raise, this tick would "spend" a
+        # reconnect attempt with no task ever running, drifting the entry toward
+        # ``FCM_ZOMBIE_MAX_RECONNECTS`` while never actually reconnecting.  On
+        # failure we leave all scheduler state untouched so a post-restart tick
+        # can retry.  There is no ``await`` between task creation and return, so
+        # the task body cannot run before the state below is committed.
+        try:
+            task = self._hass.async_create_task(
+                self._reconnect_for_starvation(entry_id, max_wait_s),
+                name=f"fcm_zombie_reconnect_{entry_id}",
+            )
+        except RuntimeError:
+            _LOGGER.debug(
+                "[entry=%s] Deferred watchdog reconnect: event loop unavailable "
+                "(shutdown in progress); scheduler state left intact for a later "
+                "tick",
+                entry_id,
+            )
+            return
+        self._zombie_next_allowed_reconnect_monotonic[entry_id] = now + backoff
+        self._zombie_reconnect_attempts[entry_id] = attempts + 1
+        self._zombie_reconnect_tasks[entry_id] = task
+
+        def _clear_task(_done: asyncio.Task[None], _eid: str = entry_id) -> None:
+            if self._zombie_reconnect_tasks.get(_eid) is _done:
+                self._zombie_reconnect_tasks.pop(_eid, None)
+
+        task.add_done_callback(_clear_task)
+        _LOGGER.info(
+            "[entry=%s] FCM data starvation detected (attempt %d/%d); forcing a "
+            "watchdog reconnect (next backoff %ds)",
+            entry_id,
+            attempts + 1,
+            FCM_ZOMBIE_MAX_RECONNECTS,
+            backoff,
+        )
+
     async def _reconnect_and_refresh_token(
         self, entry_id: str, previous_token: str, max_wait_s: float
     ) -> str | None:
@@ -3904,6 +4188,10 @@ class FcmReceiverHA:
             return None
 
         self.location_update_callbacks[canonic_id] = callback
+        # Watchdog signal (AP2.5): a locate has now been dispatched for this
+        # entry. The starvation predicate requires >= 1 locate since the last
+        # delivery, so an empty account (no locates) never looks like a zombie.
+        self._entry_last_locate_sent_monotonic[entry_id] = time.monotonic()
 
         token: str | None = None
         try:
@@ -3943,12 +4231,7 @@ class FcmReceiverHA:
                 # small margin keeps a fresh registration from being abandoned
                 # prematurely, which is the root of the deterministic first-run
                 # locate timeout.
-                _PER_ATTEMPT_WAIT_S = 4.0
-                _READY_WAIT_MARGIN_S = 2.0
-                _MAX_READY_WAIT_S = (
-                    int(FCM_CONNECTION_RETRY_COUNT) * _PER_ATTEMPT_WAIT_S
-                    + _READY_WAIT_MARGIN_S
-                )
+                _MAX_READY_WAIT_S = _max_ready_wait_s()
                 started_pc = await self._await_entry_started(
                     entry_id, pc, _MAX_READY_WAIT_S
                 )

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -514,6 +514,50 @@ FCM_MONITOR_INTERVAL_S: int = 1
 FCM_ABORT_ON_SEQ_ERROR_COUNT: int = 3
 
 # --------------------------------------------------------------------------------------
+# FCM data-starvation liveness watchdog (re-arming zombie self-heal)
+# --------------------------------------------------------------------------------------
+# A "zombie" FCM session is STARTED and keeps acking heartbeats (so the activity
+# clock and readiness gate both look healthy), yet has stopped delivering
+# ``push_received`` data messages despite locates being sent. The one-shot
+# first-locate reconnect only covers a *young* session (age < _CHURN_WINDOW_S);
+# a long-running session that goes silent is only healed by a manual reload
+# today (empirically sometimes twice). The watchdog below detects this and
+# forces a cooperative, backoff-limited reconnect that re-arms after each cycle.
+#
+# FCM_DATA_STARVATION_S: minimum gap (seconds) since the last real data delivery
+# before a STARTED, heartbeating, locate-active session is treated as starved.
+# Calibration (live DEBUG capture 2026-07-04, 2h23m healthy window): normal gaps
+# between data messages reach ~349s (they grow with the observation window; only
+# ~305s over a 71-min window), so the threshold must be a *generous* multiple of
+# the poll cycle, well above 349s, never a value near it. 900s ≈ 3 default poll
+# cycles (300s) and ≈ 30× the 30s locate timeout — conservatively large so the
+# watchdog reacts later, never more aggressively (storm-safe by construction).
+# The MCS session lifetime is ~2h, so 15-minute detection is fast enough.
+FCM_DATA_STARVATION_S: int = 900
+
+# FCM_ZOMBIE_CHECK_INTERVAL_S: how often the watchdog *evaluates* starvation.
+# The supervisor monitor loop ticks every FCM_MONITOR_INTERVAL_S (1s); evaluating
+# the predicate every tick is wasteful, so the watchdog is throttled to run at
+# most once per this interval (30× rarer than the tick, far denser than the
+# starvation window, so detection latency stays well under a minute).
+FCM_ZOMBIE_CHECK_INTERVAL_S: int = 30
+
+# FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S: first backoff window after the first
+# watchdog reconnect. Subsequent windows double (60 → 120 → 240 → …) up to the
+# cap below, so a session that stays starved is retried with growing patience.
+FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S: int = 60
+
+# FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S: upper bound of the exponential backoff
+# (equals the starvation window: never retry faster than the detection cadence).
+FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S: int = 900
+
+# FCM_ZOMBIE_MAX_RECONNECTS: hard ceiling on watchdog reconnects per starvation
+# episode. The count (and backoff) reset on the first successful data delivery
+# after a reconnect. Together with the cap and the one-in-flight lock this bounds
+# the worst case to a slow, finite series — never a reconnect storm / self-DoS.
+FCM_ZOMBIE_MAX_RECONNECTS: int = 5
+
+# --------------------------------------------------------------------------------------
 # Feature Flags (compile-time toggles for optional functionality)
 # --------------------------------------------------------------------------------------
 # FMDN Finder: Upload location reports to Google for FMDN beacons detected by Bermuda.
@@ -687,6 +731,11 @@ __all__ = [
     "FCM_CONNECTION_RETRY_COUNT",
     "FCM_MONITOR_INTERVAL_S",
     "FCM_ABORT_ON_SEQ_ERROR_COUNT",
+    "FCM_DATA_STARVATION_S",
+    "FCM_ZOMBIE_CHECK_INTERVAL_S",
+    "FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S",
+    "FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S",
+    "FCM_ZOMBIE_MAX_RECONNECTS",
     "EVENT_AUTH_ERROR",
     "EVENT_AUTH_OK",
     "TRANSLATION_KEY_AUTH_STATUS",

--- a/tests/test_fcm_receiver_liveness_watchdog.py
+++ b/tests/test_fcm_receiver_liveness_watchdog.py
@@ -1,0 +1,874 @@
+# tests/test_fcm_receiver_liveness_watchdog.py
+"""Data-starvation liveness watchdog (re-arming FCM zombie self-heal).
+
+Covers the AP1-AP4 additions to ``FcmReceiverHA``:
+
+* AP1  the separate ``_entry_last_data_delivery_monotonic`` clock and the
+  ``_stamp_data_delivery`` helper (stamped only on a real locate data delivery),
+* AP2  the pure ``_is_data_starved`` predicate,
+* AP2.5 the entry-scoped ``_entry_last_locate_sent_monotonic`` signal,
+* AP3  the re-arming reconnect (``_reconnect_for_starvation`` wrapper +
+  ``_maybe_reconnect_starved`` scheduler, backoff/cap/max, one-in-flight), and
+* AP4  the throttled supervisor wiring + ``_purge_entry_tokens`` reset/cancel.
+
+The tests exercise the real predicate/scheduler/stamp/reset logic against a
+light push-client double, never ``asyncio.run()`` (tests/AGENTS.md). Coroutine
+tests are ``async def`` and awaited directly under pytest's managed loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.Auth import fcm_receiver_ha as fcm_mod
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
+from custom_components.googlefindmy.const import (
+    FCM_DATA_STARVATION_S,
+    FCM_ZOMBIE_MAX_RECONNECTS,
+    FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S,
+    FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S,
+)
+
+
+class _RunState:
+    """Minimal stand-in for FcmPushClientRunState (only STARTED is compared)."""
+
+    STARTED = "STARTED"
+
+
+class _WatchdogPc:
+    """Push-client double: run_state, STARTED-age anchor, and async stop()."""
+
+    def __init__(
+        self,
+        run_state: object = _RunState.STARTED,
+        *,
+        started_monotonic: float | None = None,
+        age_s: float = 100.0,
+    ) -> None:
+        self.run_state = run_state
+        # Default: established session well past _CHURN_WINDOW_S (age ~100s).
+        self._started_monotonic = (
+            (time.monotonic() - age_s)
+            if started_monotonic is None
+            else started_monotonic
+        )
+        self.persistent_ids: list[str] = []
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self.run_state = "STOPPED"
+
+
+class _DummyHass:
+    """Lightweight hass stub whose ``async_create_task`` uses the live loop."""
+
+    def __init__(self) -> None:
+        self.created: list[str | None] = []
+
+    def async_create_task(
+        self, coro: Any, *, name: str | None = None
+    ) -> asyncio.Task[Any]:
+        self.created.append(name)
+        return asyncio.get_event_loop().create_task(coro, name=name)
+
+
+class _FakeTask:
+    """Minimal task stand-in: reports not-done and swallows the done-callback."""
+
+    def done(self) -> bool:
+        return False
+
+    def add_done_callback(self, _cb: Any) -> None:
+        return None
+
+
+class _RecordingHass:
+    """Hass stub that records scheduling but never runs the coroutine.
+
+    Used by the synchronous scheduler tests (no running loop): it closes the
+    passed coroutine to avoid "coroutine was never awaited" warnings and returns
+    a ``_FakeTask`` so no real asyncio task leaks between tests.
+    """
+
+    def __init__(self) -> None:
+        self.created: list[str | None] = []
+
+    def async_create_task(self, coro: Any, *, name: str | None = None) -> _FakeTask:
+        self.created.append(name)
+        coro.close()
+        return _FakeTask()
+
+
+def _make_receiver(monkeypatch: pytest.MonkeyPatch) -> FcmReceiverHA:
+    """Return a receiver with the run-state enum wired to the local stub."""
+    receiver = FcmReceiverHA()
+    monkeypatch.setattr(fcm_mod, "FcmPushClientRunState", _RunState)
+    return receiver
+
+
+def _arm_starved(
+    receiver: FcmReceiverHA,
+    entry_id: str,
+    now: float,
+    *,
+    pc: _WatchdogPc | None = None,
+) -> _WatchdogPc:
+    """Set up the canonical starved-zombie state at monotonic time *now*.
+
+    Fixed offsets (T0/T1/T3 oracle): data clock = now - (STARVATION + 1),
+    activity clock = now - 1 (heartbeat fresh), a locate sent after the last
+    delivery, and an established STARTED session (age >= churn).
+    """
+    live_pc = pc if pc is not None else _WatchdogPc(age_s=100.0)
+    receiver.pcs[entry_id] = live_pc  # type: ignore[assignment]
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - (
+        FCM_DATA_STARVATION_S + 1.0
+    )
+    receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - 0.5
+    return live_pc
+
+
+# ---------------------------------------------------------------------------
+# T0 -- Anti-zombie target proof (BLOCKING). Three asserted mutant vectors.
+# ---------------------------------------------------------------------------
+
+
+def test_t0a_watchdog_disabled_never_reconnects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T0a: a disabled watchdog (scheduler no-op) schedules 0 reconnects -> red.
+
+    The mutant disables ``_maybe_reconnect_starved``; the positive path below
+    proves the real code schedules exactly one reconnect for the same setup.
+    """
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    # Mutant: watchdog disabled.
+    monkeypatch.setattr(receiver, "_maybe_reconnect_starved", lambda eid, n: None)
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert hass.created == []  # disabled -> no reconnect (asserted mutant)
+
+    # Positive control (real code) schedules exactly one.
+    real = FcmReceiverHA._maybe_reconnect_starved
+    real(receiver, entry_id, now)
+    assert hass.created == [f"fcm_zombie_reconnect_{entry_id}"]
+
+
+def test_t0b_predicate_on_activity_clock_never_fires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T0b: keying starvation on the activity clock (K4) never fires -> red.
+
+    The activity clock is fresh (heartbeat alive), so a predicate that consults
+    it instead of the data clock returns False and no reconnect is scheduled.
+    """
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    def _mutant_activity_predicate(eid: str, n: float) -> bool:
+        last_activity = receiver._entry_last_activity_monotonic.get(eid)
+        if last_activity is None:
+            return False
+        return n - last_activity >= FCM_DATA_STARVATION_S
+
+    monkeypatch.setattr(receiver, "_is_data_starved", _mutant_activity_predicate)
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert hass.created == []  # activity-clock predicate stays False -> no heal
+
+    # The real data-clock predicate DOES classify this as starved.
+    assert FcmReceiverHA._is_data_starved(receiver, entry_id, now) is True
+
+
+def test_t0c_starvation_threshold_infinite_never_fires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """T0c: an unreachable starvation threshold (inf) never fires -> red."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    monkeypatch.setattr(fcm_mod, "FCM_DATA_STARVATION_S", float("inf"))
+    assert receiver._is_data_starved(entry_id, now) is False
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert hass.created == []
+
+
+# ---------------------------------------------------------------------------
+# T1 -- detected + healed + reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t1_zombie_detected_healed_and_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A starved zombie is detected, one reconnect fires, delivery resets state."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _DummyHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    stale = _arm_starved(receiver, entry_id, now)
+    fresh = _WatchdogPc(age_s=0.0)
+
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+
+    async def _swap(_seconds: float) -> None:
+        if receiver.pcs[entry_id] is stale:
+            receiver.pcs[entry_id] = fresh  # type: ignore[assignment]
+
+    monkeypatch.setattr(asyncio, "sleep", _swap)
+
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert receiver._zombie_reconnect_attempts[entry_id] == 1
+    task = receiver._zombie_reconnect_tasks[entry_id]
+    await task
+
+    assert stale.stopped is True  # the reconnect actually tore down the zombie
+    assert receiver.pcs[entry_id] is fresh
+
+    # A real data delivery re-arms: clock advances, backoff/count cleared.
+    receiver._stamp_data_delivery({entry_id})
+    assert entry_id in receiver._entry_last_data_delivery_monotonic
+    assert entry_id not in receiver._zombie_reconnect_attempts
+    assert entry_id not in receiver._zombie_next_allowed_reconnect_monotonic
+
+
+# ---------------------------------------------------------------------------
+# T2 -- healthy session -> no reconnect
+# ---------------------------------------------------------------------------
+
+
+def test_t2_healthy_session_no_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fresh data clock -> predicate False (mutation-inverting it fires -> red)."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    # Override: data delivered just now -> healthy.
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - 1.0
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - 0.5
+
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Mutation counter-check: a stale data clock would flip it to True.
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - (
+        FCM_DATA_STARVATION_S + 1.0
+    )
+    assert receiver._is_data_starved(entry_id, now) is True
+
+
+# ---------------------------------------------------------------------------
+# T3 -- core bug regression: heartbeats do NOT advance the data clock
+# ---------------------------------------------------------------------------
+
+
+def test_t3_heartbeat_does_not_advance_data_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare heartbeat advances the activity clock but not the data clock.
+
+    ``_stamp_data_delivery`` is the ONLY writer of the data clock; the activity
+    clock (K4) is advanced elsewhere by heartbeats. Simulate a heartbeat by
+    refreshing only the activity clock: the predicate must stay True.
+    """
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    # "Heartbeat" tick: only the activity clock moves forward.
+    receiver._entry_last_activity_monotonic[entry_id] = now
+    assert receiver._is_data_starved(entry_id, now) is True
+
+    # Mutation counter-check: wiring the data clock to the heartbeat clears it.
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now
+    assert receiver._is_data_starved(entry_id, now) is False
+
+
+# ---------------------------------------------------------------------------
+# T4 -- backoff growth + cap + max ceiling + reset
+# ---------------------------------------------------------------------------
+
+
+def test_t4_backoff_grows_caps_and_hits_max(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated starvation grows backoff up to the cap and stops at MAX; reset works."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+
+    # Never actually reconnect; keep the entry pinned starved so we can drive the
+    # scheduler through every backoff window deterministically.
+    async def _noop_reconnect(eid: str, max_wait_s: float) -> None:
+        return None
+
+    monkeypatch.setattr(receiver, "_reconnect_for_starvation", _noop_reconnect)
+
+    windows: list[float] = []
+    now = 1000.0
+    _arm_starved(receiver, entry_id, now)
+    # Re-pin data/activity/locate relative to the synthetic clock each step so
+    # the predicate stays True as ``now`` advances.
+    for _ in range(FCM_ZOMBIE_MAX_RECONNECTS + 2):
+        receiver._entry_last_data_delivery_monotonic[entry_id] = now - (
+            FCM_DATA_STARVATION_S + 1.0
+        )
+        receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+        receiver._entry_last_locate_sent_monotonic[entry_id] = now - 0.5
+        # Clear any completed task so the one-in-flight guard does not block.
+        receiver._zombie_reconnect_tasks.pop(entry_id, None)
+        before = receiver._zombie_reconnect_attempts.get(entry_id, 0)
+        receiver._maybe_reconnect_starved(entry_id, now)
+        after = receiver._zombie_reconnect_attempts.get(entry_id, 0)
+        if after > before:
+            windows.append(
+                receiver._zombie_next_allowed_reconnect_monotonic[entry_id] - now
+            )
+            # Advance past the just-planned window for the next iteration.
+            now = receiver._zombie_next_allowed_reconnect_monotonic[entry_id]
+        else:
+            now += 1.0
+
+    # Exactly MAX reconnects scheduled, then the hard ceiling stops it.
+    assert receiver._zombie_reconnect_attempts[entry_id] == FCM_ZOMBIE_MAX_RECONNECTS
+    assert len(windows) == FCM_ZOMBIE_MAX_RECONNECTS
+    # Exponential growth from BASE, doubling, capped.
+    expected = [
+        min(
+            FCM_ZOMBIE_RECONNECT_BACKOFF_BASE_S * (2**i),
+            FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S,
+        )
+        for i in range(FCM_ZOMBIE_MAX_RECONNECTS)
+    ]
+    assert windows == expected
+    assert windows[-1] == FCM_ZOMBIE_RECONNECT_BACKOFF_CAP_S  # cap reached
+
+    # First real delivery resets count + backoff (re-arm).
+    receiver._stamp_data_delivery({entry_id})
+    assert entry_id not in receiver._zombie_reconnect_attempts
+    assert entry_id not in receiver._zombie_next_allowed_reconnect_monotonic
+
+
+# ---------------------------------------------------------------------------
+# T5 -- one-in-flight guard + shared serialization lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t5_one_in_flight_and_shared_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No second reconnect while one is in flight; watchdog shares the locate lock."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _DummyHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    stale = _arm_starved(receiver, entry_id, now)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+
+    async def _blocking_stop() -> None:
+        stale.stopped = True
+        entered.set()
+        await release.wait()
+
+    monkeypatch.setattr(stale, "stop", _blocking_stop)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    receiver._maybe_reconnect_starved(entry_id, now)
+    await entered.wait()  # first reconnect task is parked mid-stop().
+
+    # One-in-flight guard: a second scheduling attempt does not create a task.
+    created_before = len(hass.created)
+    receiver._maybe_reconnect_starved(entry_id, now + 10_000.0)
+    assert len(hass.created) == created_before  # no second task scheduled
+
+    # The shared first-locate lock is held by the watchdog reconnect.
+    assert receiver._get_first_locate_lock(entry_id).locked() is True
+
+    release.set()
+    await receiver._zombie_reconnect_tasks[entry_id]
+    assert receiver._get_first_locate_lock(entry_id).locked() is False
+
+
+# ---------------------------------------------------------------------------
+# T6 -- empty account (no locate) -> no false positive
+# ---------------------------------------------------------------------------
+
+
+def test_t6_empty_account_no_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No locate ever sent -> not starved even with an old/absent data clock."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    receiver.pcs[entry_id] = _WatchdogPc(age_s=100.0)  # type: ignore[assignment]
+    receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+    # No data delivery, no locate sent.
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Even an ancient data clock without a locate stays non-starved.
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - (
+        FCM_DATA_STARVATION_S + 1.0
+    )
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # A stale locate delivered *before* the last delivery also does not qualify
+    # (no locate since the last delivery).
+    receiver._entry_last_data_delivery_monotonic[entry_id] = now - 10.0
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - 20.0
+    assert receiver._is_data_starved(entry_id, now) is False
+
+
+# ---------------------------------------------------------------------------
+# T7 -- teardown reset + in-flight task cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t7_purge_resets_state_and_cancels_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_purge_entry_tokens`` clears all watchdog state and cancels the task."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    receiver._zombie_reconnect_attempts[entry_id] = 2
+    receiver._zombie_next_allowed_reconnect_monotonic[entry_id] = now + 60.0
+    receiver._zombie_next_eval_monotonic[entry_id] = now + 30.0
+
+    started = asyncio.Event()
+
+    async def _long_reconnect() -> None:
+        started.set()
+        await asyncio.Event().wait()  # never completes on its own
+
+    task = asyncio.get_event_loop().create_task(_long_reconnect())
+    receiver._zombie_reconnect_tasks[entry_id] = task  # type: ignore[assignment]
+    await started.wait()
+
+    receiver._purge_entry_tokens(entry_id)
+
+    assert entry_id not in receiver._entry_last_data_delivery_monotonic
+    assert entry_id not in receiver._entry_last_locate_sent_monotonic
+    assert entry_id not in receiver._zombie_reconnect_attempts
+    assert entry_id not in receiver._zombie_next_allowed_reconnect_monotonic
+    assert entry_id not in receiver._zombie_next_eval_monotonic
+    assert entry_id not in receiver._zombie_reconnect_tasks
+    assert task.cancelled() or task.cancelling()  # cancellation requested
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+# ---------------------------------------------------------------------------
+# T8 -- deadlock regression: reconnect is scheduled, never inline-awaited
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t8_reconnect_is_scheduled_not_inline_awaited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scheduler returns immediately (task scheduled), never blocking on it.
+
+    Mutation counter-check A: an inline ``await`` on the reconnect would block the
+    caller until the replacement is built -- proven here by a reconnect that
+    never completes; the scheduler must still return promptly with a pending
+    task. Mutation counter-check B: routing the watchdog through
+    ``_reconnect_for_first_locate`` performs NO reconnect on an aged session
+    (its reuse gate short-circuits), so the zombie is never torn down.
+    """
+    receiver = _make_receiver(monkeypatch)
+    hass = _DummyHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    stale = _arm_starved(receiver, entry_id, now)
+
+    reconnect_ran = asyncio.Event()
+
+    async def _never_finishing(eid: str, max_wait_s: float) -> None:
+        reconnect_ran.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(receiver, "_reconnect_for_starvation", _never_finishing)
+
+    # Scheduler returns synchronously even though the reconnect never finishes.
+    receiver._maybe_reconnect_starved(entry_id, now)
+    task = receiver._zombie_reconnect_tasks[entry_id]
+    assert not task.done()  # scheduled, not awaited inline
+    await reconnect_ran.wait()  # the task did start on the loop
+    assert not task.done()  # still running; caller was never blocked
+    task.cancel()
+
+    # Gegen-probe B: the reuse-gated first-locate reconnect does nothing for an
+    # aged (age >= churn) zombie -- proving the dedicated wrapper is required.
+    monkeypatch.setattr(receiver, "nudge_retry", lambda eid=None: True)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    stale.stopped = False
+    result = await receiver._reconnect_for_first_locate(entry_id, 1.0)
+    assert result is stale  # returned as-is, NOT reconnected
+    assert stale.stopped is False  # aged zombie was never torn down
+
+
+# ---------------------------------------------------------------------------
+# T9 -- target_entries stamp (multi-entry fan-out)
+# ---------------------------------------------------------------------------
+
+
+def test_t9_stamp_all_target_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A token-routed delivery stamps EVERY target entry, not just one."""
+    receiver = _make_receiver(monkeypatch)
+    before = time.monotonic()
+    receiver._stamp_data_delivery({"entry-1", "entry-2"})
+    after = time.monotonic()
+
+    for eid in ("entry-1", "entry-2"):
+        stamped = receiver._entry_last_data_delivery_monotonic[eid]
+        assert before <= stamped <= after
+
+    # Mutation counter-check: stamping only ``entry_id`` would leave a co-routed
+    # multi-account entry unstamped and thus falsely starving.
+    receiver._entry_last_data_delivery_monotonic.clear()
+    receiver._stamp_data_delivery({"entry-1"})  # single-entry routing
+    assert "entry-1" in receiver._entry_last_data_delivery_monotonic
+    assert "entry-2" not in receiver._entry_last_data_delivery_monotonic
+
+    # A ``None`` (broadcast/unknown) routing set stamps nothing (conservative).
+    receiver._entry_last_data_delivery_monotonic.clear()
+    receiver._stamp_data_delivery(None)
+    assert receiver._entry_last_data_delivery_monotonic == {}
+
+
+# ---------------------------------------------------------------------------
+# T10-T13 -- _is_data_starved false-positive guards (storm safety, AP2)
+# Each guard rules out a class of non-zombie so the re-arming reconnect never
+# fires on a healthy/young/dead/empty session. Every vector pairs the guarded
+# verdict with a mutation counter-check that flips it.
+# ---------------------------------------------------------------------------
+
+
+def test_t10_young_session_not_starved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A session younger than the churn window is never starved (age guard)."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    # Fully armed for starvation, but the session is brand new (age < churn 15s).
+    _arm_starved(receiver, entry_id, now, pc=_WatchdogPc(age_s=5.0))
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Mutation counter-check: an established session (age past churn) fires.
+    receiver.pcs[entry_id] = _WatchdogPc(age_s=100.0)  # type: ignore[assignment]
+    assert receiver._is_data_starved(entry_id, now) is True
+
+
+def test_t11_missing_activity_clock_not_starved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No activity clock recorded -> not starved (heartbeat health unknown)."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    del receiver._entry_last_activity_monotonic[entry_id]
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Mutation counter-check: a fresh activity clock restores the starved verdict.
+    receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+    assert receiver._is_data_starved(entry_id, now) is True
+
+
+def test_t12_dead_heartbeat_not_starved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale activity clock is a dead socket (idle-reset's job), not a zombie."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    # Heartbeat older than the freshness window (FCM_IDLE_RESET_AFTER_S = 90s).
+    receiver._entry_last_activity_monotonic[entry_id] = now - (
+        receiver._activity_stale_after_s + 1.0
+    )
+    assert receiver._is_data_starved(entry_id, now) is False
+
+    # Mutation counter-check: a fresh heartbeat is a live-but-silent zombie.
+    receiver._entry_last_activity_monotonic[entry_id] = now - 1.0
+    assert receiver._is_data_starved(entry_id, now) is True
+
+
+def test_t13_never_delivered_with_locate_is_starved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Never delivered, but an old locate is pending -> starved (no data clock)."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    # No data delivery ever; the locate is older than the starvation threshold.
+    del receiver._entry_last_data_delivery_monotonic[entry_id]
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - (
+        FCM_DATA_STARVATION_S + 1.0
+    )
+    assert receiver._is_data_starved(entry_id, now) is True
+
+    # Mutation counter-check: a recent locate (within threshold) is not yet starved.
+    receiver._entry_last_locate_sent_monotonic[entry_id] = now - 1.0
+    assert receiver._is_data_starved(entry_id, now) is False
+
+
+# ---------------------------------------------------------------------------
+# T14 -- reconnect wrapper aborts when the client vanished under the lock (AP3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t14_reconnect_wrapper_no_client_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wrapper returns without reconnecting when no live client is present."""
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    calls: list[tuple[str, Any, float]] = []
+
+    async def _record(eid: str, pc: Any, wait: float) -> None:
+        calls.append((eid, pc, wait))
+
+    monkeypatch.setattr(receiver, "_force_first_locate_reconnect", _record)
+
+    # No pc registered: the supervisor tore it down before the lock was acquired.
+    await receiver._reconnect_for_starvation(entry_id, 30.0)
+    assert calls == []
+
+    # Mutation counter-check: a live STARTED client reconnects unconditionally.
+    receiver.pcs[entry_id] = _WatchdogPc(age_s=100.0)  # type: ignore[assignment]
+    await receiver._reconnect_for_starvation(entry_id, 30.0)
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# T15-T16 -- scheduler early-exit guards (AP3): no hass, open backoff window
+# ---------------------------------------------------------------------------
+
+
+def test_t15_scheduler_without_hass_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The scheduler is a safe no-op (no crash, no attempt) when hass is absent."""
+    receiver = _make_receiver(monkeypatch)
+    receiver._hass = None  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    receiver._maybe_reconnect_starved(entry_id, now)  # must not raise
+    assert entry_id not in receiver._zombie_reconnect_attempts
+
+    # Mutation counter-check: with a hass the same setup schedules one reconnect.
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert len(hass.created) == 1
+    assert receiver._zombie_reconnect_attempts[entry_id] == 1
+
+
+def test_t16_scheduler_inside_backoff_window_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inside an open backoff window the scheduler defers (no new reconnect)."""
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+    # Backoff window still open: the next allowed reconnect is in the future.
+    receiver._zombie_next_allowed_reconnect_monotonic[entry_id] = now + 60.0
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert hass.created == []
+
+    # Mutation counter-check: once the window has elapsed the reconnect schedules.
+    receiver._zombie_next_allowed_reconnect_monotonic[entry_id] = now - 1.0
+    receiver._maybe_reconnect_starved(entry_id, now)
+    assert len(hass.created) == 1
+
+
+# ---------------------------------------------------------------------------
+# T17 -- delivery integration: the cb-hit handler branch stamps the data clock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t17_delivery_stamps_data_clock_via_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real cb-hit delivery through the handler stamps the data clock.
+
+    Drives ``_handle_notification_async`` straight to the ``if cb:`` branch with
+    controlled parsing/routing doubles; the real ``_stamp_data_delivery`` call
+    at the delivery site must advance the routed entry's data clock. A mutation
+    dropping that call would leave the clock unstamped -> this test goes red.
+    """
+    receiver = _make_receiver(monkeypatch)
+    entry_id = "entry-1"
+    canonic_id = "canonic-1"
+    cb_calls: list[str] = []
+
+    async def _cb(cid: str, hex_str: str) -> None:
+        cb_calls.append(cid)
+
+    monkeypatch.setattr(receiver, "_extract_hex_payload", lambda payload: "deadbeef")
+
+    async def _canonic(_hex: str) -> str:
+        return canonic_id
+
+    monkeypatch.setattr(receiver, "_extract_canonic_id_async", _canonic)
+    monkeypatch.setattr(receiver, "_extract_push_token", lambda envelope: None)
+    monkeypatch.setattr(
+        receiver, "_route_target_entries", lambda e, c, t: ({entry_id}, "test")
+    )
+    monkeypatch.setattr(receiver, "_coordinators_for_entries", lambda entries: [])
+    monkeypatch.setattr(receiver, "_log_push_received", lambda *a, **k: None)
+
+    async def _run_cb(cb: Any, cid: str, hex_str: str) -> None:
+        await cb(cid, hex_str)
+
+    monkeypatch.setattr(receiver, "_run_callback_async", _run_cb)
+    receiver.location_update_callbacks[canonic_id] = _cb  # type: ignore[assignment]
+
+    before = time.monotonic()
+    await receiver._handle_notification_async(entry_id, {"foo": "bar"})
+    after = time.monotonic()
+
+    # The delivery-site stamp ran: the routed entry's data clock is fresh.
+    stamped = receiver._entry_last_data_delivery_monotonic[entry_id]
+    assert before <= stamped <= after
+    # The cb-hit branch really executed (proves we reached the stamp call site).
+    assert cb_calls == [canonic_id]
+
+
+# ---------------------------------------------------------------------------
+# T18 -- F1 regression: the watchdog bounds the reconnect's wait-for-STARTED
+# to the conservative readiness budget (~22s), never FCM_DATA_STARVATION_S.
+# ---------------------------------------------------------------------------
+
+
+def test_t18_watchdog_wait_budget_is_ready_budget_not_starvation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scheduler passes ``_max_ready_wait_s()`` (~22s) to the reconnect.
+
+    ``_reconnect_for_starvation`` holds the shared per-entry first-locate lock
+    while awaiting STARTED; binding the wait to FCM_DATA_STARVATION_S (900s)
+    would starve a concurrent manual locate on the same entry for up to 15
+    minutes (Codex F1). Mutation guard: reverting the scheduler to pass
+    ``float(FCM_DATA_STARVATION_S)`` makes ``recorded[0] == 900.0`` -> red.
+    """
+    receiver = _make_receiver(monkeypatch)
+    hass = _RecordingHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    recorded: list[float] = []
+
+    async def _noop() -> None:
+        return None
+
+    def _capture(eid: str, max_wait_s: float) -> Any:
+        # Sync spy: record the budget at coroutine-creation time. The async
+        # body never runs (``_RecordingHass`` closes the coroutine), so the
+        # value must be captured here, not inside an awaited body.
+        recorded.append(max_wait_s)
+        return _noop()
+
+    monkeypatch.setattr(receiver, "_reconnect_for_starvation", _capture)
+
+    receiver._maybe_reconnect_starved(entry_id, now)
+
+    # Exactly one reconnect scheduled, carrying the bounded readiness budget.
+    assert hass.created == [f"fcm_zombie_reconnect_{entry_id}"]
+    assert recorded == [fcm_mod._max_ready_wait_s()]
+    # The budget is the conservative ~22s, strictly below the 900s starvation
+    # threshold whose lock-hold would starve a concurrent manual locate.
+    assert recorded[0] == pytest.approx(22.0)
+    assert recorded[0] < float(FCM_DATA_STARVATION_S)
+
+
+def test_t19_scheduling_failure_during_shutdown_spends_no_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shutdown-time ``async_create_task`` failure leaves scheduler state intact.
+
+    During HA shutdown the event loop is closing and ``async_create_task`` raises
+    ``RuntimeError`` (Codex F3). The scheduler must swallow it AND leave the
+    attempt counter, backoff window and task registry untouched, so the tick does
+    not "spend" a reconnect attempt with no task ever running (which would drift
+    the entry toward ``FCM_ZOMBIE_MAX_RECONNECTS`` while never reconnecting).
+    Mutation guards: (a) dropping the ``try/except`` lets the ``RuntimeError``
+    propagate -> red; (b) committing the counter before task creation leaves
+    ``entry_id in _zombie_reconnect_attempts`` -> red.
+    """
+    receiver = _make_receiver(monkeypatch)
+
+    class _ShutdownHass:
+        """Stub whose ``async_create_task`` fails as during a closing loop."""
+
+        def __init__(self) -> None:
+            self.created: list[str | None] = []
+
+        def async_create_task(self, coro: Any, *, name: str | None = None) -> Any:
+            self.created.append(name)
+            coro.close()  # avoid "coroutine was never awaited" warning
+            raise RuntimeError("Event loop is closed")
+
+    hass = _ShutdownHass()
+    receiver._hass = hass  # type: ignore[assignment]
+    entry_id = "entry-1"
+    now = time.monotonic()
+    _arm_starved(receiver, entry_id, now)
+
+    # Must not raise despite the loop-closed failure.
+    receiver._maybe_reconnect_starved(entry_id, now)
+
+    # It attempted to schedule exactly once...
+    assert hass.created == [f"fcm_zombie_reconnect_{entry_id}"]
+    # ...but committed NO scheduler state: no spent attempt, no backoff window,
+    # no dangling task registration.
+    assert entry_id not in receiver._zombie_reconnect_attempts
+    assert entry_id not in receiver._zombie_next_allowed_reconnect_monotonic
+    assert entry_id not in receiver._zombie_reconnect_tasks
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Self-heals the transient FCM push-session **"zombie"**: the session reaches
`STARTED`, keeps heartbeating, but never delivers location callbacks, so the
integration silently stops updating until the user reloads it (reported as a
"reload every ~2 h" symptom). A per-entry liveness watchdog now detects this and
performs a cooperative single reconnect instead of relying on a manual reload.

The failure mode was confirmed live during a DEBUG capture (a fresh session
reaching `STARTED` but not delivering, healed by a one-shot reconnect); the
watchdog generalises that one-shot recovery into a re-arming guard.

## What changed

- **`const.py`** — new tunables: data-starvation threshold, the shared
  max-ready-wait budget, reconnect backoff/cap and the MAX-reconnect ceiling.
- **`fcm_receiver_ha.py`** — a per-entry data-delivery clock plus a starvation
  predicate (`STARTED` + established + fresh heartbeat + data-gap > threshold +
  a locate issued since the last delivery) drives a single cooperative reconnect
  with backoff and a MAX ceiling.
  - **F1 (lock-starvation):** the starvation guard shares the native ready-wait
    budget (`_max_ready_wait_s` SSOT, ~22 s) instead of a 900 s magic value, so
    it cannot starve concurrent readiness waiters.
  - **F3 (shutdown drift):** `_maybe_reconnect_starved` is commit-after-success —
    the task is scheduled first (guarded against `RuntimeError` on loop
    shutdown), and the backoff window, attempt counter and task registry are
    committed only after the task is guaranteed created; a shutdown scheduling
    failure spends no reconnect attempt.

## Testing

- New watchdog suite: healthy-baseline no-fire oracles (T0a/b/c, validated
  against a live ~349 s max-gap baseline), starvation detection + cooperative
  reconnect, the deadlock/reuse-gate guard (T8), the F1 shared-budget bound
  (T18, mutation-sharp) and the F3 commit-after-success invariant (T19,
  mutation-sharp).
- Delta-coverage of the changed production lines is complete; full repo suite
  green; `ruff` (check + format, 0.14.14) and `mypy` clean.

### Known limitations / residual risk

This self-heal reduces reload frequency for the transient FCM "zombie"
(session reaches STARTED, keeps heartbeating, but never delivers). It is
honest about what it does **not** guarantee:

1. **Detection is a signature hypothesis, not a proven catch.** The watchdog
   fires on a signature (STARTED + established + fresh heartbeat + data-gap >
   threshold + a locate issued since the last delivery). It was validated
   against a healthy live baseline (~349 s max gap over a 2h23m window) and
   against asserted-mutant test oracles, but **never against a real zombie**
   (the failure mode needs ~2 h and did not reproduce during the DEBUG window).
   Catch-proof criterion for anyone reproducing: a `_reconnect_for_starvation`
   emission carrying the `entry_id` and a logged data-gap above the threshold
   proves a true catch; its absence during a confirmed 2 h stall is a
   false-negative.

2. **Post-MAX silence: manual reload remains the fallback.** After
   `FCM_ZOMBIE_MAX_RECONNECTS` (=5) attempts are exhausted without a real
   delivery, the counter stays at MAX and the watchdog goes quiet (reset only
   on a genuine callback delivery or on reload/purge). For the pathological
   never-recovery case, a **manual reload is still required**: the fix lowers
   how often, it does not abolish it.

3. **No deep security audit of the reconnect path.** Storm-safety was checked
   informally by an adversarial REFUTE review pass over the diff, not by a full
   owasp-security audit. Backoff/cap/MAX and the synchronous in-flight guard
   bound the storm surface, but this is a lighter substitute, not a formal audit.

4. **A persistent ADM-token (Nova auth) failure is a separate, unaddressed
   mode.** Locations are *requested* over the Nova/ADM auth path
   (`NovaApi/nova_request.py`); only the *reply* arrives over FCM. A DEBUG
   capture on 1.7.10 showed a single poll timeout whose root cause was a
   **transient** ADM-token 401 refresh cycle (measured token TTL briefly
   collapsed to ~1 min for a ~60 s window), which self-healed without a reload.
   A **persistent** ADM-token 401 would present almost identically to the zombie
   ("connected, no fresh data") yet lives in a different subsystem: this watchdog
   reconnects the FCM push session and never touches the ADM token, so it cannot
   heal that case and a reload would still be required. This is a plausible but
   unconfirmed (Tier-2) alternative root cause for a "reload every ~2 h" user and
   is deliberately out of scope here.

Follow-up (non-blocking): the starvation threshold is a fixed
`FCM_DATA_STARVATION_S`; a healthy gap grows with observation time, so an
adaptive/configurable threshold is a reasonable future refinement (self-limiting
today because the cooperative reconnect re-arms).
