### PR TITLE
fix(gfmy): tie tracker metadata to the published display row (Codex #202)

### DIFF
--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -73,6 +73,13 @@ from .ha_typing import RestoreEntity, TrackerEntity, callback
 
 _LOGGER = logging.getLogger(__name__)
 
+# Sentinel distinguishing "caller passed no row" (fall back to the live
+# current-or-cache lookup) from "caller explicitly passed a row" (which may
+# legitimately be None -> no data). Without this, an explicit None argument
+# would silently fall back to the internal lookup and reintroduce a second
+# source of truth for the published age/status (Codex #202).
+_ROW_UNSET: Any = object()
+
 # Read-only mirror of coordinator state; no I/O performed per-entity.
 PARALLEL_UPDATES = 0
 
@@ -1071,9 +1078,37 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         except (TypeError, ValueError):
             return DEFAULT_STALE_THRESHOLD
 
-    def _get_location_age(self) -> float | None:
-        """Return the age of the location data in seconds, or None if unknown."""
-        data = self._current_row() or self._last_good_accuracy_data
+    def _select_display_row(self) -> dict[str, Any] | None:
+        """Return the single row whose data is actually published.
+
+        This is the one source of truth for every published value (coordinates,
+        name, age, status, extra attributes): the current row if it carries a
+        usable accuracy, otherwise the last accuracy-bearing fix. A fresh update
+        can arrive with valid lat/lon yet no accuracy; publishing coordinates
+        from the cached fix while deriving age/status/attributes from the
+        accuracy-less current row would show cached coordinates with fresh
+        metadata (Codex #202). Binding every consumer to this row keeps the
+        published snapshot internally consistent.
+        """
+        current = self._current_row()
+        if current and current.get("accuracy") is not None:
+            return current
+        return self._last_good_accuracy_data
+
+    def _get_location_age(self, row: Any = _ROW_UNSET) -> float | None:
+        """Return the age of the location data in seconds, or None if unknown.
+
+        With no argument the age reflects the live current-or-cache lookup (used
+        by the liveness gate). When an explicit ``row`` is passed it is used
+        verbatim, so callers can tie the published age to the same row that
+        produced the coordinates (``_ROW_UNSET`` distinguishes "omitted" from an
+        explicit ``None``).
+        """
+        data = (
+            (self._current_row() or self._last_good_accuracy_data)
+            if row is _ROW_UNSET
+            else row
+        )
         if not data:
             return None
         last_seen = data.get("last_seen")
@@ -1093,9 +1128,13 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         threshold = self._get_stale_threshold()
         return age > threshold
 
-    def _get_location_status(self) -> str:
-        """Return the location status string based on data age."""
-        age = self._get_location_age()
+    def _get_location_status(self, row: Any = _ROW_UNSET) -> str:
+        """Return the location status string based on data age.
+
+        Accepts an explicit ``row`` so the published status describes the age of
+        the same row that produced the coordinates (Codex #202).
+        """
+        age = self._get_location_age(row)
         if age is None:
             return "unknown"
         threshold = self._get_stale_threshold()
@@ -1127,6 +1166,14 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         """
         stale = self._is_location_stale()
 
+        # Single source of truth for every published value below (coordinates,
+        # name, age, status, extra attributes). Binding them all to this one
+        # row prevents publishing cached coordinates with fresh metadata from an
+        # accuracy-less current row (Codex #202). The liveness gate above stays
+        # separate on purpose: a live device sending accuracy-less rows must
+        # keep showing its last good position instead of flapping to "unknown".
+        display_data = self._select_display_row()
+
         # --- latitude / longitude / location_accuracy ---
         if stale:
             self._attr_latitude = None
@@ -1134,25 +1181,19 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             self._attr_location_accuracy = 0.0
             self._attr_location_name = None
         else:
-            # Prefer the current row, but only if it carries a usable accuracy.
-            # A fresh update can arrive with valid lat/lon yet no accuracy; in
-            # that case fall back to the last fix that DID carry accuracy so an
-            # accuracy-less update does not blank out otherwise-valid
-            # coordinates (spurious "unknown"). The write path keeps
-            # ``_last_good_accuracy_data`` restricted to accuracy-bearing fixes.
-            data = self._current_row()
-            if not data or data.get("accuracy") is None:
-                data = self._last_good_accuracy_data
-            if not data or data.get("accuracy") is None:
-                # Accuracy must be present for a valid GPS fix; without it
-                # HA's zone engine raises TypeError on comparison.
+            # ``display_data`` already prefers the current row and only falls
+            # back to the cached accuracy-bearing fix when the current row lacks
+            # a usable accuracy. A row without accuracy cannot be published:
+            # HA's zone engine raises TypeError on comparison, so blank the
+            # coordinates in that case.
+            if not display_data or display_data.get("accuracy") is None:
                 self._attr_latitude = None
                 self._attr_longitude = None
                 self._attr_location_accuracy = 0.0
             else:
-                self._attr_latitude = data.get("latitude")
-                self._attr_longitude = data.get("longitude")
-                acc = data.get("accuracy")
+                self._attr_latitude = display_data.get("latitude")
+                self._attr_longitude = display_data.get("longitude")
+                acc = display_data.get("accuracy")
                 try:
                     self._attr_location_accuracy = (
                         float(acc) if acc is not None else 0.0
@@ -1160,14 +1201,13 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
                 except (TypeError, ValueError):
                     self._attr_location_accuracy = 0.0
 
-            # --- location_name ---
-            name_data = self._current_row()
-            if not name_data:
+            # --- location_name (same display row as the coordinates) ---
+            if not display_data:
                 self._attr_location_name = None
             else:
-                lat = name_data.get("latitude")
-                lon = name_data.get("longitude")
-                sem = name_data.get("semantic_name")
+                lat = display_data.get("latitude")
+                lon = display_data.get("longitude")
+                sem = display_data.get("semantic_name")
                 if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
                     # Coordinates present -> let HA zone engine decide.
                     self._attr_location_name = None
@@ -1179,13 +1219,20 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
                 else:
                     self._attr_location_name = sem
 
-        # --- extra_state_attributes ---
-        row = self._current_row()
-        attributes: dict[str, Any] = _as_ha_attributes(row) or {}
+        # --- extra_state_attributes (bound to the SAME display row) ---
+        # Deriving from display_data keeps the attribute set from exposing a
+        # position that differs from the published coordinates (Codex #202).
+        attributes: dict[str, Any] = _as_ha_attributes(display_data) or {}
+        if self._attr_latitude is None:
+            # Coordinates were withheld (stale, or a display row without
+            # accuracy). Strip the positional keys so the attributes never
+            # resurrect coordinates the tracker is deliberately not publishing.
+            for _pos_key in ("latitude", "longitude", "accuracy_m", "altitude_m"):
+                attributes.pop(_pos_key, None)
 
         attributes["google_device_id"] = self.device_id
 
-        location_age = self._get_location_age()
+        location_age = self._get_location_age(display_data)
         # Use the _opt() helper so options-first lookups stay consistent with
         # the rest of the integration and mypy --strict no longer flags the
         # config_entry attribute access (Any | None has no attribute options).
@@ -1204,17 +1251,17 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         # When show_location_age is False the attribute is omitted entirely.
         # Absolute timestamps remain available via the "last_seen" attribute
         # and the sensor.*_last_seen entity.
-        attributes["location_status"] = self._get_location_status()
+        attributes["location_status"] = self._get_location_status(display_data)
 
-        if stale:
-            stale_data = self._current_row() or self._last_good_accuracy_data
-            if stale_data:
-                last_lat = stale_data.get("latitude")
-                last_lon = stale_data.get("longitude")
-                if last_lat is not None:
-                    attributes["last_latitude"] = last_lat
-                if last_lon is not None:
-                    attributes["last_longitude"] = last_lon
+        if stale and display_data:
+            # Main coordinates are withheld while stale; surface the last known
+            # position via dedicated keys instead (same display row).
+            last_lat = display_data.get("latitude")
+            last_lon = display_data.get("longitude")
+            if last_lat is not None:
+                attributes["last_latitude"] = last_lat
+            if last_lon is not None:
+                attributes["last_longitude"] = last_lon
 
         self._attr_extra_state_attributes = attributes
 
@@ -1313,9 +1360,13 @@ class GoogleFindMyLastLocationTracker(GoogleFindMyDeviceTracker):
         """Never stale - always show last known location."""
         return False
 
-    def _get_location_status(self) -> str:
-        """Return location status - always shows 'last_known' when data is aged."""
-        age = self._get_location_age()
+    def _get_location_status(self, row: Any = _ROW_UNSET) -> str:
+        """Return location status - always shows 'last_known' when data is aged.
+
+        Mirrors the parent's ``row`` parameter so the published status describes
+        the same row that produced the coordinates (Codex #202).
+        """
+        age = self._get_location_age(row)
         if age is None:
             return "unknown"
         threshold = self._get_stale_threshold()

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -478,8 +478,8 @@ def _make_show_age_tracker(
     entity.hass = SimpleNamespace()
     # Bypass stale-detection and force a deterministic age value.
     entity._is_location_stale = lambda: False  # type: ignore[method-assign]
-    entity._get_location_age = lambda: age_seconds  # type: ignore[method-assign]
-    entity._get_location_status = lambda: "available"  # type: ignore[method-assign]
+    entity._get_location_age = lambda *a, **k: age_seconds  # type: ignore[method-assign]
+    entity._get_location_status = lambda *a, **k: "available"  # type: ignore[method-assign]
     return entity
 
 
@@ -857,7 +857,7 @@ def test_home_cadence_report_not_stale_under_default_threshold() -> None:
     coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
     entity = _make_stale_probe_tracker(coordinator)
     # 2100 s = 35 min: above the old 1800 s default, below the new 3900 s one.
-    entity._get_location_age = lambda: 2100.0  # type: ignore[method-assign]
+    entity._get_location_age = lambda *a, **k: 2100.0  # type: ignore[method-assign]
 
     assert entity._get_stale_threshold() == DEFAULT_STALE_THRESHOLD
     assert DEFAULT_STALE_THRESHOLD > 1800, "default must be retuned above 1800 s"
@@ -932,3 +932,104 @@ def test_accuracy_less_update_does_not_poison_accuracy_cache(
     assert entity._last_good_accuracy_data == good, (
         "an accuracy-less update must not poison the accuracy cache"
     )
+
+
+def _make_plain_tracker(coordinator: _ShowAgeCoordinatorStub) -> Any:
+    """Build a tracker WITHOUT monkeypatching age/status/stale helpers.
+
+    Used to assert the real derivation ties every published value to the same
+    display row (Codex #202), which the show-age helper cannot verify because it
+    stubs those methods out.
+    """
+    device_tracker = importlib.import_module(
+        "custom_components.googlefindmy.device_tracker"
+    )
+    entity = device_tracker.GoogleFindMyDeviceTracker(
+        coordinator,
+        {"id": "show-age-device", "name": "Tracker"},
+        subentry_key=TRACKER_SUBENTRY_KEY,
+        subentry_identifier=TRACKER_SUBENTRY_KEY,
+    )
+    entity.hass = SimpleNamespace()
+    return entity
+
+
+def test_accuracy_less_row_ties_all_metadata_to_display_row() -> None:
+    """Codex #202: when coordinates fall back to the cached accuracy-bearing
+    fix, the age, status and extra attributes must describe that SAME cached
+    row, never the accuracy-less current row. Otherwise a moving device is shown
+    at cached coordinates with a fresh age and attributes exposing a different
+    lat/lon than the tracker properties."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
+    # Fresh current row: NEW lat/lon and a brand-new last_seen, but no accuracy.
+    coordinator._row = {
+        "id": "show-age-device",
+        "device_id": "show-age-device",
+        "name": "Tracker",
+        "latitude": 11.0,
+        "longitude": 21.0,
+        "last_seen": time.time(),
+    }
+    entity = _make_plain_tracker(coordinator)
+    # Cache: the last accuracy-bearing fix, ~2000 s old, at DIFFERENT
+    # coordinates. 2000 s sits in the "aging" band (> half the 3900 s default,
+    # below the full threshold) so its status differs from the fresh current
+    # row's "current" -- this makes the test sharp against age/status still
+    # being read from the current row.
+    entity._last_good_accuracy_data = {
+        "latitude": 10.0,
+        "longitude": 20.0,
+        "accuracy": 5,
+        "last_seen": time.time() - 2000,
+    }
+
+    entity._sync_location_attrs()
+    attrs = entity._attr_extra_state_attributes
+
+    # The liveness gate stays non-stale (current row is fresh), so coordinates
+    # are still published -- from the cached accuracy-bearing fix.
+    assert entity._attr_latitude == 10.0
+    assert entity._attr_longitude == 20.0
+    # Extra attributes must expose the SAME cached position, not the current
+    # row's 11.0/21.0 (this is the divergence Codex flagged).
+    assert attrs.get("latitude") == 10.0
+    assert attrs.get("longitude") == 20.0
+    # Age/status describe the cached row (~2000 s -> "aging"), NOT the fresh
+    # current row (which would read "current"/age 0).
+    assert attrs["location_status"] == "aging"
+    assert attrs["location_age"] == 1980  # round(2000/60)*60
+
+
+def test_stale_branch_strips_positional_attributes() -> None:
+    """Codex #202 sibling: when stale blanks the tracker coordinates, the extra
+    attributes must not resurrect latitude/longitude; the last known position
+    belongs in the dedicated last_latitude/last_longitude keys."""
+
+    coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
+    coordinator._row = {
+        "id": "show-age-device",
+        "device_id": "show-age-device",
+        "name": "Tracker",
+        "latitude": 12.0,
+        "longitude": 22.0,
+        "accuracy": 8,
+        "last_seen": time.time() - 10000,
+    }
+    entity = _make_plain_tracker(coordinator)
+    entity._is_location_stale = lambda: True  # type: ignore[method-assign]
+
+    entity._sync_location_attrs()
+    attrs = entity._attr_extra_state_attributes
+
+    # Tracker coordinates are withheld while stale.
+    assert entity._attr_latitude is None
+    assert entity._attr_longitude is None
+    # The attribute set must NOT expose latitude/longitude (would contradict the
+    # blanked tracker properties).
+    assert "latitude" not in attrs
+    assert "longitude" not in attrs
+    assert "accuracy_m" not in attrs
+    # The last known position is surfaced via the dedicated keys instead.
+    assert attrs["last_latitude"] == 12.0
+    assert attrs["last_longitude"] == 22.0


### PR DESCRIPTION
## Summary

Codex flagged a Single-Source-of-Truth bug in the device tracker's
`_sync_location_attrs()` introduced by the accuracy-less fallback (#1175):

> When the current row has a new `last_seen` and lat/lon but no `accuracy`, the
> fallback publishes coordinates from `_last_good_accuracy_data`, while
> `_get_location_age()` and `_as_ha_attributes(self._current_row())` still use
> the newer accuracy-less row. In that scenario a moving device can be shown at
> the previous cached coordinates with a fresh/current age/status, and the extra
> attributes may even expose different lat/lon than the tracker properties.

Coordinates fell back to the cached accuracy-bearing fix, but **age, status,
location_name and the extra attributes still read the current (accuracy-less)
row**. Result: cached coordinates stapled to fresh metadata, and an attribute
set exposing a different lat/lon than the published tracker position.

## Fix (architectural: one display row)

A new `_select_display_row()` is the single source of truth for every published
value: the current row if it carries a usable accuracy, otherwise the last
accuracy-bearing fix. Coordinates, `location_name`, `location_age`,
`location_status` and the extra attributes are all bound to that one row, so the
published snapshot is always internally consistent.

The liveness gate `_is_location_stale()` is deliberately **kept separate** on the
current-or-cache lookup. This preserves the goal of the wider PR series: a live
device sending accuracy-less rows (dark display / doze) must keep showing its
last good position with an honest age, instead of flapping to "unknown".

Two supporting details:

- The age/status helpers take an explicit `row` argument guarded by a
  `_ROW_UNSET` sentinel, so an explicit row (which may legitimately be `None`)
  fully overrides the internal fallback instead of silently reintroducing a
  second source of truth. The no-arg call (the liveness gate) still uses the
  current-or-cache lookup.
- When coordinates are withheld (stale, or a display row without accuracy), the
  positional keys (`latitude`/`longitude`/`accuracy_m`/`altitude_m`) are stripped
  from the extra attributes so they never resurrect coordinates the tracker is
  deliberately not publishing. This also closes the same class of bug in the
  stale branch, where `_as_ha_attributes(current_row)` previously leaked lat/lon
  while the tracker coordinates were blanked. The last known position remains
  available via the dedicated `last_latitude`/`last_longitude` keys.

## Tests

- `test_accuracy_less_row_ties_all_metadata_to_display_row`: fresh accuracy-less
  current row + older cached fix at different coordinates; asserts coordinates,
  extra-attribute lat/lon, `location_age` and `location_status` all describe the
  cached display row (not the fresh current row). Fails against the old code.
- `test_stale_branch_strips_positional_attributes`: asserts the stale branch does
  not expose `latitude`/`longitude`/`accuracy_m` and surfaces the last position
  via `last_latitude`/`last_longitude` only.

Each new assertion is mutation-proven (reverting a hunk turns the matching test
red). No version bump (stays 1.7.11).

## Verification

- Full affected regression green (device_tracker + coordinator families).
- Changed-code behavior fully covered; residual uncovered lines are pre-existing
  defensive branches (unchanged logic).
- `ruff check`/`format` (CI pin 0.14.14) and `mypy` clean on source and tests.
- Independent read-only terminal diff review: PASS.
