### PR TITLE
Harden reauth diagnostics: legacy sub-entry recording, auth fall-through probe, stable provenance labels

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3117,7 +3117,7 @@ class FcmReceiverHA:
                     if callable(recorder):
                         recorder(
                             ReauthReasonCode.DECRYPT_STALE_KEY,
-                            origin="fcm_receiver_ha.py:3004",
+                            origin="fcm_receiver_ha.py:_note_decrypt_failure_for_entry",
                         )
                     entry.async_start_reauth(hass)
 

--- a/custom_components/googlefindmy/Auth/token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/token_retrieval.py
@@ -250,9 +250,10 @@ def _perform_oauth_sync(
         # mirroring the AAS exchange path (``aas_token_retrieval`` treats
         # ``gpsoauth.AuthError`` by type), so the rejected AAS token is
         # invalidated/regenerated instead of being left in cache for a retry.
-        if gpsoauth_exceptions is not None and isinstance(
+        is_typed_autherror = gpsoauth_exceptions is not None and isinstance(
             err, gpsoauth_exceptions.AuthError
-        ):
+        )
+        if is_typed_autherror:
             raise InvalidAasTokenError(
                 f"gpsoauth rejected the AAS token while requesting scope '{scope}': {message}"
             ) from err
@@ -264,6 +265,34 @@ def _perform_oauth_sync(
             raise InvalidAasTokenError(
                 f"gpsoauth rejected the AAS token while requesting scope '{scope}': {message}"
             ) from err
+        # AP-2 field probe (typed-vs-untyped denial). The vendor auth endpoint is
+        # reverse-engineered: a genuine credential denial arrives as an ``Error``
+        # dict (handled above) or a typed ``gpsoauth.AuthError``; anything else
+        # reaching this fall-through is, by the vendor model, a transport or
+        # intermediary artifact and is (correctly) surfaced as a retryable
+        # ``RuntimeError``. Record the classification *signature* so a field
+        # occurrence of "untyped error whose text still carries an HTTP auth
+        # marker, treated as transient" -- the fingerprint of a *missed* denial
+        # slipping past ``allow_http_generic=False`` -- becomes observable.
+        # Redaction: only the exception type name, the typed-flag and which
+        # markers are present; never ``str(err)`` (may carry a token or email).
+        # ``is_typed_autherror`` is structurally False here (the typed branch
+        # raised above); it is logged verbatim so the fall-through signature is
+        # explicit rather than implied.
+        http_auth_markers = [
+            marker
+            for marker in ("401", "403", "unauthorized", "forbidden")
+            if marker in message.lower()
+        ]
+        _LOGGER.debug(
+            "Auth token fetch for scope %r fell through to a retryable "
+            "RuntimeError (err_type=%s, is_typed_autherror=%s, "
+            "http_auth_markers=%s)",
+            scope,
+            type(err).__name__,
+            is_typed_autherror,
+            http_auth_markers,
+        )
         raise RuntimeError(
             f"Failed to get auth token for scope '{scope}': {err}"
         ) from err

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -517,7 +517,7 @@ class LocateOperations(_MixinBase):
                 # poll-cycle equivalent uses (polling.py) -- not an owner-key code.
                 self.record_reauth_reason(
                     ReauthReasonCode.SPOT_AUTH_PERMANENT,
-                    origin="locate.py:521",
+                    origin="locate.py:async_locate_device:spot_auth",
                 )
                 entry = getattr(self, "config_entry", None)
                 reauth_started = False
@@ -663,7 +663,7 @@ class LocateOperations(_MixinBase):
                 # (polling.py, _finalize_cycle_decrypt_state) -- not an AAS/token code.
                 self.record_reauth_reason(
                     ReauthReasonCode.DECRYPT_STALE_KEY,
-                    origin="locate.py:656",
+                    origin="locate.py:async_locate_device:decrypt_stale_key",
                 )
                 entry = getattr(self, "config_entry", None)
                 reauth_started = False

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1565,7 +1565,7 @@ class PollingOperations(_MixinBase):
             # exception carries none.
             self.record_reauth_reason(
                 getattr(auth_exc, "reauth_code", ReauthReasonCode.UNKNOWN),
-                origin="polling.py:1541",
+                origin="polling.py:_async_update_data",
             )
             raise auth_exc
         except UpdateFailed as update_err:
@@ -1601,7 +1601,7 @@ class PollingOperations(_MixinBase):
         # once. The reason code rides on the exception attribute when present.
         self.record_reauth_reason(
             getattr(reauth_exc, "reauth_code", ReauthReasonCode.UNKNOWN),
-            origin="polling.py:1565",
+            origin="polling.py:_request_poll_reauth",
         )
         entry = getattr(self, "config_entry", None)
         if entry is None:

--- a/custom_components/googlefindmy/repairs.py
+++ b/custom_components/googlefindmy/repairs.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
 from ._reauth_reason import ReauthReasonCode
+from .coordinator import GoogleFindMyCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,10 +117,25 @@ class FcmReauthRepairFlow(RepairsFlow):  # type: ignore[misc]
         # coordinator is reachable only via ``entry.runtime_data`` and only when
         # the entry is loaded, so record defensively and never let a missing
         # coordinator break the repair UI.
-        coordinator = getattr(getattr(entry, "runtime_data", None), "coordinator", None)
+        #
+        # RUNTIME_DATA DUALITY (mirrors the ``isinstance`` handling in
+        # ``__init__.py``): in the normal case ``runtime_data`` is a wrapper
+        # whose ``.coordinator`` attribute holds the coordinator, but on the
+        # legacy sub-entry path ``runtime_data`` *is* a bare
+        # ``GoogleFindMyCoordinator``. Resolve both shapes so the reauth reason
+        # is never silently dropped on legacy sub-entries.
+        rd = getattr(entry, "runtime_data", None)
+        coordinator = (
+            rd
+            if isinstance(rd, GoogleFindMyCoordinator)
+            else getattr(rd, "coordinator", None)
+        )
         recorder = getattr(coordinator, "record_reauth_reason", None)
         if callable(recorder):
-            recorder(ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:112")
+            recorder(
+                ReauthReasonCode.FCM_AUTH_FATAL,
+                origin="repairs.py:_async_start_reauth",
+            )
 
         try:
             entry.async_start_reauth(self.hass)

--- a/tests/test_diagnostics_buffer_summary.py
+++ b/tests/test_diagnostics_buffer_summary.py
@@ -245,7 +245,7 @@ def test_diagnostics_includes_reauth_reason_when_recorded(
     coordinator = _StubCoordinator()
     coordinator._reauth_reason = ReauthReason(
         code=ReauthReasonCode.HTTP_401_AFTER_REFRESH,
-        origin="polling.py:1541",
+        origin="polling.py:_async_update_data",
         counters={"consecutive_transient_auth_failures": 3},
         recorded_at=1_700_000_000.0,
     )
@@ -268,6 +268,6 @@ def test_diagnostics_includes_reauth_reason_when_recorded(
 
     reauth = payload["coordinator"]["reauth_reason"]
     assert reauth["code"] == "http_401_after_refresh"
-    assert reauth["origin"] == "polling.py:1541"
+    assert reauth["origin"] == "polling.py:_async_update_data"
     assert reauth["counters"] == {"consecutive_transient_auth_failures": 3}
     # Mutation counter-check: skipping the wiring line drops this key entirely.

--- a/tests/test_fcm_repair_reauth.py
+++ b/tests/test_fcm_repair_reauth.py
@@ -235,7 +235,48 @@ async def test_fix_flow_confirm_records_reauth_reason() -> None:
     assert flow._async_start_reauth() is True
 
     recorder.assert_called_once_with(
-        ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:112"
+        ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:_async_start_reauth"
+    )
+    entry.async_start_reauth.assert_called_once_with(hass)
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_records_reason_on_legacy_subentry_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AP-1: on the legacy sub-entry path ``runtime_data`` *is* a bare
+    ``GoogleFindMyCoordinator`` (no wrapper). The reauth reason must still be
+    recorded via the ``isinstance`` branch, not silently dropped by a
+    wrapper-only ``.coordinator`` lookup.
+    """
+
+    class _BareCoordinator:
+        """Lightweight stand-in the production ``isinstance`` check accepts."""
+
+    recorder = MagicMock(return_value=None)
+    bare_coordinator = _BareCoordinator()
+    bare_coordinator.record_reauth_reason = recorder  # type: ignore[attr-defined]
+    # Make ``isinstance(rd, GoogleFindMyCoordinator)`` fire for the stand-in;
+    # constructing a real coordinator would drag in the full runtime.
+    monkeypatch.setattr(repairs, "GoogleFindMyCoordinator", _BareCoordinator)
+
+    entry = SimpleNamespace(
+        async_start_reauth=MagicMock(return_value=None),
+        # Legacy sub-entry shape: runtime_data IS the coordinator, no wrapper.
+        runtime_data=bare_coordinator,
+    )
+    hass = SimpleNamespace(
+        config_entries=SimpleNamespace(
+            async_get_entry=lambda entry_id: (entry if entry_id == "entry-id" else None)
+        )
+    )
+    flow = repairs.FcmReauthRepairFlow("entry-id")
+    flow.hass = hass
+
+    assert flow._async_start_reauth() is True
+
+    recorder.assert_called_once_with(
+        ReauthReasonCode.FCM_AUTH_FATAL, origin="repairs.py:_async_start_reauth"
     )
     entry.async_start_reauth.assert_called_once_with(hass)
 

--- a/tests/test_reauth_reason.py
+++ b/tests/test_reauth_reason.py
@@ -50,10 +50,11 @@ class TestReauthReasonModel:
 
     def test_dataclass_is_slotted_and_defaults_empty(self) -> None:
         reason = ReauthReason(
-            code=ReauthReasonCode.DECRYPT_STALE_KEY, origin="locate.py:656"
+            code=ReauthReasonCode.DECRYPT_STALE_KEY,
+            origin="locate.py:async_locate_device:decrypt_stale_key",
         )
         assert reason.code is ReauthReasonCode.DECRYPT_STALE_KEY
-        assert reason.origin == "locate.py:656"
+        assert reason.origin == "locate.py:async_locate_device:decrypt_stale_key"
         assert reason.counters == {}
         assert reason.recorded_at == 0.0
         # slots=True ⇒ no __dict__, and unknown attributes are rejected.
@@ -73,13 +74,13 @@ class TestRecordReauthReason:
     def test_stores_reason_with_code_origin_and_counter_snapshot(self) -> None:
         coord = self._coordinator()
         coord.record_reauth_reason(
-            ReauthReasonCode.HTTP_401_AFTER_REFRESH, "polling.py:1541"
+            ReauthReasonCode.HTTP_401_AFTER_REFRESH, "polling.py:_async_update_data"
         )
         reason = coord._reauth_reason
         assert reason is not None
         # Mutation-sharp: wrong code or origin fails here.
         assert reason.code is ReauthReasonCode.HTTP_401_AFTER_REFRESH
-        assert reason.origin == "polling.py:1541"
+        assert reason.origin == "polling.py:_async_update_data"
         # Default snapshot captures the live transient-auth counter + threshold.
         assert reason.counters["consecutive_transient_auth_failures"] == 2
         assert reason.counters["max_transient_auth_failures"] >= 1
@@ -89,7 +90,7 @@ class TestRecordReauthReason:
         coord = self._coordinator()
         coord.record_reauth_reason(
             ReauthReasonCode.DECRYPT_STALE_KEY,
-            "locate.py:656",
+            "locate.py:async_locate_device:decrypt_stale_key",
             counters={"custom": 7},
         )
         reason = coord._reauth_reason
@@ -101,16 +102,21 @@ class TestRecordReauthReason:
         coord = self._coordinator()
         with caplog.at_level(logging.WARNING):
             coord.record_reauth_reason(
-                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+                ReauthReasonCode.DECRYPT_STALE_KEY,
+                "locate.py:async_locate_device:decrypt_stale_key",
             )
             coord.record_reauth_reason(
-                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+                ReauthReasonCode.DECRYPT_STALE_KEY,
+                "locate.py:async_locate_device:decrypt_stale_key",
             )
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         # De-dup: identical (code, origin) warns exactly once.
         assert len(warnings) == 1
         assert warnings[0].reauth_code == "decrypt_stale_key"
-        assert warnings[0].reauth_origin == "locate.py:656"
+        assert (
+            warnings[0].reauth_origin
+            == "locate.py:async_locate_device:decrypt_stale_key"
+        )
 
     def test_distinct_origin_warns_again(
         self, caplog: pytest.LogCaptureFixture
@@ -120,10 +126,11 @@ class TestRecordReauthReason:
             # Same code, two real emitting origins (locate direct + poll cycle):
             # a distinct origin is a distinct dedup key, so it warns again.
             coord.record_reauth_reason(
-                ReauthReasonCode.DECRYPT_STALE_KEY, "polling.py:619"
+                ReauthReasonCode.DECRYPT_STALE_KEY, "polling.py:_request_poll_reauth"
             )
             coord.record_reauth_reason(
-                ReauthReasonCode.DECRYPT_STALE_KEY, "locate.py:656"
+                ReauthReasonCode.DECRYPT_STALE_KEY,
+                "locate.py:async_locate_device:decrypt_stale_key",
             )
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         # A different origin is a distinct dedup key ⇒ warns again.
@@ -139,14 +146,14 @@ class TestDiagnosticsReauthReasonBlock:
     def test_serializes_recorded_reason(self) -> None:
         reason = ReauthReason(
             code=ReauthReasonCode.HTTP_401_AFTER_REFRESH,
-            origin="api.py:1062",
+            origin="fixture:diagnostics_serialization",
             counters={"consecutive_transient_auth_failures": 3},
             recorded_at=1_700_000_000.0,
         )
         block = _reauth_reason_block(MagicMock(_reauth_reason=reason))
         assert block is not None
         assert block["code"] == "http_401_after_refresh"
-        assert block["origin"] == "api.py:1062"
+        assert block["origin"] == "fixture:diagnostics_serialization"
         assert block["counters"] == {"consecutive_transient_auth_failures": 3}
         # recorded_at is rendered as an ISO-8601 string, not a raw float.
         assert isinstance(block["recorded_at"], str)
@@ -156,7 +163,7 @@ class TestDiagnosticsReauthReasonBlock:
         # Literal-only invariant: only genuine ints survive; bool/str dropped.
         reason = ReauthReason(
             code=ReauthReasonCode.UNKNOWN,
-            origin="api.py:1099",
+            origin="fixture:counter_filter",
             counters={"good": 4, "flag": True, "text": "leak"},  # type: ignore[dict-item]
             recorded_at=1_700_000_000.0,
         )


### PR DESCRIPTION
## What this changes

Three focused diagnostics/robustness fixes on the reauth path (P2/P3 from the review of PR #199):

### 1. Reauth-reason recording on legacy sub-entry coordinators (P2)
On the legacy sub-entry path `entry.runtime_data` **is** a bare `GoogleFindMyCoordinator`, not a wrapper exposing `.coordinator`. The repair flow's flat `getattr(..., "coordinator")` lookup silently dropped the reauth reason on those entries. It now resolves both shapes via the same `isinstance(runtime_data, GoogleFindMyCoordinator)` pattern `__init__.py` already uses, with a risk comment documenting the duality. A new regression test covers the bare-coordinator branch.

### 2. Typed-vs-untyped auth fall-through probe (P2/DEBUG)
Records, at DEBUG, the classification *signature* of an exception that falls through `_perform_oauth_sync` to a retryable `RuntimeError`: the exception type, a typed-flag, and which HTTP auth markers (`401/403/unauthorized/forbidden`) the text carries. Redaction-safe: it never logs `str(err)` (may carry a token or email), only the type name, a bool, and the matched static markers.

### 3. Stable provenance labels (P3)
The `origin="file.py:NNNN"` reauth-reason labels had already drifted from their real line numbers. Replaced with stable qualified names (e.g. `polling.py:_request_poll_reauth`) across `repairs.py`, `fcm_receiver_ha.py`, `locate.py` (two distinct sites in `async_locate_device`), and `polling.py`.

## Residual risk (vendor assumption) and how this PR makes it testable

The Google auth endpoint is reverse-engineered and undocumented. By the vendor model, a genuine credential denial arrives either as an HTTP-200 form-encoded `Error=<Reason>` body or as a typed `gpsoauth.AuthError`; a real `401/403` is therefore a transport/intermediary artifact, which `allow_http_generic=False` correctly refuses to promote to an invalid-token classification. It is **not provable from vendor docs** that an untyped denial never slips through. Fix 2 does not change that classification; it makes a slip **observable**: if the field ever shows "untyped error whose text still carries an HTTP auth marker, treated as transient", that DEBUG line is the fingerprint of a missed denial and can drive a follow-up.

## Scope notes (for reviewers)
- Two adjacent review items were evaluated and deliberately **not** changed: a fallback-delivery stamp in `_stamp_data_delivery` is a no-op here (the `None` routing set is only reachable when `entry_id is None`, so there is no receiving entry to stamp; the non-stamping is a deliberate, test-protected #1162 decision), and the `hard_limit_passed` retention comment in `coordinator/helpers/update.py` is already complete.
- A persistent always-on auth-artifact counter was considered but left out: the cross-layer plumbing from the auth layer into coordinator stats is disproportionate to the DEBUG line above.

## QA
- `ruff check` + `ruff format`: clean
- `mypy --strict` on all changed files: clean
- Full test suite: green, coverage gate (73%) met
- Independent adversarial diff review (P0-P3): **PASS**, only two cosmetic P3 notes (an always-False signature value that is intentionally logged; two decoupled test fixtures that still carry old-style sample origins)

Draft: pending a final look before marking ready.