### PR TITLE
fix(fcm): log foreign-subtype drop at debug, not warning

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -685,9 +685,16 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             # amplification loop: the foreign push is simply not for us. The
             # caller (``_handle_message``) still selective-acks the message on
             # the normal path, so the server stops redelivering it.
-            self._log_warn_with_limit(
-                "Subtype %s in data message does not match"
-                + "app id client was registered with %s",
+            #
+            # Log at *debug*, not warning. Dropping a foreign-subtype push is an
+            # expected, benign event (Google replays orphaned/superseded
+            # subscriptions under our own android_id, e.g. on reconnect); it is
+            # handled correctly above and requires no user action. Surfacing it
+            # at warning level only alarmed users about a non-issue. It stays
+            # visible under debug logging for diagnosis.
+            self.logger.debug(
+                "Subtype %s in data message does not match "
+                "app id client was registered with %s",
                 subtype,
                 self.credentials["gcm"]["app_id"],
             )

--- a/tests/test_fcmpushclient_handle_data_message.py
+++ b/tests/test_fcmpushclient_handle_data_message.py
@@ -15,6 +15,7 @@ of the ``["gcm"]["app_id"]`` dereference; the poison stub is left untouched.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
@@ -54,8 +55,10 @@ class TestHandleDataMessage:
         assert not client.callback.called
         assert client.warnings == []
 
-    def test_subtype_mismatch_drops_message(self) -> None:
-        """``subtype`` != registered app id -> warning + DROP before decrypt (R3 True).
+    def test_subtype_mismatch_drops_message(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``subtype`` != registered app id -> DEBUG log + DROP before decrypt (R3 True).
 
         A subtype mismatch means the push was encrypted for a *superseded* GCM
         registration (an old client still listening after an FCM re-registration
@@ -63,16 +66,30 @@ class TestHandleDataMessage:
         match, so decrypting would fail with a guaranteed ``ECEException`` /
         InvalidTag; that failure is caught upstream and counts toward
         ``_consecutive_decrypt_failures``, escalating to a bogus re-registration
-        cascade. The handler therefore returns after the warning. Regression
-        guard: ``_decrypt_raw_data`` is left unset, so a fall-through would raise
+        cascade. The handler therefore returns after logging.
+
+        Contract: dropping a foreign-subtype push is an *expected, benign* event,
+        so it is logged at DEBUG, never WARNING -- surfacing it at warning level
+        only alarmed users about a non-issue. This test pins that level: the
+        message appears at DEBUG and ``warnings`` stays empty. Regression guard:
+        ``_decrypt_raw_data`` is left unset, so a fall-through would raise
         ``AttributeError`` and fail loudly; the callback must not fire.
         """
         client = FcmHandleSlim()  # credentials gcm.app_id == "APPID"
         msg = make_data_message(subtype="OTHER")
 
-        client._handle_data_message(msg)
+        with caplog.at_level(logging.DEBUG):
+            client._handle_data_message(msg)
 
-        assert any("does not match" in w for w in client.warnings)
+        # Emitted at DEBUG, never WARNING (benign, expected event).
+        assert any(
+            "does not match" in r.getMessage() and r.levelno == logging.DEBUG
+            for r in caplog.records
+        )
+        assert client.warnings == []
+        # Positively pin the "never WARNING" contract, not just the empty
+        # ``warnings`` list: no record on this path may reach WARNING level.
+        assert not any(r.levelno == logging.WARNING for r in caplog.records)
         # Dropped before decrypt/callback: foreign-subtype push is not for us.
         assert not client.callback.called
 


### PR DESCRIPTION
## Summary

Follow-up to #1167. Lowers the log level of the "foreign-subtype push dropped" message from `warning` to `debug`, and fixes a missing space in that message text (`does not matchapp id` → `does not match app id`).

This is the log-hygiene increment that was prepared for #1167 but landed on the feature branch **after** that PR had already been merged, so it never made it into `1.7`. This is a clean re-submission from a fresh branch off the current `1.7`.

**No functional change, no version bump.** The drop behaviour introduced by #1167 (Fix A) is unchanged — only the log level of the accompanying message changes.

## Why this message should be `debug`, not `warning`

After #1167, the FCM client correctly **drops** pushes whose subtype does not match the client's own registered app id (they belong to an orphaned, superseded registration under the same device id and can never be decrypted with the current keys). On every HA restart Google re-delivers the messages queued for that device, including the ones for dead subscriptions, so this drop is an **expected, harmless, recurring** event with no action required from the user.

Logging it at `warning` alarms users about a non-problem (this is exactly the report that motivated the follow-up: the `does not match` warning re-appearing on a plain restart). At `debug` it disappears from the normal log while remaining visible when debug logging is enabled for diagnostics. Real, current-subtype messages continue to be processed exactly as before.

The deeper root cause — actively unregistering the stale subscription at Google so no orphans accumulate — is intentionally **out of scope** here and is being prepared as a separate PR.

## Changes

- `custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py`: foreign-subtype drop now logs via `self.logger.debug(...)` (idiomatic for expected/benign events in this file) instead of the rate-limited warning helper; message-text space fix.
- `tests/test_fcmpushclient_handle_data_message.py`: `test_subtype_mismatch_drops_message` updated to the new contract (asserts DEBUG-level log via `caplog`, `warnings == []`), plus a positive "never WARNING" assertion guarding against regressions. The drop itself (the early `return`) is still asserted.

## Verification

- `pytest tests/test_fcmpushclient_handle_data_message.py` — 12 passed
- `ruff check` + `ruff format --check` (0.15.20, matching `poetry.lock`) — clean
- Version guard: stays `1.7.11`, no bump
