### PR TITLE
feat(sensor): Plus Code (Open Location Code) sensor and map popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,10 @@ message listing the available IDs so you can pick the right account.
 - Böttger, L. (2024). GoogleFindMyTools [Computer software]. https://github.com/leonboe1/GoogleFindMyTools
 - Firebase Cloud Messaging integration. https://github.com/home-assistant/mobile-apps-fcm-push
 - @txitxo0 for his amazing work on the MQTT based tool that I used to help kickstart this project!
+- Open Location Code (Plus Code) encoder, (c) Google (Apache-2.0), vendored from
+  [google/open-location-code](https://github.com/google/open-location-code),
+  commit `dcff1534f70a0d7244d0d1c357c20f0aa28ab355`; modified: encode-only path.
+  See [`custom_components/googlefindmy/vendor/openlocationcode/LICENSE`](custom_components/googlefindmy/vendor/openlocationcode/LICENSE).
 
 [1]: https://developers.home-assistant.io/blog/2019/10/05/simple-mode/?utm_source=chatgpt.com "Simple Mode in Home Assistant 1.0"
 

--- a/custom_components/googlefindmy/coordinator/__init__.py
+++ b/custom_components/googlefindmy/coordinator/__init__.py
@@ -42,10 +42,14 @@ from .helpers import parse_last_seen_timestamp
 # nested .helpers.geo submodule, which keeps them tolerant of plain ModuleType
 # coordinator stubs in tests. geo is a pure, dependency-light module.
 from .helpers.geo import (
+    has_usable_accuracy,
     is_valid_accuracy,
+    location_age_seconds,
     recorded_accuracy_pair,
     resolve_seeded_accuracy,
+    resolve_stale_threshold,
     safe_accuracy,
+    select_display_row,
 )
 
 # Re-export stats classes from helpers (commonly needed)
@@ -103,12 +107,16 @@ __all__ = [
     # Public functions
     "format_epoch_utc",
     "get_recorder",
+    "has_usable_accuracy",
     "is_valid_accuracy",
+    "location_age_seconds",
     "normalize_epoch_seconds",
     "parse_last_seen_timestamp",
     "recorded_accuracy_pair",
     "resolve_seeded_accuracy",
+    "resolve_stale_threshold",
     "safe_accuracy",
+    "select_display_row",
     # Semi-public functions
     "_as_ha_attributes",
     "_sync_get_last_gps_from_history",

--- a/custom_components/googlefindmy/coordinator/helpers/geo.py
+++ b/custom_components/googlefindmy/coordinator/helpers/geo.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, TypeVar
+
+_RowT = TypeVar("_RowT", bound=Mapping[str, Any])
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -243,6 +245,84 @@ def recorded_accuracy_pair(
         raw = attributes.get("gps_accuracy")
     flag = attributes.get("accuracy_estimated")
     return raw, (bool(flag) if flag is not None else None)
+
+
+# ---------------------------------------------------------------------------
+# Display-row selection & staleness
+# ---------------------------------------------------------------------------
+# Single source of truth for "which fix actually gets published" and "is that
+# fix too old to publish". The device_tracker owns the stateful last-good cache
+# and its restore wiring; these pure helpers let every location consumer
+# (tracker, Plus Code sensor) apply the identical accuracy/staleness gate so no
+# consumer publishes a coordinate the tracker deliberately hides (Codex #202 /
+# PR #1179).
+
+
+def has_usable_accuracy(row: Mapping[str, Any] | None) -> bool:
+    """Return ``True`` when ``row`` carries a non-``None`` accuracy.
+
+    Mirrors the tracker's publish gate: an accuracy-less fix is deliberately
+    withheld (HA's zone engine raises ``TypeError`` comparing it, and the
+    integration hides accuracy-less positions on purpose).
+    """
+    return row is not None and row.get("accuracy") is not None
+
+
+def select_display_row(
+    current: _RowT | None,
+    last_good: _RowT | None,
+) -> _RowT | None:
+    """Return the single row whose data is actually published.
+
+    The current row when it carries a usable accuracy, otherwise the last
+    accuracy-bearing fix. Binding every consumer to this one row keeps the
+    published snapshot internally consistent: a fresh update can arrive with
+    valid lat/lon yet no accuracy, and publishing that coordinate would leak a
+    position the tracker hides (Codex #202).
+    """
+    if has_usable_accuracy(current):
+        return current
+    return last_good
+
+
+def location_age_seconds(row: Mapping[str, Any] | None, now: float) -> float | None:
+    """Return the age of ``row`` in seconds relative to ``now``, or ``None``.
+
+    ``now`` is injected rather than read from the clock so the computation stays
+    pure and testable. Returns ``None`` when there is no row or its ``last_seen``
+    is missing or non-numeric.
+    """
+    if not row:
+        return None
+    last_seen = row.get("last_seen")
+    if last_seen is None:
+        return None
+    try:
+        return now - float(last_seen)
+    except (TypeError, ValueError):
+        return None
+
+
+def resolve_stale_threshold(coordinator: Any) -> int:
+    """Return the configured stale threshold in seconds for ``coordinator``.
+
+    Duck-typed SSOT reader shared by the device_tracker and the Plus Code
+    sensor: reads ``config_entry.options[OPT_STALE_THRESHOLD]`` and falls back
+    to ``DEFAULT_STALE_THRESHOLD`` on any absence or malformed value.
+    """
+    from ...const import DEFAULT_STALE_THRESHOLD, OPT_STALE_THRESHOLD
+
+    entry = getattr(coordinator, "config_entry", None)
+    if entry is None:
+        return DEFAULT_STALE_THRESHOLD
+    options = getattr(entry, "options", {})
+    if not isinstance(options, Mapping):
+        return DEFAULT_STALE_THRESHOLD
+    threshold = options.get(OPT_STALE_THRESHOLD, DEFAULT_STALE_THRESHOLD)
+    try:
+        return int(threshold)
+    except (TypeError, ValueError):
+        return DEFAULT_STALE_THRESHOLD
 
 
 def resolve_seeded_accuracy(raw: Any, flag: bool | None) -> tuple[float, bool | None]:

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -43,18 +43,19 @@ from .const import (
     CONF_OAUTH_TOKEN,
     DATA_SECRET_BUNDLE,
     DEFAULT_SHOW_LOCATION_AGE,
-    DEFAULT_STALE_THRESHOLD,
     DOMAIN,
     OPT_SHOW_LOCATION_AGE,
-    OPT_STALE_THRESHOLD,
     TRACKER_SUBENTRY_KEY,
 )
 from .coordinator import (
     GoogleFindMyCoordinator,
     _as_ha_attributes,
+    location_age_seconds,
     parse_last_seen_timestamp,
     recorded_accuracy_pair,
     resolve_seeded_accuracy,
+    resolve_stale_threshold,
+    select_display_row,
 )
 from .discovery import (
     CLOUD_DISCOVERY_NAMESPACE,
@@ -1087,18 +1088,12 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         return True
 
     def _get_stale_threshold(self) -> int:
-        """Return the configured stale threshold in seconds."""
-        entry = getattr(self.coordinator, "config_entry", None)
-        if entry is None:
-            return DEFAULT_STALE_THRESHOLD
-        options = getattr(entry, "options", {})
-        if not isinstance(options, Mapping):
-            return DEFAULT_STALE_THRESHOLD
-        threshold = options.get(OPT_STALE_THRESHOLD, DEFAULT_STALE_THRESHOLD)
-        try:
-            return int(threshold)
-        except (TypeError, ValueError):
-            return DEFAULT_STALE_THRESHOLD
+        """Return the configured stale threshold in seconds.
+
+        Delegates to the shared SSOT reader so the tracker and the Plus Code
+        sensor resolve the threshold identically.
+        """
+        return resolve_stale_threshold(self.coordinator)
 
     def _select_display_row(self) -> dict[str, Any] | None:
         """Return the single row whose data is actually published.
@@ -1112,10 +1107,7 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
         metadata (Codex #202). Binding every consumer to this row keeps the
         published snapshot internally consistent.
         """
-        current = self._current_row()
-        if current and current.get("accuracy") is not None:
-            return current
-        return self._last_good_accuracy_data
+        return select_display_row(self._current_row(), self._last_good_accuracy_data)
 
     def _get_location_age(self, row: Any = _ROW_UNSET) -> float | None:
         """Return the age of the location data in seconds, or None if unknown.
@@ -1131,16 +1123,7 @@ class GoogleFindMyDeviceTracker(GoogleFindMyDeviceEntity, TrackerEntity, Restore
             if row is _ROW_UNSET
             else row
         )
-        if not data:
-            return None
-        last_seen = data.get("last_seen")
-        if last_seen is None:
-            return None
-        try:
-            last_seen_epoch = float(last_seen)
-            return time.time() - last_seen_epoch
-        except (TypeError, ValueError):
-            return None
+        return location_age_seconds(data, time.time())
 
     def _is_location_stale(self) -> bool:
         """Return True if the location data is considered stale."""

--- a/custom_components/googlefindmy/icons.json
+++ b/custom_components/googlefindmy/icons.json
@@ -57,6 +57,9 @@
       "last_seen": {
         "default": "mdi:clock-outline"
       },
+      "plus_code": {
+        "default": "mdi:map-marker"
+      },
       "semantic_labels": {
         "default": "mdi:format-list-text"
       },

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -626,9 +626,7 @@ class GoogleFindMyMapView(HomeAssistantView):
                                         ts, tz=dt_util.UTC
                                     ).isoformat(),
                                     last_seen=ts,
-                                    is_own_report=state.attributes.get(
-                                        "is_own_report"
-                                    ),
+                                    is_own_report=state.attributes.get("is_own_report"),
                                     semantic_location=state.attributes.get(
                                         "semantic_name"
                                     ),

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -28,6 +28,7 @@ from .const import (
     map_token_secret_seed,
 )
 from .ha_typing import HomeAssistantView
+from .vendor.openlocationcode import encode as _encode_plus_code
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,6 +44,98 @@ def _resolve_coordinator_class() -> type[Any]:
 
         _COORDINATOR_CLASS = _GoogleFindMyCoordinator
     return _COORDINATOR_CLASS
+
+
+# Inline SVG "content copy" icon (no icon-font dependency). Braceless, so it is
+# safe to interpolate into the map HTML f-string via a single placeholder.
+_MAP_COPY_ICON_SVG = (
+    '<svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">'
+    '<path fill="currentColor" d="M16 1H4a2 2 0 0 0-2 2v12h2V3h12V1zm3 4H8a2 2 '
+    "0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"
+    '"/></svg>'
+)
+
+# Clipboard copy helper injected once into the map <script>. Defined as a plain
+# (non-f) string so its literal JS braces need no doubling; it is interpolated
+# into the f-string via a single ``{_MAP_COPY_HELPER_JS}`` placeholder.
+#
+# Secure-context aware: navigator.clipboard is undefined on plain-LAN
+# http://<ip>:8123 (window.isSecureContext === false); fall back to a hidden
+# textarea + execCommand so copy still works outside HTTPS / Nabu Casa.
+_MAP_COPY_HELPER_JS = """
+        function gfmyFlashCopied(iconEl) {
+            if (!iconEl) { return; }
+            iconEl.classList.add('gfmy-copied');
+            setTimeout(function() { iconEl.classList.remove('gfmy-copied'); }, 1000);
+        }
+        function gfmyFallbackCopy(value) {
+            var ta = document.createElement('textarea');
+            ta.value = value;            // property assignment, never innerHTML
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'absolute';
+            ta.style.left = '-9999px';
+            document.body.appendChild(ta);
+            ta.select();
+            try { document.execCommand('copy'); } catch (e) { /* no-op */ }
+            document.body.removeChild(ta);
+        }
+        function gfmyCopyToClipboard(value, iconEl) {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(value).then(
+                    function() { gfmyFlashCopied(iconEl); },
+                    function() { gfmyFallbackCopy(value); gfmyFlashCopied(iconEl); }
+                );
+                return;
+            }
+            gfmyFallbackCopy(value);
+            gfmyFlashCopied(iconEl);
+        }
+"""
+
+
+def _plus_code_for(lat: float, lon: float) -> str | None:
+    """Return the full 10-digit Plus Code for a coordinate, or None if invalid.
+
+    Offline, deterministic, no API key. Guards non-finite (NaN/inf) inputs so a
+    corrupted fix yields no code rather than a bogus one. The 10-digit code is an
+    11-character string including the ``+`` separator (e.g. ``8FVC9G8F+6X``).
+    """
+    try:
+        if not math.isfinite(lat) or not math.isfinite(lon):
+            return None
+        return _encode_plus_code(float(lat), float(lon), 10)
+    except (ValueError, TypeError):
+        return None
+
+
+def _build_location_entry(
+    *,
+    lat: float,
+    lon: float,
+    accuracy: float,
+    accuracy_estimated: bool,
+    timestamp: str,
+    last_seen: float,
+    is_own_report: Any,
+    semantic_location: Any,
+) -> dict[str, Any]:
+    """Build one map location payload dict, incl. the derived Plus Code.
+
+    Extracted as a pure module function so the server-side ``plus_code`` wiring
+    is unit-testable without the HTTP stack. All pre-existing fields are passed
+    through unchanged; ``plus_code`` is the only added key.
+    """
+    return {
+        "lat": lat,
+        "lon": lon,
+        "accuracy": accuracy,
+        "accuracy_estimated": accuracy_estimated,
+        "timestamp": timestamp,
+        "last_seen": last_seen,
+        "is_own_report": is_own_report,
+        "semantic_location": semantic_location,
+        "plus_code": _plus_code_for(lat, lon),
+    }
 
 
 _SAFE_ACCURACY: Any = None
@@ -524,22 +617,22 @@ class GoogleFindMyMapView(HomeAssistantView):
                                 else not is_valid_accuracy(raw_accuracy)
                             )
                             locations.append(
-                                {
-                                    "lat": lat,
-                                    "lon": lon,
-                                    "accuracy": acc,
-                                    "accuracy_estimated": estimated,
-                                    "timestamp": datetime.fromtimestamp(
+                                _build_location_entry(
+                                    lat=lat,
+                                    lon=lon,
+                                    accuracy=acc,
+                                    accuracy_estimated=estimated,
+                                    timestamp=datetime.fromtimestamp(
                                         ts, tz=dt_util.UTC
                                     ).isoformat(),
-                                    "last_seen": ts,
-                                    "is_own_report": state.attributes.get(
+                                    last_seen=ts,
+                                    is_own_report=state.attributes.get(
                                         "is_own_report"
                                     ),
-                                    "semantic_location": state.attributes.get(
+                                    semantic_location=state.attributes.get(
                                         "semantic_name"
                                     ),
-                                }
+                                )
                             )
                         except (ValueError, TypeError, KeyError):
                             continue  # Skip invalid states
@@ -611,6 +704,9 @@ class GoogleFindMyMapView(HomeAssistantView):
         }}
         button:hover {{ background: #0056b3; }}
         .stats {{ font-size: 12px; color: #666; text-align: center; margin-top: 10px; border-top: 1px solid #eee; padding-top: 5px; }}
+        .gfmy-copy {{ cursor: pointer; color: #007bff; display: inline-flex; vertical-align: middle; margin-left: 3px; }}
+        .gfmy-copy:hover {{ color: #0056b3; }}
+        .gfmy-copy.gfmy-copied {{ color: #28a745; }}
     </style>
 </head>
 <body>
@@ -645,6 +741,8 @@ class GoogleFindMyMapView(HomeAssistantView):
 
         var locations = {locations_json};
         var markers = L.layerGroup().addTo(map);
+        var GFMY_COPY_ICON = '{_MAP_COPY_ICON_SVG}';
+{_MAP_COPY_HELPER_JS}
 
         // Accuracy-circle / marker-fade constants (two separate concerns):
         // FOCUS_FILL_OPACITY: fill of the single focus disc. Deliberately below
@@ -726,18 +824,58 @@ class GoogleFindMyMapView(HomeAssistantView):
                 var date = new Date(loc.timestamp).toLocaleString();
                 var source = loc.is_own_report ? "Own Device" : "Crowdsourced";
 
-                // autoPan: false keeps the auto-opened popup from panning the map
-                // away from fitBounds (see plan risk: openPopup autoPan jump).
-                marker.bindPopup(
+                // Google-Maps-ready decimal degrees: dot decimal separator (JS
+                // default) and "lat, lon" order with a comma+space separator.
+                var coordStr = loc.lat + ", " + loc.lon;
+                var popupHtml =
                     "<b>Time:</b> " + date + "<br>" +
                     "<b>Accuracy:</b> " + loc.accuracy.toFixed(1) + "m<br>" +
-                    "<b>Source:</b> " + source + "<br>" +
-                    (loc.semantic_location ? "<b>Location:</b> " + loc.semantic_location : ""),
-                    {{autoPan: false}}
-                );
+                    "<b>Source:</b> " + source + "<br>";
+                if (loc.semantic_location) {{
+                    popupHtml += "<b>Location:</b> " + loc.semantic_location + "<br>";
+                }}
+                if (loc.plus_code) {{
+                    popupHtml += "<b>Plus Code:</b> " + loc.plus_code +
+                        " <span class='gfmy-copy gfmy-copy-plus' role='button' tabindex='0'" +
+                        " title='Copy to clipboard'" +
+                        " aria-label='Copy Plus Code to clipboard'>" +
+                        GFMY_COPY_ICON + "</span><br>";
+                }}
+                popupHtml += "<b>Coordinates:</b> " + coordStr +
+                    " <span class='gfmy-copy gfmy-copy-coords' role='button' tabindex='0'" +
+                    " title='Copy to clipboard'" +
+                    " aria-label='Copy coordinates to clipboard'>" +
+                    GFMY_COPY_ICON + "</span>";
+
+                // autoPan: false keeps the auto-opened popup from panning the map
+                // away from fitBounds (see plan risk: openPopup autoPan jump).
+                marker.bindPopup(popupHtml, {{autoPan: false}});
 
                 // LAYER 3 lifecycle: the single focus disc follows the popup.
-                marker.on('popupopen', function() {{ setFocus(loc, [loc.lat, loc.lon]); }});
+                // Copy icons are wired here (popupopen): the handlers read the
+                // raw value from the ``loc`` closure, never from the rendered
+                // DOM, so no value is round-tripped through markup (OWASP H1).
+                marker.on('popupopen', function(e) {{
+                    setFocus(loc, [loc.lat, loc.lon]);
+                    var popupEl = e.popup.getElement();
+                    if (!popupEl) {{ return; }}
+                    var pcBtn = popupEl.querySelector('.gfmy-copy-plus');
+                    if (pcBtn && loc.plus_code) {{
+                        pcBtn.onclick = function(ev) {{
+                            ev.stopPropagation();
+                            ev.preventDefault();
+                            gfmyCopyToClipboard(loc.plus_code, pcBtn);
+                        }};
+                    }}
+                    var coBtn = popupEl.querySelector('.gfmy-copy-coords');
+                    if (coBtn) {{
+                        coBtn.onclick = function(ev) {{
+                            ev.stopPropagation();
+                            ev.preventDefault();
+                            gfmyCopyToClipboard(loc.lat + ", " + loc.lon, coBtn);
+                        }};
+                    }}
+                }});
                 marker.on('popupclose', function() {{
                     if (focusCircle) {{ map.removeLayer(focusCircle); focusCircle = null; }}
                 }});

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -16,6 +16,7 @@ Best practices:
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Callable, Iterable, Mapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
@@ -63,6 +64,7 @@ from .entity import (
     subentry_type as _subentry_type,
 )
 from .ha_typing import RestoreSensor, SensorEntity, callback
+from .vendor.openlocationcode import encode as _encode_plus_code
 
 if TYPE_CHECKING:
     from .eid_resolver import GoogleFindMyEIDResolver
@@ -88,6 +90,12 @@ LAST_SEEN_DESCRIPTION = SensorEntityDescription(
     translation_key="last_seen",
     icon="mdi:clock-outline",
     device_class=SensorDeviceClass.TIMESTAMP,
+)
+
+PLUS_CODE_DESCRIPTION = SensorEntityDescription(
+    key="plus_code",
+    translation_key="plus_code",
+    icon="mdi:map-marker",
 )
 
 SEMANTIC_LABEL_DESCRIPTION = SensorEntityDescription(
@@ -545,6 +553,19 @@ async def async_setup_entry(
                     known_ids.add(dev_id)
                     entities.append(entity)
 
+                    # --- Plus Code sensor (always, alongside LastSeen) ---
+                    plus_code_entity = GoogleFindMyPlusCodeSensor(
+                        coordinator,
+                        device,
+                        subentry_key=tracker_scope.subentry_key,
+                        subentry_identifier=tracker_identifier,
+                    )
+                    pc_uid = getattr(plus_code_entity, "unique_id", None)
+                    if not isinstance(pc_uid, str) or pc_uid not in added_unique_ids:
+                        if isinstance(pc_uid, str):
+                            added_unique_ids.add(pc_uid)
+                        entities.append(plus_code_entity)
+
                 # --- BLE Battery sensor (when resolver has data) ---
                 if dev_id not in known_battery_ids and resolver is not None:
                     battery_state = None
@@ -794,6 +815,9 @@ async def async_setup_entry(
                     expected.add(
                         f"{DOMAIN}_{entry_id}_{tracker_scope.identifier}_{dev_id}_last_seen"
                     )
+                    expected.add(
+                        f"{DOMAIN}_{entry_id}_{tracker_scope.identifier}_{dev_id}_plus_code"
+                    )
             return expected
 
         def _build_entities(missing: set[str]) -> list[SensorEntity]:
@@ -838,17 +862,26 @@ async def async_setup_entry(
                         continue
                     if not _is_visible_device(dev_id):
                         continue
-                    unique_id = f"{DOMAIN}_{entry_id}_{tracker_scope.identifier}_{dev_id}_last_seen"
-                    if unique_id not in missing:
-                        continue
-                    built.append(
-                        GoogleFindMyLastSeenSensor(
-                            coordinator,
-                            device,
-                            subentry_key=tracker_scope.subentry_key,
-                            subentry_identifier=tracker_scope.identifier,
+                    ls_uid = f"{DOMAIN}_{entry_id}_{tracker_scope.identifier}_{dev_id}_last_seen"
+                    pc_uid = f"{DOMAIN}_{entry_id}_{tracker_scope.identifier}_{dev_id}_plus_code"
+                    if ls_uid in missing:
+                        built.append(
+                            GoogleFindMyLastSeenSensor(
+                                coordinator,
+                                device,
+                                subentry_key=tracker_scope.subentry_key,
+                                subentry_identifier=tracker_scope.identifier,
+                            )
                         )
-                    )
+                    if pc_uid in missing:
+                        built.append(
+                            GoogleFindMyPlusCodeSensor(
+                                coordinator,
+                                device,
+                                subentry_key=tracker_scope.subentry_key,
+                                subentry_identifier=tracker_scope.identifier,
+                            )
+                        )
             return built
 
         recovery_manager.register_sensor_platform(
@@ -1360,6 +1393,134 @@ class GoogleFindMyLastSeenSensor(GoogleFindMyDeviceEntity, RestoreSensor):
 
         # Set our native value now (no need to wait for next coordinator tick)
         self._attr_native_value = datetime.fromtimestamp(ts, tz=UTC)
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Expose DeviceInfo using the shared entity helper."""
+
+        return super().device_info
+
+
+# ------------------------------- Per-Device Plus Code -------------------------
+
+
+class GoogleFindMyPlusCodeSensor(GoogleFindMyDeviceEntity, RestoreSensor):
+    """Per-device sensor exposing the Google Plus Code (Open Location Code).
+
+    The value is a deterministic function of the device's latest known
+    latitude/longitude (offline, no API key, no network). It is derived live
+    from the coordinator's current location row:
+
+    - A valid fix -> the full 10-digit Plus Code (11 characters incl. the ``+``
+      separator, e.g. ``8FVC9G8F+6X``), directly usable in Google Maps.
+    - No fix / invalid coordinates -> ``None`` (no stale "last value"). The
+      underlying coordinate cache is restored by the device_tracker across
+      restarts, so this derived text needs no separate restore wiring; it
+      subclasses ``RestoreSensor`` for parity with the other per-device sensors.
+
+    Unlike the device_tracker, this is a plain text sensor and deliberately
+    carries no ``latitude``/``longitude`` attributes, so Home Assistant does not
+    plot a spurious extra map marker for it.
+    """
+
+    _attr_has_entity_name = True
+    _attr_entity_registry_enabled_default = True
+    entity_description = PLUS_CODE_DESCRIPTION
+
+    def __init__(
+        self,
+        coordinator: GoogleFindMyCoordinator,
+        device: dict[str, Any],
+        *,
+        subentry_key: str,
+        subentry_identifier: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            device,
+            subentry_key=subentry_key,
+            subentry_identifier=subentry_identifier,
+            fallback_label=device.get("name"),
+        )
+        self._device_id: str | None = device.get("id")
+        safe_id = self._device_id if self._device_id is not None else "unknown"
+        entry_id = self.entry_id or "default"
+        # Namespace unique_id by entry for safety (keeps multi-entry setups clean).
+        self._attr_unique_id = self.build_unique_id(
+            DOMAIN,
+            entry_id,
+            subentry_identifier,
+            f"{safe_id}_plus_code",
+            separator="_",
+        )
+
+    def _current_plus_code(self) -> str | None:
+        """Compute the Plus Code from the device's current location row.
+
+        Returns ``None`` when there is no row or the coordinates are missing or
+        non-finite (NaN/inf), so the sensor state is ``unknown`` rather than a
+        stale or bogus code.
+        """
+        dev_id = self._device_id
+        if not dev_id:
+            return None
+        row = self.coordinator.get_device_location_data_for_subentry(
+            self.subentry_key, dev_id
+        )
+        lat = row.get("latitude") if row else None
+        lon = row.get("longitude") if row else None
+        # Reject missing, boolean (a bool is an int subclass), and non-finite
+        # (NaN/inf) coordinates so the state is ``unknown`` rather than bogus.
+        if (
+            not isinstance(lat, (int, float))
+            or not isinstance(lon, (int, float))
+            or isinstance(lat, bool)
+            or isinstance(lon, bool)
+            or not math.isfinite(lat)
+            or not math.isfinite(lon)
+        ):
+            return None
+        try:
+            return _encode_plus_code(float(lat), float(lon), 10)
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current Plus Code (11 chars incl. ``+``) or ``None``."""
+        return self._current_plus_code()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return non-coordinate metadata.
+
+        Must not include ``latitude``/``longitude``: a text sensor that carried
+        both would be auto-plotted by HA as a spurious third map marker.
+        """
+        return {"code_length": 10}
+
+    @property
+    def available(self) -> bool:
+        """Mirror device presence, falling back to coordinator availability."""
+        if not super().available:
+            return False
+        dev_id = self._device_id
+        if not dev_id:
+            return False
+        return self.coordinator_has_device()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Keep the device label in sync and push the recomputed state."""
+        if not self.coordinator_has_device():
+            self.async_write_ha_state()
+            return
+        self.refresh_device_label_from_coordinator(log_prefix="PlusCode")
+        current_name = self._device.get("name")
+        if isinstance(current_name, str):
+            self.maybe_update_device_registry_name(current_name)
         self.async_write_ha_state()
 
     @property

--- a/custom_components/googlefindmy/sensor.py
+++ b/custom_components/googlefindmy/sensor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import math
+import time
 from collections.abc import Callable, Iterable, Mapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
@@ -50,6 +51,9 @@ from .coordinator import (
     GoogleFindMyCoordinator,
     SemanticLabelRecord,
     _as_ha_attributes,
+    has_usable_accuracy,
+    location_age_seconds,
+    resolve_stale_threshold,
 )
 from .entity import (
     GoogleFindMyDeviceEntity,
@@ -1457,11 +1461,23 @@ class GoogleFindMyPlusCodeSensor(GoogleFindMyDeviceEntity, RestoreSensor):
         )
 
     def _current_plus_code(self) -> str | None:
-        """Compute the Plus Code from the device's current location row.
+        """Compute the Plus Code from the device's published location.
 
-        Returns ``None`` when there is no row or the coordinates are missing or
-        non-finite (NaN/inf), so the sensor state is ``unknown`` rather than a
-        stale or bogus code.
+        Applies the same accuracy and staleness gate the device_tracker uses
+        before it publishes live coordinates (shared SSOT helpers), so the Plus
+        Code never encodes a position the tracker/map deliberately hide (Codex
+        #202 / PR #1179):
+
+        - a fix without a usable accuracy is withheld -> ``None``;
+        - a stale fix (older than the configured threshold) is withheld ->
+          ``None``.
+
+        This sensor intentionally holds no last-good-accuracy cache of its own.
+        When the current row lacks accuracy the tracker falls back to its cached
+        fix for the *marker*; the Plus Code reports ``unknown`` instead of
+        duplicating that per-entity cache and its restore wiring in a second
+        entity. Last-good parity, if ever wanted, is a separate feature, not
+        this bugfix.
         """
         dev_id = self._device_id
         if not dev_id:
@@ -1469,6 +1485,15 @@ class GoogleFindMyPlusCodeSensor(GoogleFindMyDeviceEntity, RestoreSensor):
         row = self.coordinator.get_device_location_data_for_subentry(
             self.subentry_key, dev_id
         )
+        # Accuracy gate: mirror the tracker's publish decision.
+        if not has_usable_accuracy(row):
+            return None
+        # Staleness gate: a fix older than the configured threshold is withheld
+        # exactly as the tracker blanks its live coordinates when stale.
+        threshold = resolve_stale_threshold(self.coordinator)
+        age = location_age_seconds(row, time.time())
+        if age is not None and age > threshold:
+            return None
         lat = row.get("latitude") if row else None
         lon = row.get("longitude") if row else None
         # Reject missing, boolean (a bool is an int subclass), and non-finite

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "BLE Battery"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Last Seen",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "BLE-Akku"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Zuletzt gesehen",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "BLE Battery"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Last Seen",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "Batería BLE"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Visto por última vez",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "Batterie BLE"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Vu pour la dernière fois",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "סוללת BLE"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "נראה לאחרונה",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "Batteria BLE"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Ultima volta visto",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "BLE-batterij"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Laatst gezien",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "Bateria BLE"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Ostatnio widziany",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "Bateria BLE"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Visto pela última vez",
         "state_attributes": {

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -606,6 +606,9 @@
       "ble_battery": {
         "name": "Bateria BLE"
       },
+      "plus_code": {
+        "name": "Plus Code"
+      },
       "last_seen": {
         "name": "Visto pela última vez",
         "state_attributes": {

--- a/custom_components/googlefindmy/vendor/__init__.py
+++ b/custom_components/googlefindmy/vendor/__init__.py
@@ -1,0 +1,6 @@
+"""Vendored third-party code bundled with the integration.
+
+Each subpackage carries its own upstream license header and, where the license
+requires it, a bundled ``LICENSE`` file. See the individual subpackages and the
+project ``README.md`` ("Credits") for attribution details.
+"""

--- a/custom_components/googlefindmy/vendor/__init__.py
+++ b/custom_components/googlefindmy/vendor/__init__.py
@@ -1,3 +1,4 @@
+# custom_components/googlefindmy/vendor/__init__.py
 """Vendored third-party code bundled with the integration.
 
 Each subpackage carries its own upstream license header and, where the license

--- a/custom_components/googlefindmy/vendor/openlocationcode/LICENSE
+++ b/custom_components/googlefindmy/vendor/openlocationcode/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/custom_components/googlefindmy/vendor/openlocationcode/__init__.py
+++ b/custom_components/googlefindmy/vendor/openlocationcode/__init__.py
@@ -1,0 +1,10 @@
+"""Vendored Open Location Code (Plus Code) encoder.
+
+Apache-2.0, vendored from https://github.com/google/open-location-code; see the
+module header in ``openlocationcode.py`` and the bundled ``LICENSE`` file.
+Only the encode path is vendored; consumers import :func:`encode` from here.
+"""
+
+from .openlocationcode import encode
+
+__all__ = ["encode"]

--- a/custom_components/googlefindmy/vendor/openlocationcode/__init__.py
+++ b/custom_components/googlefindmy/vendor/openlocationcode/__init__.py
@@ -1,3 +1,4 @@
+# custom_components/googlefindmy/vendor/openlocationcode/__init__.py
 """Vendored Open Location Code (Plus Code) encoder.
 
 Apache-2.0, vendored from https://github.com/google/open-location-code; see the

--- a/custom_components/googlefindmy/vendor/openlocationcode/openlocationcode.py
+++ b/custom_components/googlefindmy/vendor/openlocationcode/openlocationcode.py
@@ -1,3 +1,4 @@
+# custom_components/googlefindmy/vendor/openlocationcode/openlocationcode.py
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,13 +32,13 @@ See https://github.com/google/open-location-code for the full reference.
 import math
 
 # A separator used to break the code into two parts to aid memorability.
-SEPARATOR_ = '+'
+SEPARATOR_ = "+"
 
 # The number of characters to place before the separator.
 SEPARATOR_POSITION_ = 8
 
 # The character set used to encode the values.
-CODE_ALPHABET_ = '23456789CFGHJMPQRVWX'
+CODE_ALPHABET_ = "23456789CFGHJMPQRVWX"
 
 # The base to use to convert numbers to/from.
 ENCODING_BASE_ = len(CODE_ALPHABET_)
@@ -73,13 +74,15 @@ GRID_ROWS_ = 5
 
 # Multiply latitude by this much to make it a multiple of the finest
 # precision.
-FINAL_LAT_PRECISION_ = PAIR_PRECISION_ * GRID_ROWS_**(MAX_DIGIT_COUNT_ -
-                                                      PAIR_CODE_LENGTH_)
+FINAL_LAT_PRECISION_ = PAIR_PRECISION_ * GRID_ROWS_ ** (
+    MAX_DIGIT_COUNT_ - PAIR_CODE_LENGTH_
+)
 
 # Multiply longitude by this much to make it a multiple of the finest
 # precision.
-FINAL_LNG_PRECISION_ = PAIR_PRECISION_ * GRID_COLUMNS_**(MAX_DIGIT_COUNT_ -
-                                                         PAIR_CODE_LENGTH_)
+FINAL_LNG_PRECISION_ = PAIR_PRECISION_ * GRID_COLUMNS_ ** (
+    MAX_DIGIT_COUNT_ - PAIR_CODE_LENGTH_
+)
 
 
 def locationToIntegers(latitude: float, longitude: float) -> tuple[int, int]:
@@ -144,13 +147,13 @@ def encodeIntegers(latVal: int, lngVal: int, codeLength: int) -> str:
     This function is exposed for testing purposes and should not be called
     directly.
     """
-    if codeLength < MIN_DIGIT_COUNT_ or (codeLength < PAIR_CODE_LENGTH_ and
-                                         codeLength % 2 == 1):
-        raise ValueError('Invalid Open Location Code length - ' +
-                         str(codeLength))
+    if codeLength < MIN_DIGIT_COUNT_ or (
+        codeLength < PAIR_CODE_LENGTH_ and codeLength % 2 == 1
+    ):
+        raise ValueError("Invalid Open Location Code length - " + str(codeLength))
     codeLength = min(codeLength, MAX_DIGIT_COUNT_)
     # Initialise the code string.
-    code = ''
+    code = ""
 
     # Compute the grid part of the code if necessary.
     if codeLength > PAIR_CODE_LENGTH_:
@@ -176,8 +179,7 @@ def encodeIntegers(latVal: int, lngVal: int, codeLength: int) -> str:
 
     # If we don't need to pad the code, return the requested section.
     if codeLength >= SEPARATOR_POSITION_:
-        return code[0:codeLength + 1]
+        return code[0 : codeLength + 1]
 
     # Pad and return the code.
-    return code[0:codeLength] + ''.zfill(SEPARATOR_POSITION_ -
-                                         codeLength) + SEPARATOR_
+    return code[0:codeLength] + "".zfill(SEPARATOR_POSITION_ - codeLength) + SEPARATOR_

--- a/custom_components/googlefindmy/vendor/openlocationcode/openlocationcode.py
+++ b/custom_components/googlefindmy/vendor/openlocationcode/openlocationcode.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Vendored from https://github.com/google/open-location-code
+# (python/openlocationcode/openlocationcode.py), commit
+# dcff1534f70a0d7244d0d1c357c20f0aa28ab355, Apache-2.0.
+# Modified from the original: extracted the encode-only path (encode,
+# locationToIntegers, encodeIntegers and the constants they require);
+# removed decode/shorten/recover/isValid/isShort/isFull/CodeArea helpers and
+# the now-unused ``import re``; added type annotations for mypy strict.
+# Encoding logic is otherwise unchanged so the output matches upstream and the
+# official test vectors.
+"""Open Location Code (Plus Code) encoder, vendored (encode-only path).
+
+Plus Codes are short 10-11 character codes usable instead of street addresses.
+They are generated offline from latitude/longitude with no API key or network.
+See https://github.com/google/open-location-code for the full reference.
+"""
+
+import math
+
+# A separator used to break the code into two parts to aid memorability.
+SEPARATOR_ = '+'
+
+# The number of characters to place before the separator.
+SEPARATOR_POSITION_ = 8
+
+# The character set used to encode the values.
+CODE_ALPHABET_ = '23456789CFGHJMPQRVWX'
+
+# The base to use to convert numbers to/from.
+ENCODING_BASE_ = len(CODE_ALPHABET_)
+
+# The maximum value for latitude in degrees.
+LATITUDE_MAX_ = 90
+
+# The maximum value for longitude in degrees.
+LONGITUDE_MAX_ = 180
+
+# The min number of digits to process in a Plus Code.
+MIN_DIGIT_COUNT_ = 2
+
+# The max number of digits to process in a Plus Code.
+MAX_DIGIT_COUNT_ = 15
+
+# Maximum code length using lat/lng pair encoding. The area of such a
+# code is approximately 13x13 meters (at the equator), and should be suitable
+# for identifying buildings. This excludes prefix and separator characters.
+PAIR_CODE_LENGTH_ = 10
+
+# Inverse of the precision of the pair section of the code.
+PAIR_PRECISION_ = ENCODING_BASE_**3
+
+# Number of digits in the grid precision part of the code.
+GRID_CODE_LENGTH_ = MAX_DIGIT_COUNT_ - PAIR_CODE_LENGTH_
+
+# Number of columns in the grid refinement method.
+GRID_COLUMNS_ = 4
+
+# Number of rows in the grid refinement method.
+GRID_ROWS_ = 5
+
+# Multiply latitude by this much to make it a multiple of the finest
+# precision.
+FINAL_LAT_PRECISION_ = PAIR_PRECISION_ * GRID_ROWS_**(MAX_DIGIT_COUNT_ -
+                                                      PAIR_CODE_LENGTH_)
+
+# Multiply longitude by this much to make it a multiple of the finest
+# precision.
+FINAL_LNG_PRECISION_ = PAIR_PRECISION_ * GRID_COLUMNS_**(MAX_DIGIT_COUNT_ -
+                                                         PAIR_CODE_LENGTH_)
+
+
+def locationToIntegers(latitude: float, longitude: float) -> tuple[int, int]:
+    """
+    Convert location in degrees into the integer representations.
+
+    This function is exposed for testing purposes and should not be called
+    directly.
+
+    Args:
+      latitude: Latitude in degrees.
+      longitude: Longitude in degrees.
+    Return:
+      A tuple of the [latitude, longitude] values as integers.
+    """
+    latVal = int(math.floor(latitude * FINAL_LAT_PRECISION_))
+    latVal += LATITUDE_MAX_ * FINAL_LAT_PRECISION_
+    if latVal < 0:
+        latVal = 0
+    elif latVal >= 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_:
+        latVal = 2 * LATITUDE_MAX_ * FINAL_LAT_PRECISION_ - 1
+
+    lngVal = int(math.floor(longitude * FINAL_LNG_PRECISION_))
+    lngVal += LONGITUDE_MAX_ * FINAL_LNG_PRECISION_
+    if lngVal < 0:
+        # Python's % operator differs from other languages in that it returns
+        # the same sign as the divisor. This means we don't need to add the
+        # range to the result.
+        lngVal = lngVal % (2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_)
+    elif lngVal >= 2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_:
+        lngVal = lngVal % (2 * LONGITUDE_MAX_ * FINAL_LNG_PRECISION_)
+    return (latVal, lngVal)
+
+
+def encode(
+    latitude: float, longitude: float, codeLength: int = PAIR_CODE_LENGTH_
+) -> str:
+    """
+    Encode a location into an Open Location Code.
+    Produces a code of the specified length, or the default length if no length
+    is provided.
+    The length determines the accuracy of the code. The default length is
+    10 characters, returning a code of approximately 13.5x13.5 meters. Longer
+    codes represent smaller areas, but lengths > 14 are sub-centimetre and so
+    11 or 12 are probably the limit of useful codes.
+    Args:
+      latitude: A latitude in signed decimal degrees. Will be clipped to the
+          range -90 to 90.
+      longitude: A longitude in signed decimal degrees. Will be normalised to
+          the range -180 to 180.
+      codeLength: The number of significant digits in the output code, not
+          including any separator characters.
+    """
+    (latInt, lngInt) = locationToIntegers(latitude, longitude)
+    return encodeIntegers(latInt, lngInt, codeLength)
+
+
+def encodeIntegers(latVal: int, lngVal: int, codeLength: int) -> str:
+    """
+    Encode a location, as two integer values, into a code.
+
+    This function is exposed for testing purposes and should not be called
+    directly.
+    """
+    if codeLength < MIN_DIGIT_COUNT_ or (codeLength < PAIR_CODE_LENGTH_ and
+                                         codeLength % 2 == 1):
+        raise ValueError('Invalid Open Location Code length - ' +
+                         str(codeLength))
+    codeLength = min(codeLength, MAX_DIGIT_COUNT_)
+    # Initialise the code string.
+    code = ''
+
+    # Compute the grid part of the code if necessary.
+    if codeLength > PAIR_CODE_LENGTH_:
+        for i in range(0, MAX_DIGIT_COUNT_ - PAIR_CODE_LENGTH_):
+            latDigit = latVal % GRID_ROWS_
+            lngDigit = lngVal % GRID_COLUMNS_
+            ndx = latDigit * GRID_COLUMNS_ + lngDigit
+            code = CODE_ALPHABET_[ndx] + code
+            latVal //= GRID_ROWS_
+            lngVal //= GRID_COLUMNS_
+    else:
+        latVal //= pow(GRID_ROWS_, GRID_CODE_LENGTH_)
+        lngVal //= pow(GRID_COLUMNS_, GRID_CODE_LENGTH_)
+    # Compute the pair section of the code.
+    for i in range(0, PAIR_CODE_LENGTH_ // 2):
+        code = CODE_ALPHABET_[lngVal % ENCODING_BASE_] + code
+        code = CODE_ALPHABET_[latVal % ENCODING_BASE_] + code
+        latVal //= ENCODING_BASE_
+        lngVal //= ENCODING_BASE_
+
+    # Add the separator character.
+    code = code[:SEPARATOR_POSITION_] + SEPARATOR_ + code[SEPARATOR_POSITION_:]
+
+    # If we don't need to pad the code, return the requested section.
+    if codeLength >= SEPARATOR_POSITION_:
+        return code[0:codeLength + 1]
+
+    # Pad and return the code.
+    return code[0:codeLength] + ''.zfill(SEPARATOR_POSITION_ -
+                                         codeLength) + SEPARATOR_

--- a/tests/test_coordinator_geo.py
+++ b/tests/test_coordinator_geo.py
@@ -1,3 +1,4 @@
+# tests/test_coordinator_geo.py
 """Tests for coordinator_geo.py - Phase 1 of coordinator refactoring.
 
 These tests validate the geographic utility functions extracted
@@ -8,6 +9,7 @@ Test categories:
 2. coerce_float - Safe float conversion
 3. safe_accuracy - GPS accuracy normalization
 4. haversine_distance - Distance calculation between coordinates
+5. display-row selection & staleness - shared publish gate SSOT
 
 REQUIREMENT: 100% test coverage for all extracted functions.
 """
@@ -15,14 +17,23 @@ REQUIREMENT: 100% test coverage for all extracted functions.
 from __future__ import annotations
 
 import math
+from types import SimpleNamespace
 
+from custom_components.googlefindmy.const import (
+    DEFAULT_STALE_THRESHOLD,
+    OPT_STALE_THRESHOLD,
+)
 from custom_components.googlefindmy.coordinator.helpers.geo import (
     DEFAULT_ACCURACY_FALLBACK_M,
     clamp,
     coerce_float,
+    has_usable_accuracy,
     haversine_distance,
+    location_age_seconds,
     resolve_seeded_accuracy,
+    resolve_stale_threshold,
     safe_accuracy,
+    select_display_row,
 )
 
 # ---------------------------------------------------------------------------
@@ -469,3 +480,89 @@ class TestResolveSeededAccuracy:
         accuracy, estimated = resolve_seeded_accuracy(0.5, None)
         assert accuracy == 0.5
         assert estimated is None
+
+
+# ---------------------------------------------------------------------------
+# Display-row selection & staleness Tests (shared publish-gate SSOT)
+# ---------------------------------------------------------------------------
+
+
+class TestHasUsableAccuracy:
+    """has_usable_accuracy - the tracker's publish gate as a pure predicate."""
+
+    def test_none_row_is_not_usable(self) -> None:
+        assert has_usable_accuracy(None) is False
+
+    def test_row_without_accuracy_key_is_not_usable(self) -> None:
+        assert has_usable_accuracy({"latitude": 1.0, "longitude": 2.0}) is False
+
+    def test_row_with_none_accuracy_is_not_usable(self) -> None:
+        assert has_usable_accuracy({"accuracy": None}) is False
+
+    def test_row_with_numeric_accuracy_is_usable(self) -> None:
+        assert has_usable_accuracy({"accuracy": 12.0}) is True
+
+    def test_zero_accuracy_counts_as_present(self) -> None:
+        # ``has_usable_accuracy`` only checks presence; ``safe_accuracy`` owns
+        # the "0.0 means no accuracy" policy downstream.
+        assert has_usable_accuracy({"accuracy": 0.0}) is True
+
+
+class TestSelectDisplayRow:
+    """select_display_row - current row if it has accuracy, else last good."""
+
+    def test_current_with_accuracy_wins(self) -> None:
+        current = {"latitude": 1.0, "accuracy": 5.0}
+        last_good = {"latitude": 9.0, "accuracy": 5.0}
+        assert select_display_row(current, last_good) is current
+
+    def test_accuracy_less_current_falls_back_to_last_good(self) -> None:
+        current = {"latitude": 1.0, "accuracy": None}
+        last_good = {"latitude": 9.0, "accuracy": 5.0}
+        assert select_display_row(current, last_good) is last_good
+
+    def test_no_current_falls_back_to_last_good(self) -> None:
+        last_good = {"latitude": 9.0, "accuracy": 5.0}
+        assert select_display_row(None, last_good) is last_good
+
+    def test_both_missing_yields_none(self) -> None:
+        assert select_display_row(None, None) is None
+
+
+class TestLocationAgeSeconds:
+    """location_age_seconds - pure age arithmetic with an injected ``now``."""
+
+    def test_none_row_yields_none(self) -> None:
+        assert location_age_seconds(None, 1_000.0) is None
+
+    def test_missing_last_seen_yields_none(self) -> None:
+        assert location_age_seconds({"latitude": 1.0}, 1_000.0) is None
+
+    def test_non_numeric_last_seen_yields_none(self) -> None:
+        assert location_age_seconds({"last_seen": "nope"}, 1_000.0) is None
+
+    def test_age_is_now_minus_last_seen(self) -> None:
+        assert location_age_seconds({"last_seen": 900.0}, 1_000.0) == 100.0
+
+
+class TestResolveStaleThreshold:
+    """resolve_stale_threshold - duck-typed config reader with safe fallbacks."""
+
+    def test_missing_config_entry_returns_default(self) -> None:
+        coordinator = SimpleNamespace(config_entry=None)
+        assert resolve_stale_threshold(coordinator) == DEFAULT_STALE_THRESHOLD
+
+    def test_non_mapping_options_returns_default(self) -> None:
+        entry = SimpleNamespace(options=None)
+        coordinator = SimpleNamespace(config_entry=entry)
+        assert resolve_stale_threshold(coordinator) == DEFAULT_STALE_THRESHOLD
+
+    def test_configured_value_is_returned(self) -> None:
+        entry = SimpleNamespace(options={OPT_STALE_THRESHOLD: 1234})
+        coordinator = SimpleNamespace(config_entry=entry)
+        assert resolve_stale_threshold(coordinator) == 1234
+
+    def test_malformed_value_falls_back_to_default(self) -> None:
+        entry = SimpleNamespace(options={OPT_STALE_THRESHOLD: "abc"})
+        coordinator = SimpleNamespace(config_entry=entry)
+        assert resolve_stale_threshold(coordinator) == DEFAULT_STALE_THRESHOLD

--- a/tests/test_entity_registry_subentry_alignment.py
+++ b/tests/test_entity_registry_subentry_alignment.py
@@ -177,19 +177,25 @@ async def test_entity_registry_subentry_alignment(
     entries = list(getattr(registry, "entities", {}).values())
     assert entries, "platform setup should register at least one entity"
 
+    # Per-device tracker-scope sensors are identified by their unique_id suffix:
+    # last_seen (timestamp) and plus_code (Open Location Code) both belong to the
+    # tracker subentry, not the diagnostic service scope.
+    tracker_sensor_suffixes = ("_last_seen", "_plus_code")
+
     service_entries = [
         item
         for item in entries
         if item.platform == "binary_sensor"
         or (
-            item.platform == "sensor" and not str(item.unique_id).endswith("_last_seen")
+            item.platform == "sensor"
+            and not str(item.unique_id).endswith(tracker_sensor_suffixes)
         )
     ]
     tracker_entries = [
         item
         for item in entries
         if item.platform == "device_tracker"
-        or str(item.unique_id).endswith("_last_seen")
+        or str(item.unique_id).endswith(tracker_sensor_suffixes)
     ]
 
     assert service_entries, "diagnostic entities must be present for validation"

--- a/tests/test_guard_path_header.py
+++ b/tests/test_guard_path_header.py
@@ -42,7 +42,6 @@ LEGACY_ALLOWLIST: set[str] = {
     "tests/test_coordinator_cache.py",
     "tests/test_coordinator_cache_merge.py",
     "tests/test_coordinator_cache_update.py",
-    "tests/test_coordinator_geo.py",
     "tests/test_coordinator_identity.py",
     "tests/test_coordinator_key_priority.py",
     "tests/test_coordinator_polling.py",

--- a/tests/test_map_view_plus_code.py
+++ b/tests/test_map_view_plus_code.py
@@ -1,0 +1,80 @@
+# tests/test_map_view_plus_code.py
+"""Server-side tests for the map-view Plus Code wiring.
+
+Covers the extracted pure builder ``_build_location_entry`` (and its helper
+``_plus_code_for``), so the ``plus_code`` payload field is verified without the
+HTTP stack. The client-side copy JS is intentionally not unit-tested (no JS test
+harness in the repo); it is exercised via the manual checklist in the plan's AP3
+regression check for both the HTTPS and plain-LAN HTTP contexts.
+"""
+
+from __future__ import annotations
+
+import math
+
+from custom_components.googlefindmy import map_view
+
+
+def test_build_location_entry_adds_plus_code() -> None:
+    """A valid coordinate yields the correct 10-digit Plus Code in the payload."""
+    entry = map_view._build_location_entry(
+        lat=47.365590,
+        lon=8.524997,
+        accuracy=12.0,
+        accuracy_estimated=False,
+        timestamp="2026-07-09T12:00:00+00:00",
+        last_seen=1_700_000_000,
+        is_own_report=True,
+        semantic_location="Home",
+    )
+    assert entry["plus_code"] == "8FVC9G8F+6X"
+    assert len(entry["plus_code"]) == 11
+    assert entry["plus_code"][8] == "+"
+
+
+def test_build_location_entry_passes_through_existing_fields() -> None:
+    """Pre-existing payload fields are unchanged; only plus_code is added."""
+    entry = map_view._build_location_entry(
+        lat=52.5219,
+        lon=13.4132,
+        accuracy=8.5,
+        accuracy_estimated=True,
+        timestamp="2026-07-09T12:00:00+00:00",
+        last_seen=1_700_000_123,
+        is_own_report=False,
+        semantic_location=None,
+    )
+    assert entry["lat"] == 52.5219
+    assert entry["lon"] == 13.4132
+    assert entry["accuracy"] == 8.5
+    assert entry["accuracy_estimated"] is True
+    assert entry["timestamp"] == "2026-07-09T12:00:00+00:00"
+    assert entry["last_seen"] == 1_700_000_123
+    assert entry["is_own_report"] is False
+    assert entry["semantic_location"] is None
+    # The added key exists and no coordinate keys leak beyond lat/lon.
+    assert "plus_code" in entry
+    assert set(entry) == {
+        "lat",
+        "lon",
+        "accuracy",
+        "accuracy_estimated",
+        "timestamp",
+        "last_seen",
+        "is_own_report",
+        "semantic_location",
+        "plus_code",
+    }
+
+
+def test_plus_code_for_rejects_non_finite() -> None:
+    """NaN/inf coordinates yield None rather than a bogus code."""
+    assert map_view._plus_code_for(math.nan, 13.0) is None
+    assert map_view._plus_code_for(52.0, math.inf) is None
+    assert map_view._plus_code_for(-math.inf, math.nan) is None
+
+
+def test_plus_code_for_valid_coordinate() -> None:
+    """A finite coordinate returns an 11-character code with the separator."""
+    code = map_view._plus_code_for(47.365590, 8.524997)
+    assert code == "8FVC9G8F+6X"

--- a/tests/test_open_location_code.py
+++ b/tests/test_open_location_code.py
@@ -1,0 +1,79 @@
+# tests/test_open_location_code.py
+"""Unit tests for the vendored Open Location Code (Plus Code) encoder.
+
+The encoder is vendored verbatim (encode-only path) from
+``github.com/google/open-location-code`` at commit
+``dcff1534f70a0d7244d0d1c357c20f0aa28ab355``. These vectors are taken verbatim
+from that commit's ``test_data/encoding.csv`` (the ``latitude,longitude`` and
+final ``code`` columns) and were confirmed to round-trip through ``encode()``
+for ``code_length=10``. The float-boundary rows of that CSV (which the upstream
+harness checks via the integer path ``encodeIntegers``) are intentionally not
+used here, because ``encode()`` on exact cell edges is a known float artifact
+shared with upstream and would not add signal.
+
+A 10-digit code is 11 characters long including the ``+`` separator after the
+8th digit (e.g. ``8FVC9G8F+6X``) and uses only the OLC alphabet.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.googlefindmy.vendor.openlocationcode import encode
+
+# OLC digit alphabet plus the separator; a valid code contains nothing else.
+_ALPHABET = set("23456789CFGHJMPQRVWX")
+
+# (latitude, longitude, expected 10-digit code) — verbatim from encoding.csv.
+_VECTORS: list[tuple[float, float, str]] = [
+    # Landmark from the upstream module docstring (Zurich).
+    (47.365590, 8.524997, "8FVC9G8F+6X"),
+    (20.3700625, 2.7821875, "7FG49QCJ+2V"),
+    (47.0000625, 8.0000625, "8FVC2222+22"),
+    (-41.2730625, 174.7859375, "4VCPPQGP+Q9"),
+    # South-west extreme (latitude/longitude near -90 / -180).
+    (-89.9999375, -179.9999375, "22222222+22"),
+    # Latitude clipped at the north pole.
+    (90.0, 1.0, "CFX3X2X2+X2"),
+    # Latitude beyond +90 is clipped into range.
+    (91.3759, -96.45974, "C6X5XGXR+X4"),
+]
+
+# Longitude outside [-180, 180) must normalise: 728.0000625 == 8.0000625 (+2*360).
+_WRAP_VECTORS: list[tuple[float, float, str]] = [
+    (47.0000625, 728.0000625, "8FVC2222+22"),
+    (47.0000625, -711.9999375, "8FVC2222+22"),
+]
+
+
+@pytest.mark.parametrize(("lat", "lon", "expected"), _VECTORS)
+def test_encode_matches_official_vectors(lat: float, lon: float, expected: str) -> None:
+    """Encoding a coordinate at length 10 reproduces the official code."""
+    assert encode(lat, lon, 10) == expected
+
+
+@pytest.mark.parametrize(("lat", "lon", "expected"), _WRAP_VECTORS)
+def test_encode_normalizes_longitude(lat: float, lon: float, expected: str) -> None:
+    """Out-of-range longitude is normalised into [-180, 180) before encoding."""
+    assert encode(lat, lon, 10) == expected
+
+
+def test_encode_default_length_is_ten() -> None:
+    """The default code length is 10 (11 chars incl. separator)."""
+    assert encode(47.365590, 8.524997) == "8FVC9G8F+6X"
+
+
+def test_encode_format_invariants() -> None:
+    """A length-10 code is 11 chars, separator at index 8, OLC alphabet only."""
+    code = encode(52.5219, 13.4132, 10)
+    assert len(code) == 11
+    assert code[8] == "+"
+    assert set(code) - {"+"} <= _ALPHABET
+
+
+def test_encode_rejects_invalid_length() -> None:
+    """Odd lengths below the pair-code length are rejected (upstream contract)."""
+    with pytest.raises(ValueError):
+        encode(0.0, 0.0, 1)
+    with pytest.raises(ValueError):
+        encode(0.0, 0.0, 9)

--- a/tests/test_plus_code_sensor.py
+++ b/tests/test_plus_code_sensor.py
@@ -18,6 +18,7 @@ run inside pytest-asyncio's managed loop (see ``tests/AGENTS.md`` "Async tests")
 from __future__ import annotations
 
 import importlib
+import time
 from collections.abc import Callable, Iterable
 from types import SimpleNamespace
 from typing import Any
@@ -33,7 +34,11 @@ from tests.helpers.config_entries_stub import make_config_entry
 # All tests in this module are async and run in pytest-asyncio's managed loop.
 pytestmark = pytest.mark.asyncio
 
-# A decoder row with a real position. Its latitude/longitude drive the encoder.
+# A fresh timestamp so the position rows pass the sensor's staleness gate (it
+# mirrors the tracker: a fix older than the configured threshold is withheld).
+_FRESH_LAST_SEEN = time.time()
+
+# A decoder row with a real, recent position. Its lat/lon drive the encoder.
 _POSITION_ROW: dict[str, Any] = {
     "id": "dev-1",
     "device_id": "dev-1",
@@ -41,7 +46,7 @@ _POSITION_ROW: dict[str, Any] = {
     "latitude": 52.5200,
     "longitude": 13.4050,
     "accuracy": 12.0,
-    "last_seen": 1_700_000_000,
+    "last_seen": _FRESH_LAST_SEEN,
     "source_label": "Owner",
     "source_rank": 1,
 }
@@ -49,12 +54,14 @@ _POSITION_ROW: dict[str, Any] = {
 # encode(52.5200, 13.4050, 10) at the pinned upstream commit. 11 chars incl. "+".
 _EXPECTED_CODE = "9F4MGCC4+22"
 
-# A row whose coordinates are missing -> the sensor must yield None (no code).
+# A row that clears the accuracy/staleness gate but has no coordinates -> the
+# sensor must yield None at the coordinate guard specifically.
 _NO_COORDS_ROW: dict[str, Any] = {
     "id": "dev-1",
     "device_id": "dev-1",
     "name": "Pixel",
-    "last_seen": 1_700_000_000,
+    "accuracy": 12.0,
+    "last_seen": _FRESH_LAST_SEEN,
 }
 
 
@@ -222,3 +229,33 @@ async def test_plus_code_sensor_non_finite_coords_yield_none(
     )
     assert nan_entity.native_value is None
     assert inf_entity.native_value is None
+
+
+async def test_plus_code_sensor_accuracy_less_row_yields_none(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """A fresh row with valid lat/lon but no accuracy -> native_value None.
+
+    Display-row policy (Codex #202 / PR #1179): the tracker withholds an
+    accuracy-less fix, so the Plus Code must not encode that coordinate either.
+    Reverting the accuracy gate turns this test red (mutation check).
+    """
+    accuracy_less_row = {**_POSITION_ROW, "accuracy": None}
+    entity = await _build_plus_code_sensor(
+        accuracy_less_row, deterministic_config_subentry_id
+    )
+    assert entity.native_value is None
+
+
+async def test_plus_code_sensor_stale_row_yields_none(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """An accuracy-bearing but stale fix -> native_value None.
+
+    The tracker blanks live coordinates once a fix is older than the configured
+    stale threshold; the Plus Code applies the same gate. Reverting the
+    staleness gate turns this test red (mutation check).
+    """
+    stale_row = {**_POSITION_ROW, "last_seen": _FRESH_LAST_SEEN - 1_000_000}
+    entity = await _build_plus_code_sensor(stale_row, deterministic_config_subentry_id)
+    assert entity.native_value is None

--- a/tests/test_plus_code_sensor.py
+++ b/tests/test_plus_code_sensor.py
@@ -1,0 +1,224 @@
+# tests/test_plus_code_sensor.py
+"""Behavior tests for ``GoogleFindMyPlusCodeSensor``.
+
+Mirrors ``tests/test_last_seen_sensor_no_map_attributes.py``: a stub coordinator
+subclasses the real coordinator, and ``sensor.async_setup_entry`` is driven with
+a capture callback so the sensor is obtained through the genuine live setup path
+(``_build_entities()`` @ sensor.py, alongside the LastSeen sensor).
+
+Covers:
+- the success case (a position row yields the correct Plus Code);
+- the negative control (no/invalid row -> ``native_value`` is ``None``, no crash);
+- the map-marker guard (no ``latitude``/``longitude`` state attributes).
+
+Authored as coroutines and awaited directly (never ``asyncio.run()``): HA tests
+run inside pytest-asyncio's managed loop (see ``tests/AGENTS.md`` "Async tests").
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable, Iterable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.const import (
+    SERVICE_SUBENTRY_KEY,
+    TRACKER_SUBENTRY_KEY,
+)
+from tests.helpers.config_entries_stub import make_config_entry
+
+# All tests in this module are async and run in pytest-asyncio's managed loop.
+pytestmark = pytest.mark.asyncio
+
+# A decoder row with a real position. Its latitude/longitude drive the encoder.
+_POSITION_ROW: dict[str, Any] = {
+    "id": "dev-1",
+    "device_id": "dev-1",
+    "name": "Pixel",
+    "latitude": 52.5200,
+    "longitude": 13.4050,
+    "accuracy": 12.0,
+    "last_seen": 1_700_000_000,
+    "source_label": "Owner",
+    "source_rank": 1,
+}
+
+# encode(52.5200, 13.4050, 10) at the pinned upstream commit. 11 chars incl. "+".
+_EXPECTED_CODE = "9F4MGCC4+22"
+
+# A row whose coordinates are missing -> the sensor must yield None (no code).
+_NO_COORDS_ROW: dict[str, Any] = {
+    "id": "dev-1",
+    "device_id": "dev-1",
+    "name": "Pixel",
+    "last_seen": 1_700_000_000,
+}
+
+
+async def _build_plus_code_sensor(
+    row: dict[str, Any] | None,
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> Any:
+    """Construct a real ``GoogleFindMyPlusCodeSensor`` via the platform setup path.
+
+    Mirrors the LastSeen test harness: a stub coordinator subclassing the real
+    coordinator serves ``row`` from ``get_device_location_data_for_subentry`` so
+    the value under test sees a controlled position.
+    """
+
+    del (
+        deterministic_config_subentry_id
+    )  # side effect: patches ensure_config_subentry_id
+
+    device_tracker = importlib.import_module(
+        "custom_components.googlefindmy.device_tracker"
+    )
+    sensor = importlib.import_module("custom_components.googlefindmy.sensor")
+
+    class _StubCoordinator(device_tracker.GoogleFindMyCoordinator):
+        def __init__(self, devices: Iterable[dict[str, Any]]) -> None:
+            self._snapshot = list(devices)
+            self._listeners: list[Callable[[], None]] = []
+            self.hass = SimpleNamespace()
+            self.config_entry = make_config_entry(entry_id="entry-id")
+            self.stats: dict[str, int] = {}
+            self._device_names: dict[str, str] = {}
+            self._device_location_data: dict[str, Any] = {}
+            self._device_caps: dict[str, Any] = {}
+            self._present_last_seen: dict[str, float] = {}
+            self._row: dict[str, Any] | None = row
+
+        def async_add_listener(
+            self, listener: Callable[[], None]
+        ) -> Callable[[], None]:
+            self._listeners.append(listener)
+            return lambda: None
+
+        def stable_subentry_identifier(
+            self, *, key: str | None = None, feature: str | None = None
+        ) -> str:
+            assert key is not None
+            return f"{key}-identifier"
+
+        def get_subentry_metadata(
+            self, *, key: str | None = None, feature: str | None = None
+        ) -> Any:
+            if key is not None:
+                resolved = key
+            elif feature in {"button", "device_tracker", "sensor"}:
+                resolved = TRACKER_SUBENTRY_KEY
+            elif feature == "binary_sensor":
+                resolved = SERVICE_SUBENTRY_KEY
+            else:
+                resolved = TRACKER_SUBENTRY_KEY
+            return SimpleNamespace(key=resolved)
+
+        def get_subentry_snapshot(
+            self, key: str | None = None, *, feature: str | None = None
+        ) -> list[dict[str, Any]]:
+            return list(self._snapshot)
+
+        def get_device_location_data_for_subentry(
+            self, subentry_key: str, device_id: str
+        ) -> dict[str, Any] | None:
+            return self._row
+
+    class _StubConfigEntry:
+        def __init__(self, coordinator: _StubCoordinator) -> None:
+            self.runtime_data = coordinator
+            self.entry_id = "entry-id"
+            self.data: dict[str, Any] = {}
+            self.options: dict[str, Any] = {}
+            self._unsub: list[Callable[[], None]] = []
+
+        def async_on_unload(self, callback: Callable[[], None]) -> None:
+            self._unsub.append(callback)
+
+    coordinator = _StubCoordinator([{"id": "dev-1", "name": "Pixel"}])
+    entry = _StubConfigEntry(coordinator)
+
+    sensor_added: list[list[Any]] = []
+
+    def _capture_sensor(entities, update_before_add: bool = False):
+        sensor_added.append(list(entities))
+
+    await sensor.async_setup_entry(SimpleNamespace(), entry, _capture_sensor)
+
+    plus_code_entities = [
+        entity
+        for batch in sensor_added
+        for entity in batch
+        if isinstance(entity, sensor.GoogleFindMyPlusCodeSensor)
+    ]
+    assert len(plus_code_entities) == 1
+    return plus_code_entities[0]
+
+
+async def test_plus_code_sensor_encodes_position(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """A position row yields the full 10-digit Plus Code as native_value."""
+    entity = await _build_plus_code_sensor(
+        _POSITION_ROW, deterministic_config_subentry_id
+    )
+    assert entity.native_value == _EXPECTED_CODE
+    assert len(entity.native_value) == 11
+    assert entity.native_value[8] == "+"
+
+
+async def test_plus_code_sensor_has_no_map_coordinates(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """The text sensor must not advertise latitude/longitude (no third marker)."""
+    entity = await _build_plus_code_sensor(
+        _POSITION_ROW, deterministic_config_subentry_id
+    )
+    attrs = entity.extra_state_attributes or {}
+    assert "latitude" not in attrs
+    assert "longitude" not in attrs
+
+
+async def test_plus_code_sensor_none_row_yields_none(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """No location row -> native_value None (no stale last value), no crash."""
+    entity = await _build_plus_code_sensor(None, deterministic_config_subentry_id)
+    assert entity.native_value is None
+
+
+async def test_plus_code_sensor_missing_coords_yields_none(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """A row without latitude/longitude -> native_value None, no crash."""
+    entity = await _build_plus_code_sensor(
+        _NO_COORDS_ROW, deterministic_config_subentry_id
+    )
+    assert entity.native_value is None
+
+
+async def test_plus_code_sensor_boolean_coords_yield_none(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """Boolean coordinates (bool is an int subclass) -> native_value None."""
+    row = {**_POSITION_ROW, "latitude": True, "longitude": False}
+    entity = await _build_plus_code_sensor(row, deterministic_config_subentry_id)
+    assert entity.native_value is None
+
+
+async def test_plus_code_sensor_non_finite_coords_yield_none(
+    deterministic_config_subentry_id: Callable[[Any, str, str | None], str],
+) -> None:
+    """NaN/inf coordinates -> native_value None (no bogus code), no crash."""
+    nan_row = {**_POSITION_ROW, "latitude": float("nan")}
+    inf_row = {**_POSITION_ROW, "longitude": float("inf")}
+    nan_entity = await _build_plus_code_sensor(
+        nan_row, deterministic_config_subentry_id
+    )
+    inf_entity = await _build_plus_code_sensor(
+        inf_row, deterministic_config_subentry_id
+    )
+    assert nan_entity.native_value is None
+    assert inf_entity.native_value is None

--- a/tests/test_sensor_subentry_setup.py
+++ b/tests/test_sensor_subentry_setup.py
@@ -111,6 +111,7 @@ async def test_setup_iterates_sensor_subentries(stub_coordinator_factory: Any) -
         f"{DOMAIN}_{entry.entry_id}_{service_subentry.subentry_id}_encryption_key_status",
         f"{DOMAIN}_{entry.entry_id}_{service_subentry.subentry_id}_background_updates",
         f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_device-1_last_seen",
+        f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_device-1_plus_code",
     }
 
 
@@ -168,12 +169,13 @@ async def test_dispatcher_adds_new_tracker_subentries(
     await asyncio.gather(*pending)
 
     configs = [config for _, config in added]
-    assert configs.count(tracker_subentry.subentry_id) == 1
-    assert configs.count(new_subentry.subentry_id) == 1
+    # Each tracker device now emits two sensors: last_seen and plus_code.
+    assert configs.count(tracker_subentry.subentry_id) == 2
+    assert configs.count(new_subentry.subentry_id) == 2
     # Service scope now emits three diagnostic sensors: semantic_labels,
     # encryption_key_status (AP-10) and the background_updates stat.
     assert configs.count(service_subentry.subentry_id) == 3
-    assert len({entity.unique_id for entity, _ in added}) == 5
+    assert len({entity.unique_id for entity, _ in added}) == 7
     assert entry._unload_callbacks, "dispatcher listener should be cleaned up on unload"
 
 
@@ -225,9 +227,9 @@ async def test_dispatcher_deduplicates_existing_subentry_signals(
     async_dispatcher_send(hass, signal, service_subentry.subentry_id)
     await asyncio.gather(*pending)
 
-    # Four entities: service semantic_labels + encryption_key_status (AP-10) +
-    # background_updates stat, plus the tracker last_seen sensor.
-    assert len(added) == initial_count == 4
+    # Five entities: service semantic_labels + encryption_key_status (AP-10) +
+    # background_updates stat, plus the tracker last_seen and plus_code sensors.
+    assert len(added) == initial_count == 5
     assert {config for _, config in added} == {
         service_subentry.subentry_id,
         tracker_subentry.subentry_id,
@@ -276,6 +278,7 @@ async def test_hidden_tracker_sensors_skip_invisible_devices(
 
     assert {entity.unique_id for entity, _ in added} == {
         f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_visible-device_last_seen",
+        f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_visible-device_plus_code",
         f"{DOMAIN}_{entry.entry_id}_service_background_updates",
         f"{DOMAIN}_{entry.entry_id}_service_semantic_labels",
         f"{DOMAIN}_{entry.entry_id}_service_encryption_key_status",
@@ -340,16 +343,29 @@ async def test_recovery_skips_hidden_tracker_sensors(
     assert registration is not None
 
     visible_unique_id = f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_visible-device_last_seen"
+    visible_plus_code_unique_id = f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_visible-device_plus_code"
     hidden_unique_id = f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_hidden-device_last_seen"
+    hidden_plus_code_unique_id = f"{DOMAIN}_{entry.entry_id}_{tracker_subentry.subentry_id}_hidden-device_plus_code"
     service_unique_id = f"{DOMAIN}_{entry.entry_id}_service_background_updates"
 
-    assert registration.expected_unique_ids() == {visible_unique_id, service_unique_id}
+    assert registration.expected_unique_ids() == {
+        visible_unique_id,
+        visible_plus_code_unique_id,
+        service_unique_id,
+    }
 
-    missing = {visible_unique_id, hidden_unique_id, service_unique_id}
+    missing = {
+        visible_unique_id,
+        visible_plus_code_unique_id,
+        hidden_unique_id,
+        hidden_plus_code_unique_id,
+        service_unique_id,
+    }
     recovered = registration.entity_factory(missing)
 
     assert {entity.unique_id for entity in recovered} == {
         visible_unique_id,
+        visible_plus_code_unique_id,
         service_unique_id,
     }
 


### PR DESCRIPTION
## Summary

Adds the Google **Plus Code** (Open Location Code, OLC) for every tracker device:

1. A new per-device text sensor `GoogleFindMyPlusCodeSensor` exposing the full
   10-digit Plus Code (11 chars incl. the `+` separator, e.g. `8FVC9G8F+6X`).
2. Two extra lines in the existing map info popup for the selected device:
   the **Plus Code** and the **raw coordinates** in Google-Maps-ready decimal
   degrees (`lat, lon`), each with a **copy-to-clipboard** icon.

The code is computed locally, offline and without an API key from the
coordinates the integration already has. No reverse geocoding, no network.

## Details

- **Vendored encoder** (`vendor/openlocationcode/`): the encode-only path of
  Google's reference Python encoder, vendored verbatim from
  `google/open-location-code` @ `dcff1534f70a0d7244d0d1c357c20f0aa28ab355`
  (Apache-2.0). Verified against the official `test_data/encoding.csv` vectors.
- **Sensor**: modeled on `GoogleFindMyLastSeenSensor`; a `RestoreSensor` whose
  `native_value` is derived live from the current location row and is `None`
  when there is no valid fix (no stale value, no NaN/inf). It deliberately
  carries no `latitude`/`longitude` attributes, so HA does not plot a spurious
  extra map marker. Registered on all three sensor paths (live setup + the two
  recovery callbacks).
- **Map popup**: `plus_code` is computed server-side in the extracted pure
  helper `_build_location_entry`; the raw coordinate line is formatted
  client-side from the numeric `loc.lat`/`loc.lon`. The copy icons read the raw
  value from the `loc` closure (never from the DOM) and use
  `navigator.clipboard` with a hidden-textarea + `execCommand` fallback so copy
  also works on plain-LAN `http://<ip>:8123` (non-secure context). Handlers
  call `stopPropagation`/`preventDefault` so the map does not pan or close.

## License / attribution (Apache-2.0 in a GPLv3 project)

Apache-2.0 is one-way compatible with GPLv3. The vendored file keeps its verbatim
Apache short header + SPDX identifier + an upstream provenance/commit line + a
stated-changes line; a full Apache-2.0 `LICENSE` is bundled next to it, and the
README "Credits" section attributes it. The upstream Python encoder carries no
copyright line, so none is invented; upstream has no `NOTICE`, so none is added.
The project `LICENSE` stays GPLv3.

Note: this Apache-2.0 file is compatible with GPLv3 but not GPLv2; a future
switch to "GPL-2.0-or-later" would require revisiting it.

## Tests

- `tests/test_open_location_code.py`: encoder vs. official vectors, format
  invariants, longitude normalization, invalid-length rejection.
- `tests/test_plus_code_sensor.py`: success case, no-map-coordinates guard,
  and negative controls (no row / missing coordinates -> `native_value None`).
- `tests/test_map_view_plus_code.py`: server-side `plus_code` wiring and
  non-finite-coordinate guard.
- Existing sensor-setup/registry-alignment tests updated for the new per-device
  sensor. Full suite green, ruff and mypy strict clean.

The client-side copy JS is not unit-tested (no JS harness in the repo); it is
verified manually on both HTTPS (Nabu Casa) and plain-LAN HTTP.
