### PR TITLE
feat(map): localize the map view into all shipped UI languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ When a dependency pin changes, delete the archive (and `.wheelhouse/`) or rerun
 - ⏱️ **Configurable Polling**: Flexible polling intervals with rate limit protection
 - 🔔 **Sound Button Entity**: Devices include button entity that plays a sound on supported devices
 - ✅ **Attribute grading system**: Best location data is selected automatically based on recency, accuracy, and source of data
-- 📍 **Historical Map-View**: Each tracker has a filterable Map-View that shows tracker movement with location data
+- 📍 **Historical Map-View**: Each tracker has a filterable Map-View that shows tracker movement with location data, localized into every shipped UI language
 - 📋 **Statistic Entity**: Detailed statistics for monitoring integration performance
 - #️⃣ **Multi-Account Support**: Add multiple Find Hub Google accounts that show up separately
 - ❣️ **More to come!**
@@ -333,6 +333,22 @@ On **32-bit ARM (armv6/armv7)** there is no `gmpy2` wheel and a source build
 fails, so it cannot be used there. Because the effect is already small after the
 #1140 optimizations and only touches legacy trackers, installing `gmpy2` is a
 minor, optional tweak rather than a recommended step.
+
+## Map View localization
+
+The Map View is a self-rendered HTML page served by the integration, so it does
+**not** receive Home Assistant's frontend translations (those cover only entity,
+config and service strings). Its labels live in a dedicated catalog,
+[`custom_components/googlefindmy/map_i18n.py`](custom_components/googlefindmy/map_i18n.py),
+and are resolved server-side from `hass.config.language` with an English
+fallback. `Plus Code` stays untranslated on purpose (it is Google's brand name).
+
+To add or adjust a language, edit the `MAP_LABELS` dict in that module: add a
+locale entry with the **same key set** as `en` (a unit test enforces that every
+locale carries every key with a non-empty value). This catalog is intentionally
+separate from `strings.json` / `translations/`, so `make translation-check`,
+`translation_key_check.py` and `translation_placeholder_check.py` are unaffected
+by map-label changes and there is no hassfest schema risk.
 
 ## Known limitations
 

--- a/custom_components/googlefindmy/map_i18n.py
+++ b/custom_components/googlefindmy/map_i18n.py
@@ -1,0 +1,303 @@
+# custom_components/googlefindmy/map_i18n.py
+"""Localization catalog for the self-rendered Leaflet map view.
+
+Home Assistant loads ``translations/*.json`` only for entity, config and
+service strings into the frontend. The map is a self-built aiohttp HTML page
+(``map_view._generate_map_html``) that never receives those translations, so it
+needs its own catalog. This module is that dedicated catalog: it is resolved
+server-side from ``hass.config.language`` with an English fallback.
+
+It is deliberately kept **out** of ``strings.json`` / ``translations/`` so it
+cannot trip the hassfest schema check (a non-standard top-level section there is
+a CI risk). See the plan decision A1.
+
+Leaf module: standard library only, with no imports from ``map_view`` or
+``coordinator``, so it can be imported from either without an import cycle.
+
+Catalog invariants (enforced by ``tests/test_map_i18n.py``):
+- every locale carries the exact same key set as ``en``;
+- every value is a non-empty string;
+- ``en`` is complete and is the fallback source.
+
+Attribute-safety note: the copy-tooltip values are injected into single-quoted
+HTML attributes in the client JS (mirroring the pre-existing English literals),
+so no catalog value may contain a single quote ``'``. Keep translations quote
+free; the ``en`` reference values already are.
+"""
+
+from __future__ import annotations
+
+# Languages that render right-to-left. Only ``he`` (Hebrew) is shipped today.
+RTL_LANGUAGES: frozenset[str] = frozenset({"he"})
+
+# Full label catalog: locale code -> {label key -> translated string}.
+#
+# The 15 inventoried source strings map to 18 catalog keys, because the plural
+# string ``Showing N points`` splits into ``showing_points_one`` /
+# ``showing_points_other`` and the two dual-value strings (own/crowdsourced,
+# copy plus-code/coordinates) carry two keys each. ``{n}`` in the plural forms
+# is substituted by ``format_showing`` via ``str.replace`` (never ``.format``),
+# so literal braces need no escaping.
+MAP_LABELS: dict[str, dict[str, str]] = {
+    "en": {
+        "unknown_device": "Unknown Device",
+        "location_history": "Location History",
+        "start_time": "Start Time",
+        "end_time": "End Time",
+        "min_accuracy": "Min Accuracy (meters)",
+        "apply_filters": "Apply Filters",
+        "showing_points_one": "Showing {n} point",
+        "showing_points_other": "Showing {n} points",
+        "time": "Time:",
+        "accuracy": "Accuracy:",
+        "source": "Source:",
+        "own_device": "Own Device",
+        "crowdsourced": "Crowdsourced",
+        "location": "Location:",
+        "coordinates": "Coordinates:",
+        "copy_to_clipboard": "Copy to clipboard",
+        "copy_plus_code": "Copy Plus Code to clipboard",
+        "copy_coordinates": "Copy coordinates to clipboard",
+    },
+    "de": {
+        "unknown_device": "Unbekanntes Gerät",
+        "location_history": "Standortverlauf",
+        "start_time": "Startzeit",
+        "end_time": "Endzeit",
+        "min_accuracy": "Mindestgenauigkeit (Meter)",
+        "apply_filters": "Filter anwenden",
+        "showing_points_one": "{n} Punkt angezeigt",
+        "showing_points_other": "{n} Punkte angezeigt",
+        "time": "Zeit:",
+        "accuracy": "Genauigkeit:",
+        "source": "Quelle:",
+        "own_device": "Eigenes Gerät",
+        "crowdsourced": "Fremdnetzwerk",
+        "location": "Ort:",
+        "coordinates": "Koordinaten:",
+        "copy_to_clipboard": "In die Zwischenablage kopieren",
+        "copy_plus_code": "Plus Code in die Zwischenablage kopieren",
+        "copy_coordinates": "Koordinaten in die Zwischenablage kopieren",
+    },
+    "es": {
+        "unknown_device": "Dispositivo desconocido",
+        "location_history": "Historial de ubicaciones",
+        "start_time": "Hora de inicio",
+        "end_time": "Hora de fin",
+        "min_accuracy": "Precisión mínima (metros)",
+        "apply_filters": "Aplicar filtros",
+        "showing_points_one": "Mostrando {n} punto",
+        "showing_points_other": "Mostrando {n} puntos",
+        "time": "Hora:",
+        "accuracy": "Precisión:",
+        "source": "Fuente:",
+        "own_device": "Dispositivo propio",
+        "crowdsourced": "Red colaborativa",
+        "location": "Ubicación:",
+        "coordinates": "Coordenadas:",
+        "copy_to_clipboard": "Copiar al portapapeles",
+        "copy_plus_code": "Copiar Plus Code al portapapeles",
+        "copy_coordinates": "Copiar coordenadas al portapapeles",
+    },
+    "fr": {
+        "unknown_device": "Appareil inconnu",
+        "location_history": "Historique de localisation",
+        "start_time": "Heure de début",
+        "end_time": "Heure de fin",
+        "min_accuracy": "Précision min. (mètres)",
+        "apply_filters": "Appliquer les filtres",
+        "showing_points_one": "{n} point affiché",
+        "showing_points_other": "{n} points affichés",
+        "time": "Heure :",
+        "accuracy": "Précision :",
+        "source": "Source :",
+        "own_device": "Appareil personnel",
+        "crowdsourced": "Réseau participatif",
+        "location": "Lieu :",
+        "coordinates": "Coordonnées :",
+        "copy_to_clipboard": "Copier dans le presse-papiers",
+        "copy_plus_code": "Copier le Plus Code dans le presse-papiers",
+        "copy_coordinates": "Copier les coordonnées dans le presse-papiers",
+    },
+    "he": {
+        "unknown_device": "מכשיר לא ידוע",
+        "location_history": "היסטוריית מיקומים",
+        "start_time": "שעת התחלה",
+        "end_time": "שעת סיום",
+        "min_accuracy": "דיוק מזערי (מטרים)",
+        "apply_filters": "החל מסננים",
+        "showing_points_one": "מציג {n} נקודה",
+        "showing_points_other": "מציג {n} נקודות",
+        "time": "זמן:",
+        "accuracy": "דיוק:",
+        "source": "מקור:",
+        "own_device": "מכשיר שלי",
+        "crowdsourced": "רשת שיתופית",
+        "location": "מיקום:",
+        "coordinates": "קואורדינטות:",
+        "copy_to_clipboard": "העתק ללוח",
+        "copy_plus_code": "העתק Plus Code ללוח",
+        "copy_coordinates": "העתק קואורדינטות ללוח",
+    },
+    "it": {
+        "unknown_device": "Dispositivo sconosciuto",
+        "location_history": "Cronologia posizioni",
+        "start_time": "Ora di inizio",
+        "end_time": "Ora di fine",
+        "min_accuracy": "Precisione minima (metri)",
+        "apply_filters": "Applica filtri",
+        "showing_points_one": "{n} punto mostrato",
+        "showing_points_other": "{n} punti mostrati",
+        "time": "Ora:",
+        "accuracy": "Precisione:",
+        "source": "Sorgente:",
+        "own_device": "Dispositivo proprio",
+        "crowdsourced": "Rete condivisa",
+        "location": "Posizione:",
+        "coordinates": "Coordinate:",
+        "copy_to_clipboard": "Copia negli appunti",
+        "copy_plus_code": "Copia il Plus Code negli appunti",
+        "copy_coordinates": "Copia le coordinate negli appunti",
+    },
+    "nl": {
+        "unknown_device": "Onbekend apparaat",
+        "location_history": "Locatiegeschiedenis",
+        "start_time": "Starttijd",
+        "end_time": "Eindtijd",
+        "min_accuracy": "Min. nauwkeurigheid (meters)",
+        "apply_filters": "Filters toepassen",
+        "showing_points_one": "{n} punt weergegeven",
+        "showing_points_other": "{n} punten weergegeven",
+        "time": "Tijd:",
+        "accuracy": "Nauwkeurigheid:",
+        "source": "Bron:",
+        "own_device": "Eigen apparaat",
+        "crowdsourced": "Netwerkmelding",
+        "location": "Locatie:",
+        "coordinates": "Coördinaten:",
+        "copy_to_clipboard": "Naar klembord kopiëren",
+        "copy_plus_code": "Plus Code naar klembord kopiëren",
+        "copy_coordinates": "Coördinaten naar klembord kopiëren",
+    },
+    "pl": {
+        "unknown_device": "Nieznane urządzenie",
+        "location_history": "Historia lokalizacji",
+        "start_time": "Czas rozpoczęcia",
+        "end_time": "Czas zakończenia",
+        "min_accuracy": "Min. dokładność (metry)",
+        "apply_filters": "Zastosuj filtry",
+        "showing_points_one": "Pokazano {n} punkt",
+        "showing_points_other": "Pokazano {n} punktów",
+        "time": "Czas:",
+        "accuracy": "Dokładność:",
+        "source": "Źródło:",
+        "own_device": "Własne urządzenie",
+        "crowdsourced": "Sieć społecznościowa",
+        "location": "Lokalizacja:",
+        "coordinates": "Współrzędne:",
+        "copy_to_clipboard": "Kopiuj do schowka",
+        "copy_plus_code": "Kopiuj Plus Code do schowka",
+        "copy_coordinates": "Kopiuj współrzędne do schowka",
+    },
+    "pt-BR": {
+        "unknown_device": "Dispositivo desconhecido",
+        "location_history": "Histórico de localização",
+        "start_time": "Hora de início",
+        "end_time": "Hora de término",
+        "min_accuracy": "Precisão mínima (metros)",
+        "apply_filters": "Aplicar filtros",
+        "showing_points_one": "Exibindo {n} ponto",
+        "showing_points_other": "Exibindo {n} pontos",
+        "time": "Hora:",
+        "accuracy": "Precisão:",
+        "source": "Fonte:",
+        "own_device": "Dispositivo próprio",
+        "crowdsourced": "Rede colaborativa",
+        "location": "Local:",
+        "coordinates": "Coordenadas:",
+        "copy_to_clipboard": "Copiar para a área de transferência",
+        "copy_plus_code": "Copiar Plus Code para a área de transferência",
+        "copy_coordinates": "Copiar coordenadas para a área de transferência",
+    },
+    "pt": {
+        "unknown_device": "Dispositivo desconhecido",
+        "location_history": "Histórico de localização",
+        "start_time": "Hora de início",
+        "end_time": "Hora de fim",
+        "min_accuracy": "Precisão mínima (metros)",
+        "apply_filters": "Aplicar filtros",
+        "showing_points_one": "A mostrar {n} ponto",
+        "showing_points_other": "A mostrar {n} pontos",
+        "time": "Hora:",
+        "accuracy": "Precisão:",
+        "source": "Fonte:",
+        "own_device": "Dispositivo próprio",
+        "crowdsourced": "Rede colaborativa",
+        "location": "Localização:",
+        "coordinates": "Coordenadas:",
+        "copy_to_clipboard": "Copiar para a área de transferência",
+        "copy_plus_code": "Copiar Plus Code para a área de transferência",
+        "copy_coordinates": "Copiar coordenadas para a área de transferência",
+    },
+}
+
+
+def resolve_map_labels(language: str | None) -> dict[str, str]:
+    """Resolve the map label set for a Home Assistant UI language.
+
+    Three-stage, case-insensitive resolution, always returning a full label set
+    (never empty, never a partial dict):
+
+    1. exact code match (``pt-BR`` is preferred over its base ``pt``);
+    2. base language without region (``de-DE`` -> ``de``);
+    3. English fallback for an unknown or missing language.
+
+    A fresh copy is returned so callers cannot mutate the shared catalog.
+    """
+
+    if not language:
+        return dict(MAP_LABELS["en"])
+
+    lowered = language.strip().lower()
+    if not lowered:
+        return dict(MAP_LABELS["en"])
+
+    for code, labels in MAP_LABELS.items():
+        if code.lower() == lowered:
+            return dict(labels)
+
+    base = lowered.split("-", 1)[0]
+    for code, labels in MAP_LABELS.items():
+        if code.lower() == base:
+            return dict(labels)
+
+    return dict(MAP_LABELS["en"])
+
+
+def format_showing(labels: dict[str, str], count: int) -> str:
+    """Return the localized ``Showing N points`` string for ``count`` points.
+
+    Uses a minimal two-form plural (``n == 1`` -> singular, else plural). This is
+    intentionally simple: only one plural string exists in the map (plan A5). For
+    languages with richer plural rules (for example Polish) the ``_other`` form is
+    used for all non-singular counts, a deliberate, documented simplification.
+    """
+
+    key = "showing_points_one" if count == 1 else "showing_points_other"
+    template = labels.get(key) or labels["showing_points_other"]
+    return template.replace("{n}", str(count))
+
+
+def is_rtl(language: str | None) -> bool:
+    """Return ``True`` if the language renders right-to-left (for example ``he``).
+
+    Case-insensitive, region-tolerant (``he-IL`` -> ``he``).
+    """
+
+    if not language:
+        return False
+    lowered = language.strip().lower()
+    if lowered in RTL_LANGUAGES:
+        return True
+    base = lowered.split("-", 1)[0]
+    return base in RTL_LANGUAGES

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -28,6 +28,7 @@ from .const import (
     map_token_secret_seed,
 )
 from .ha_typing import HomeAssistantView
+from .map_i18n import format_showing, is_rtl, resolve_map_labels
 from .vendor.openlocationcode import encode as _encode_plus_code
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,6 +45,20 @@ def _resolve_coordinator_class() -> type[Any]:
 
         _COORDINATOR_CLASS = _GoogleFindMyCoordinator
     return _COORDINATOR_CLASS
+
+
+def _resolve_language(hass: Any) -> str | None:
+    """Best-effort read of the Home Assistant UI language.
+
+    Returns the configured ``hass.config.language`` when present, otherwise
+    ``None`` so the label resolver falls back to English. Read defensively via
+    ``getattr`` so a degraded or stubbed ``hass`` (no ``config``) never crashes
+    the map render; a missing language is a fail-safe English page, not an error.
+    """
+
+    config = getattr(hass, "config", None)
+    language = getattr(config, "language", None)
+    return language if isinstance(language, str) else None
 
 
 # Inline SVG "content copy" icon (no icon-font dependency). Braceless, so it is
@@ -474,7 +489,9 @@ class GoogleFindMyMapView(HomeAssistantView):
 
         if not device_name:
             # Name fallback order: coordinator data -> device registry metadata -> placeholder.
-            device_name = "Unknown Device"
+            device_name = resolve_map_labels(_resolve_language(self.hass))[
+                "unknown_device"
+            ]
 
         # 4. Parse Filters (Time & Accuracy)
         end_time = dt_util.utcnow()
@@ -677,10 +694,22 @@ class GoogleFindMyMapView(HomeAssistantView):
         start_local = dt_util.as_local(start_time).strftime("%Y-%m-%dT%H:%M")
         end_local = dt_util.as_local(end_time).strftime("%Y-%m-%dT%H:%M")
 
+        # Localize the self-rendered map. HA frontend translations do not reach
+        # this hand-built HTML page, so labels are resolved server-side from the
+        # UI language (English fallback). Client-JS labels are serialized once as
+        # a JSON object and read by key in the browser; server-side panel labels
+        # are interpolated as escaped f-string values (plan A2/A3).
+        language = _resolve_language(self.hass)
+        labels = resolve_map_labels(language)
+        labels_json = json.dumps(labels)
+        html_attrs = f'lang="{escape(language or "en")}"'
+        if is_rtl(language):
+            html_attrs += ' dir="rtl"'
+
         return f"""<!DOCTYPE html>
-<html>
+<html {html_attrs}>
 <head>
-    <title>{escape(device_name)} - Location History</title>
+    <title>{escape(device_name)} - {escape(labels["location_history"])}</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
@@ -711,20 +740,20 @@ class GoogleFindMyMapView(HomeAssistantView):
     <div class="controls">
         <h3>{escape(device_name)}</h3>
         <div class="control-group">
-            <label>Start Time</label>
+            <label>{escape(labels["start_time"])}</label>
             <input type="datetime-local" id="start" value="{start_local}">
         </div>
         <div class="control-group">
-            <label>End Time</label>
+            <label>{escape(labels["end_time"])}</label>
             <input type="datetime-local" id="end" value="{end_local}">
         </div>
         <div class="control-group">
-            <label>Min Accuracy (meters): <span id="acc-val">{accuracy_filter}</span></label>
+            <label>{escape(labels["min_accuracy"])}: <span id="acc-val">{accuracy_filter}</span></label>
             <input type="range" id="accuracy" min="0" max="500" step="10" value="{accuracy_filter}" oninput="document.getElementById('acc-val').innerText = this.value">
         </div>
-        <button onclick="applyFilters()">Apply Filters</button>
+        <button onclick="applyFilters()">{escape(labels["apply_filters"])}</button>
         <div class="stats">
-            Showing {len(locations)} points
+            {escape(format_showing(labels, len(locations)))}
         </div>
     </div>
     <div id="map"></div>
@@ -740,6 +769,11 @@ class GoogleFindMyMapView(HomeAssistantView):
         var locations = {locations_json};
         var markers = L.layerGroup().addTo(map);
         var GFMY_COPY_ICON = '{_MAP_COPY_ICON_SVG}';
+        // Localized labels, serialized once server-side; read by key in the
+        // browser. json.dumps emits a valid JS object literal; the surrounding
+        // f-string treats this as a single replacement field, so the object's
+        // braces are inserted as data and never parsed as f-string syntax.
+        var GFMY_LABELS = {labels_json};
 {_MAP_COPY_HELPER_JS}
 
         // Accuracy-circle / marker-fade constants (two separate concerns):
@@ -820,29 +854,29 @@ class GoogleFindMyMapView(HomeAssistantView):
                 }});
 
                 var date = new Date(loc.timestamp).toLocaleString();
-                var source = loc.is_own_report ? "Own Device" : "Crowdsourced";
+                var source = loc.is_own_report ? GFMY_LABELS.own_device : GFMY_LABELS.crowdsourced;
 
                 // Google-Maps-ready decimal degrees: dot decimal separator (JS
                 // default) and "lat, lon" order with a comma+space separator.
                 var coordStr = loc.lat + ", " + loc.lon;
                 var popupHtml =
-                    "<b>Time:</b> " + date + "<br>" +
-                    "<b>Accuracy:</b> " + loc.accuracy.toFixed(1) + "m<br>" +
-                    "<b>Source:</b> " + source + "<br>";
+                    "<b>" + GFMY_LABELS.time + "</b> " + date + "<br>" +
+                    "<b>" + GFMY_LABELS.accuracy + "</b> " + loc.accuracy.toFixed(1) + "m<br>" +
+                    "<b>" + GFMY_LABELS.source + "</b> " + source + "<br>";
                 if (loc.semantic_location) {{
-                    popupHtml += "<b>Location:</b> " + loc.semantic_location + "<br>";
+                    popupHtml += "<b>" + GFMY_LABELS.location + "</b> " + loc.semantic_location + "<br>";
                 }}
                 if (loc.plus_code) {{
                     popupHtml += "<b>Plus Code:</b> " + loc.plus_code +
                         " <span class='gfmy-copy gfmy-copy-plus' role='button' tabindex='0'" +
-                        " title='Copy to clipboard'" +
-                        " aria-label='Copy Plus Code to clipboard'>" +
+                        " title='" + GFMY_LABELS.copy_to_clipboard + "'" +
+                        " aria-label='" + GFMY_LABELS.copy_plus_code + "'>" +
                         GFMY_COPY_ICON + "</span><br>";
                 }}
-                popupHtml += "<b>Coordinates:</b> " + coordStr +
+                popupHtml += "<b>" + GFMY_LABELS.coordinates + "</b> " + coordStr +
                     " <span class='gfmy-copy gfmy-copy-coords' role='button' tabindex='0'" +
-                    " title='Copy to clipboard'" +
-                    " aria-label='Copy coordinates to clipboard'>" +
+                    " title='" + GFMY_LABELS.copy_to_clipboard + "'" +
+                    " aria-label='" + GFMY_LABELS.copy_coordinates + "'>" +
                     GFMY_COPY_ICON + "</span>";
 
                 // autoPan: false keeps the auto-opened popup from panning the map

--- a/tests/test_map_i18n.py
+++ b/tests/test_map_i18n.py
@@ -1,0 +1,137 @@
+# tests/test_map_i18n.py
+"""Unit tests for the map-view localization catalog (``map_i18n``).
+
+Covers the pure catalog invariants and resolution helpers without the HTTP
+stack: completeness (same key set and non-empty values across every locale),
+three-stage language resolution with English fallback, region normalization,
+the minimal plural helper, and RTL detection.
+"""
+
+from __future__ import annotations
+
+from custom_components.googlefindmy import map_i18n
+from custom_components.googlefindmy.map_i18n import (
+    MAP_LABELS,
+    format_showing,
+    is_rtl,
+    resolve_map_labels,
+)
+
+_EXPECTED_LOCALES = {"de", "en", "es", "fr", "he", "it", "nl", "pl", "pt-BR", "pt"}
+
+
+def test_all_ten_locales_present() -> None:
+    """The catalog ships exactly the ten locales the repo maintains."""
+    assert set(MAP_LABELS) == _EXPECTED_LOCALES
+
+
+def test_every_locale_has_the_english_key_set_and_nonempty_values() -> None:
+    """Completeness guard: no locale may drop a key or carry an empty value.
+
+    This is the core of the "all languages covered" requirement: every locale
+    must expose the exact ``en`` key set (no missing, no extra key) AND every
+    value must be a non-empty string. The non-empty check closes the blind spot
+    a pure key-set comparison would leave (an empty ``""`` label would pass a
+    key-only guard but render a blank UI string).
+    """
+    english_keys = set(MAP_LABELS["en"])
+    assert english_keys, "English reference catalog must not be empty"
+
+    for locale, labels in MAP_LABELS.items():
+        assert set(labels) == english_keys, (
+            f"locale {locale!r} key set differs from en: "
+            f"missing={english_keys - set(labels)}, extra={set(labels) - english_keys}"
+        )
+        for key, value in labels.items():
+            assert isinstance(value, str) and value.strip() != "", (
+                f"locale {locale!r} key {key!r} must be a non-empty string, got {value!r}"
+            )
+
+
+def test_no_catalog_value_contains_a_single_quote() -> None:
+    """Copy tooltips are injected into single-quoted HTML attributes.
+
+    The client JS builds ``title='...'``/``aria-label='...'`` attributes by
+    concatenating catalog values into single-quoted attributes (mirroring the
+    pre-existing English literals). A value containing ``'`` would break the
+    attribute, so the catalog must stay single-quote free.
+    """
+    for locale, labels in MAP_LABELS.items():
+        for key, value in labels.items():
+            assert "'" not in value, (
+                f"locale {locale!r} key {key!r} contains a single quote"
+            )
+
+
+def test_resolve_none_and_unknown_fall_back_to_english() -> None:
+    """A missing or unknown language yields the English label set."""
+    english = MAP_LABELS["en"]
+    assert resolve_map_labels(None) == english
+    assert resolve_map_labels("") == english
+    assert resolve_map_labels("   ") == english
+    assert resolve_map_labels("xx") == english
+    assert resolve_map_labels("zz-ZZ") == english
+
+
+def test_resolve_exact_code_is_case_insensitive() -> None:
+    """Exact codes resolve regardless of case, including region-qualified ones."""
+    assert resolve_map_labels("de")["source"] == MAP_LABELS["de"]["source"]
+    assert resolve_map_labels("DE")["source"] == MAP_LABELS["de"]["source"]
+    assert resolve_map_labels("pt-BR")["end_time"] == MAP_LABELS["pt-BR"]["end_time"]
+    assert resolve_map_labels("pt-br")["end_time"] == MAP_LABELS["pt-BR"]["end_time"]
+
+
+def test_pt_br_is_preferred_over_base_pt() -> None:
+    """The exact ``pt-BR`` code wins over the base ``pt`` (distinct values)."""
+    assert MAP_LABELS["pt-BR"]["end_time"] != MAP_LABELS["pt"]["end_time"]
+    assert resolve_map_labels("pt-BR")["end_time"] == MAP_LABELS["pt-BR"]["end_time"]
+
+
+def test_region_qualified_code_falls_back_to_base_language() -> None:
+    """A region-qualified code with no exact match uses the base language."""
+    # de-DE has no exact entry -> base 'de'.
+    assert resolve_map_labels("de-DE")["source"] == MAP_LABELS["de"]["source"]
+    # pt-PT has no exact entry -> base 'pt' (not pt-BR).
+    assert resolve_map_labels("pt-PT")["end_time"] == MAP_LABELS["pt"]["end_time"]
+
+
+def test_resolve_returns_a_defensive_copy() -> None:
+    """Mutating the resolved dict must not corrupt the shared catalog."""
+    labels = resolve_map_labels("de")
+    labels["source"] = "TAMPERED"
+    assert MAP_LABELS["de"]["source"] != "TAMPERED"
+
+
+def test_format_showing_singular_vs_plural() -> None:
+    """``format_showing`` selects singular only for exactly one point."""
+    english = resolve_map_labels("en")
+    assert format_showing(english, 1) == "Showing 1 point"
+    assert format_showing(english, 0) == "Showing 0 points"
+    assert format_showing(english, 2) == "Showing 2 points"
+    assert format_showing(english, 42) == "Showing 42 points"
+
+
+def test_format_showing_localizes_and_substitutes_count() -> None:
+    """The plural helper works per locale and substitutes ``{n}``."""
+    german = resolve_map_labels("de")
+    assert format_showing(german, 1) == "1 Punkt angezeigt"
+    assert format_showing(german, 3) == "3 Punkte angezeigt"
+    # No literal placeholder must survive.
+    assert "{n}" not in format_showing(german, 5)
+
+
+def test_is_rtl_detection() -> None:
+    """Only Hebrew (and its region variants) is right-to-left."""
+    assert is_rtl("he") is True
+    assert is_rtl("he-IL") is True
+    assert is_rtl("HE") is True
+    assert is_rtl("en") is False
+    assert is_rtl("de") is False
+    assert is_rtl(None) is False
+    assert is_rtl("") is False
+
+
+def test_rtl_languages_constant_is_a_frozenset() -> None:
+    """RTL set is an immutable frozenset containing Hebrew."""
+    assert isinstance(map_i18n.RTL_LANGUAGES, frozenset)
+    assert "he" in map_i18n.RTL_LANGUAGES

--- a/tests/test_map_view_features.py
+++ b/tests/test_map_view_features.py
@@ -517,7 +517,7 @@ async def test_accuracy_filter_drops_points_worse_than_threshold(
     )
 
     assert response.status == 200
-    assert "showing 1 points" in response.text.lower()
+    assert "showing 1 point" in response.text.lower()
     assert '"lat": 10.0' in response.text
     assert '"lat": 50.0' not in response.text
 
@@ -640,7 +640,7 @@ async def test_invalid_accuracy_rendered_as_fallback_when_filter_off(
     response = await _render_map_with_states(monkeypatch, [unknown], {"accuracy": "0"})
 
     assert response.status == 200
-    assert "showing 1 points" in response.text.lower()
+    assert "showing 1 point" in response.text.lower()
     assert '"lat": 33.0' in response.text
     assert '"accuracy": 200.0' in response.text
     assert '"accuracy": 0.0' not in response.text
@@ -805,7 +805,7 @@ async def test_entity_entry_refetched_when_missing(
     )
 
     assert response.status == 200
-    assert "showing 1 points" in response.text.lower()
+    assert "showing 1 point" in response.text.lower()
 
 
 @pytest.mark.asyncio
@@ -897,7 +897,7 @@ async def test_last_seen_non_string_falls_back_to_state_time(
     )
 
     assert response.status == 200
-    assert "showing 1 points" in response.text.lower()
+    assert "showing 1 point" in response.text.lower()
 
 
 @pytest.mark.asyncio
@@ -916,7 +916,7 @@ async def test_last_seen_unparseable_string_falls_back_to_state_time(
     )
 
     assert response.status == 200
-    assert "showing 1 points" in response.text.lower()
+    assert "showing 1 point" in response.text.lower()
 
 
 @pytest.mark.asyncio
@@ -935,7 +935,7 @@ async def test_invalid_state_is_skipped(
     )
 
     assert response.status == 200
-    assert "showing 1 points" in response.text.lower()
+    assert "showing 1 point" in response.text.lower()
     assert '"lat": 77.0' in response.text
 
 

--- a/tests/test_map_view_i18n.py
+++ b/tests/test_map_view_i18n.py
@@ -1,0 +1,160 @@
+# tests/test_map_view_i18n.py
+"""Server-side render tests for map-view localization.
+
+Exercises ``_generate_map_html`` end to end for a localized language (German),
+the English fallback for an unknown language, and the RTL attributes for Hebrew.
+The negative rest-string assertion guarantees that no English source label
+leaks into a non-English render, catching any string AP2 forgot to route
+through the catalog.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from custom_components.googlefindmy import map_view
+from custom_components.googlefindmy.map_i18n import format_showing, resolve_map_labels
+
+_NOW = datetime(2024, 1, 1, tzinfo=UTC)
+
+# English source labels in the exact rendered form. The exact form (with the
+# surrounding <b>.. tag, > label < markup, or attribute context) is required so
+# the negative assertion does not false-fail on JS identifiers or CSS ids that
+# merely contain the lower-cased word (for example ``loc.accuracy`` or
+# ``id="accuracy"``). These must NOT appear in a non-English render.
+_ENGLISH_EXACT_FORMS = (
+    ">Start Time<",
+    ">End Time<",
+    "Min Accuracy (meters)",
+    ">Apply Filters<",
+    "<b>Time:</b>",
+    "<b>Accuracy:</b>",
+    "<b>Source:</b>",
+    "<b>Location:</b>",
+    "<b>Coordinates:</b>",
+    "Own Device",
+    "Crowdsourced",
+    "Copy to clipboard",
+    "Copy Plus Code to clipboard",
+    "Copy coordinates to clipboard",
+    " - Location History",
+    "Unknown Device",
+)
+
+# Deliberately source-language / non-translatable; must survive every render.
+_ALWAYS_PRESENT = (
+    "<b>Plus Code:</b>",  # Google brand name (proper noun)
+    "© OpenStreetMap contributors",  # map attribution
+)
+
+
+def _make_view(language: str | None) -> map_view.GoogleFindMyMapView:
+    if language is None:
+        hass = SimpleNamespace()
+    else:
+        hass = SimpleNamespace(config=SimpleNamespace(language=language))
+    return map_view.GoogleFindMyMapView(hass)
+
+
+def _sample_locations() -> list[dict[str, object]]:
+    return [
+        {
+            "lat": 52.5219,
+            "lon": 13.4132,
+            "accuracy": 8.0,
+            "accuracy_estimated": False,
+            "timestamp": _NOW.isoformat(),
+            "last_seen": 1_735_000_000,
+            "is_own_report": True,
+            "semantic_location": "Home",
+            "plus_code": "9F4MGCC7+Q7",
+        }
+    ]
+
+
+def _render(language: str | None) -> str:
+    view = _make_view(language)
+    return view._generate_map_html(
+        "MyPhone",
+        _sample_locations(),
+        "device-1",
+        _NOW,
+        _NOW + timedelta(days=1),
+        0,
+    )
+
+
+def test_german_render_uses_german_panel_labels() -> None:
+    """A ``de`` language renders German panel labels, not the English ones."""
+    html = _render("de")
+    assert ">Startzeit<" in html
+    assert ">Filter anwenden<" in html
+    assert "Mindestgenauigkeit (Meter)" in html
+    assert "<b>Quelle:</b>" not in html  # sanity: label lives inside JS concat
+    # German popup labels are injected via the JS label object.
+    labels = resolve_map_labels("de")
+    assert f'"source": "{labels["source"]}"' in html
+    assert f'"coordinates": "{labels["coordinates"]}"' in html
+
+
+def test_german_render_contains_no_english_source_label() -> None:
+    """Negative rest-string guard: no English source label survives in ``de``.
+
+    Iterates the full inventory in exact rendered form. A single hard-coded
+    English string that AP2 forgot to route through the catalog would fail here.
+    """
+    html = _render("de")
+    for english in _ENGLISH_EXACT_FORMS:
+        assert english not in html, (
+            f"English source label leaked into de render: {english!r}"
+        )
+    # The German plural stat line must be present instead of the English one.
+    german = resolve_map_labels("de")
+    assert format_showing(german, len(_sample_locations())) in html
+    assert (
+        format_showing(resolve_map_labels("en"), len(_sample_locations())) not in html
+    )
+
+
+def test_non_translatable_strings_always_present_in_german_render() -> None:
+    """Proper nouns / attribution stay source-language even under localization."""
+    html = _render("de")
+    for keep in _ALWAYS_PRESENT:
+        assert keep in html, f"non-translatable string missing from de render: {keep!r}"
+    # The accuracy unit symbol stays untranslated.
+    assert 'toFixed(1) + "m<br>"' in html
+    # The device name passes through unchanged.
+    assert "MyPhone" in html
+
+
+def test_unknown_language_falls_back_to_english() -> None:
+    """An unknown language renders the English catalog (fail-safe)."""
+    html = _render("xx")
+    assert ">Start Time<" in html
+    assert ">Apply Filters<" in html
+    assert " - Location History" in html
+    assert '<html lang="xx">' in html  # lang attribute reflects the raw request
+
+
+def test_stub_hass_without_config_renders_english() -> None:
+    """A degraded hass without ``config`` never crashes; it renders English."""
+    html = _render(None)
+    assert ">Start Time<" in html
+    assert '<html lang="en">' in html
+
+
+def test_hebrew_sets_rtl_and_lang_attributes() -> None:
+    """Hebrew (RTL) sets both ``dir="rtl"`` and ``lang="he"``."""
+    html = _render("he")
+    assert '<html lang="he" dir="rtl">' in html
+    # Hebrew label present, English absent.
+    assert resolve_map_labels("he")["start_time"] in html
+    assert ">Start Time<" not in html
+
+
+def test_english_render_has_no_rtl_attribute() -> None:
+    """A left-to-right language must not carry ``dir="rtl"``."""
+    html = _render("en")
+    assert '<html lang="en">' in html
+    assert 'dir="rtl"' not in html


### PR DESCRIPTION
## What

Localizes the self-rendered Leaflet map view (`map_view.py`) into all ten shipped UI languages (de, en, es, fr, he, it, nl, pl, pt-BR, pt). Until now the map was hard-coded English-only, even though the rest of the integration is fully translated.

## Why

The map is a self-built aiohttp HTML page, so it never receives Home Assistant's frontend translations (those cover only entity/config/service strings). Users running HA in a non-English language still saw an all-English map. This closes that gap.

## How

- **New catalog `custom_components/googlefindmy/map_i18n.py`** (leaf module, stdlib only): `MAP_LABELS` holds every label per locale, plus three pure helpers — `resolve_map_labels` (three-stage, case-insensitive resolution: exact code → base language `de-DE`→`de` → English fallback; `pt-BR` preferred over base `pt`), `format_showing` (minimal singular/plural), `is_rtl`.
- **`map_view.py` wiring**: labels resolved server-side from `hass.config.language` (read defensively, English fallback, never crashes on a degraded `hass`). Panel labels interpolated as escaped f-string values; client-JS labels serialized once via `json.dumps` into a `GFMY_LABELS` object and read by key in the browser. `<html>` gets `lang="…"` always and `dir="rtl"` for Hebrew.
- **Deliberately not translated**: `Plus Code:` (Google brand name), the `m` unit symbol, `© OpenStreetMap contributors` (map attribution), the device name, HTTP status texts.
- **Kept out of `strings.json`/`translations/`** on purpose, so hassfest and the i18n key/placeholder checks are unaffected (no schema risk).

## Tests

- `tests/test_map_i18n.py`: completeness guard (every locale carries the exact `en` key set **and** non-empty values), fallback, region normalization, `pt-BR` vs `pt`, plural, RTL, defensive-copy, single-quote safety.
- `tests/test_map_view_i18n.py`: German render uses German labels; **negative rest-string guard** (no English source label in exact rendered form leaks into a `de` render); unknown language → English fallback; degraded `hass` renders English; Hebrew sets `dir="rtl"`; English has no `dir`.
- Existing `test_map_view_features.py`: the six `"showing 1 points"` assertions corrected to `"showing 1 point"` (proper singular is now rendered — a grammar improvement, per AGENTS.md 3.1 Test Corrections).
- Full suite green, `ruff check` + `ruff format --check` clean, `mypy --strict` clean on changed files. Changed lines fully covered (`map_i18n.py` 100%, `map_view.py` 99%; the 2 uncovered lines are pre-existing defensive branches).
