### PR TITLE
feat(map): shorten displayed popup coordinates, keep copy full precision (1.7.13)

### DIFF
--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -27,7 +27,7 @@ CONFIG_ENTRY_VERSION: int = 2
 # cross-reference, so the manifest side is anchored in this directory's AGENTS.md
 # ("Version bump touches three files"). pyproject.toml carries the reverse reference
 # in a TOML comment.
-INTEGRATION_VERSION: str = "1.7.12"
+INTEGRATION_VERSION: str = "1.7.13"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/custom_components/googlefindmy/manifest.json
+++ b/custom_components/googlefindmy/manifest.json
@@ -35,5 +35,5 @@
     "selenium>=4.25.0",
     "undetected_chromedriver>=3.5.5"
   ],
-  "version": "1.7.12"
+  "version": "1.7.13"
 }

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -774,6 +774,8 @@ class GoogleFindMyMapView(HomeAssistantView):
         // f-string treats this as a single replacement field, so the object's
         // braces are inserted as data and never parsed as f-string syntax.
         var GFMY_LABELS = {labels_json};
+        // Display-only precision for popup coordinates; copy keeps full precision.
+        var GFMY_COORD_DISPLAY_DECIMALS = 5;
 {_MAP_COPY_HELPER_JS}
 
         // Accuracy-circle / marker-fade constants (two separate concerns):
@@ -859,6 +861,9 @@ class GoogleFindMyMapView(HomeAssistantView):
                 // Google-Maps-ready decimal degrees: dot decimal separator (JS
                 // default) and "lat, lon" order with a comma+space separator.
                 var coordStr = loc.lat + ", " + loc.lon;
+                // Display-only: round to N decimals, then strip padding zeros so a
+                // shorter source value stays short. Copy path keeps coordStr raw.
+                var coordDisplay = Number(Number(loc.lat).toFixed(GFMY_COORD_DISPLAY_DECIMALS)) + ", " + Number(Number(loc.lon).toFixed(GFMY_COORD_DISPLAY_DECIMALS));
                 var popupHtml =
                     "<b>" + GFMY_LABELS.time + "</b> " + date + "<br>" +
                     "<b>" + GFMY_LABELS.accuracy + "</b> " + loc.accuracy.toFixed(1) + "m<br>" +
@@ -873,7 +878,7 @@ class GoogleFindMyMapView(HomeAssistantView):
                         " aria-label='" + GFMY_LABELS.copy_plus_code + "'>" +
                         GFMY_COPY_ICON + "</span><br>";
                 }}
-                popupHtml += "<b>" + GFMY_LABELS.coordinates + "</b> " + coordStr +
+                popupHtml += "<b>" + GFMY_LABELS.coordinates + "</b> " + coordDisplay +
                     " <span class='gfmy-copy gfmy-copy-coords' role='button' tabindex='0'" +
                     " title='" + GFMY_LABELS.copy_to_clipboard + "'" +
                     " aria-label='" + GFMY_LABELS.copy_coordinates + "'>" +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "googlefindmy-ha"
 # [tool.semantic_release] version_toml below); on release branches it MUST be
 # bumped by hand alongside the other two. Canonical anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
-version = "1.7.12"
+version = "1.7.13"
 description = "Home Assistant integration for Google's Find My Device network."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_map_view_features.py
+++ b/tests/test_map_view_features.py
@@ -1099,3 +1099,43 @@ async def test_newest_point_can_be_estimated(
     assert len(locations) == 2
     assert locations[0]["accuracy_estimated"] is False
     assert locations[-1]["accuracy_estimated"] is True
+
+
+@pytest.mark.asyncio
+async def test_popup_coordinates_display_is_shortened_copy_stays_raw(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Popup shows rounded coordinates; the copy button keeps full precision.
+
+    The display line must read from ``coordDisplay`` (rounded via the named
+    ``GFMY_COORD_DISPLAY_DECIMALS`` constant, then padding zeros stripped), while
+    the coordinate copy handler must still serialize the raw ``loc.lat``/
+    ``loc.lon`` without any ``toFixed``. Reverting the display back to
+    ``coordStr`` (the mutation counter-proof) makes assertion (a)/(e) fail.
+    """
+
+    state = _StubState(latitude=10.8368252529521, longitude=49.7380204)
+    state.attributes["gps_accuracy"] = 58
+    state.attributes["last_seen"] = 1704067200.0
+
+    response = await _render_map_with_states(monkeypatch, [state], {"accuracy": "0"})
+    assert response.status == 200
+    html = response.text
+
+    # (a) display precision constant is defined at script level and set to 5
+    assert "var GFMY_COORD_DISPLAY_DECIMALS = 5;" in html
+    # (b) the coordinates display line reads coordDisplay, not the raw coordStr
+    assert 'GFMY_LABELS.coordinates + "</b> " + coordDisplay +' in html
+    # (c) mutation counter-proof: the display line must NOT use coordStr
+    assert 'GFMY_LABELS.coordinates + "</b> " + coordStr +' not in html
+    # (d) copy handler keeps the raw full-precision expression, no toFixed
+    assert 'gfmyCopyToClipboard(loc.lat + ", " + loc.lon, coBtn)' in html
+    # (e) display expression strips padding zeros via the outer Number(...)
+    assert (
+        "var coordDisplay = "
+        "Number(Number(loc.lat).toFixed(GFMY_COORD_DISPLAY_DECIMALS)) + "
+        '", " + '
+        "Number(Number(loc.lon).toFixed(GFMY_COORD_DISPLAY_DECIMALS));"
+    ) in html
+    # (f) copy path is untouched by rounding: no toFixed inside the copy handler
+    assert 'gfmyCopyToClipboard(loc.lat + ", " + loc.lon, coBtn).toFixed' not in html


### PR DESCRIPTION
## Summary

The map popup rendered the raw full-precision coordinate (for example
`10.8368252529521`), which is visually noisy. Users who copy the value want the
long form, but the on-screen display should be short.

This PR splits display from copy at exactly one point in the code:

- A single named JS constant `GFMY_COORD_DISPLAY_DECIMALS = 5` (script level).
- A display-only `coordDisplay` that rounds each axis to at most 5 decimals and
  strips padding zeros (`Number(Number(loc.lat).toFixed(...))`).
- The coordinates display line now reads `coordDisplay`.
- `coordStr` and the clipboard copy handler keep the raw, byte-identical
  full-precision value (no `toFixed` in the copy path).

5 decimals resolve to ~1.1 m, well below the device accuracy (~58 m in the
reference screenshot), so the display hides no real precision; it is a pure
presentation change.

## Behavior

| | Before | After |
|---|---|---|
| Popup display | `10.8368252529521, 49.7380204` | `10.83683, 49.73802` |
| Copy button | full precision | full precision (unchanged) |

## Scope / invariants

- Geo logic (markers, `bounds.extend`, focus disc, plus code) keeps reading the
  raw `loc.lat`/`loc.lon`. The diff touches only the display string.
- No i18n string changes; the labels `coordinates` / `copy_coordinates` are
  unchanged.
- The Plus Code sensor and tracker `plus_code` attribute are out of scope.

## Tests

- New regression test `test_popup_coordinates_display_is_shortened_copy_stays_raw`
  asserts the display line uses `coordDisplay`, the copy handler keeps the raw
  expression without `toFixed`, and the padding-zero strip is present.
- Mutation counter-proof: reverting the display back to `coordStr` turns the
  test red.
- Full suite: 4843 passed, 20 skipped. `ruff`, `ruff format`, `mypy --strict`
  clean. `map_view.py` coverage 99%.

## Version

Bumps the integration to `1.7.13` in `const.py`, `manifest.json`, and
`pyproject.toml`.
