### PR TITLE
fix(fcm): unregister orphaned webpush subscription on re-registration

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -649,6 +649,108 @@ class FcmRegister:
         return None
 
     # ---------------------------------------------------------------------
+    # GCM (Unregister — best-effort orphan cleanup)
+    # ---------------------------------------------------------------------
+    async def gcm_unregister(
+        self,
+        app_id: str,
+        android_id: str,
+        security_token: str,
+    ) -> None:
+        """Best-effort unregister of a superseded GCM subscription.
+
+        Sends a ``delete=true`` POST to ``/c2dm/register3`` for the OLD
+        ``app_id`` (subtype) after a successful re-registration, so Google
+        stops delivering pushes for the now-orphaned subscription (the
+        source of the benign "Subtype does not match" debug logs).
+
+        The request mirrors the canonical Chromium GCM unregister body
+        (``app`` / ``X-subtype`` / ``device`` / ``delete=true``; see
+        Chromium ``google_apis/gcm/engine/unregistration_request.cc``).
+        The ``sender`` field is retained for parity with ``gcm_register``
+        and ignored by the server for a delete.
+
+        This is strictly best-effort: exactly one attempt, a fixed
+        timeout, and every failure is swallowed at ``debug`` level. An
+        unregister failure must NEVER break or delay the surrounding
+        re-registration — the new subscription is already live by the
+        time this runs (see ``reregister_keeping_identity``).
+
+        :param app_id: OLD (superseded) GCM app_id / subtype to delete.
+        :param android_id: Device android_id (stable identity; auth only).
+        :param security_token: Device security_token (auth only).
+        """
+        headers = {
+            "Authorization": f"AidLogin {android_id}:{security_token}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        body = {
+            "app": self.config.chrome_id,
+            "X-subtype": app_id,
+            "device": android_id,
+            "sender": GCM_SERVER_KEY_B64,
+            "delete": "true",
+        }
+
+        if self._log_debug_verbose:
+            _logger.debug(
+                "GCM unregister request via /c2dm/register3: "
+                "app=%s, X-subtype=%s, device=%s, delete=true",
+                body["app"],
+                self._redact(body["X-subtype"]),
+                self._redact(body["device"]),
+            )
+
+        try:
+            async with self._session.post(
+                url=GCM_REGISTER3_URL,
+                headers=headers,
+                data=body,
+                timeout=self.CLIENT_TIMEOUT,
+            ) as resp:
+                response_text = await resp.text()
+        except Exception as exc:  # network/aiohttp failure — best-effort
+            _logger.debug(
+                "GCM unregister for X-subtype=%s failed (ignored, best-effort): %s",
+                self._redact(app_id),
+                exc,
+            )
+            return
+
+        # Defensive line-based parse mirroring ``gcm_register``. A success
+        # echoes ``deleted=<app_id>``; ``Error=<code>`` or a missing/HTML
+        # body means the unregister was ineffective. All three outcomes are
+        # harmless and terminal — the surrounding flow is unaffected.
+        deleted = False
+        error_code: str | None = None
+        for line in response_text.splitlines():
+            key, _, value = line.partition("=")
+            lower_key = key.strip().lower()
+            if lower_key == "deleted":
+                deleted = True
+                break
+            if lower_key == "error":
+                error_code = value.strip().upper()
+
+        if deleted:
+            _logger.debug(
+                "GCM unregister effective for X-subtype=%s (deleted)",
+                self._redact(app_id),
+            )
+        elif error_code:
+            _logger.debug(
+                "GCM unregister for X-subtype=%s ineffective (Error=%s, ignored)",
+                self._redact(app_id),
+                error_code,
+            )
+        else:
+            _logger.debug(
+                "GCM unregister for X-subtype=%s: no deleted/Error marker "
+                "in response (ignored)",
+                self._redact(app_id),
+            )
+
+    # ---------------------------------------------------------------------
     # FCM (Install + Registration)
     # ---------------------------------------------------------------------
     async def fcm_install_and_register(
@@ -985,6 +1087,11 @@ class FcmRegister:
 
         android_id = self.credentials["gcm"]["android_id"]
         security_token = self.credentials["gcm"]["security_token"]
+        # Capture the OLD app_id BEFORE it is overwritten by the fresh
+        # registration below, so we can unregister the superseded
+        # subscription afterwards. ``.get()`` tolerates legacy credentials
+        # that predate the app_id key.
+        old_app_id = self.credentials["gcm"].get("app_id")
 
         # Step 1: Check-in with existing device identity
         try:
@@ -1033,6 +1140,14 @@ class FcmRegister:
                 self.credentials_updated_callback(res)
             except Exception as e:
                 _logger.debug("credentials_updated_callback raised", exc_info=e)
+
+        # Step 4: Best-effort unregister of the now-orphaned OLD subscription.
+        # Runs only AFTER the new registration is fully secured and persisted,
+        # so a failure here can never cost us the working subscription. Guarded
+        # against a no-op self-delete (missing/unchanged app_id).
+        new_app_id = gcm_data.get("app_id")
+        if old_app_id and old_app_id != new_app_id:
+            await self.gcm_unregister(old_app_id, android_id, security_token)
 
         _logger.info(
             "Re-registered FCM with existing device identity (android_id preserved)"

--- a/tests/test_fcm_register.py
+++ b/tests/test_fcm_register.py
@@ -973,3 +973,260 @@ async def test_checkin_or_register_preserves_on_transient(
     with pytest.raises(FcmCheckinTransientError):
         await register.checkin_or_register()
     assert register_called is False
+
+
+# ---------------------------------------------------------------------
+# gcm_unregister — best-effort orphan cleanup on re-registration
+# ---------------------------------------------------------------------
+
+_OLD_APP_ID = "wp:bundle#0d7d2715-75d9-47a0-88ec-32e9d91e88dd"
+_NEW_APP_ID = "wp:bundle#f23ca93d-683d-4fb9-aaee-fdbd82dd079a"
+_ANDROID_ID = "1234567890"
+_SECURITY_TOKEN = "9876543210"
+
+
+class _RaisingSession:
+    """Session stub whose ``post`` records the call, then raises (best-effort
+    failure path for the unregister)."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def post(
+        self, *, url: str, headers: dict[str, str], data: dict[str, Any], timeout: Any
+    ) -> Any:
+        self.calls.append({"url": url, "data": dict(data), "headers": dict(headers)})
+        raise OSError("network down")
+
+
+def _build_reregister(
+    session: Any,
+    *,
+    old_app_id: str | None,
+    new_app_id: str = _NEW_APP_ID,
+) -> FcmRegister:
+    """FcmRegister wired for ``reregister_keeping_identity`` with every network
+    step EXCEPT the unregister POST stubbed out, so the only ``session.post``
+    that can occur is the orphan unregister under test."""
+    config = FcmRegisterConfig(
+        project_id="proj",
+        app_id="app",
+        api_key="key",
+        messaging_sender_id="1234567890123",
+        bundle_id="bundle",
+    )
+    gcm_creds: dict[str, Any] = {
+        "android_id": _ANDROID_ID,
+        "security_token": _SECURITY_TOKEN,
+    }
+    if old_app_id is not None:
+        gcm_creds["app_id"] = old_app_id
+    credentials = {"gcm": gcm_creds, "fcm": {"registration": {"token": "old"}}}
+    register = FcmRegister(config, credentials=credentials, http_client_session=session)
+
+    async def fake_check_in(self, android_id=None, security_token=None):  # type: ignore[no-untyped-def]
+        return {"androidId": android_id, "securityToken": security_token}
+
+    async def fake_gcm_register(self, gcm_response, retries=5):  # type: ignore[no-untyped-def]
+        return {
+            "token": "new-gcm-token",
+            "app_id": new_app_id,
+            "android_id": gcm_response["androidId"],
+            "security_token": gcm_response["securityToken"],
+        }
+
+    def fake_generate_keys(self):  # type: ignore[no-untyped-def]
+        return {"public": "pub", "private": "priv", "auth_secret": "sec"}
+
+    async def fake_fcm_install_and_register(self, gcm_data, keys):  # type: ignore[no-untyped-def]
+        return {"registration": {"token": "new-fcm-token"}}
+
+    register.gcm_check_in = types.MethodType(fake_check_in, register)
+    register.gcm_register = types.MethodType(fake_gcm_register, register)
+    register.generate_keys = types.MethodType(fake_generate_keys, register)
+    register.fcm_install_and_register = types.MethodType(
+        fake_fcm_install_and_register, register
+    )
+    return register
+
+
+def test_reregister_unregisters_old_subscription() -> None:
+    """(a) A successful re-registration fires exactly one ``delete=true`` POST
+    to register3 carrying the OLD app_id as X-subtype."""
+    session = _FakeSession(
+        [_FakeResponse(200, f"deleted={_OLD_APP_ID}", {"Content-Type": "text/plain"})]
+    )
+    register = _build_reregister(session, old_app_id=_OLD_APP_ID)
+
+    result = asyncio.run(register.reregister_keeping_identity())
+
+    assert result["gcm"]["app_id"] == _NEW_APP_ID
+    assert len(session.calls) == 1
+    call = session.calls[0]
+    assert call["url"] == GCM_REGISTER3_URL
+    assert call["data"]["delete"] == "true"
+    assert call["data"]["X-subtype"] == _OLD_APP_ID
+    assert call["data"]["device"] == _ANDROID_ID
+    assert call["headers"]["Authorization"] == (
+        f"AidLogin {_ANDROID_ID}:{_SECURITY_TOKEN}"
+    )
+
+
+def test_reregister_survives_unregister_failure() -> None:
+    """(b) An unregister that raises must not break the re-registration: the
+    caller still returns valid fresh credentials, and it was attempted once."""
+    session = _RaisingSession()
+    register = _build_reregister(session, old_app_id=_OLD_APP_ID)
+
+    result = asyncio.run(register.reregister_keeping_identity())
+
+    assert result["gcm"]["app_id"] == _NEW_APP_ID
+    assert result["fcm"]["registration"]["token"] == "new-fcm-token"
+    assert len(session.calls) == 1  # exactly one best-effort attempt, no retry
+
+
+def test_reregister_without_old_app_id_skips_unregister() -> None:
+    """(c) Without a prior app_id (first-time / legacy identity) no delete POST
+    is emitted."""
+    session = _FakeSession([])  # any post would raise "no responses configured"
+    register = _build_reregister(session, old_app_id=None)
+
+    result = asyncio.run(register.reregister_keeping_identity())
+
+    assert result["gcm"]["app_id"] == _NEW_APP_ID
+    assert session.calls == []
+
+
+def test_reregister_unchanged_app_id_skips_unregister() -> None:
+    """(c2) A no-op re-registration that yields the SAME app_id must not
+    self-delete the still-current subscription."""
+    session = _FakeSession([])
+    register = _build_reregister(
+        session, old_app_id=_OLD_APP_ID, new_app_id=_OLD_APP_ID
+    )
+
+    result = asyncio.run(register.reregister_keeping_identity())
+
+    assert result["gcm"]["app_id"] == _OLD_APP_ID
+    assert session.calls == []
+
+
+def test_reregister_unregister_redacts_secrets(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(d) No unredacted secret/id (old app_id, android_id, security_token, or
+    the AidLogin auth header) may appear in the DEBUG log; only the ``•••``
+    redacted tail form is emitted."""
+    session = _FakeSession(
+        [_FakeResponse(200, f"deleted={_OLD_APP_ID}", {"Content-Type": "text/plain"})]
+    )
+    register = _build_reregister(session, old_app_id=_OLD_APP_ID)
+    register._log_debug_verbose = True  # exercise the verbose request log too
+
+    with caplog.at_level(logging.DEBUG):
+        result = asyncio.run(register.reregister_keeping_identity())
+
+    assert result["gcm"]["app_id"] == _NEW_APP_ID
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert _OLD_APP_ID not in logged
+    assert _ANDROID_ID not in logged
+    assert _SECURITY_TOKEN not in logged
+    assert "AidLogin" not in logged
+    assert "•••" in logged
+
+
+# ---------------------------------------------------------------------
+# gcm_unregister — outcome-log contract (each of the four terminal
+# outcomes must be observable at DEBUG, so a user who enables debug
+# logging and presses the "regenerate FCM token" button can tell whether
+# the orphan cleanup succeeded or not). These also close the parse-branch
+# coverage for the ``Error=`` and "no marker" responses.
+# ---------------------------------------------------------------------
+
+
+def test_reregister_unregister_success_is_visible_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(e) A ``deleted=`` response logs an *effective* outcome at DEBUG,
+    without needing the verbose flag — this is what the user sees on a
+    successful button-triggered cleanup."""
+    session = _FakeSession(
+        [_FakeResponse(200, f"deleted={_OLD_APP_ID}", {"Content-Type": "text/plain"})]
+    )
+    register = _build_reregister(session, old_app_id=_OLD_APP_ID)
+
+    with caplog.at_level(logging.DEBUG):
+        result = asyncio.run(register.reregister_keeping_identity())
+
+    assert result["gcm"]["app_id"] == _NEW_APP_ID
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "GCM unregister effective" in logged
+    assert "deleted" in logged
+    assert _OLD_APP_ID not in logged  # still redacted
+
+
+def test_reregister_unregister_error_is_visible_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(f) A server ``Error=<code>`` response is a non-exceptional, ineffective
+    outcome: no raise, exactly one attempt, and a DEBUG line naming the code so
+    the user sees the cleanup did NOT succeed. Closes the ``Error`` parse/log
+    branch."""
+    session = _FakeSession(
+        [
+            _FakeResponse(
+                200, "Error=PHONE_REGISTRATION_ERROR", {"Content-Type": "text/plain"}
+            )
+        ]
+    )
+    register = _build_reregister(session, old_app_id=_OLD_APP_ID)
+
+    with caplog.at_level(logging.DEBUG):
+        result = asyncio.run(register.reregister_keeping_identity())
+
+    assert result["gcm"]["app_id"] == _NEW_APP_ID  # re-registration unaffected
+    assert len(session.calls) == 1  # one best-effort attempt, no retry
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "ineffective" in logged
+    assert "PHONE_REGISTRATION_ERROR" in logged
+    assert _OLD_APP_ID not in logged  # still redacted
+
+
+def test_reregister_unregister_no_marker_is_visible_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(g) A 200 response with neither ``deleted`` nor ``Error`` (e.g. an HTML
+    error page) is reported as an ineffective "no marker" outcome at DEBUG,
+    never raising. Closes the else-branch of the parser."""
+    session = _FakeSession(
+        [_FakeResponse(200, "<html>gateway</html>", {"Content-Type": "text/html"})]
+    )
+    register = _build_reregister(session, old_app_id=_OLD_APP_ID)
+
+    with caplog.at_level(logging.DEBUG):
+        result = asyncio.run(register.reregister_keeping_identity())
+
+    assert result["gcm"]["app_id"] == _NEW_APP_ID
+    assert len(session.calls) == 1
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "no deleted/Error marker" in logged
+    assert _OLD_APP_ID not in logged  # still redacted
+
+
+def test_reregister_unregister_network_failure_is_visible_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """(h) A network/aiohttp failure is swallowed but reported at DEBUG as a
+    best-effort failure, so the user sees the cleanup was attempted and did not
+    succeed. Complements (b), which asserts survival without the log contract."""
+    session = _RaisingSession()
+    register = _build_reregister(session, old_app_id=_OLD_APP_ID)
+
+    with caplog.at_level(logging.DEBUG):
+        result = asyncio.run(register.reregister_keeping_identity())
+
+    assert result["gcm"]["app_id"] == _NEW_APP_ID
+    assert len(session.calls) == 1
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "failed (ignored, best-effort)" in logged
+    assert _OLD_APP_ID not in logged  # still redacted


### PR DESCRIPTION
## What this fixes

Some users saw log lines like:

```
Subtype wp:com.google.android.apps.adm#<old-id> in data message does not
match app id client was registered with wp:...adm#<current-id>
```

These come from **orphaned push subscriptions**. Whenever the integration
re-registers with Google while keeping the same device identity, it mints a
new `app_id`, but the **old** webpush subscription was never cancelled. Google
keeps replaying pushes for that dead subscription, and they arrive on the new
client as "does not match" messages. Over time these orphans pile up, and a
restart replays all of their accumulated pushes at once.

PR #1167 (drop foreign-subtype pushes) and #1168 (log at `debug`) already
silenced the alarming log. **This PR removes the cause**: the old subscription
is now actively cancelled at Google, so orphans stop accumulating in the first
place.

## What you'll see (for users)

When you enable debug logging and press **"Regenerate FCM token"**, the log now
tells you whether the old subscription was cleaned up:

| Situation | Level | Message |
|---|---|---|
| Re-registration succeeded | INFO | `Re-registered FCM with existing device identity` |
| Old subscription removed | DEBUG | `GCM unregister effective ... (deleted)` |
| Google reported it couldn't remove it | DEBUG | `... ineffective (Error=..., ignored)` |
| Response had no clear marker | DEBUG | `... no deleted/Error marker in response (ignored)` |
| Network hiccup | DEBUG | `... failed (ignored, best-effort)` |

Normal `debug` logging is enough — no special verbose flag needed. If the
cleanup ever fails, **nothing breaks**: the new registration is already done,
and the leftover simply expires on Google's side as before.

## Technical details

- New `FcmRegister.gcm_unregister(...)`: a `register3` POST carrying
  `app` / `X-subtype` / `device` / `delete=true`, matching the canonical
  Chromium GCM unregister request (`unregistration_request.cc`).
- Wired into `reregister_keeping_identity()` only: the old `app_id` is captured
  **before** it is overwritten, and the unregister fires **after** the new
  registration's success callback, guarded by `old_app_id and old != new`.
- `register()` (fresh installs) is intentionally untouched — nothing to clean up.
- Strictly best-effort: single attempt, fixed timeout, catches I/O errors and
  never raises, never blocks re-registration; `CancelledError` still propagates.
- Secrets are never logged; ids only via `_redact`.

## Safety: account isolation

The unregister authenticates with the firing client's own
`android_id`/`security_token` (`AidLogin ...`), so `delete=true` is scoped to
that device's own subscriptions. A push for account A is delivered only over
account A's own MCS connection, and a delete issued by account A can only reach
account A's registrations. A second account cannot be affected on either the
delivery or the deletion axis.

## Testing

- 9 unregister tests, covering all four terminal outcomes
  (deleted / server `Error` / no-marker / network failure), each asserting the
  **per-outcome debug-log contract** (a regression guard: a refactor that
  silences success/failure breaks a test) and that the old `app_id` stays
  redacted.
- Diff-scoped coverage of the new statements is **100%** (measured with
  `diff-cover`).
- Full local run green: 32/32 in `tests/test_fcm_register.py`,
  `ruff 0.15.20` check + format, `mypy --strict`.

## Version

No version bump — this belongs to the same release line as the related FCM
fixes and carries no user-facing API change.
