### PR TITLE
fix(fcm): actually unregister orphaned webpush subscription (integration fix for #1169)

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -2125,7 +2125,17 @@ class FcmReceiverHA:
                 # Identity is usable: strip only the renewable GCM token parts
                 # and keep android_id/security_token for a fast re-register.
                 gcm.pop("token", None)
-                gcm.pop("app_id", None)
+                # Rescue the superseded subscription id across the invalidation
+                # so the subsequent reregister_keeping_identity() can unregister
+                # the now-orphaned webpush subscription. Popping it outright (the
+                # pre-fix #1169 behaviour) left ``old_app_id = None`` at capture
+                # time, so the unregister guard never fired and orphaned
+                # subscriptions kept accumulating at Google (the "does not match"
+                # warnings). Keeping it in a dedicated slot also lets a
+                # restart-triggered re-register clean up the orphan.
+                orphan_app_id = gcm.pop("app_id", None)
+                if orphan_app_id:
+                    gcm["orphan_app_id"] = orphan_app_id
                 _LOGGER.info(
                     "[entry=%s] Invalidated FCM tokens; "
                     "android_id/security_token preserved for re-registration",

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -1089,9 +1089,13 @@ class FcmRegister:
         security_token = self.credentials["gcm"]["security_token"]
         # Capture the OLD app_id BEFORE it is overwritten by the fresh
         # registration below, so we can unregister the superseded
-        # subscription afterwards. ``.get()`` tolerates legacy credentials
-        # that predate the app_id key.
-        old_app_id = self.credentials["gcm"].get("app_id")
+        # subscription afterwards. In the live button/restart flow the active
+        # ``app_id`` slot has already been cleared by ``_invalidate_fcm_tokens``,
+        # which rescues the value into ``orphan_app_id``; fall back to that so the
+        # unregister still fires. ``.get()`` tolerates legacy credentials that
+        # predate both keys.
+        gcm_creds = self.credentials["gcm"]
+        old_app_id = gcm_creds.get("app_id") or gcm_creds.get("orphan_app_id")
 
         # Step 1: Check-in with existing device identity
         try:

--- a/tests/test_fcm_orphan_unregister_integration.py
+++ b/tests/test_fcm_orphan_unregister_integration.py
@@ -1,3 +1,4 @@
+# tests/test_fcm_orphan_unregister_integration.py
 """End-to-end regression for the orphaned-subscription unregister.
 
 PR #1169 shipped ``gcm_unregister`` plus a capture of ``old_app_id`` inside

--- a/tests/test_fcm_orphan_unregister_integration.py
+++ b/tests/test_fcm_orphan_unregister_integration.py
@@ -1,0 +1,209 @@
+"""End-to-end regression for the orphaned-subscription unregister.
+
+PR #1169 shipped ``gcm_unregister`` plus a capture of ``old_app_id`` inside
+``reregister_keeping_identity``, and every unit test passed — yet the fix was a
+production no-op. The unit tests constructed ``FcmRegister`` with ``app_id``
+already present in ``credentials["gcm"]``, a precondition the *real* caller never
+establishes: the FCM-renew button (and a restart) first runs
+``FcmReceiverHA._invalidate_fcm_tokens``, which cleared the ``app_id`` slot
+BEFORE ``reregister_keeping_identity`` ran, so ``old_app_id`` was always ``None``
+and the unregister guard never fired.
+
+These tests exercise the genuine chain — ``_invalidate_fcm_tokens`` →
+``reregister_keeping_identity`` → ``gcm_unregister`` — with the exact credential
+object the invalidation produces, so a regression to either half of the fix
+(dropping ``app_id`` without rescuing it, or reading only ``app_id`` at capture)
+fails here. It is the coverage the pure-unit view structurally could not give:
+100% diff coverage of a method under an unrealistic precondition proves nothing
+about the integration path that establishes that precondition.
+"""
+
+from __future__ import annotations
+
+import types
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.Auth.fcm_receiver_ha import FcmReceiverHA
+from custom_components.googlefindmy.Auth.firebase_messaging.const import (
+    GCM_REGISTER3_URL,
+)
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmregister import (
+    FcmRegister,
+    FcmRegisterConfig,
+)
+
+# Real-shaped values: an int-convertible android_id/security_token (so the
+# identity survives invalidation) and two distinct webpush subtypes.
+_ANDROID_ID = 1234567890123456
+_SECURITY_TOKEN = "9876543210987654"
+_OLD_APP_ID = "wp:com.google.android.apps.adm#0d7d2715-75d9-47a0-88ec-32e9d91e88dd"
+_NEW_APP_ID = "wp:com.google.android.apps.adm#f23ca93d-683d-4fb9-aaee-fdbd82dd079a"
+
+
+@dataclass
+class _FakeResponse:
+    status: int
+    text_value: str
+    headers: dict[str, str]
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def text(self) -> str:
+        return self.text_value
+
+
+class _RecordingSession:
+    """aiohttp session stub: records every post, replays queued responses.
+
+    Every network step of ``reregister_keeping_identity`` is stubbed on the
+    ``FcmRegister`` instance EXCEPT the unregister POST, so any recorded call is
+    the orphan unregister under test.
+    """
+
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    def post(
+        self, *, url: str, headers: dict[str, str], data: dict[str, Any], timeout: Any
+    ) -> _FakeResponse:
+        self.calls.append({"url": url, "data": dict(data), "headers": dict(headers)})
+        if not self._responses:
+            raise AssertionError("No more responses configured")
+        return self._responses.pop(0)
+
+
+def _full_creds() -> dict[str, Any]:
+    """Credentials exactly as they exist for a live, fully-registered entry."""
+    return {
+        "gcm": {
+            "android_id": _ANDROID_ID,
+            "security_token": _SECURITY_TOKEN,
+            "token": "old-gcm-token",
+            "app_id": _OLD_APP_ID,
+        },
+        "fcm": {"registration": {"token": "old-fcm-token"}},
+        "keys": {"private": "x"},
+    }
+
+
+def _build_register_on(
+    credentials: dict[str, Any], session: _RecordingSession
+) -> FcmRegister:
+    """Wire an ``FcmRegister`` on the given (invalidated) creds with every
+    network step stubbed except the unregister POST."""
+    config = FcmRegisterConfig(
+        project_id="proj",
+        app_id="app",
+        api_key="key",
+        messaging_sender_id="1234567890123",
+        bundle_id="bundle",
+    )
+    register = FcmRegister(config, credentials=credentials, http_client_session=session)
+
+    async def fake_check_in(self, android_id=None, security_token=None):  # type: ignore[no-untyped-def]
+        return {"androidId": android_id, "securityToken": security_token}
+
+    async def fake_gcm_register(self, gcm_response, retries=5):  # type: ignore[no-untyped-def]
+        return {
+            "token": "new-gcm-token",
+            "app_id": _NEW_APP_ID,
+            "android_id": gcm_response["androidId"],
+            "security_token": gcm_response["securityToken"],
+        }
+
+    def fake_generate_keys(self):  # type: ignore[no-untyped-def]
+        return {"public": "pub", "private": "priv", "auth_secret": "sec"}
+
+    async def fake_fcm_install_and_register(self, gcm_data, keys):  # type: ignore[no-untyped-def]
+        return {"registration": {"token": "new-fcm-token"}}
+
+    register.gcm_check_in = types.MethodType(fake_check_in, register)
+    register.gcm_register = types.MethodType(fake_gcm_register, register)
+    register.generate_keys = types.MethodType(fake_generate_keys, register)
+    register.fcm_install_and_register = types.MethodType(
+        fake_fcm_install_and_register, register
+    )
+    return register
+
+
+@pytest.mark.asyncio
+async def test_invalidate_then_reregister_unregisters_orphan() -> None:
+    """The genuine button/restart chain must unregister the orphan.
+
+    Reproduces exactly what production does: full creds → the real
+    ``_invalidate_fcm_tokens`` → hand the resulting partial creds to
+    ``reregister_keeping_identity`` → assert one ``delete=true`` POST carrying the
+    OLD subtype. Pre-fix this recorded ZERO calls (``old_app_id`` was ``None``),
+    which is the exact production no-op the live button test exposed.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-e2e-orphan"
+    receiver.creds[entry_id] = _full_creds()
+
+    # 1. The real invalidation the FCM-renew button triggers.
+    await receiver._invalidate_fcm_tokens(entry_id)
+    invalidated = receiver.creds[entry_id]
+
+    # Sanity: this is the partial-creds state that drives reregister, and the
+    # superseded subtype survived the invalidation (the fix under test).
+    assert "fcm" not in invalidated
+    assert "gcm" in invalidated
+    assert "app_id" not in invalidated["gcm"]
+    assert invalidated["gcm"]["orphan_app_id"] == _OLD_APP_ID
+
+    # 2. Feed the EXACT invalidated creds to FcmRegister, as the receiver does.
+    session = _RecordingSession(
+        [_FakeResponse(200, f"deleted={_OLD_APP_ID}", {"Content-Type": "text/plain"})]
+    )
+    register = _build_register_on(invalidated, session)
+
+    result = await register.reregister_keeping_identity()
+
+    # 3. Re-registration produced fresh creds ...
+    assert result["gcm"]["app_id"] == _NEW_APP_ID
+    # ... and the orphan MUST have been unregistered (the bug: 0 calls).
+    assert len(session.calls) == 1, "orphan unregister did not fire"
+    call = session.calls[0]
+    assert call["url"] == GCM_REGISTER3_URL
+    assert call["data"]["delete"] == "true"
+    assert call["data"]["X-subtype"] == _OLD_APP_ID
+    assert call["data"]["device"] == _ANDROID_ID
+    assert call["headers"]["Authorization"] == (
+        f"AidLogin {_ANDROID_ID}:{_SECURITY_TOKEN}"
+    )
+
+    # 4. The rescue slot must not leak into the freshly persisted credentials.
+    assert "orphan_app_id" not in result["gcm"]
+
+
+@pytest.mark.asyncio
+async def test_invalidate_then_reregister_survives_unregister_failure() -> None:
+    """A best-effort unregister failure on the real chain never costs the fresh
+    registration: the caller still returns valid new creds, attempted once."""
+    receiver = FcmReceiverHA()
+    entry_id = "entry-e2e-orphan-fail"
+    receiver.creds[entry_id] = _full_creds()
+    await receiver._invalidate_fcm_tokens(entry_id)
+    invalidated = receiver.creds[entry_id]
+
+    class _RaisingSession(_RecordingSession):
+        def post(self, **kwargs: Any) -> Any:  # type: ignore[override]
+            self.calls.append({"url": kwargs["url"], "data": dict(kwargs["data"])})
+            raise OSError("network down")
+
+    session = _RaisingSession([])
+    register = _build_register_on(invalidated, session)
+
+    result = await register.reregister_keeping_identity()
+
+    assert result["gcm"]["app_id"] == _NEW_APP_ID
+    assert result["fcm"]["registration"]["token"] == "new-fcm-token"
+    assert len(session.calls) == 1  # attempted exactly once, no retry

--- a/tests/test_fcm_receiver.py
+++ b/tests/test_fcm_receiver.py
@@ -1079,7 +1079,38 @@ async def test_invalidate_fcm_tokens_preserves_complete_gcm_identity() -> None:
     assert gcm["android_id"] == 1234567890123456
     assert gcm["security_token"] == "9876543210987654"
     assert "token" not in gcm  # renewable gcm token stripped
+    # The active app_id slot is cleared, but the superseded id is rescued into
+    # ``orphan_app_id`` so reregister_keeping_identity() can unregister it.
     assert "app_id" not in gcm
+    assert gcm["orphan_app_id"] == "app-1"
+
+
+@pytest.mark.asyncio
+async def test_invalidate_fcm_tokens_no_app_id_leaves_no_orphan_slot() -> None:
+    """A complete identity without an ``app_id`` (first-time / legacy creds)
+    invalidates without creating an empty ``orphan_app_id`` slot.
+
+    Guards the falsy branch of the orphan-rescue: nothing to unregister means no
+    sidecar key, so reregister_keeping_identity() correctly skips the delete POST.
+    """
+    receiver = FcmReceiverHA()
+    entry_id = "entry-no-app-id"
+    receiver.creds[entry_id] = {
+        "gcm": {
+            "android_id": 1234567890123456,
+            "security_token": "9876543210987654",
+            "token": "gcm-tok",
+        },
+        "fcm": {"registration": {"token": "fcm-tok"}},
+        "keys": {"private": "x"},
+    }
+
+    await receiver._invalidate_fcm_tokens(entry_id)
+
+    gcm = receiver.creds[entry_id]["gcm"]
+    assert "token" not in gcm
+    assert "app_id" not in gcm
+    assert "orphan_app_id" not in gcm  # no orphan to rescue -> no empty slot
 
 
 @pytest.mark.asyncio

--- a/tests/test_pip_audit_security.py
+++ b/tests/test_pip_audit_security.py
@@ -42,6 +42,10 @@ IGNORED_VULNERABILITIES: dict[str, str] = {
     # The vulnerable sign_digest() function is NOT used in this project.
     # ECDH operations use the 'cryptography' library instead.
     "CVE-2024-23342": "ecdsa timing attack - sign_digest() not used; only curve definitions imported",
+    # Same finding as CVE-2024-23342 above, re-keyed by the advisory DB under a
+    # new primary PYSEC id (CVE-2024-23342 is now only an alias). The ignore
+    # match is by primary id, so the alias id must be listed explicitly.
+    "PYSEC-2026-1325": "ecdsa timing attack (alias of CVE-2024-23342) - sign_digest() not used; only curve definitions imported",
     # protobuf DoS via ParseDict() recursion bypass - this project only uses
     # MessageToDict/MessageToJson (protobuf→dict/json), never ParseDict (dict→protobuf).
     # The vulnerable json_format.ParseDict() function is NOT used anywhere.


### PR DESCRIPTION
## What this fixes (for users)

After you press **“Regenerate FCM token”** (or restart Home Assistant), the integration re-registers with Google using your existing device identity. The *old* push subscription is left behind as an **orphan**. Google keeps delivering to that stale subscription for a while, which your client can no longer decrypt — this is the source of the recurring log lines:

```
Subtype wp:com.google.android.apps.adm#<old> in data message does not match
app id client was registered with wp:com.google.android.apps.adm#<new>
```

PR #1167/#1168 made those lines quiet (dropped the foreign push, logged at debug). **This PR removes their cause:** after a successful re-registration the old subscription is now actively unregistered at Google, so no orphan is left to spam.

### What you’ll see in the debug log after pressing the button

With integration debug logging on, each re-registration now shows the outcome of the cleanup:

| Outcome | Level | Message |
|---|---|---|
| Re-registration succeeded | INFO | `Re-registered FCM with existing device identity` |
| Orphan unregister **succeeded** | DEBUG | `GCM unregister effective … (deleted)` |
| Orphan unregister ineffective (server said so) | DEBUG | `… ineffective (Error=…, ignored)` |
| Network error | DEBUG | `… failed (ignored, best-effort)` |

## Why PR #1169 alone did not work (root cause)

PR #1169 added the `gcm_unregister` call and captured the old `app_id` inside `reregister_keeping_identity`, and every unit test passed — but in production it was a **no-op**. The button/restart path first runs `_invalidate_fcm_tokens`, which cleared the `app_id` slot **before** `reregister_keeping_identity` captured it, so `old_app_id` was always `None` and the unregister guard never fired. A live button press confirmed it: full re-registration cascade in the log, **zero** `gcm_unregister` lines.

The unit tests missed this because they constructed `FcmRegister` **with** `app_id` already set — a precondition the real caller never establishes. 100 % diff coverage of a method under an unrealistic precondition proved nothing about the integration path.

## The fix (for developers)

- **`fcm_receiver_ha.py::_invalidate_fcm_tokens`** — instead of dropping the old `app_id`, rescue it into a dedicated `gcm["orphan_app_id"]` slot. This survives persistence, so a restart-triggered re-register can also clean up the orphan.
- **`fcmregister.py::reregister_keeping_identity`** — capture `old_app_id = gcm.get("app_id") or gcm.get("orphan_app_id")`. The existing best-effort guard/unregister is unchanged. The rescue slot never leaks into the freshly persisted credentials (a fresh `res` dict replaces `self.credentials`).

### Safety (account isolation, unchanged)

The unregister authenticates over the client’s **own** `android_id`/`security_token` (`AidLogin`), so a `delete=true` is scoped to the caller’s own device and can never touch another account’s subscription. Cross-account damage is structurally impossible (delivery is per-`entry_id`; the delete scope is per device identity).

## Tests

- **New integration regression** (`test_fcm_orphan_unregister_integration.py`): reproduces the genuine chain — real `_invalidate_fcm_tokens` → `reregister_keeping_identity` → `gcm_unregister` — with the exact credential object the invalidation produces. It asserts one `delete=true` POST carrying the OLD subtype. **Verified it fails against the #1169 code** (records 0 calls) and passes with this fix — a real regression guard, not the unit-precondition trap.
- Plus a best-effort-failure variant and a “complete identity without app_id → no empty orphan slot” branch test.
- Updated the existing invalidation unit test for the new `orphan_app_id` contract.
- Diff-scoped coverage: 100 % of the new statements and branches. 468 FCM/receiver/register tests green. `ruff 0.15.20` (check + format) and `mypy` strict green. **No version bump.**

Follows #1167 (drop foreign-subtype pushes), #1168 (log at debug), #1169 (added `gcm_unregister`).
