### PR TITLE
fix(fcm): split first-locate delivery proof from the RMQ2 receipt list

### DIFF
--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3866,12 +3866,16 @@ class FcmReceiverHA:
         Trigger (T-A + per-entry sharpening): the session is *young*
         (STARTED age < ``_CHURN_WINDOW_S``, measured from this client's own
         STARTED transition) **and** this client has not delivered any data
-        message since login.  Delivery is read from the library's
-        ``persistent_ids`` list, which is reset to ``[]`` on each successful
-        login and appended to only when a ``DataMessageStanza`` is *actually
-        delivered* (decrypted and dispatched to the callback) — a dropped
-        foreign-subtype or control push is selective-acked but deliberately not
-        recorded, so a non-empty list stays a clean "has delivered" proof.  It
+        message since login.  Delivery is read from the library's dedicated
+        ``_first_data_message_delivered`` flag, which is reset to ``False`` on
+        each successful login and set ``True`` only when a ``DataMessageStanza``
+        is *actually delivered* (decrypted and dispatched to the callback).  It
+        deliberately does *not* read ``persistent_ids`` for this: that list
+        records *every* selective-acked message (including dropped
+        foreign-subtype/control pushes) because it is the RMQ2 login dedup, so a
+        dropped orphan push arriving first would falsely mark the session as
+        "has delivered" — the two contracts (all acked vs. only delivered)
+        conflict on one field, so delivery proof is a separate signal.  It also
         deliberately does *not* use
         the activity clock (``last_message_time`` / ``_entry_last_activity_
         monotonic``), which a bare heartbeat ack also advances and which would
@@ -3883,7 +3887,7 @@ class FcmReceiverHA:
         age = self._session_age_s(pc)
         if age is None or age >= _CHURN_WINDOW_S:
             return False
-        delivered = bool(getattr(pc, "persistent_ids", None))
+        delivered = bool(getattr(pc, "_first_data_message_delivered", False))
         return not delivered
 
     async def _force_first_locate_reconnect(

--- a/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
+++ b/custom_components/googlefindmy/Auth/fcm_receiver_ha.py
@@ -3868,8 +3868,11 @@ class FcmReceiverHA:
         STARTED transition) **and** this client has not delivered any data
         message since login.  Delivery is read from the library's
         ``persistent_ids`` list, which is reset to ``[]`` on each successful
-        login and appended to only for a ``DataMessageStanza`` — so a non-empty
-        list is a clean "has delivered" proof.  It deliberately does *not* use
+        login and appended to only when a ``DataMessageStanza`` is *actually
+        delivered* (decrypted and dispatched to the callback) — a dropped
+        foreign-subtype or control push is selective-acked but deliberately not
+        recorded, so a non-empty list stays a clean "has delivered" proof.  It
+        deliberately does *not* use
         the activity clock (``last_message_time`` / ``_entry_last_activity_
         monotonic``), which a bare heartbeat ack also advances and which would
         therefore never separate a broken fresh session (heartbeats, zero data)

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -641,7 +641,21 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
     def _handle_data_message(
         self,
         msg: DataMessageStanza,
-    ) -> None:
+    ) -> bool:
+        """Decrypt and dispatch one data message; report whether it was delivered.
+
+        Returns ``True`` only when a real payload was decrypted and handed to the
+        notification callback. Returns ``False`` for the non-delivering paths that
+        the caller must still selective-ack but must NOT record as a delivery: a
+        ``deleted_messages`` control stanza, a missing-credentials guard hit, and a
+        foreign-``subtype`` drop (a push encrypted for a superseded GCM
+        registration). The caller (``_handle_message``) gates ``persistent_ids`` on
+        this return, keeping both consumers of that list accurate: the first-locate
+        reconnect proof (``fcm_receiver_ha._needs_first_locate_reconnect``) and the
+        RMQ2 login dedup (``received_persistent_id``). A decrypt failure raises (it
+        is caught upstream in ``_process_one_inbound_message``) and therefore also
+        does not count as delivered -- the raise skips the caller's append.
+        """
         self.logger.debug(
             "Received data message Stream ID: %s, Last: %s, Status: %s",
             msg.stream_id,
@@ -654,7 +668,7 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             == "deleted_messages"
         ):
             # The deleted_messages message does not contain data.
-            return
+            return False
         crypto_key = self._extract_header_param(
             self._app_data_by_key(msg, "crypto-key"), "dh"
         )
@@ -670,7 +684,7 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         # unreachable dead code for the ``None``/``{}`` states it was meant to
         # protect against.
         if not self.credentials:
-            return
+            return False
         if subtype != self.credentials["gcm"]["app_id"]:
             # Drop, do not fall through to decrypt. A subtype mismatch means this
             # push was encrypted for a *different* (superseded) GCM registration
@@ -698,7 +712,7 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
                 subtype,
                 self.credentials["gcm"]["app_id"],
             )
-            return
+            return False
 
         decrypted = self._decrypt_raw_data(
             self.credentials, crypto_key, salt, msg.raw_data
@@ -754,6 +768,10 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
                 "Unexpected exception calling notification callback\n"
             )
             self._try_increment_error_count(ErrorType.NOTIFY)
+
+        # Reached only after a real decrypt + callback dispatch: a genuine
+        # delivery, so the caller records ``persistent_id`` as delivered.
+        return True
 
     def _new_input_stream_id_available(self) -> bool:
         return self.last_input_stream_id_reported != self.input_stream_id
@@ -868,9 +886,16 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
             return
 
         if isinstance(msg, DataMessageStanza):
-            self._handle_data_message(msg)
-            self.persistent_ids.append(msg.persistent_id)
-            # Acking is cheap; keep it to avoid server redelivery
+            delivered = self._handle_data_message(msg)
+            if delivered:
+                # Record only genuine deliveries. ``persistent_ids`` is both the
+                # first-locate reconnect's "has delivered" proof and the RMQ2
+                # login dedup; a dropped foreign-subtype/control push must not be
+                # counted, or a superseded push arriving before the first real
+                # locate would falsely suppress the needed reconnect.
+                self.persistent_ids.append(msg.persistent_id)
+            # Ack unconditionally (cheap): even a dropped/foreign push must be
+            # selective-acked so the server stops redelivering it.
             await self._send_selective_ack(msg.persistent_id)
         elif isinstance(msg, HeartbeatPing):
             await self._handle_ping(msg)

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -667,9 +667,12 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         pushes to stop the server replaying them. The two consumers therefore use
         two separate signals -- their contracts conflict on a single field (all
         acked vs. only delivered), so a shared ``persistent_ids`` cannot satisfy
-        both. A decrypt failure raises (it is caught upstream in
-        ``_process_one_inbound_message``) and therefore also does not count as
-        delivered -- the raise skips the caller's ``persistent_ids`` append too.
+        both. A decrypt failure raises (caught upstream in
+        ``_process_one_inbound_message``): it never counts as delivered, and the
+        raise unwinds before the caller's own ``persistent_ids`` append. That
+        handler still records the acked ``persistent_id`` for RMQ2 dedup when it
+        selective-acks the poison push, so the append happens at the ack site
+        instead of here (see ``_process_one_inbound_message``).
         """
         self.logger.debug(
             "Received data message Stream ID: %s, Last: %s, Status: %s",
@@ -1095,7 +1098,23 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
                 persistent_id,
                 decrypt_err,
             )
-            return await self._ack_or_disconnect(persistent_id)
+            acked = await self._ack_or_disconnect(persistent_id)
+            if acked and persistent_id:
+                # RMQ2-dedup parity with the delivered/dropped path in
+                # ``_handle_message``: a poison push we selective-ack must also be
+                # recorded in ``persistent_ids`` so the next ``_login`` reports it
+                # in ``received_persistent_id``. The decrypt-failure raise unwinds
+                # ``_handle_message`` *before* its own ``persistent_ids.append``,
+                # so without recording here the server keeps replaying the same
+                # undecryptable push across reconnects, re-incrementing
+                # ``_consecutive_decrypt_failures`` toward a bogus re-registration.
+                # Record only on a real ack: a dead-writer ``False`` means the push
+                # was NOT acked (the supervisor reconnects and the server replays,
+                # so a later attempt records it instead). The escalation branch
+                # above raises before reaching this point, so a message that
+                # escalates to re-registration is correctly never recorded.
+                self.persistent_ids.append(persistent_id)
+            return acked
 
     async def _listen(self) -> None:
         """Listens for push notifications until an error or stop() occurs."""

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -307,12 +307,22 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
 
         self.run_state: FcmPushClientRunState = FcmPushClientRunState.CREATED
         # Monotonic timestamp of this client's STARTED transition (set in
-        # ``_handle_message`` on a successful login, alongside ``persistent_ids``).
+        # ``_handle_message`` on a successful login, alongside the
+        # ``persistent_ids`` and ``_first_data_message_delivered`` resets).
         # Consumers measure "session age since STARTED" from this instead of the
         # supervisor's pre-start timestamp, which is recorded before ``start()``
         # and can trail the actual STARTED transition by the connection budget
         # (~15-20s). ``None`` until the client first reaches STARTED.
         self._started_monotonic: float | None = None
+        # First-locate reconnect "has delivered" proof, kept *separate* from
+        # ``persistent_ids``. ``persistent_ids`` must record every selective-acked
+        # message for the RMQ2 login dedup (``received_persistent_id``); this flag
+        # must count only genuine deliveries (decrypted + dispatched). The two
+        # contracts conflict on one field, so they are split: this flag is set
+        # only when ``_handle_data_message`` reports a real delivery and reset to
+        # ``False`` on each successful login, alongside ``persistent_ids = []``.
+        # Consumed cross-module by ``fcm_receiver_ha._needs_first_locate_reconnect``.
+        self._first_data_message_delivered: bool = False
         self.tasks: list[asyncio.Task[None]] = []
         # Set by ``_listen`` when stored FCM key material is found to be
         # corrupt/undecodable. The supervisor reads this after the listener
@@ -646,15 +656,20 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
 
         Returns ``True`` only when a real payload was decrypted and handed to the
         notification callback. Returns ``False`` for the non-delivering paths that
-        the caller must still selective-ack but must NOT record as a delivery: a
+        the caller must still selective-ack but must NOT count as a delivery: a
         ``deleted_messages`` control stanza, a missing-credentials guard hit, and a
         foreign-``subtype`` drop (a push encrypted for a superseded GCM
-        registration). The caller (``_handle_message``) gates ``persistent_ids`` on
-        this return, keeping both consumers of that list accurate: the first-locate
-        reconnect proof (``fcm_receiver_ha._needs_first_locate_reconnect``) and the
-        RMQ2 login dedup (``received_persistent_id``). A decrypt failure raises (it
-        is caught upstream in ``_process_one_inbound_message``) and therefore also
-        does not count as delivered -- the raise skips the caller's append.
+        registration). The caller (``_handle_message``) uses this return to gate
+        the *delivery proof only* (``_first_data_message_delivered``, read by
+        ``fcm_receiver_ha._needs_first_locate_reconnect``); it still records
+        ``persistent_ids`` for EVERY acked message, because that list is the RMQ2
+        login dedup (``received_persistent_id``) and must include even dropped
+        pushes to stop the server replaying them. The two consumers therefore use
+        two separate signals -- their contracts conflict on a single field (all
+        acked vs. only delivered), so a shared ``persistent_ids`` cannot satisfy
+        both. A decrypt failure raises (it is caught upstream in
+        ``_process_one_inbound_message``) and therefore also does not count as
+        delivered -- the raise skips the caller's ``persistent_ids`` append too.
         """
         self.logger.debug(
             "Received data message Stream ID: %s, Last: %s, Status: %s",
@@ -881,19 +896,32 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
                 self._started_monotonic = time.monotonic()
                 self.run_state = FcmPushClientRunState.STARTED
                 self.persistent_ids = []
+                # Reset the delivery proof for the new login session, mirroring
+                # the ``persistent_ids`` reset above (see ``__init__``): the fresh
+                # session has not delivered a data message yet.
+                self._first_data_message_delivered = False
                 # Refresh activity timestamp
                 self.last_message_time = time.time()
             return
 
         if isinstance(msg, DataMessageStanza):
             delivered = self._handle_data_message(msg)
+            # Record EVERY selective-acked message in ``persistent_ids``: it is the
+            # sole source ``_login`` extends into ``received_persistent_id`` (RMQ2
+            # dedup), so after a stream restart the server is told about all IDs we
+            # already received and does not redeliver them. A dropped
+            # foreign-subtype/control push is still received and acked, so it must
+            # be recorded here too -- omitting it lets the server replay that same
+            # orphan push across reconnects, delivering+acking it repeatedly.
+            self.persistent_ids.append(msg.persistent_id)
             if delivered:
-                # Record only genuine deliveries. ``persistent_ids`` is both the
-                # first-locate reconnect's "has delivered" proof and the RMQ2
-                # login dedup; a dropped foreign-subtype/control push must not be
-                # counted, or a superseded push arriving before the first real
-                # locate would falsely suppress the needed reconnect.
-                self.persistent_ids.append(msg.persistent_id)
+                # Delivery proof for the first-locate reconnect is a *separate*
+                # signal (see ``__init__``): only a genuine decrypt+dispatch counts.
+                # A dropped push must NOT set it, or a superseded push arriving
+                # before the first real locate would falsely suppress the needed
+                # reconnect. This is why the proof cannot share ``persistent_ids``
+                # (whose RMQ2 role requires recording that very dropped push).
+                self._first_data_message_delivered = True
             # Ack unconditionally (cheap): even a dropped/foreign push must be
             # selective-acked so the server stops redelivering it.
             await self._send_selective_ack(msg.persistent_id)

--- a/tests/test_fcm_receiver_manual_locate.py
+++ b/tests/test_fcm_receiver_manual_locate.py
@@ -336,9 +336,13 @@ class _ReconnectPc:
         run_state: object,
         persistent_ids: list[str] | None = None,
         started_monotonic: float | None = None,
+        first_data_message_delivered: bool = False,
     ) -> None:
         self.run_state = run_state
         self.persistent_ids = list(persistent_ids or [])
+        # Delivery proof read by ``_needs_first_locate_reconnect`` (split from
+        # ``persistent_ids``, which now carries only the RMQ2 receipt list).
+        self._first_data_message_delivered = first_data_message_delivered
         # STARTED-transition anchor consumed by ``_session_age_s``. Defaults to
         # "just reached STARTED" (young session) so the common case is terse;
         # the established-session test passes an old timestamp explicitly.
@@ -459,8 +463,8 @@ async def test_manual_locate_no_reconnect_when_already_delivered(
     cache = DummyCache()
     _wire_manual_locate(monkeypatch, receiver, entry_id, cache)
 
-    # Young (default STARTED stamp) but already delivered (persistent_ids set).
-    stale = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=["pid-1"])
+    # Young (default STARTED stamp) but already delivered (delivery proof set).
+    stale = _ReconnectPc(run_state=_RunState.STARTED, first_data_message_delivered=True)
     receiver.pcs[entry_id] = stale  # type: ignore[assignment]
 
     nudged: list[str | None] = []
@@ -816,7 +820,7 @@ async def test_first_locate_reconnect_uses_current_when_no_longer_fresh(
     """A client that has since delivered is used as-is, without a reconnect.
 
     Between the cheap branch pre-check and acquiring the per-entry lock the
-    session may have delivered its first push (``persistent_ids`` filled).  The
+    session may have delivered its first push (delivery proof set).  The
     authoritative re-check under the lock must then reuse it, never tear it down.
     """
     receiver = FcmReceiverHA()
@@ -828,7 +832,9 @@ async def test_first_locate_reconnect_uses_current_when_no_longer_fresh(
         receiver, "nudge_retry", lambda eid=None: bool(nudged.append(eid)) or True
     )
 
-    delivered = _ReconnectPc(run_state=_RunState.STARTED, persistent_ids=["pid-1"])
+    delivered = _ReconnectPc(
+        run_state=_RunState.STARTED, first_data_message_delivered=True
+    )
     receiver.pcs[entry_id] = delivered  # type: ignore[assignment]
 
     result = await receiver._reconnect_for_first_locate(entry_id, 5.0)

--- a/tests/test_fcmpushclient_drop_not_delivered.py
+++ b/tests/test_fcmpushclient_drop_not_delivered.py
@@ -1,22 +1,29 @@
 # tests/test_fcmpushclient_drop_not_delivered.py
-"""Regression: a dropped foreign-subtype push must not count as delivered.
+"""Regression: split the delivery proof from the RMQ2 receipt list.
 
-PR #1167 added a subtype-mismatch drop inside ``_handle_data_message`` (a push
-encrypted for a *superseded* GCM registration returns early, before decrypt).
-The caller ``_handle_message`` used to append ``msg.persistent_id`` to
-``persistent_ids`` unconditionally. ``fcm_receiver_ha._needs_first_locate_
-reconnect`` reads a non-empty ``persistent_ids`` as proof that the fresh session
-has already delivered its first data message -- so a superseded/orphan push
-arriving before any real locate falsely suppressed the needed first-locate
-reconnect, leaving the entry to the slower starvation-recovery path (Codex
-review on merge commit 5d2d280).
+``persistent_ids`` has two consumers with *conflicting* contracts on one field:
 
-The fix makes ``_handle_data_message`` report whether a real payload was
-delivered; ``_handle_message`` records ``persistent_ids`` only for genuine
-deliveries while still selective-acking every message. These tests drive the
-real (unbound) ``_handle_message`` against real ``DataMessageStanza`` protos and
-pin both halves of the contract: dropped -> acked but NOT recorded; delivered ->
-acked AND recorded.
+* ``_login`` extends ``received_persistent_id`` from it (RMQ2 dedup) -- it must
+  record **every** selective-acked message, or the server replays an already
+  received orphan/control push across reconnects and it is delivered+acked
+  repeatedly.
+* ``fcm_receiver_ha._needs_first_locate_reconnect`` reads it as a "has
+  delivered" proof -- it must count **only** genuine deliveries, or a superseded
+  push arriving before the first real locate falsely suppresses the needed
+  first-locate reconnect.
+
+PR #1167 added a foreign-``subtype`` drop; the caller then appended every push
+unconditionally, breaking the reconnect proof (first Codex finding). PR #1173
+gated the append on delivery -- which fixed the reconnect proof but broke the
+RMQ2 dedup (second Codex finding: dropped-but-acked IDs vanished from the login
+receipt list). The correct fix splits the two signals: ``persistent_ids`` again
+records every acked message (RMQ2), while a dedicated
+``_first_data_message_delivered`` flag carries the delivery proof.
+
+These tests drive the real (unbound) ``_handle_message`` against real
+``DataMessageStanza`` protos and pin all halves of the contract: dropped ->
+acked AND recorded in ``persistent_ids`` (RMQ2) but delivery flag stays False;
+delivered -> acked AND recorded AND delivery flag True.
 """
 
 from __future__ import annotations
@@ -78,6 +85,8 @@ class _HandleMessageSlim:
         self._try_increment_error_count = Mock()
         self._consecutive_decrypt_failures = 0
         self.persistent_ids: list[str] = []
+        # Delivery proof, split from ``persistent_ids`` (see module docstring).
+        self._first_data_message_delivered = False
         self.last_message_time: float = 0.0
         self.input_stream_id = 0
         # Reached only on the matching-subtype (delivered) path.
@@ -99,33 +108,63 @@ class _HandleMessageSlim:
     _extract_header_param = staticmethod(FcmPushClient._extract_header_param)
 
 
-async def test_dropped_subtype_is_acked_but_not_recorded() -> None:
-    """Foreign-subtype push: selective-acked, but NOT added to ``persistent_ids``."""
+async def test_dropped_subtype_is_acked_and_recorded_but_not_delivered() -> None:
+    """Foreign-subtype push: selective-acked AND kept in ``persistent_ids`` (RMQ2),
+    but the delivery proof stays False so the reconnect is not suppressed."""
     client = _HandleMessageSlim()
     msg = _make_stanza(persistent_id="pid-drop", subtype="OTHER")
 
     await client._handle_message(msg)
 
-    # Not a delivery -> the reconnect "has delivered" proof stays empty. This is
-    # the core of the Codex fix: an orphan push no longer suppresses the reconnect.
-    assert client.persistent_ids == []
+    # RMQ2 dedup: the dropped-but-acked id MUST survive in ``persistent_ids`` --
+    # this is the exact list ``_login`` extends into ``received_persistent_id``
+    # (fcmpushclient.py:_login), so the server does not replay the orphan push.
+    assert client.persistent_ids == ["pid-drop"]
+    # Reconnect proof: NOT a delivery -> the flag stays False, so an orphan push
+    # no longer falsely suppresses the first-locate reconnect (core of the fix).
+    assert client._first_data_message_delivered is False
     # Still selective-acked so the server stops redelivering the orphan push.
     client._send_selective_ack.assert_awaited_once_with("pid-drop")
     # Dropped before decrypt: the notification callback never fired.
     assert not client.callback.called
 
 
-async def test_delivered_message_is_acked_and_recorded() -> None:
-    """Matching-subtype push: dispatched, recorded in ``persistent_ids`` AND acked."""
+async def test_delivered_message_is_acked_recorded_and_flagged() -> None:
+    """Matching-subtype push: dispatched, recorded in ``persistent_ids`` AND acked
+    AND the delivery proof flag is set."""
     client = _HandleMessageSlim()
     msg = _make_stanza(persistent_id="pid-ok", subtype="APPID")
 
     await client._handle_message(msg)
 
-    # A genuine delivery -> recorded as the first-locate "has delivered" proof.
     assert client.persistent_ids == ["pid-ok"]
+    # A genuine delivery -> recorded as the first-locate "has delivered" proof.
+    assert client._first_data_message_delivered is True
     client._send_selective_ack.assert_awaited_once_with("pid-ok")
     assert client.callback.called
+
+
+async def test_dropped_then_delivered_records_both_ids_for_rmq2() -> None:
+    """Mixed sequence: an orphan drop followed by a real locate.
+
+    Both ids stay in ``persistent_ids`` (RMQ2 must dedup both across a restart),
+    while the delivery proof flips True only on the genuine delivery. Guards the
+    exact second Codex finding: the dropped id must not be lost from the receipt
+    list even though it did not count as a delivery.
+    """
+    client = _HandleMessageSlim()
+
+    await client._handle_message(
+        _make_stanza(persistent_id="pid-drop", subtype="OTHER")
+    )
+    # After only the drop: recorded for RMQ2, but not yet "delivered".
+    assert client.persistent_ids == ["pid-drop"]
+    assert client._first_data_message_delivered is False
+
+    await client._handle_message(_make_stanza(persistent_id="pid-ok", subtype="APPID"))
+    # Both ids present for the RMQ2 receipt list; delivery proof now True.
+    assert client.persistent_ids == ["pid-drop", "pid-ok"]
+    assert client._first_data_message_delivered is True
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_fcmpushclient_drop_not_delivered.py
+++ b/tests/test_fcmpushclient_drop_not_delivered.py
@@ -1,0 +1,132 @@
+# tests/test_fcmpushclient_drop_not_delivered.py
+"""Regression: a dropped foreign-subtype push must not count as delivered.
+
+PR #1167 added a subtype-mismatch drop inside ``_handle_data_message`` (a push
+encrypted for a *superseded* GCM registration returns early, before decrypt).
+The caller ``_handle_message`` used to append ``msg.persistent_id`` to
+``persistent_ids`` unconditionally. ``fcm_receiver_ha._needs_first_locate_
+reconnect`` reads a non-empty ``persistent_ids`` as proof that the fresh session
+has already delivered its first data message -- so a superseded/orphan push
+arriving before any real locate falsely suppressed the needed first-locate
+reconnect, leaving the entry to the slower starvation-recovery path (Codex
+review on merge commit 5d2d280).
+
+The fix makes ``_handle_data_message`` report whether a real payload was
+delivered; ``_handle_message`` records ``persistent_ids`` only for genuine
+deliveries while still selective-acking every message. These tests drive the
+real (unbound) ``_handle_message`` against real ``DataMessageStanza`` protos and
+pin both halves of the contract: dropped -> acked but NOT recorded; delivered ->
+acked AND recorded.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.googlefindmy.Auth.firebase_messaging.fcmpushclient import (
+    FcmPushClient,
+)
+from custom_components.googlefindmy.Auth.firebase_messaging.proto.mcs_pb2 import (  # pylint: disable=no-name-in-module
+    DataMessageStanza,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_stanza(*, persistent_id: str, subtype: str) -> DataMessageStanza:
+    """Build a real ``DataMessageStanza`` with the app_data the handler reads.
+
+    Includes ``crypto-key``/``encryption`` (parsed on every path before the
+    subtype check) plus the ``subtype`` under test. A real proto is required
+    because ``_handle_message`` dispatches on ``isinstance(msg,
+    DataMessageStanza)``.
+    """
+    msg = DataMessageStanza()
+    msg.persistent_id = persistent_id
+    msg.raw_data = b"raw-body"
+    for key, value in (
+        ("crypto-key", "dh=BPK_value"),
+        ("encryption", "salt=SALT_value"),
+        ("subtype", subtype),
+    ):
+        app_datum = msg.app_data.add()
+        app_datum.key = key
+        app_datum.value = value
+    return msg
+
+
+class _HandleMessageSlim:
+    """Composition stub binding the real ``_handle_message`` + ``_handle_data_message``.
+
+    Mirrors only the attributes those methods read on the ``DataMessageStanza``
+    branch. ``_decrypt_raw_data`` is stubbed so the *delivered* case needs no real
+    crypto; the *dropped* case returns before ever reaching it. Same additive
+    composition discipline as ``tests/helpers/fcm_handle_stub.FcmHandleSlim``.
+    """
+
+    def __init__(self) -> None:
+        self.logger = logging.getLogger(__name__ + "._HandleMessageSlim")
+        self.logger.propagate = True
+        self.credentials: Any = {"gcm": {"app_id": "APPID"}, "keys": {}}
+        self.callback = Mock()  # synchronous: production calls it un-awaited
+        self.callback_context = object()
+        self._reset_error_count = Mock()
+        self._try_increment_error_count = Mock()
+        self._consecutive_decrypt_failures = 0
+        self.persistent_ids: list[str] = []
+        self.last_message_time: float = 0.0
+        self.input_stream_id = 0
+        # Reached only on the matching-subtype (delivered) path.
+        self._decrypt_raw_data = lambda credentials, crypto_key, salt, raw_data: (
+            b'{"ok": true}'
+        )
+        self._send_selective_ack = AsyncMock(return_value=None)
+
+    def _log_warn_with_limit(self, msg: str, *args: object) -> None:
+        self.logger.warning(msg, *args)
+
+    def _log_verbose(self, msg: str, *args: object) -> None:
+        self.logger.debug(msg, *args)
+
+    # Bind the real production coroutines/functions to this light container.
+    _handle_message = FcmPushClient._handle_message  # type: ignore[assignment]
+    _handle_data_message = FcmPushClient._handle_data_message  # type: ignore[assignment]
+    _app_data_by_key = FcmPushClient._app_data_by_key  # type: ignore[assignment]
+    _extract_header_param = staticmethod(FcmPushClient._extract_header_param)
+
+
+async def test_dropped_subtype_is_acked_but_not_recorded() -> None:
+    """Foreign-subtype push: selective-acked, but NOT added to ``persistent_ids``."""
+    client = _HandleMessageSlim()
+    msg = _make_stanza(persistent_id="pid-drop", subtype="OTHER")
+
+    await client._handle_message(msg)
+
+    # Not a delivery -> the reconnect "has delivered" proof stays empty. This is
+    # the core of the Codex fix: an orphan push no longer suppresses the reconnect.
+    assert client.persistent_ids == []
+    # Still selective-acked so the server stops redelivering the orphan push.
+    client._send_selective_ack.assert_awaited_once_with("pid-drop")
+    # Dropped before decrypt: the notification callback never fired.
+    assert not client.callback.called
+
+
+async def test_delivered_message_is_acked_and_recorded() -> None:
+    """Matching-subtype push: dispatched, recorded in ``persistent_ids`` AND acked."""
+    client = _HandleMessageSlim()
+    msg = _make_stanza(persistent_id="pid-ok", subtype="APPID")
+
+    await client._handle_message(msg)
+
+    # A genuine delivery -> recorded as the first-locate "has delivered" proof.
+    assert client.persistent_ids == ["pid-ok"]
+    client._send_selective_ack.assert_awaited_once_with("pid-ok")
+    assert client.callback.called
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_fcmpushclient_handle_data_message.py
+++ b/tests/test_fcmpushclient_handle_data_message.py
@@ -50,7 +50,7 @@ class TestHandleDataMessage:
         client = FcmHandleSlim()
         msg = make_data_message(message_type="deleted_messages")
 
-        client._handle_data_message(msg)
+        assert client._handle_data_message(msg) is False
 
         assert not client.callback.called
         assert client.warnings == []
@@ -79,8 +79,11 @@ class TestHandleDataMessage:
         msg = make_data_message(subtype="OTHER")
 
         with caplog.at_level(logging.DEBUG):
-            client._handle_data_message(msg)
+            delivered = client._handle_data_message(msg)
 
+        # A dropped foreign-subtype push is not a delivery: the caller must
+        # selective-ack it but must NOT record it in ``persistent_ids`` (Codex P2).
+        assert delivered is False
         # Emitted at DEBUG, never WARNING (benign, expected event).
         assert any(
             "does not match" in r.getMessage() and r.levelno == logging.DEBUG
@@ -99,7 +102,7 @@ class TestHandleDataMessage:
         _set_decrypt(client, b'{"ok": true}')
         msg = make_data_message(subtype="APPID")
 
-        client._handle_data_message(msg)
+        assert client._handle_data_message(msg) is True
 
         assert client.warnings == []
         assert client.callback.called
@@ -118,7 +121,7 @@ class TestHandleDataMessage:
         client = FcmHandleSlim(credentials=credentials)
         msg = make_data_message(subtype="APPID")
 
-        client._handle_data_message(msg)
+        assert client._handle_data_message(msg) is False
 
         assert not client.callback.called
         assert client.warnings == []
@@ -129,7 +132,7 @@ class TestHandleDataMessage:
         _set_decrypt(client, b'{"k": "v"}')
         msg = make_data_message()
 
-        client._handle_data_message(msg)
+        assert client._handle_data_message(msg) is True
 
         client.callback.assert_called_once()
         ret_val = client.callback.call_args.args[0]
@@ -187,7 +190,9 @@ class TestHandleDataMessage:
         _set_decrypt(client, b'{"k": "v"}')
         msg = make_data_message()
 
-        client._handle_data_message(msg)
+        # Delivered = decrypted + dispatched; a raising HA callback still counts as
+        # a delivery (the payload reached the callback), matching prior semantics.
+        assert client._handle_data_message(msg) is True
 
         client._try_increment_error_count.assert_called_once_with(ErrorType.NOTIFY)
         assert not client._reset_error_count.called

--- a/tests/test_fcmpushclient_poison_message.py
+++ b/tests/test_fcmpushclient_poison_message.py
@@ -590,3 +590,90 @@ async def test_non_ece_poison_never_escalates(
     assert client.credential_error is None
     assert client._send_selective_ack.await_count == count
     assert not _outer_catch_was_hit(caplog)
+
+
+# ---------------------------------------------------------------------------
+# RMQ2 dedup parity for the poison path (Codex follow-up on PR #1173): a
+# selective-acked poison push must also be recorded in ``persistent_ids`` so the
+# next ``_login`` reports it in ``received_persistent_id``. The decrypt-failure
+# raise unwinds ``_handle_message`` before its own append, so the ack site in
+# ``_process_one_inbound_message`` records it instead -- but only on a real ack.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poison_ack_records_persistent_id_for_rmq2(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A selective-acked poison push is recorded in ``persistent_ids`` (RMQ2 dedup).
+
+    Without this the next ``_login`` omits the id from ``received_persistent_id``,
+    so the server replays the same undecryptable push across reconnects (repeated
+    decrypt failures drifting toward a bogus re-registration).
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-rmq2-001", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+
+    await client._listen()
+
+    client._send_selective_ack.assert_awaited_once_with("poison-rmq2-001")
+    assert client.persistent_ids == ["poison-rmq2-001"]
+
+
+@pytest.mark.asyncio
+async def test_dead_writer_poison_not_recorded_for_rmq2(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A poison push whose ack fails (dead writer) is NOT recorded for RMQ2.
+
+    ``_ack_or_disconnect`` returns ``False`` when the writer half is dead, so the
+    push was never acknowledged. Recording it would wrongly tell RMQ2 the server
+    may drop it; instead the supervisor reconnects, the server replays it, and a
+    later successful ack records it then. ``persistent_ids`` must stay empty.
+    """
+    caplog.set_level(logging.WARNING)
+    client = FcmPushClientSlim()
+    msg = make_poison_data_message("poison-rmq2-002", kind="padding")
+    client._receive_msg = _stream_messages(client, [msg])
+    client._handle_message = _make_handle_side_effect(
+        [binascii.Error("Incorrect padding")]
+    )
+    client._send_selective_ack = AsyncMock(side_effect=OSError("writer half-dead"))
+
+    await client._listen()
+
+    assert client.do_listen is False
+    assert client.persistent_ids == []
+
+
+@pytest.mark.asyncio
+async def test_escalating_ece_not_recorded_but_prior_acks_are(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """On stale-key escalation only the acked ECEs are recorded, not the escalating one.
+
+    The nth consecutive ECE raises ``CredentialDecryptionError`` *before* the ack
+    site, so it is never acked and never recorded. The first n-1 were acked, so
+    ``persistent_ids`` holds exactly those n-1 ids for RMQ2 dedup.
+    """
+    caplog.set_level(logging.ERROR)
+    client = FcmPushClientSlim()
+    n = _MAX_CONSECUTIVE_DECRYPT_FAILURES
+    messages = [
+        make_poison_data_message(f"ece-rmq2-{i:03d}", kind="value") for i in range(n)
+    ]
+    client._receive_msg = _stream_messages(client, messages)
+    client._handle_message = _make_handle_side_effect(
+        [http_ece.ECEException("Decryption error: bad auth tag")] * n
+    )
+
+    await client._listen()
+
+    assert isinstance(client.credential_error, CredentialDecryptionError)
+    expected = [f"ece-rmq2-{i:03d}" for i in range(n - 1)]
+    assert client.persistent_ids == expected

--- a/tests/test_fcmpushclient_started_stamp.py
+++ b/tests/test_fcmpushclient_started_stamp.py
@@ -36,6 +36,7 @@ async def test_login_success_stamps_started_monotonic() -> None:
     slim._reset_error_count = Mock()  # type: ignore[attr-defined]
     slim.run_state = FcmPushClientRunState.CREATED  # type: ignore[attr-defined]
     slim.persistent_ids = ["stale-pid"]  # type: ignore[attr-defined]
+    slim._first_data_message_delivered = True  # type: ignore[attr-defined]
     slim._started_monotonic = None  # type: ignore[attr-defined]
 
     await slim._handle_message(LoginResponse())  # type: ignore[arg-type]
@@ -45,6 +46,9 @@ async def test_login_success_stamps_started_monotonic() -> None:
     # And the accompanying STARTED state + persistent-ids reset happened.
     assert slim.run_state == FcmPushClientRunState.STARTED  # type: ignore[attr-defined]
     assert slim.persistent_ids == []  # type: ignore[attr-defined]
+    # The separate delivery proof is reset too, so the fresh session correctly
+    # reads as "not yet delivered" until a real data message arrives.
+    assert slim._first_data_message_delivered is False  # type: ignore[attr-defined]
     slim._reset_error_count.assert_called_once_with(ErrorType.LOGIN)  # type: ignore[attr-defined]
 
 


### PR DESCRIPTION
## Summary

`persistent_ids` on the FCM push client is read by **two** consumers whose
content contracts conflict on the same field:

1. **RMQ2 login dedup** -- `_login` extends `LoginRequest.received_persistent_id`
   from it, so it must contain **every** selective-acked message; otherwise the
   server replays an already-received orphan/control push across reconnects and
   it is delivered+acked repeatedly.
2. **First-locate reconnect proof** -- `_needs_first_locate_reconnect` reads it
   as "this session has delivered a data message", so it must count **only**
   genuine deliveries.

A single field cannot satisfy both. This PR resolves the conflict by **splitting
the two signals**.

## Two commits, two Codex findings

- **Commit 1 (`9acdcff`)** addressed the first Codex finding: the unconditional
  append (from #1167's subtype drop) made a dropped foreign-subtype push count
  as "delivered", suppressing the needed first-locate reconnect. It gated the
  append on delivery.
- **Commit 2 (`a1c9b18`)** addresses the second Codex finding: that gating broke
  consumer 1 -- dropped-but-acked ids vanished from the RMQ2 receipt list, so a
  stream restart no longer told RMQ2 about them and the same orphan push was
  delivered+acked repeatedly. Re-gating one shared field cannot satisfy both
  contracts, so the signals are split.

## Final design

- `persistent_ids`: **unconditional append again** (records every acked id) ->
  RMQ2 dedup correct.
- `_first_data_message_delivered`: a **dedicated bool**, set only on a genuine
  decrypt+dispatch and reset to `False` on each login, read by
  `_needs_first_locate_reconnect` as the delivery proof.

Both consumers now use separate signals, so neither contract can regress the
other.

## Tests

- Drop regression reframed to pin **both** contracts: dropped -> acked AND
  recorded in `persistent_ids` (RMQ2) but delivery flag stays `False`; delivered
  -> both.
- New mixed-sequence guard (orphan drop then real locate): both ids stay in
  `persistent_ids`, flag flips only on the genuine delivery.
- Login flag-reset assertion added.
- Consumer (manual-locate) tests switched to the dedicated flag.
- Mutation-proven in both directions; ruff (0.14.14 + CI 0.15.20) and mypy clean.

No version bump (behavioural fix).

---

## Follow-up (Codex review on `9acdcff`): RMQ2 dedup parity for the poison path

The delivery-proof split above fixed `persistent_ids` for the drop path, but the
decrypt-failure/poison path had a symmetric gap: `_process_one_inbound_message`
selective-acks a poison push, yet the raise unwinds `_handle_message` before its
`persistent_ids` append, so the acked id never entered the RMQ2 receipt list
(`_login.received_persistent_id`). The server then replays the same undecryptable
push across reconnects, re-incrementing `_consecutive_decrypt_failures` toward a
bogus re-registration.

Fix: record the acked `persistent_id` at the ack site, but only on a real ack
(dead-writer `False` is not recorded; the stale-key escalation raises before this
point and is correctly never recorded). Three regression tests added (positive
record, dead-writer not recorded, escalation not recorded), `_handle_data_message`
docstring updated (SA-7). No version bump.