### PR TITLE
refactor: add explicit set annotations for mypy 2 strict compliance

### DIFF
--- a/custom_components/googlefindmy/coordinator/registry.py
+++ b/custom_components/googlefindmy/coordinator/registry.py
@@ -797,7 +797,9 @@ class RegistryOperations(_MixinBase):
             )
         else:
             # Keep metadata fresh if it drifted (rare)
-            raw_device_identifiers = getattr(device, "identifiers", set()) or set()
+            raw_device_identifiers: set[tuple[str, str]] = (
+                getattr(device, "identifiers", set()) or set()
+            )
             device_identifiers = set(raw_device_identifiers)
             identifiers_to_apply = set(identifiers)
             extraneous_service_identifiers: set[tuple[Any, ...]] = set()

--- a/custom_components/googlefindmy/services.py
+++ b/custom_components/googlefindmy/services.py
@@ -527,7 +527,7 @@ async def async_rebuild_device_registry(hass: HomeAssistant, call: ServiceCall) 
                     if correct_tracker_subentry_id in normalized_subentries:
                         tracker_linked_entry_ids.add(normalized_entry_id)
 
-            raw_links = getattr(device, "config_entries", set()) or set()
+            raw_links: set[str] = getattr(device, "config_entries", set()) or set()
             linked_entry_ids = {
                 str(link_entry_id)
                 for link_entry_id in raw_links
@@ -1097,7 +1097,9 @@ async def async_register_services(hass: HomeAssistant, ctx: dict[str, Any]) -> N
             return token_cache[cache_key]
 
         def _device_is_service(device: Any) -> bool:
-            identifiers = getattr(device, "identifiers", set()) or set()
+            identifiers: set[tuple[str, str]] = (
+                getattr(device, "identifiers", set()) or set()
+            )
             for domain, ident in identifiers:
                 if domain != DOMAIN:
                     continue
@@ -1113,7 +1115,9 @@ async def async_register_services(hass: HomeAssistant, ctx: dict[str, Any]) -> N
             if isinstance(serial, str) and serial:
                 return serial
 
-            identifiers = getattr(device, "identifiers", set()) or set()
+            identifiers: set[tuple[str, str]] = (
+                getattr(device, "identifiers", set()) or set()
+            )
             for domain, ident in identifiers:
                 if domain != DOMAIN:
                     continue
@@ -1140,7 +1144,9 @@ async def async_register_services(hass: HomeAssistant, ctx: dict[str, Any]) -> N
         dev_reg = dr.async_get(hass)
         updated_count = 0
         for device in getattr(dev_reg, "devices", {}).values():
-            identifiers = getattr(device, "identifiers", set()) or set()
+            identifiers: set[tuple[str, str]] = (
+                getattr(device, "identifiers", set()) or set()
+            )
             if not any(domain == DOMAIN for domain, _ in identifiers):
                 continue
 


### PR DESCRIPTION
## Summary

Adds explicit type annotations to five `getattr(device, ..., set()) or set()` locals whose element type the strict type checker cannot infer.

These surfaced as `mypy 2.1.0` `[var-annotated]` errors in the pip-audit lock refresh (#1165). This PR lands the fix **independently on `1.7`**, decoupled from the toolchain bump: the annotations are **forward-compatible** and harmless under the current pinned `mypy 1.19.1`, so they are safe to merge on their own.

## Changes

| File | Local | Annotation |
|---|---|---|
| `services.py` | `raw_links` (device `config_entries`) | `set[str]` |
| `services.py` | `identifiers` (×3, device `identifiers`) | `set[tuple[str, str]]` |
| `coordinator/registry.py` | `raw_device_identifiers` | `set[tuple[str, str]]` |

No runtime behavior change; annotation-only. The `registry.py` annotation is set-operation compatible with the existing sibling `extraneous_service_identifiers: set[tuple[Any, ...]]` (set difference accepts `AbstractSet[Any]`).

## Verification

- `ruff check .` and `ruff format --check .` green with the `1.7`-pinned ruff `0.14.14`.
- `py_compile` clean.
- No new errors under `mypy 1.19.1` (annotating a local is inert for an already-satisfied checker).

## Relationship to #1165

#1165 (pip-audit toolchain bump to `mypy 2` / `ruff 0.15`) also contains these annotations, because it needs them to pass `mypy 2 --strict`. Merging this PR first is the clean order: the annotations then land via this focused, reviewable change and #1165 carries the identical lines (content-identical, conflict-free either merge order).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>