### PR TITLE
fix(gfmy): restore last_seen so staleness survives a restart

### DIFF
--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -32,6 +32,10 @@ from ..KeyBackup.cloud_key_decryptor import decrypt_eik
 # Re-export helpers subpackage
 from . import helpers
 
+# Re-export the ISO/epoch timestamp parser (dependency-light, used by the
+# device_tracker restore path to recover last_seen after a restart).
+from .helpers import parse_last_seen_timestamp
+
 # Re-export the canonical GPS accuracy normalizer. Exposing it as a direct
 # attribute of the coordinator package (mirroring GoogleFindMyCoordinator) lets
 # lightweight consumers such as map_view resolve it without reaching into the
@@ -101,6 +105,7 @@ __all__ = [
     "get_recorder",
     "is_valid_accuracy",
     "normalize_epoch_seconds",
+    "parse_last_seen_timestamp",
     "recorded_accuracy_pair",
     "resolve_seeded_accuracy",
     "safe_accuracy",

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -52,6 +52,7 @@ from .const import (
 from .coordinator import (
     GoogleFindMyCoordinator,
     _as_ha_attributes,
+    parse_last_seen_timestamp,
     recorded_accuracy_pair,
     resolve_seeded_accuracy,
 )
@@ -970,6 +971,22 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             restored = {}
 
         if restored:
+            # Restore last_seen so the recovered fix carries its true age.
+            # _get_location_age() reads ``last_seen`` as an epoch float; without
+            # it the age is unknown and _is_location_stale() assumes "not stale",
+            # so a position that predates the restart would look fresh until the
+            # next poll. The recorded value is an ISO string (or last_seen_utc);
+            # parse_last_seen_timestamp() normalizes both back to epoch seconds.
+            last_seen = parse_last_seen_timestamp(
+                last_state.attributes.get("last_seen")
+            )
+            if last_seen is None:
+                last_seen = parse_last_seen_timestamp(
+                    last_state.attributes.get("last_seen_utc")
+                )
+            if last_seen is not None:
+                restored["last_seen"] = last_seen
+
             self._last_good_accuracy_data = {**restored}
             # Prime coordinator cache using its public API (no private access).
             dev_id = self.device_id

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -9,6 +9,7 @@ import importlib
 import logging
 import time
 from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -815,6 +816,113 @@ async def test_restore_marks_estimated_for_flagless_invalid_accuracy(
 
     assert coordinator.primed["data"]["accuracy"] == 200.0
     assert coordinator.primed["data"]["accuracy_estimated"] is True
+
+
+@pytest.mark.asyncio
+async def test_restore_recovers_last_seen_age(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restore must recover last_seen so staleness survives a restart.
+
+    Without last_seen the restored row has no age: _get_location_age() returns
+    None and _is_location_stale() assumes "not stale", so a fix that predates
+    the restart looks fresh until the next poll. The restore path parses the
+    recorded ISO last_seen back to epoch seconds and seeds it into the cache
+    row, so the recovered position is correctly aged and flagged stale.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    old_epoch = time.time() - (DEFAULT_STALE_THRESHOLD + 5000)
+    old_iso = (
+        datetime.fromtimestamp(old_epoch, tz=UTC).isoformat().replace("+00:00", "Z")
+    )
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "gps_accuracy": 50,
+            "last_seen": old_iso,
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    # last_seen is recovered as an epoch float within a second of the source.
+    assert seeded["last_seen"] == pytest.approx(old_epoch, abs=1.0)
+    assert entity._last_good_accuracy_data["last_seen"] == pytest.approx(
+        old_epoch, abs=1.0
+    )
+    # Behavioural consequence: the restored row carries its true age and the
+    # status derived from it is "stale" (not the age-less "unknown").
+    age = entity._get_location_age(seeded)
+    assert age is not None and age > DEFAULT_STALE_THRESHOLD
+    assert entity._get_location_status(seeded) == "stale"
+
+
+@pytest.mark.asyncio
+async def test_restore_recovers_last_seen_from_utc_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``last_seen`` is absent, the restore falls back to ``last_seen_utc``.
+
+    Both keys carry the same ISO timestamp; only one may be present in a given
+    recorded state. The fallback keeps the recovered age correct in either case.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    old_epoch = time.time() - (DEFAULT_STALE_THRESHOLD + 5000)
+    old_iso = (
+        datetime.fromtimestamp(old_epoch, tz=UTC).isoformat().replace("+00:00", "Z")
+    )
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "gps_accuracy": 50,
+            # No "last_seen"; only the UTC mirror is recorded.
+            "last_seen_utc": old_iso,
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    assert seeded["last_seen"] == pytest.approx(old_epoch, abs=1.0)
+    assert entity._get_location_status(seeded) == "stale"
+
+
+@pytest.mark.asyncio
+async def test_restore_without_timestamp_leaves_last_seen_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recorded state without any timestamp seeds no last_seen (old behavior).
+
+    With neither ``last_seen`` nor ``last_seen_utc`` present, the restore must
+    not fabricate an age: the key stays absent and the age remains unknown.
+    """
+
+    coordinator = _RestoreCoordinatorStub()
+    entity = _build_restore_entity(
+        coordinator,
+        monkeypatch,
+        {
+            "latitude": 10.0,
+            "longitude": 20.0,
+            "gps_accuracy": 50,
+            # No last_seen / last_seen_utc at all.
+        },
+    )
+
+    await entity.async_added_to_hass()
+
+    seeded = coordinator.primed["data"]
+    assert "last_seen" not in seeded
+    assert entity._get_location_age(seeded) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Follow-up to the recorder-keys fix (#1177) and BSkando PR #202. Fable's review of that fix raised an orthogonal, pre-existing issue in the restart restore path.

`async_added_to_hass()` re-seeds the coordinator cache from the last recorded state so a cold boot shows a sensible position before the first poll. It restores `latitude`/`longitude`/`accuracy`/`accuracy_estimated`, but **not** `last_seen`.

Consequence: `_get_location_age()` reads `last_seen` as an epoch float. Without it the age is unknown, and `_is_location_stale()` returns `False` ("assume not stale"). So after a restart an old restored fix is presented as **fresh** (status `unknown`, coordinates shown) until the next real poll, hiding that the position predates the restart.

## Fix

In the `if restored:` block, parse the recorded `last_seen` (an ISO-8601 string, or `last_seen_utc` as fallback) back to epoch seconds and seed it into the restored cache row. The recovered position then carries its true age, so `_get_location_age()` returns the real age and the status derives correctly (`stale`/`aging`/`current` instead of the age-less `unknown`).

The parse uses the existing dependency-light helper `parse_last_seen_timestamp` (`coordinator/helpers/subentry.py`), which already handles numeric epochs, millisecond epochs, and ISO-8601 strings and is covered by its own tests. It is now re-exported at the `coordinator` package top level (next to `normalize_epoch_seconds`), the same channel `device_tracker` already uses for `recorded_accuracy_pair`.

Considered and rejected: importing `location_recorder._extract_last_seen`. That module carries heavy top-level `homeassistant.components.recorder` imports and is otherwise only imported lazily, so a top-level import from `device_tracker` would pull the recorder dependency into its import graph (coupling regression). The dependency-light `parse_last_seen_timestamp` avoids that.

## Verification

- New regression test `test_restore_recovers_last_seen_age`: a restored state with an old ISO `last_seen` yields a seeded row whose `last_seen` is the correct epoch, and whose derived status is `stale` (not the age-less `unknown`). Mutation-checked (dropping the `last_seen` seed turns it red with `KeyError`).
- `parse_last_seen_timestamp` re-export smoke-checked; its own subentry tests stay green.
- Broad regression across device_tracker/coordinator/subentry/map_view/restore green (1799).
- ruff 0.14.14 (CI pin) + isort + format clean, mypy clean, `asyncio.run` guard green, ASCII-only additions.
- Diff is 3 files, +67/-0 (pure additions); `location_recorder` untouched. No version bump (stays 1.7.11).
