### PR TITLE
fix(gfmy): harden six P3 follow-up findings from PR #201 audit

### DIFF
--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmpushclient.py
@@ -703,7 +703,15 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
         # protect against.
         if not self.credentials:
             return False
-        if subtype != self.credentials["gcm"]["app_id"]:
+        # Resolve our registered app_id defensively. ``credentials`` is truthy
+        # here, but the ``gcm`` sub-dict or its ``app_id`` can be transiently
+        # absent during a credential swap/invalidate window; a hard
+        # ``["gcm"]["app_id"]`` would raise ``KeyError`` in that window. The
+        # sibling read in ``_decrypt_raw_data`` already uses ``.get("gcm")`` for
+        # the same reason. A ``None`` registered id simply means we cannot own
+        # this push, so the mismatch check below drops it safely.
+        registered_app_id = (self.credentials.get("gcm") or {}).get("app_id")
+        if subtype != registered_app_id:
             # Drop, do not fall through to decrypt. A subtype mismatch means this
             # push was encrypted for a *different* (superseded) GCM registration
             # -- e.g. an old client instance still listening after an FCM
@@ -728,7 +736,7 @@ class FcmPushClient[NotificationContextT]:  # pylint:disable=too-many-instance-a
                 "Subtype %s in data message does not match "
                 "app id client was registered with %s",
                 subtype,
-                self.credentials["gcm"]["app_id"],
+                registered_app_id,
             )
             return False
 

--- a/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
+++ b/custom_components/googlefindmy/Auth/firebase_messaging/fcmregister.py
@@ -690,6 +690,14 @@ class FcmRegister:
         short timeout bounds how long a stalled delete can keep push
         reception offline (worst case 5 s instead of 100 s).
 
+        No retry by design: since the receiver now hard-drops foreign-subtype
+        pushes at the decrypt boundary (see ``fcmpushclient`` subtype guard), a
+        failed unregister is merely cosmetic -- the orphaned subscription can
+        only produce benign "Subtype does not match" debug logs, never a
+        functional fault or the decrypt-failure amplification loop. Retrying a
+        best-effort cleanup would add latency to the critical re-registration
+        path for zero correctness benefit, so a single attempt is intentional.
+
         :param app_id: OLD (superseded) GCM app_id / subtype to delete.
         :param android_id: Device android_id (stable identity; auth only).
         :param security_token: Device security_token (auth only).

--- a/custom_components/googlefindmy/Auth/token_refresh.py
+++ b/custom_components/googlefindmy/Auth/token_refresh.py
@@ -2,7 +2,9 @@
 """Token refresh utilities for manual regeneration of ADM and FCM tokens.
 
 This module provides entry-scoped token regeneration with:
-- Shared cooldown (3 minutes) across all token refresh operations
+- Per-entry, per-token-type cooldown (3 minutes); FCM and ADM refreshes are
+  rate-limited independently so refreshing one does not disable the sibling
+  button (see ``_cooldown_key``)
 - Proper dependency handling (ADM depends on AAS)
 - Info-level logging for visibility of regeneration operations
 
@@ -117,7 +119,7 @@ async def async_regenerate_fcm_token(
     """Regenerate FCM/GCM tokens while preserving device identity.
 
     This function:
-    1. Checks and enforces the shared cooldown
+    1. Checks and enforces the per-token-type cooldown
     2. Invalidates FCM tokens (keeps GCM android_id/security_token)
     3. Triggers re-registration via the FCM receiver
 
@@ -194,7 +196,7 @@ async def async_regenerate_adm_token(
     """Regenerate the ADM token.
 
     This function:
-    1. Checks and enforces the shared cooldown
+    1. Checks and enforces the per-token-type cooldown
     2. Invalidates the ADM token in the cache
     3. Triggers a fresh ADM token generation (which may use existing AAS
        or regenerate it if needed)
@@ -273,7 +275,16 @@ async def async_regenerate_adm_token(
 
 
 def clear_cooldown(entry_id: str, token_type: str | None = None) -> None:
-    """Clear the cooldown for a specific entry/type (for testing purposes)."""
+    """Clear the cooldown for a specific entry/type (for testing purposes).
+
+    ``token_type`` must be supplied to clear a real production cooldown:
+    production only ever records per-type keys (``entry_id:fcm`` /
+    ``entry_id:adm`` via ``_record_refresh``). Calling this without a
+    ``token_type`` targets the legacy entry-only key (see ``_cooldown_key``)
+    and is therefore a no-op against the typed keys the buttons actually use.
+    To wipe every key for a test, use ``clear_all_cooldowns()`` or call this
+    once per token type.
+    """
     _last_refresh_timestamps.pop(_cooldown_key(entry_id, token_type), None)
 
 

--- a/custom_components/googlefindmy/SpotApi/spot_request.py
+++ b/custom_components/googlefindmy/SpotApi/spot_request.py
@@ -186,16 +186,28 @@ async def _invalidate_token_async(
         await cache.set(f"spot_token_{username}", None)
     elif kind == "adm":
         await cache.set(f"adm_token_{username}", None)
-    else:
-        # Only clear the quasi-permanent AAS master token when the failing
-        # token is NOT a short-lived scoped token. A scoped (spot/adm) auth
-        # failure is routinely transient (an expired scoped token); nulling
-        # the AAS here would destroy the parent credential in the volatile
-        # cache and force a user-visible reauth, even though the retry can
-        # mint a fresh scoped token from the still-valid AAS. A genuinely
-        # revoked AAS is handled separately via _clear_aas_token_async /
-        # InvalidAasTokenError.
+    elif kind == "aas":
+        # Intentional, explicit clear of the quasi-permanent AAS master token.
+        # This branch is only taken for a genuinely non-scoped kind; a scoped
+        # (spot/adm) auth failure is routinely transient (an expired scoped
+        # token), and nulling the AAS there would destroy the parent credential
+        # in the volatile cache and force a user-visible reauth, even though the
+        # retry can mint a fresh scoped token from the still-valid AAS. A
+        # genuinely revoked AAS is normally handled via _clear_aas_token_async /
+        # InvalidAasTokenError; this explicit "aas" kind mirrors that intent.
         await cache.set(DATA_AAS_TOKEN, None)
+    else:
+        # Defensive whitelist tail: an unrecognized token kind must NEVER fall
+        # through to the destructive AAS-master clear. The sole caller
+        # (_pick_auth_token_async) currently yields only "spot"/"adm"; a future
+        # third scoped kind added there would otherwise silently null the parent
+        # AAS credential (the exact destructive default this hardening removes).
+        # Log and no-op instead, leaving every cached token untouched.
+        _LOGGER.warning(
+            "Unexpected token kind %r in _invalidate_token_async; no token "
+            "cleared (AAS master preserved)",
+            kind,
+        )
 
 
 async def _clear_aas_token_async(*, cache: TokenCache | None = None) -> None:

--- a/custom_components/googlefindmy/button.py
+++ b/custom_components/googlefindmy/button.py
@@ -1450,7 +1450,13 @@ class GoogleFindMyRegenerateFcmTokenButton(GoogleFindMyTokenRefreshButtonBase):
         """Handle the button press to regenerate FCM token."""
         from .Auth.token_refresh import async_regenerate_fcm_token
 
-        entry_id = self.entry_id or "unknown"
+        # Fall back to "default", matching ``available``/``extra_state_attributes``
+        # and ``__init__`` above. The value becomes the cooldown key
+        # (``async_regenerate_fcm_token`` records under it); a divergent fallback
+        # here (e.g. "unknown") would record the cooldown under a different key
+        # than ``available`` reads, so an ``entry_id is None`` button could never
+        # see its own cooldown. Keep every fallback identical.
+        entry_id = self.entry_id or "default"
 
         if not self.available:
             _LOGGER.info(
@@ -1524,7 +1530,11 @@ class GoogleFindMyRegenerateAdmTokenButton(GoogleFindMyTokenRefreshButtonBase):
         """Handle the button press to regenerate ADM token."""
         from .Auth.token_refresh import async_regenerate_adm_token
 
-        entry_id = self.entry_id or "unknown"
+        # Fall back to "default", matching ``available`` above. This value is the
+        # cooldown key; a divergent fallback (e.g. "unknown") would record the
+        # cooldown under a different key than ``available`` reads, so an
+        # ``entry_id is None`` button could never see its own cooldown.
+        entry_id = self.entry_id or "default"
 
         if not self.available:
             _LOGGER.info(

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -162,7 +162,9 @@ LOCATE_COOLDOWN_S: int = DEFAULT_MIN_POLL_INTERVAL
 TOKEN_REFRESH_COOLDOWN_S: int = 180
 """Cooldown window (seconds) between token regeneration requests (3 minutes).
 
-This cooldown is shared across all token regeneration buttons (AAS/ADM).
+This window is applied per entry and per token type, so the FCM and ADM
+regeneration buttons are rate-limited independently (a refresh of one does
+not disable the sibling button). See ``token_refresh._cooldown_key``.
 """
 
 # EID resolver refresh trigger debounce policy

--- a/tests/test_fcmpushclient_drop_not_delivered.py
+++ b/tests/test_fcmpushclient_drop_not_delivered.py
@@ -167,5 +167,40 @@ async def test_dropped_then_delivered_records_both_ids_for_rmq2() -> None:
     assert client._first_data_message_delivered is True
 
 
+async def test_missing_gcm_key_drops_without_keyerror() -> None:
+    """Hardening: truthy credentials lacking the ``gcm`` sub-dict must drop, not raise.
+
+    During a credential swap/invalidate window ``self.credentials`` can be a
+    truthy dict without ``gcm``. A hard ``["gcm"]["app_id"]`` deref would raise
+    ``KeyError``; the ``.get("gcm")`` resolution treats the absent id as "not
+    ours" and drops the push on the same safe path as a subtype mismatch.
+    """
+    client = _HandleMessageSlim()
+    client.credentials = {"keys": {}}  # no "gcm" sub-dict
+    msg = _make_stanza(persistent_id="pid-nogcm", subtype="APPID")
+
+    # Must not raise; behaves like a foreign-subtype drop.
+    await client._handle_message(msg)
+
+    assert client.persistent_ids == ["pid-nogcm"]  # RMQ2 receipt kept
+    assert client._first_data_message_delivered is False  # not a delivery
+    client._send_selective_ack.assert_awaited_once_with("pid-nogcm")
+    assert not client.callback.called  # dropped before decrypt
+
+
+async def test_gcm_without_app_id_drops_without_keyerror() -> None:
+    """Hardening: ``gcm`` present but missing ``app_id`` must drop, not raise."""
+    client = _HandleMessageSlim()
+    client.credentials = {"gcm": {}, "keys": {}}  # gcm dict without app_id
+    msg = _make_stanza(persistent_id="pid-noappid", subtype="APPID")
+
+    await client._handle_message(msg)
+
+    assert client.persistent_ids == ["pid-noappid"]
+    assert client._first_data_message_delivered is False
+    client._send_selective_ack.assert_awaited_once_with("pid-noappid")
+    assert not client.callback.called
+
+
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_invalidate_token_preserves_aas.py
+++ b/tests/test_invalidate_token_preserves_aas.py
@@ -72,8 +72,36 @@ async def test_non_scoped_kind_still_clears_aas() -> None:
         "aas", "user@example.com", cache=cache
     )
 
-    # A non-scoped kind falls through and clears the AAS (defensive path).
+    # The explicit "aas" kind clears the AAS (intentional, documented path).
     assert cache._data.get(DATA_AAS_TOKEN) is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_kind_preserves_aas_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Defensive tail: an unrecognized kind must NOT clear the AAS master.
+
+    Only "spot"/"adm" (scoped) and the explicit "aas" kind are handled; any
+    future/unknown kind must fall into the whitelist tail, which logs a warning
+    and clears nothing (in particular it must never null the parent AAS
+    credential -- the destructive default this hardening removes).
+    """
+    cache = _DummyCache()
+    await cache.set(DATA_AAS_TOKEN, "aas_et/master")
+    await cache.set("spot_token_user@example.com", "ya29.scoped")
+
+    with caplog.at_level("WARNING"):
+        await spot_request_module._invalidate_token_async(
+            "nova", "user@example.com", cache=cache
+        )
+
+    # Nothing cleared: AAS master and the unrelated scoped token both survive.
+    assert cache._data.get(DATA_AAS_TOKEN) == "aas_et/master"
+    assert cache._data.get("spot_token_user@example.com") == "ya29.scoped"
+    assert any(
+        "Unexpected token kind" in record.getMessage() for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_token_refresh.py
+++ b/tests/test_token_refresh.py
@@ -2,7 +2,7 @@
 """Unit tests for token regeneration functionality.
 
 Tests cover:
-- Cooldown mechanism (shared across all token refresh operations)
+- Cooldown mechanism (scoped per entry and per token type)
 - AAS token regeneration
 - ADM token regeneration
 - Token dependency handling (ADM depends on AAS)

--- a/tests/test_token_refresh_buttons.py
+++ b/tests/test_token_refresh_buttons.py
@@ -631,6 +631,78 @@ class TestTokenRefreshButtonPress:
 
         mock_regenerate.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_press_fallback_key_matches_availability_when_entry_id_none(
+        self, stub_coordinator_factory: Any
+    ) -> None:
+        """entry_id=None must use the SAME cooldown fallback key on press as on read.
+
+        ``available``/``extra_state_attributes``/``__init__`` fall back to
+        "default"; ``async_press`` previously fell back to "unknown", so with a
+        missing entry_id the press recorded its cooldown under a different key
+        than ``available`` reads -- the button could never see its own cooldown.
+        This pins both paths to "default".
+        """
+        loop = asyncio.get_running_loop()
+        hass = _make_hass(loop)
+
+        entry = _ConfigEntryStub()
+        service_subentry = ConfigSubentry(
+            data={"group_key": SERVICE_SUBENTRY_KEY, "features": ("button",)},
+            subentry_type=SUBENTRY_TYPE_SERVICE,
+            title="Service",
+            subentry_id="service-subentry",
+        )
+        entry.subentries = {service_subentry.subentry_id: service_subentry}
+
+        coordinator_cls = stub_coordinator_factory(
+            subentry_key="tracker",
+            service_subentry_key=SERVICE_SUBENTRY_KEY,
+        )
+        coordinator = coordinator_cls(
+            hass, cache=SimpleNamespace(entry_id=entry.entry_id)
+        )
+        coordinator.config_entry = entry
+
+        token_cache = _MockTokenCache(entry.entry_id)
+        entry.runtime_data = SimpleNamespace(
+            coordinator=coordinator,
+            token_cache=token_cache,
+        )
+
+        add_entities, added, pending = _make_add_entities(hass, loop)
+
+        await button.async_setup_entry(hass, entry, add_entities)
+        await asyncio.gather(*pending)
+
+        fcm_button = next(
+            (
+                entity
+                for entity, _ in added
+                if "regenerate_fcm_token" in (getattr(entity, "unique_id", "") or "")
+            ),
+            None,
+        )
+        assert fcm_button is not None
+
+        # Simulate a runtime entry_id of None (property returns None for a
+        # missing/empty config-entry id); this makes the fallback observable.
+        entry.entry_id = None
+        assert fcm_button.entry_id is None
+        # ``available`` derives its cooldown key from the "default" fallback.
+        assert fcm_button.available is True
+
+        with patch(
+            "custom_components.googlefindmy.Auth.token_refresh.async_regenerate_fcm_token",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_regenerate:
+            await fcm_button.async_press()
+
+        # The press must record under the SAME fallback key ("default"), not
+        # a divergent "unknown", so availability and the recorded cooldown agree.
+        mock_regenerate.assert_called_once_with(hass=hass, entry_id="default")
+
 
 class TestTokenRefreshButtonUniqueIds:
     """Test token refresh button unique ID generation."""


### PR DESCRIPTION
## PR #201 follow-up: six P3 hardening findings

Independent Fable + Opus audit of PR #201 surfaced six P3 (non-blocking) findings. None blocked the merge, but they are worth mitigating while the release line is open. Each is addressed below; findings that need no code change still get a docstring that records the situation and decision basis.

### Findings

| # | File | Fix | Kind |
|---|------|-----|------|
| P3-1 | `const.py`, `token_refresh.py`, `test_token_refresh.py` | Docstrings said the cooldown is "shared across all" token buttons; it is scoped **per entry and per token type** (`_cooldown_key`). Corrected 5 drifted docstrings. | doc |
| P3-2 | `SpotApi/spot_request.py` | `_invalidate_token_async` had a destructive catch-all `else` that nulled the AAS master token for any non-spot/adm kind. Split into an explicit `elif kind == "aas"` (intentional clear) and a **safe defensive `else`** that logs a warning and clears nothing, so a future token kind cannot silently destroy the parent credential. | code |
| P3-3 | `token_refresh.py` | `clear_cooldown(entry_id)` without a `token_type` is a no-op against the typed production keys (it only clears the legacy entry-only key). Documented; pointed at `clear_all_cooldowns()`. | doc |
| P3-4 | `Auth/firebase_messaging/fcmpushclient.py` | `self.credentials["gcm"]["app_id"]` could `KeyError` in a credential-swap window. Hardened to `(self.credentials.get("gcm") or {}).get("app_id")`, mirroring the sibling `.get("gcm")` in `_decrypt_raw_data`; a `None` id drops the push on the same safe path as a subtype mismatch. | code |
| P3-5 | `button.py` | `async_press` fell back to `"unknown"` while `available`/`__init__` used `"default"` for the same cooldown key. With `entry_id=None` the press recorded its cooldown under a different key than availability read. Unified both `async_press` fallbacks to `"default"`. | code |
| P3-6 | `Auth/firebase_messaging/fcmregister.py` | Documented the no-retry decision basis for the best-effort orphan `gcm_unregister`: since the receiver now hard-drops foreign-subtype pushes, a failed unregister is merely cosmetic (benign debug logs), never a functional fault. | doc |

### Verification

- **Tests:** 94 passed across the affected families; 3 new behavioral tests (P3-2 unknown-kind, P3-4 missing-gcm/app_id, P3-5 entry_id-None key consistency).
- **Mutation cross-proofs:** reverting each of the three code fixes turns its new test red (P3-2 -> AAS nulled + no warning; P3-4 -> KeyError; P3-5 -> `entry_id="unknown"`).
- **Changed-code coverage:** all delta source lines covered.
- **Lint/type:** ruff 0.14.14 and 0.15.20 (check + format) clean, no parity drift; mypy clean on source and tests; `asyncio.run` guard green.
