### PR TITLE
fix(gfmy): retune stale threshold to home cadence + accuracy-less fallback

### DIFF
--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -225,7 +225,7 @@ DEFAULT_DELETE_CACHES_ON_REMOVE: bool = True
 # the tracker state becomes "unknown". This is always enabled.
 # Users who need the last known location can use the "Last Location" entity.
 #
-# Sachverhalt (empirically observed, HA history July 2026):
+# Situation (empirically observed, HA history July 2026):
 # A stationary device at home (smartphone with a dark display, or a Bluetooth
 # tag scanned only by the household's own dark-display phones) reports through
 # the FMDN network roughly every ~30 minutes. Every spurious "unknown" flip in
@@ -242,7 +242,7 @@ DEFAULT_DELETE_CACHES_ON_REMOVE: bool = True
 # poll does not help - Google returns the last reported fix for a dozing
 # device, so last_seen only advances when the device itself reports.
 #
-# Entscheidungsgrundlage for the default: 3900 s (65 minutes) ~= 2x the
+# Rationale for the default: 3900 s (65 minutes) ~= 2x the
 # observed ~30 min home cadence plus margin to tolerate one missed report
 # cycle, which removes the flapping for both smartphones and tags while still
 # flagging a genuinely absent device within ~1 h. The threshold stays

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -225,19 +225,33 @@ DEFAULT_DELETE_CACHES_ON_REMOVE: bool = True
 # the tracker state becomes "unknown". This is always enabled.
 # Users who need the last known location can use the "Last Location" entity.
 #
-# Based on real-world FMDN tracker update intervals:
-# - Typical update interval: 2-4 minutes (median ~3.4 min)
-# - 95th percentile: ~8 minutes
-# - 99th percentile: ~14 minutes
+# Sachverhalt (empirically observed, HA history July 2026):
+# A stationary device at home (smartphone with a dark display, or a Bluetooth
+# tag scanned only by the household's own dark-display phones) reports through
+# the FMDN network roughly every ~30 minutes. Every spurious "unknown" flip in
+# the field carried last_seen ~1800-1835 s old, i.e. exactly at the previous
+# 1800 s threshold: the threshold sat directly on the natural home reporting
+# cadence, so any minor delay tipped an otherwise-present device into "stale"
+# and blanked its coordinates until the next report arrived.
 #
-# Note: EID rotation (1024s) is NOT relevant here. When participating in the
-# FMDN network, we receive updates from smartphones that see the tracker.
-# The update frequency depends on smartphone density and tracker visibility,
-# not on EID rotation.
+# The earlier 1800 s were calibrated to ACTIVE FMDN tracker-scan statistics
+# (median ~3.4 min, p95 ~8 min, p99 ~14 min) that hold when many foreign
+# phones continuously scan a tracker. They do NOT hold for a device sitting at
+# home: a dozing smartphone reports its own position only occasionally, and a
+# tag at home is seen only by the few (also dozing) household phones. A shorter
+# poll does not help - Google returns the last reported fix for a dozing
+# device, so last_seen only advances when the device itself reports.
 #
-# Default: 1800 seconds (30 minutes) - conservative value for "really gone"
-# Minimum: 300 seconds (5 minutes) - allows ~2-3 typical update cycles
-DEFAULT_STALE_THRESHOLD: int = 1800
+# Entscheidungsgrundlage for the default: 3900 s (65 minutes) ~= 2x the
+# observed ~30 min home cadence plus margin to tolerate one missed report
+# cycle, which removes the flapping for both smartphones and tags while still
+# flagging a genuinely absent device within ~1 h. The threshold stays
+# user-configurable (min 300 s, max 86400 s); only the default was mistuned.
+#
+# Note: EID rotation (1024s) is NOT relevant here.
+# Default: 3900 seconds (65 minutes) - ~2x the observed home reporting cadence
+# Minimum: 300 seconds (5 minutes) - allows ~2-3 active-scan update cycles
+DEFAULT_STALE_THRESHOLD: int = 3900
 DEFAULT_SHOW_LOCATION_AGE: bool = True
 
 CONTRIBUTOR_MODE_HIGH_TRAFFIC: str = "high_traffic"

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -1134,7 +1134,15 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             self._attr_location_accuracy = 0.0
             self._attr_location_name = None
         else:
-            data = self._current_row() or self._last_good_accuracy_data
+            # Prefer the current row, but only if it carries a usable accuracy.
+            # A fresh update can arrive with valid lat/lon yet no accuracy; in
+            # that case fall back to the last fix that DID carry accuracy so an
+            # accuracy-less update does not blank out otherwise-valid
+            # coordinates (spurious "unknown"). The write path keeps
+            # ``_last_good_accuracy_data`` restricted to accuracy-bearing fixes.
+            data = self._current_row()
+            if not data or data.get("accuracy") is None:
+                data = self._last_good_accuracy_data
             if not data or data.get("accuracy") is None:
                 # Accuracy must be present for a valid GPS fix; without it
                 # HA's zone engine raises TypeError on comparison.
@@ -1237,11 +1245,19 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
 
         lat = device_data.get("latitude")
         lon = device_data.get("longitude")
+        acc = device_data.get("accuracy")
 
-        if lat is not None and lon is not None:
+        if lat is not None and lon is not None and acc is not None:
+            # Only cache fixes that actually carry accuracy; the read-path
+            # fallback in _sync_location_attrs relies on this cache holding a
+            # usable fix (its name is _last_good_ACCURACY_data). Overwriting it
+            # with an accuracy-less fix would poison the fallback and could
+            # blank valid coordinates on a later accuracy-less update.
             self._last_good_accuracy_data = device_data.copy()
         elif self._last_good_accuracy_data is None:
-            # Preserve semantic-only updates when no prior location is available.
+            # Bootstrap only: preserve the first update (semantic-only or
+            # accuracy-less) when nothing better has been seen yet, so the
+            # entity still has *something* to report.
             self._last_good_accuracy_data = device_data.copy()
 
         self._sync_location_attrs()

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import time
 from collections.abc import Callable, Coroutine
 from types import SimpleNamespace
 from typing import Any
@@ -14,7 +15,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from custom_components.googlefindmy.const import DOMAIN, TRACKER_SUBENTRY_KEY
+from custom_components.googlefindmy.const import (
+    DEFAULT_STALE_THRESHOLD,
+    DOMAIN,
+    TRACKER_SUBENTRY_KEY,
+)
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from custom_components.googlefindmy.coordinator import registry as coordinator_registry
 from tests.helpers.config_entries_stub import make_config_entry
@@ -810,3 +815,120 @@ async def test_restore_marks_estimated_for_flagless_invalid_accuracy(
 
     assert coordinator.primed["data"]["accuracy"] == 200.0
     assert coordinator.primed["data"]["accuracy_estimated"] is True
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the stale-threshold retune (spurious "unknown" flapping)
+# and the latent accuracy-less-fallback bug B1 (PR #201 follow-up audit).
+#
+# Root cause: a stationary device at home (dozing smartphone, or a tag scanned
+# only by the household's own dozing phones) reports via FMDN roughly every
+# ~30 min. The previous 1800 s default sat exactly on that cadence, so any
+# delayed report tipped an otherwise-present device into "stale" and blanked
+# its coordinates. B1 is the sibling defect: a fresh row with valid lat/lon but
+# no accuracy was blanked instead of falling back to the last accuracy-bearing
+# fix, and the "last good accuracy" cache was overwritten by accuracy-less
+# rows.
+# ---------------------------------------------------------------------------
+
+
+def _make_stale_probe_tracker(coordinator: _ShowAgeCoordinatorStub) -> Any:
+    """Build a tracker with the REAL stale methods (no overrides), so the
+    default threshold actually governs the stale decision."""
+
+    device_tracker = importlib.import_module(
+        "custom_components.googlefindmy.device_tracker"
+    )
+    entity = device_tracker.GoogleFindMyDeviceTracker(
+        coordinator,
+        {"id": "show-age-device", "name": "Tracker"},
+        subentry_key=TRACKER_SUBENTRY_KEY,
+        subentry_identifier=TRACKER_SUBENTRY_KEY,
+    )
+    entity.hass = SimpleNamespace()
+    return entity
+
+
+def test_home_cadence_report_not_stale_under_default_threshold() -> None:
+    """A ~35 min old fix (typical home reporting cadence) must NOT be stale
+    under the retuned default. Under the previous 1800 s default the very same
+    age would have flipped to "stale" and blanked the coordinates."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
+    entity = _make_stale_probe_tracker(coordinator)
+    # 2100 s = 35 min: above the old 1800 s default, below the new 3900 s one.
+    entity._get_location_age = lambda: 2100.0  # type: ignore[method-assign]
+
+    assert entity._get_stale_threshold() == DEFAULT_STALE_THRESHOLD
+    assert DEFAULT_STALE_THRESHOLD > 1800, "default must be retuned above 1800 s"
+    assert entity._is_location_stale() is False, (
+        "a 35 min old home report must not be treated as stale"
+    )
+
+
+def test_accuracy_less_fresh_row_falls_back_to_cached_fix() -> None:
+    """B1 read path: a fresh row with valid lat/lon but no accuracy must fall
+    back to the last accuracy-bearing fix instead of blanking coordinates."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=100.0)
+    # Fresh current row: valid coordinates, but the accuracy key is absent.
+    coordinator._row = {
+        "id": "show-age-device",
+        "device_id": "show-age-device",
+        "name": "Tracker",
+        "latitude": 11.0,
+        "longitude": 21.0,
+        "last_seen": time.time(),
+    }
+    entity = _make_show_age_tracker(coordinator, age_seconds=100.0)
+    # Prime the cache with a good, accuracy-bearing fix.
+    entity._last_good_accuracy_data = {
+        "latitude": 10.0,
+        "longitude": 20.0,
+        "accuracy": 5,
+        "last_seen": time.time() - 100,
+    }
+
+    entity._sync_location_attrs()
+
+    # Coordinates come from the cached accuracy-bearing fix, not nulled.
+    assert entity._attr_latitude == 10.0
+    assert entity._attr_longitude == 20.0
+    assert entity._attr_location_accuracy == 5.0
+
+
+def test_accuracy_less_update_does_not_poison_accuracy_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B1 write path: an accuracy-less update must NOT overwrite the cached
+    accuracy-bearing fix (the cache is _last_good_ACCURACY_data)."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=100.0)
+    coordinator._row = {
+        "id": "show-age-device",
+        "device_id": "show-age-device",
+        "name": "Tracker",
+        "latitude": 11.0,
+        "longitude": 21.0,
+        "last_seen": time.time(),
+    }
+    entity = _make_show_age_tracker(coordinator, age_seconds=100.0)
+    good = {
+        "latitude": 10.0,
+        "longitude": 20.0,
+        "accuracy": 5,
+        "last_seen": time.time() - 100,
+    }
+    entity._last_good_accuracy_data = dict(good)
+    # Isolate the cache-update branch of _handle_coordinator_update.
+    monkeypatch.setattr(entity, "_sync_location_attrs", lambda: None)
+    monkeypatch.setattr(entity, "async_write_ha_state", lambda: None)
+    monkeypatch.setattr(
+        entity, "refresh_device_label_from_coordinator", lambda **kw: None
+    )
+
+    entity._handle_coordinator_update()
+
+    assert entity._last_good_accuracy_data == good, (
+        "an accuracy-less update must not poison the accuracy cache"
+    )


### PR DESCRIPTION
## Summary

Fixes spurious `unknown` flapping of Google Find My device trackers **at home**. Devices that are demonstrably present (a smartphone on the desk, a tag in a drawer) repeatedly flip to `unknown` and back, sometimes within seconds, sometimes ~180 s apart. Root cause: the stale-threshold default was tuned for *active* tracker-scan cadence and sat directly on the natural *home* reporting cadence.

No version bump (stays `1.7.11`).

## Root cause (empirically grounded)

A stationary device at home reports through the FMDN network only about **every ~30 minutes**:
- a **smartphone** with a dark display reports its own position occasionally (Doze / battery saver), and
- a **Bluetooth tag** at home is seen only by the household's own (also dozing) phones, i.e. the very same ~30 min cadence — confirmed empirically from the logs, so this is **not** a smartphone-only effect.

The Home Assistant history showed **every** spurious `unknown` transition carrying `location_status=stale` with `last_seen` aged **1800–1835 s**, i.e. exactly the previous `DEFAULT_STALE_THRESHOLD = 1800`. The threshold sat on the reporting cadence, so any minor delay tipped an otherwise-present device into `stale`, which blanks the coordinates until the next report arrives (1–2 s if it lands immediately, otherwise up to ~180 s over the locate/token cooldown).

The earlier `1800 s` were calibrated to **active** FMDN tracker-scan statistics (median ~3.4 min, p95 ~8 min, p99 ~14 min), which hold when many foreign phones continuously scan a tracker — not for a device sitting at home. A shorter poll does not help: Google returns the last reported fix for a dozing device, so `last_seen` only advances when the device itself reports.

## Changes

**Fix 1 — retune `DEFAULT_STALE_THRESHOLD` 1800 → 3900 s (65 min)** (`const.py`).
~2× the observed ~30 min home cadence plus margin for one missed report cycle. Removes the flapping for **both** smartphones and tags while still flagging a genuinely absent device within ~1 h. The threshold stays user-configurable (`min 300 s`, `max 86400 s`); only the default was mistuned. The code comment is rewritten to state the observed cadence and the decision rationale.

**Fix 2 — latent accuracy-less-fallback bug (same "spurious unknown" family)** (`device_tracker.py`).
- Read path (`_sync_location_attrs`): a fresh row with valid lat/lon but **no accuracy** was blanked to `unknown`. It now falls back to the last accuracy-bearing fix (`_last_good_accuracy_data`) instead of blanking otherwise-valid coordinates.
- Write path (`_handle_coordinator_update`): `_last_good_accuracy_data` is now overwritten **only** by fixes that actually carry accuracy (its name is `_last_good_ACCURACY_data`); an accuracy-less update no longer poisons the fallback cache. The bootstrap `elif … is None` case is preserved so the entity always has something to report.

## Tests

Three new regression tests in `tests/test_device_tracker.py`, each proven sharp by a mutation gegenprobe (revert the fix → its test goes red):
- `test_home_cadence_report_not_stale_under_default_threshold` — a 35 min old home report is not stale under 3900 s (was stale under 1800 s).
- `test_accuracy_less_fresh_row_falls_back_to_cached_fix` — B1 read path.
- `test_accuracy_less_update_does_not_poison_accuracy_cache` — B1 write path.

## Verification

- 2374 tests pass (device_tracker / sensor / coordinator / fcm / restore / stale sweep); 43 in the directly touched families.
- Changed-code coverage: all delta logic lines exercised.
- ruff 0.14.14 **and** 0.15.x (check + format) clean; mypy clean on source and tests; `asyncio.run` guard green.
- Independent read-only terminal-diff review: PASS.

## Risk

Low. A phone that goes offline **at home** (dead battery) now shows its last position as valid for up to ~65 min before turning `unknown`, instead of ~30 min. Leaving the house is unaffected: a moving phone emits fresh fixes. Users who prefer the old behavior can lower the `stale_threshold` option.
