### PR TITLE
fix(fcm): bound best-effort orphan unregister with a short timeout

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -176,6 +176,16 @@ class FcmRegister:
 
     CLIENT_TIMEOUT = ClientTimeout(total=100)
 
+    # Short, bounded timeout for the best-effort orphan unregister. It runs
+    # inside the re-registration critical path (see ``reregister_keeping_identity``
+    # step 4) AFTER the new subscription is already persisted, so a stalled
+    # ``/c2dm/register3`` delete (e.g. silently dropped traffic) must not hold
+    # the caller — and thus push reception — hostage for the full 100 s
+    # ``CLIENT_TIMEOUT``. A healthy delete round-trips in well under a second;
+    # 5 s tolerates a slow-but-alive network while capping the worst-case
+    # push-offline window.
+    UNREGISTER_TIMEOUT = ClientTimeout(total=5)
+
     def __init__(
         self,
         config: FcmRegisterConfig,
@@ -670,11 +680,15 @@ class FcmRegister:
         The ``sender`` field is retained for parity with ``gcm_register``
         and ignored by the server for a delete.
 
-        This is strictly best-effort: exactly one attempt, a fixed
-        timeout, and every failure is swallowed at ``debug`` level. An
-        unregister failure must NEVER break or delay the surrounding
-        re-registration — the new subscription is already live by the
-        time this runs (see ``reregister_keeping_identity``).
+        This is strictly best-effort: exactly one attempt, a short fixed
+        timeout (``UNREGISTER_TIMEOUT``, 5 s — NOT the class-wide 100 s
+        ``CLIENT_TIMEOUT``), and every failure is swallowed at ``debug``
+        level. An unregister failure must NEVER break or delay the
+        surrounding re-registration — the new subscription is already
+        live by the time this runs (see ``reregister_keeping_identity``).
+        Because this runs synchronously inside that critical path, the
+        short timeout bounds how long a stalled delete can keep push
+        reception offline (worst case 5 s instead of 100 s).
 
         :param app_id: OLD (superseded) GCM app_id / subtype to delete.
         :param android_id: Device android_id (stable identity; auth only).
@@ -706,7 +720,7 @@ class FcmRegister:
                 url=GCM_REGISTER3_URL,
                 headers=headers,
                 data=body,
-                timeout=self.CLIENT_TIMEOUT,
+                timeout=self.UNREGISTER_TIMEOUT,
             ) as resp:
                 response_text = await resp.text()
         except Exception as exc:  # network/aiohttp failure — best-effort

--- a/tests/test_fcm_register.py
+++ b/tests/test_fcm_register.py
@@ -59,7 +59,14 @@ class _FakeSession:
     def post(
         self, *, url: str, headers: dict[str, str], data: dict[str, Any], timeout: Any
     ) -> _FakeResponse:
-        self.calls.append({"url": url, "data": dict(data), "headers": dict(headers)})
+        self.calls.append(
+            {
+                "url": url,
+                "data": dict(data),
+                "headers": dict(headers),
+                "timeout": timeout,
+            }
+        )
         if not self._responses:
             raise AssertionError("No more responses configured for FakeSession")
         return self._responses.pop(0)
@@ -1075,6 +1082,29 @@ async def test_reregister_unregisters_old_subscription() -> None:
     assert call["headers"]["Authorization"] == (
         f"AidLogin {_ANDROID_ID}:{_SECURITY_TOKEN}"
     )
+
+
+@pytest.mark.asyncio
+async def test_unregister_uses_short_bounded_timeout() -> None:
+    """(a2) The best-effort unregister runs inside the re-registration critical
+    path, so it MUST use the short ``UNREGISTER_TIMEOUT`` (5 s), never the
+    class-wide 100 s ``CLIENT_TIMEOUT`` — otherwise a stalled delete keeps push
+    reception offline for up to 100 s after the new subscription is already
+    persisted (Codex P2)."""
+    session = _FakeSession(
+        [_FakeResponse(200, f"deleted={_OLD_APP_ID}", {"Content-Type": "text/plain"})]
+    )
+    register = _build_reregister(session, old_app_id=_OLD_APP_ID)
+
+    await register.reregister_keeping_identity()
+
+    assert len(session.calls) == 1
+    used = session.calls[0]["timeout"]
+    assert used is FcmRegister.UNREGISTER_TIMEOUT
+    assert used is not FcmRegister.CLIENT_TIMEOUT
+    assert used.total == 5
+    # Intent guard: the cleanup bound must stay well below the register path.
+    assert used.total < FcmRegister.CLIENT_TIMEOUT.total
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Addresses the Codex **P2** finding on `fcmregister.py:710` ("Use a short timeout for best-effort unregister").

The best-effort orphan unregister (`gcm_unregister`, shipped in #1169/#1170) runs **synchronously inside the re-registration critical path**: `reregister_keeping_identity` awaits it in step 4, *before* returning the freshly persisted credentials, and `_register_for_fcm_entry` waits for that return before the supervisor restarts the FCM client.

The cleanup POST reused the class-wide `CLIENT_TIMEOUT` of **100 s**. When the `/c2dm/register3` delete stalls (e.g. silently dropped traffic), that awaited cleanup keeps **push reception offline for up to 100 s** even though the new subscription is already live.

## Fix

Introduce a dedicated `UNREGISTER_TIMEOUT = ClientTimeout(total=5)` and use it for the cleanup POST, honouring the method's own documented "fixed timeout" contract. This caps the worst-case push-offline window at **5 s instead of 100 s**.

### Why a short timeout, not fire-and-forget

`fcmregister.py` (under `Auth/firebase_messaging/`) is the low-level, HA-agnostic FCM client. Spawning a detached `asyncio.create_task` here would be a layering break: task lifecycle (GC-safe references, cancellation on reload/shutdown) belongs to the HA-aware supervisor layer, not this vendored client. A bounded inline timeout keeps the delete deterministic, testable, and in-layer, while the delay it can add is now negligible. A healthy delete round-trips well under a second.

## Tests

- New `test_unregister_uses_short_bounded_timeout` asserts the unregister POST uses `UNREGISTER_TIMEOUT` (5 s), not the 100 s `CLIENT_TIMEOUT`, exercised through the real `reregister_keeping_identity` path.
- Mutation-proof: reverting to `CLIENT_TIMEOUT` turns the test red.
- `_FakeSession` now records the `timeout` argument (additive, no existing test relies on a full-dict comparison).

## Scope / non-goals

- No version bump.
- Breadth-swept: the five other `CLIENT_TIMEOUT` uses are the must-succeed check-in/register requests whose result *is* the return value; 100 s is appropriate there. `gcm_unregister` is the only best-effort, error-swallowing call in the critical path.

Local: 35 passed (file + integration), changed lines covered, `ruff check`/`format` clean on 0.14.14 and 0.15.20.