### PR TITLE
Keep recorder positional keys for stale states + restore last_seen (BSkando #202)

### DIFF
--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -32,6 +32,10 @@ from ..KeyBackup.cloud_key_decryptor import decrypt_eik
 # Re-export helpers subpackage
 from . import helpers
 
+# Re-export the ISO/epoch timestamp parser (dependency-light, used by the
+# device_tracker restore path to recover last_seen after a restart).
+from .helpers import parse_last_seen_timestamp
+
 # Re-export the canonical GPS accuracy normalizer. Exposing it as a direct
 # attribute of the coordinator package (mirroring GoogleFindMyCoordinator) lets
 # lightweight consumers such as map_view resolve it without reaching into the
@@ -101,6 +105,7 @@ __all__ = [
     "get_recorder",
     "is_valid_accuracy",
     "normalize_epoch_seconds",
+    "parse_last_seen_timestamp",
     "recorded_accuracy_pair",
     "resolve_seeded_accuracy",
     "safe_accuracy",

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -524,8 +524,11 @@ def _sync_get_last_gps_from_history(
 
         last_state = samples[-1]
         attrs = getattr(last_state, "attributes", {}) or {}
-        lat = attrs.get("latitude")
-        lon = attrs.get("longitude")
+        # Stale/blank recorded states withhold the plain latitude/longitude keys;
+        # the last known fix lives in the recorder-only last_latitude/last_longitude
+        # keys. Fall back to those so history reconstruction still finds a position.
+        lat = attrs.get("latitude", attrs.get("last_latitude"))
+        lon = attrs.get("longitude", attrs.get("last_longitude"))
         if lat is None or lon is None:
             return None
 
@@ -1664,8 +1667,15 @@ class GoogleFindMyCoordinator(
 
             state = self.hass.states.get(entity_id)
             if state:
-                lat = state.attributes.get("latitude")
-                lon = state.attributes.get("longitude")
+                # Stale/blank states withhold the plain latitude/longitude keys;
+                # fall back to the recorder-only last_latitude/last_longitude so
+                # the snapshot keeps the last known position.
+                lat = state.attributes.get(
+                    "latitude", state.attributes.get("last_latitude")
+                )
+                lon = state.attributes.get(
+                    "longitude", state.attributes.get("last_longitude")
+                )
                 # Same authoritative read as the history path: take accuracy
                 # from accuracy_m (stable producer attribute) over the volatile
                 # gps_accuracy and carry accuracy_estimated, so a fallback radius

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -52,6 +52,7 @@ from .const import (
 from .coordinator import (
     GoogleFindMyCoordinator,
     _as_ha_attributes,
+    parse_last_seen_timestamp,
     recorded_accuracy_pair,
     resolve_seeded_accuracy,
 )
@@ -970,6 +971,22 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             restored = {}
 
         if restored:
+            # Restore last_seen so the recovered fix carries its true age.
+            # _get_location_age() reads ``last_seen`` as an epoch float; without
+            # it the age is unknown and _is_location_stale() assumes "not stale",
+            # so a position that predates the restart would look fresh until the
+            # next poll. The recorded value is an ISO string (or last_seen_utc);
+            # parse_last_seen_timestamp() normalizes both back to epoch seconds.
+            last_seen = parse_last_seen_timestamp(
+                last_state.attributes.get("last_seen")
+            )
+            if last_seen is None:
+                last_seen = parse_last_seen_timestamp(
+                    last_state.attributes.get("last_seen_utc")
+                )
+            if last_seen is not None:
+                restored["last_seen"] = last_seen
+
             self._last_good_accuracy_data = {**restored}
             # Prime coordinator cache using its public API (no private access).
             dev_id = self.device_id

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -1223,13 +1223,14 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         # Deriving from display_data keeps the attribute set from exposing a
         # position that differs from the published coordinates (Codex #202).
         attributes: dict[str, Any] = _as_ha_attributes(display_data) or {}
-        if self._attr_latitude is None:
-            # Coordinates were withheld (stale, or a display row without
-            # accuracy). Strip the positional keys so the attributes never
-            # resurrect coordinates the tracker is deliberately not publishing.
-            for _pos_key in ("latitude", "longitude", "accuracy_m", "altitude_m"):
-                attributes.pop(_pos_key, None)
-
+        # The positional keys (latitude/longitude/accuracy_m/altitude_m) are
+        # deliberately kept even when the entity coordinates are withheld
+        # (stale, or a display row without accuracy). They are recorder-facing
+        # producer keys, distinct from the live entity position (_attr_latitude):
+        # async_added_to_hass() restores the cache from them after a restart and
+        # map_view reads them for location history. Because they come from the
+        # same display row as last_latitude/last_longitude below, no divergence
+        # with the published coordinates is introduced (Codex #202 stays fixed).
         attributes["google_device_id"] = self.device_id
 
         location_age = self._get_location_age(display_data)

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -923,12 +923,17 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         if not last_state:
             return
 
-        # Standard device_tracker attributes (with safe fallbacks for legacy keys)
+        # Standard device_tracker attributes. Fresh states expose the position via
+        # the plain latitude/longitude keys; stale/blank states withhold them (the
+        # producer strips them so a withheld position is not republished as the
+        # live GPS attribute) and keep the last known fix in the recorder-only
+        # last_latitude/last_longitude keys. Fall back to those so a restart still
+        # recovers the last position.
         lat = last_state.attributes.get(
-            ATTR_LATITUDE, last_state.attributes.get("latitude")
+            ATTR_LATITUDE, last_state.attributes.get("last_latitude")
         )
         lon = last_state.attributes.get(
-            ATTR_LONGITUDE, last_state.attributes.get("longitude")
+            ATTR_LONGITUDE, last_state.attributes.get("last_longitude")
         )
         # Read the accuracy value AND its estimated-provenance flag from the
         # same authoritative source as map_view and the snapshot builders:
@@ -1240,14 +1245,22 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         # Deriving from display_data keeps the attribute set from exposing a
         # position that differs from the published coordinates (Codex #202).
         attributes: dict[str, Any] = _as_ha_attributes(display_data) or {}
-        # The positional keys (latitude/longitude/accuracy_m/altitude_m) are
-        # deliberately kept even when the entity coordinates are withheld
-        # (stale, or a display row without accuracy). They are recorder-facing
-        # producer keys, distinct from the live entity position (_attr_latitude):
-        # async_added_to_hass() restores the cache from them after a restart and
-        # map_view reads them for location history. Because they come from the
-        # same display row as last_latitude/last_longitude below, no divergence
-        # with the published coordinates is introduced (Codex #202 stays fixed).
+        # Decouple the live GPS keys from the recorder-only keys. When the live
+        # coordinates are withheld (_attr_latitude is None: stale, or a display
+        # row without usable accuracy), HA's TrackerEntity.state_attributes omits
+        # latitude/longitude -- but extra_state_attributes is merged last
+        # (entity.py: attr |= extra_state_attributes), so leaving the plain
+        # latitude/longitude keys here would republish the withheld position as
+        # the live GPS attribute. closest()/proximity/the built-in map would then
+        # treat a stale fix as the current location (Codex #1177). Strip the plain
+        # keys (via the HA constants, same house-style as the timestamp sensor)
+        # and expose the last known position through the recorder-only
+        # last_latitude/last_longitude keys below. accuracy_m/altitude_m are not
+        # HA GPS attributes and stay untouched, so restore/history/snapshot keep
+        # the accuracy radius (Codex #202 stays fixed: no divergent live position).
+        if self._attr_latitude is None:
+            attributes.pop(ATTR_LATITUDE, None)
+            attributes.pop(ATTR_LONGITUDE, None)
         attributes["google_device_id"] = self.device_id
 
         location_age = self._get_location_age(display_data)
@@ -1271,9 +1284,13 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         # and the sensor.*_last_seen entity.
         attributes["location_status"] = self._get_location_status(display_data)
 
-        if stale and display_data:
-            # Main coordinates are withheld while stale; surface the last known
-            # position via dedicated keys instead (same display row).
+        if self._attr_latitude is None and display_data:
+            # Live coordinates are withheld (stale, or a display row without
+            # usable accuracy -- both blank _attr_latitude, not just stale);
+            # surface the last known position via dedicated recorder-only keys
+            # instead (same display row). These feed the restore/history/snapshot
+            # readers, which fall back to them when the plain latitude/longitude
+            # keys are absent (stripped above).
             last_lat = display_data.get("latitude")
             last_lon = display_data.get("longitude")
             if last_lat is not None:

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -172,6 +172,30 @@ def _fallback_recorded_accuracy_pair(
     return raw, (bool(flag) if flag is not None else None)
 
 
+_PARSE_LAST_SEEN_TIMESTAMP: Any = None
+
+
+def _resolve_parse_last_seen_timestamp() -> Any:
+    """Import the canonical last_seen timestamp parser lazily.
+
+    ``parse_last_seen_timestamp`` is the single source of truth for turning a
+    recorded ``last_seen``/``last_seen_utc`` attribute (numeric epoch or ISO 8601
+    string) back into epoch seconds. Resolving it here (re-exported on
+    ``.coordinator``, exactly like ``_resolve_safe_accuracy``) keeps the map
+    history timestamps in lockstep with the device_tracker restore path instead
+    of re-deriving the parsing in the view. The stub coordinator module exposes
+    it as a direct attribute (see the test loader), mirroring ``safe_accuracy``,
+    so no in-view fallback copy is needed.
+    """
+
+    global _PARSE_LAST_SEEN_TIMESTAMP
+    if _PARSE_LAST_SEEN_TIMESTAMP is None:
+        from .coordinator import parse_last_seen_timestamp as _parse
+
+        _PARSE_LAST_SEEN_TIMESTAMP = _parse
+    return _PARSE_LAST_SEEN_TIMESTAMP
+
+
 # ------------------------------- HTML Helpers -------------------------------
 
 
@@ -388,6 +412,7 @@ class GoogleFindMyMapView(HomeAssistantView):
         safe_accuracy = _resolve_safe_accuracy()
         is_valid_accuracy = _resolve_is_valid_accuracy()
         recorded_accuracy_pair = _resolve_recorded_accuracy_pair()
+        parse_last_seen_timestamp = _resolve_parse_last_seen_timestamp()
         if entity_id:
             try:
                 from homeassistant.components.recorder import get_instance
@@ -455,20 +480,26 @@ class GoogleFindMyMapView(HomeAssistantView):
                             if accuracy_filter > 0 and acc > accuracy_filter:
                                 continue
 
-                            # Determine timestamp (prefer last_seen attribute if available for precision)
+                            # Determine timestamp (prefer the recorded report
+                            # time over the recorder write time for precision).
+                            # Parse ``last_seen`` first, then ``last_seen_utc`` as
+                            # the same fallback, through the canonical parser --
+                            # mirroring the device_tracker restore path, which
+                            # accepts recorder-only rows carrying only
+                            # ``last_seen_utc``. Without the second key those
+                            # restored/legacy rows would plot at ``last_updated``
+                            # (the recorder write/restart time), making a stale
+                            # fix appear fresh and sort/dedupe incorrectly.
                             ts = state.last_updated.timestamp()
-                            raw_last_seen = state.attributes.get("last_seen")
-                            if raw_last_seen is not None:
-                                try:
-                                    ts = float(raw_last_seen)
-                                except (ValueError, TypeError):
-                                    if isinstance(raw_last_seen, str):
-                                        try:
-                                            ts = datetime.fromisoformat(
-                                                raw_last_seen.replace("Z", "+00:00")
-                                            ).timestamp()
-                                        except ValueError:
-                                            pass
+                            parsed_ts = parse_last_seen_timestamp(
+                                state.attributes.get("last_seen")
+                            )
+                            if parsed_ts is None:
+                                parsed_ts = parse_last_seen_timestamp(
+                                    state.attributes.get("last_seen_utc")
+                                )
+                            if parsed_ts is not None:
+                                ts = parsed_ts
 
                             if ts in seen_timestamps:
                                 continue

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -408,8 +408,22 @@ class GoogleFindMyMapView(HomeAssistantView):
                 if entity_id in history:
                     for state in history[entity_id]:
                         try:
-                            lat = float(state.attributes.get("latitude"))
-                            lon = float(state.attributes.get("longitude"))
+                            # Stale/blank recorded states withhold the plain
+                            # latitude/longitude keys; the last known fix lives in
+                            # the recorder-only last_latitude/last_longitude keys.
+                            # Fall back to those so the history still plots the
+                            # point (a TypeError from a fully missing pair is
+                            # caught below and skips the sample).
+                            lat = float(
+                                state.attributes.get(
+                                    "latitude", state.attributes.get("last_latitude")
+                                )
+                            )
+                            lon = float(
+                                state.attributes.get(
+                                    "longitude", state.attributes.get("last_longitude")
+                                )
+                            )
                             # Read the accuracy value AND its estimated-provenance
                             # flag from the same authoritative source. ``accuracy_m``
                             # is the stable producer attribute; it survives Home

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1001,10 +1001,13 @@ def test_accuracy_less_row_ties_all_metadata_to_display_row() -> None:
     assert attrs["location_age"] == 1980  # round(2000/60)*60
 
 
-def test_stale_branch_strips_positional_attributes() -> None:
-    """Codex #202 sibling: when stale blanks the tracker coordinates, the extra
-    attributes must not resurrect latitude/longitude; the last known position
-    belongs in the dedicated last_latitude/last_longitude keys."""
+def test_stale_branch_keeps_recorder_positional_attributes() -> None:
+    """Codex BSkando #202 follow-up: a stale state must KEEP the recorder-facing
+    producer keys (latitude/longitude/accuracy_m) so async_added_to_hass() can
+    re-seed the cache after a restart and map_view retains the location history.
+    These keys are distinct from the live entity coordinates (which stay blanked
+    while stale) and share the same display row as last_latitude/last_longitude,
+    so no #202 divergence is reintroduced."""
 
     coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
     coordinator._row = {
@@ -1022,14 +1025,13 @@ def test_stale_branch_strips_positional_attributes() -> None:
     entity._sync_location_attrs()
     attrs = entity._attr_extra_state_attributes
 
-    # Tracker coordinates are withheld while stale.
+    # Live tracker coordinates are withheld while stale.
     assert entity._attr_latitude is None
     assert entity._attr_longitude is None
-    # The attribute set must NOT expose latitude/longitude (would contradict the
-    # blanked tracker properties).
-    assert "latitude" not in attrs
-    assert "longitude" not in attrs
-    assert "accuracy_m" not in attrs
-    # The last known position is surfaced via the dedicated keys instead.
+    # But the recorder-facing producer keys are preserved for restore + maps.
+    assert attrs["latitude"] == 12.0
+    assert attrs["longitude"] == 22.0
+    assert attrs["accuracy_m"] == 8.0
+    # The dedicated last-known keys remain part of the public attribute contract.
     assert attrs["last_latitude"] == 12.0
     assert attrs["last_longitude"] == 22.0

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -9,6 +9,7 @@ import importlib
 import logging
 import time
 from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -815,6 +816,113 @@ async def test_restore_marks_estimated_for_flagless_invalid_accuracy(
 
     assert coordinator.primed["data"]["accuracy"] == 200.0
     assert coordinator.primed["data"]["accuracy_estimated"] is True
+
+
+@pytest.mark.asyncio
+async def test_restore_recovers_last_seen_age(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restore must recover last_seen so staleness survives a restart.
+
+    Without last_seen the restored row has no age: _get_location_age() returns
+    None and _is_location_stale() assumes "not stale", so a fix that predates
+    the restart looks fresh until the next poll. The restore path parses the
+    recorded ISO last_seen back to epoch seconds and seeds it into the cache
+    row, so the recovered position is correctly aged and flagged stale.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    old_epoch = time.time() - (DEFAULT_STALE_THRESHOLD + 5000)
+    old_iso = (
+        datetime.fromtimestamp(old_epoch, tz=UTC).isoformat().replace("+00:00", "Z")
+    )
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "gps_accuracy": 50,
+            "last_seen": old_iso,
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    # last_seen is recovered as an epoch float within a second of the source.
+    assert seeded["last_seen"] == pytest.approx(old_epoch, abs=1.0)
+    assert entity._last_good_accuracy_data["last_seen"] == pytest.approx(
+        old_epoch, abs=1.0
+    )
+    # Behavioural consequence: the restored row carries its true age and the
+    # status derived from it is "stale" (not the age-less "unknown").
+    age = entity._get_location_age(seeded)
+    assert age is not None and age > DEFAULT_STALE_THRESHOLD
+    assert entity._get_location_status(seeded) == "stale"
+
+
+@pytest.mark.asyncio
+async def test_restore_recovers_last_seen_from_utc_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``last_seen`` is absent, the restore falls back to ``last_seen_utc``.
+
+    Both keys carry the same ISO timestamp; only one may be present in a given
+    recorded state. The fallback keeps the recovered age correct in either case.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    old_epoch = time.time() - (DEFAULT_STALE_THRESHOLD + 5000)
+    old_iso = (
+        datetime.fromtimestamp(old_epoch, tz=UTC).isoformat().replace("+00:00", "Z")
+    )
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "gps_accuracy": 50,
+            # No "last_seen"; only the UTC mirror is recorded.
+            "last_seen_utc": old_iso,
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    assert seeded["last_seen"] == pytest.approx(old_epoch, abs=1.0)
+    assert entity._get_location_status(seeded) == "stale"
+
+
+@pytest.mark.asyncio
+async def test_restore_without_timestamp_leaves_last_seen_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recorded state without any timestamp seeds no last_seen (old behavior).
+
+    With neither ``last_seen`` nor ``last_seen_utc`` present, the restore must
+    not fabricate an age: the key stays absent and the age remains unknown.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "gps_accuracy": 50,
+            # No last_seen / last_seen_utc at all.
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    assert "last_seen" not in seeded
+    assert entity._get_location_age(seeded) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -925,6 +925,47 @@ async def test_restore_without_timestamp_leaves_last_seen_unset(
     assert entity._get_location_age(seeded) is None
 
 
+@pytest.mark.asyncio
+async def test_restore_falls_back_to_recorder_only_coordinates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A state recorded while stale withholds the plain latitude/longitude keys.
+
+    The producer strips them so HA does not republish a withheld position as the
+    live GPS attribute (Codex #1177) and keeps the last known fix in the
+    recorder-only last_latitude/last_longitude keys. Restore must fall back to
+    those so a restart still recovers the position instead of coming up empty.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    old_epoch = time.time() - (DEFAULT_STALE_THRESHOLD + 5000)
+    old_iso = (
+        datetime.fromtimestamp(old_epoch, tz=UTC).isoformat().replace("+00:00", "Z")
+    )
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            # No plain latitude/longitude: this state was stale at record time,
+            # so the producer stripped them. Only the recorder-only keys carry
+            # the last known fix.
+            "last_latitude": 10.0,
+            "last_longitude": 20.0,
+            "accuracy_m": 50,
+            "last_seen": old_iso,
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    # Position recovered via the recorder-only fallback keys.
+    assert seeded["latitude"] == 10.0
+    assert seeded["longitude"] == 20.0
+    # And the recovered fix still carries its true (stale) age.
+    assert seeded["last_seen"] == pytest.approx(old_epoch, abs=1.0)
+
+
 # ---------------------------------------------------------------------------
 # Regression tests for the stale-threshold retune (spurious "unknown" flapping)
 # and the latent accuracy-less-fallback bug B1 (PR #201 follow-up audit).
@@ -1109,13 +1150,14 @@ def test_accuracy_less_row_ties_all_metadata_to_display_row() -> None:
     assert attrs["location_age"] == 1980  # round(2000/60)*60
 
 
-def test_stale_branch_keeps_recorder_positional_attributes() -> None:
-    """Codex BSkando #202 follow-up: a stale state must KEEP the recorder-facing
-    producer keys (latitude/longitude/accuracy_m) so async_added_to_hass() can
-    re-seed the cache after a restart and map_view retains the location history.
-    These keys are distinct from the live entity coordinates (which stay blanked
-    while stale) and share the same display row as last_latitude/last_longitude,
-    so no #202 divergence is reintroduced."""
+def test_stale_branch_strips_live_coordinate_keys() -> None:
+    """Codex #1177: a stale state must NOT leave the plain latitude/longitude keys
+    in extra_state_attributes. HA merges extra_state_attributes last and exposes
+    those keys as the device_tracker GPS attributes, so keeping them would
+    republish the withheld (stale) position as the live location for
+    closest()/proximity/the built-in map. The last known fix is exposed via the
+    recorder-only last_latitude/last_longitude keys instead; accuracy_m is not an
+    HA GPS attribute and stays for restore/history/snapshot."""
 
     coordinator = _ShowAgeCoordinatorStub(options={}, age_seconds=None)
     coordinator._row = {
@@ -1136,10 +1178,12 @@ def test_stale_branch_keeps_recorder_positional_attributes() -> None:
     # Live tracker coordinates are withheld while stale.
     assert entity._attr_latitude is None
     assert entity._attr_longitude is None
-    # But the recorder-facing producer keys are preserved for restore + maps.
-    assert attrs["latitude"] == 12.0
-    assert attrs["longitude"] == 22.0
+    # The plain GPS keys must be stripped so HA does not republish the stale
+    # position as the live location (the #1177 leak).
+    assert "latitude" not in attrs
+    assert "longitude" not in attrs
+    # accuracy_m is not an HA GPS attribute; it stays for restore/history.
     assert attrs["accuracy_m"] == 8.0
-    # The dedicated last-known keys remain part of the public attribute contract.
+    # The last known position is exposed via the recorder-only keys instead.
     assert attrs["last_latitude"] == 12.0
     assert attrs["last_longitude"] == 22.0

--- a/tests/test_map_view_accuracy_estimated.py
+++ b/tests/test_map_view_accuracy_estimated.py
@@ -572,3 +572,54 @@ async def test_map_view_legacy_row_without_flag_prefers_accuracy_m(
     assert len(captured) == 1
     assert captured[0]["accuracy"] == 18.0
     assert captured[0]["accuracy_estimated"] is False
+
+
+@pytest.mark.asyncio
+async def test_map_view_history_uses_last_seen_utc_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row carrying only ``last_seen_utc`` plots at its report time.
+
+    Codex #1177: once the history fallback accepts recorder-only rows, the
+    timestamp logic must parse ``last_seen_utc`` as the same fallback as the
+    device_tracker restore path. Without it a restored/legacy row lacking the
+    plain ``last_seen`` attribute would fall back to ``state.last_updated`` (the
+    recorder write/restart time), making a stale fix appear fresh and
+    sort/dedupe incorrectly. The report time (2024-01-01) and the write time
+    (2024-08-01) are deliberately far apart so the assertion discriminates the
+    fallback from the write-time default.
+    """
+
+    map_view = _load_map_view_module(monkeypatch)
+
+    device_id = "dev-lsu"
+    coordinator = _StubCoordinator(devices=[{"id": device_id, "name": "Device"}])
+    registry = _registry_for("entry-acc", device_id, coordinator)
+    entry, captured = _wire_view(
+        monkeypatch, map_view, device_id=device_id, registry=registry
+    )
+
+    report_time = datetime(2024, 1, 1, tzinfo=UTC)
+    write_time = datetime(2024, 8, 1, tzinfo=UTC)
+    states = [
+        SimpleNamespace(
+            attributes={
+                "latitude": "10.0",
+                "longitude": "20.0",
+                # Only the UTC mirror is present, no plain ``last_seen``.
+                "last_seen_utc": "2024-01-01T00:00:00Z",
+                "accuracy_m": 15.0,
+            },
+            last_updated=write_time,
+            state="legacy-lsu",
+        ),
+    ]
+    _install_history(monkeypatch, states)
+
+    response = await _run_get(map_view, entry, device_id)
+
+    assert response.status == 200
+    assert len(captured) == 1
+    # The point carries the recorded report time, not the recorder write time.
+    assert captured[0]["last_seen"] == pytest.approx(report_time.timestamp())
+    assert captured[0]["last_seen"] != pytest.approx(write_time.timestamp())

--- a/tests/test_map_view_unique_id_resolution.py
+++ b/tests/test_map_view_unique_id_resolution.py
@@ -172,6 +172,34 @@ def _load_real_is_valid_accuracy() -> Any:
     return geo.is_valid_accuracy
 
 
+def _load_real_parse_last_seen_timestamp() -> Any:
+    """Load the canonical ``parse_last_seen_timestamp`` from subentry.py by path.
+
+    Mirrors ``_load_real_safe_accuracy`` so the stub exposes the same timestamp
+    parser that production re-exports on ``coordinator.parse_last_seen_timestamp``.
+    subentry.py imports only ``math``/``datetime``/``typing`` (and defines its own
+    ``normalize_epoch_seconds`` helper), so it loads in isolation without dragging
+    in the heavy integration import chain.
+    """
+
+    subentry_path = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "googlefindmy"
+        / "coordinator"
+        / "helpers"
+        / "subentry.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "googlefindmy_test_subentry", subentry_path
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to load subentry module for testing")
+    subentry = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(subentry)
+    return subentry.parse_last_seen_timestamp
+
+
 def _load_map_view_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     """Load the map_view module with stubbed Home Assistant dependencies."""
 
@@ -269,6 +297,13 @@ def _load_map_view_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     # coordinator/__init__.py) so the map can flag estimated points without the
     # plain ModuleType stub (no __path__) breaking the lazy import.
     coordinator_module.is_valid_accuracy = _load_real_is_valid_accuracy()
+    # Mirror the production re-export of ``parse_last_seen_timestamp`` (see
+    # coordinator/__init__.py) so the map history can normalize recorded
+    # last_seen/last_seen_utc attributes without the plain ModuleType stub (no
+    # __path__) breaking the lazy import.
+    coordinator_module.parse_last_seen_timestamp = (
+        _load_real_parse_last_seen_timestamp()
+    )
     monkeypatch.setitem(
         sys.modules, "custom_components.googlefindmy.coordinator", coordinator_module
     )
@@ -622,3 +657,33 @@ def test_resolve_is_valid_accuracy_falls_back_when_symbol_missing(
 
     # Second call must hit the cache instead of re-resolving (same object).
     assert map_view._resolve_is_valid_accuracy() is is_valid_accuracy
+
+
+def test_map_view_resolves_parse_last_seen_timestamp_under_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The timestamp parser resolver must work under the coordinator stub.
+
+    The stub re-exports ``parse_last_seen_timestamp`` exactly like production
+    (coordinator/__init__.py), so ``_resolve_parse_last_seen_timestamp`` returns
+    the real parser. It normalizes numeric epochs and ISO 8601 strings (incl. the
+    ``last_seen_utc`` mirror) back to epoch seconds, and returns None for
+    unparseable input so the map history can fall through to ``last_updated``.
+    """
+
+    map_view = _load_map_view_module(monkeypatch)
+
+    parse_last_seen_timestamp = map_view._resolve_parse_last_seen_timestamp()
+
+    # ISO 8601 (the recorded last_seen/last_seen_utc shape) -> epoch seconds.
+    assert parse_last_seen_timestamp("2024-01-01T00:00:00Z") == pytest.approx(
+        datetime(2024, 1, 1, tzinfo=UTC).timestamp()
+    )
+    # Numeric epoch passes through as float.
+    assert parse_last_seen_timestamp(1704067200.0) == pytest.approx(1704067200.0)
+    # Unparseable input yields None (caller keeps the last_updated default).
+    assert parse_last_seen_timestamp("not-a-timestamp") is None
+    assert parse_last_seen_timestamp(None) is None
+
+    # Second call must hit the cache instead of re-importing (same object).
+    assert map_view._resolve_parse_last_seen_timestamp() is parse_last_seen_timestamp


### PR DESCRIPTION
## Keep recorder positional keys for stale states, and restore `last_seen` with them (BSkando #202)

This PR is now self-contained: it both restores the known-good recorder contract for stale states **and** recovers `last_seen` on restart, so the two changes can never leave a regression window between them.

### 1. Keep recorder positional keys for stale states (`2b5c8cd`)
PR #1176 introduced a strip that removed the recorder-facing producer keys (`latitude`/`longitude`/`accuracy_m`/`altitude_m`) from the HA attributes whenever the entity coordinates were withheld (stale, or an accuracy-less display row). Those keys are the persistence contract that `async_added_to_hass()` restores from after a restart and that `map_view` reads for history. The strip therefore broke restore + map history for stale states. This removes the strip and restores the long-standing behavior; the attributes stay bound to the same `display_data` row as the coordinates (no #202 divergence returns). `last_latitude`/`last_longitude` are kept (public attribute contract).

### 2. Restore `last_seen` so staleness survives a restart (`640fb77`, folded from #1178)
With the strip gone, stale states record coordinates again, and `async_added_to_hass()` reads them back into the cache. That restore path did not copy the recorded `last_seen`, so `_get_location_age()` returned `None`, `_is_location_stale()` treated the row as not stale, and the old stale coordinates were published as the live position until the next poll. The restore now recovers `last_seen` via the canonical `parse_last_seen_timestamp` (ISO->epoch, `last_seen_utc` fallback), seeding only the persisted timestamp (never `time.time()`). This closes the Codex finding on this PR.

### Verification
- Full device_tracker + coordinator regression green; 3 new restore tests (ISO, UTC fallback, no-timestamp) + inverted stale-recorder-keys test, each mutation-proven.
- ruff 0.14.14 (CI pin) + format + mypy clean, `asyncio.run` guard green.
- No version bump (stays 1.7.11).

## Update: decouple live GPS keys from recorder-only keys (Codex #1177 follow-up)

Codex flagged that PR #1177, after removing the #1176 strip, republished stale
coordinates as the live GPS attribute: when a tracker is stale (or a display row
has no usable accuracy) the entity blanks `_attr_latitude`/`_attr_longitude`, but
`extra_state_attributes` is merged last (`entity.py: attr |= extra_state_attributes`),
so the plain `latitude`/`longitude` keys survived and `closest()`/proximity/the
built-in map treated the stale fix as the current location.

Root cause: the same `latitude`/`longitude` key served two masters (live GPS and
recorder). This change decouples them permanently:

- Producer (`_sync_location_attrs`): strip the plain `latitude`/`longitude` keys
  from `extra_state_attributes` when `_attr_latitude is None` (via the HA
  constants, same house-style as the timestamp sensor). `accuracy_m`/`altitude_m`
  are not HA GPS attributes and stay. The last known position is exposed through
  the recorder-only `last_latitude`/`last_longitude` keys (gate is now
  `_attr_latitude is None`, covering both the stale and the accuracy-less blank
  path, not just `stale`).
- The four recorder readers fall back from the plain `latitude` to
  `last_latitude`: restore (`async_added_to_hass`), map history (`map_view.py`),
  history reconstruction and the snapshot builder (`coordinator/main.py`).

Result: the live GPS attribute hangs solely on `_attr_latitude`; restore, map
history and the snapshot keep the last known position via the recorder-only keys.
This folds the earlier separate `last_seen`-restore fix (PR #1178, closed) into
this PR so #1177 is self-contained.

Tests: the stale regression test is inverted (stale strips the plain keys, keeps
`accuracy_m` + `last_*`); a new restore test proves the fallback recovers the
position from the recorder-only keys. Mutation-checked (strip and fallback both
turn the tests red). No version bump.


---

**Follow-up (commit `e6d5a43`, Codex review of `c7ec354`): tie map history timestamps to the recorder-only shape.**

Once the map history fallback accepts recorder-only rows (`last_latitude`/`last_longitude`), the timestamp logic must match the restore path's contract. The history loop still parsed only `last_seen` with its own inline parser and otherwise fell back to `state.last_updated` (the recorder write/restart time). A restored/legacy row carrying only `last_seen_utc` (a shape the restore path in this PR explicitly supports) would then plot the old fix at the write time, making a stale point look fresh and sort/dedupe incorrectly.

Fix: route the map history timestamp through the canonical `parse_last_seen_timestamp` helper and add `last_seen_utc` as the same fallback (`last_seen` > `last_seen_utc` > `last_updated`), mirroring the device_tracker restore path. The helper is resolved lazily (`_resolve_parse_last_seen_timestamp`) exactly like `_resolve_safe_accuracy`; the lightweight coordinator test stub exposes it as a direct attribute, so no in-view fallback copy is needed. This also removes the duplicated inline timestamp parser (DRY). Two new tests (report-time-vs-write-time discriminator, mutation-sharp; resolver-under-stub). No version bump.
