### PR TITLE
Coverage W1 follow-up: bug-catching contract tests, floor 73 -> 74

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,7 @@ jobs:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=73 2>&1 | tee pytest_output.log
+          poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=74 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/decrypt_locations.py
@@ -940,6 +940,14 @@ def _parse_epoch_seconds(value: Any, now_s: float) -> float | None:  # noqa: PLR
         The timestamp as a float, or None if invalid or implausible.
     """
     v: float
+    # bool is an int subclass; reject it explicitly for type parity with the
+    # numeric normalizers (normalize_pair_date_value /
+    # normalize_creation_timestamp_value), which both guard with
+    # ``not isinstance(raw, bool)`` before numeric handling. Without this a
+    # bool would fall through to ``float(raw)`` and be treated as a number
+    # instead of a type-foreign value (H5 parity).
+    if isinstance(value, bool):
+        return None
     # Protobuf Timestamp: seconds (+ optional nanos)
     if hasattr(value, "seconds"):
         try:

--- a/custom_components/googlefindmy/services.py
+++ b/custom_components/googlefindmy/services.py
@@ -675,6 +675,7 @@ async def async_register_services(hass: HomeAssistant, ctx: dict[str, Any]) -> N
         - "soft_migrate_entry": Callable[[HomeAssistant, Any], Any]  # awaited per entry
         - "migrate_unique_ids": Callable[[HomeAssistant, Any], Any]
         - "relink_button_devices": Callable[[HomeAssistant, Any], Any]
+        - "relink_subentry_entities": Callable[[HomeAssistant, Any], Any]
         - "coalesce_account_entries": Callable[[HomeAssistant, ConfigEntry], Awaitable[ConfigEntry]]
         - "extract_normalized_email": Callable[[ConfigEntry], str | None]
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -376,7 +376,10 @@ skip_covered = true
 # Raised to 73 per maintainer request to lock in the coverage from the typed
 # gpsoauth AuthError classification tests; measured CI total is 73.26 %, so the
 # jitter margin is intentionally tightened to 0.26 Pp headroom here.
-fail_under = 73
+# Raised to 74 per maintainer request to lock in the Coverage W1 follow-up
+# contract tests (token_refresh, google_uploader and the remaining W1 modules);
+# measured total is 74.47 %, so ~0.47 Pp headroom here.
+fail_under = 74
 exclude_lines = [
     "if __name__ == \"__main__\":",
     "pragma: no cover",

--- a/tests/test_bermuda_listener_contracts.py
+++ b/tests/test_bermuda_listener_contracts.py
@@ -1,0 +1,273 @@
+# tests/test_bermuda_listener_contracts.py
+"""Contract tests for the Bermuda area-debounce listener.
+
+Covers ``custom_components/googlefindmy/fmdn_finder/bermuda_listener.py``:
+
+* ``_async_debounced_area_upload`` — the five debounce exits (state cleared,
+  area changed, superseded, already-scheduled, success) plus the H3 second
+  line of defence: when the float-equality supersede check
+  (``first_seen != debounce_start_time``, line 274) fails to discriminate two
+  cycles that share an identical ``time.time()`` value, the
+  ``upload_scheduled`` guard (line 284) still admits exactly one upload.
+* ``_bermuda_state_changed`` (via the registered listener) — entity/area
+  filters, the T-SAME branch (same area only refreshes ``last_seen``, no new
+  task) and the T-NEW branch (area change spawns a debounce task), and the
+  outer try/except swallowing inner errors.
+* ``async_setup_bermuda_listener`` / ``async_unload_bermuda_listener`` —
+  registration, cache init, and the no-listener unload branch.
+
+``asyncio.sleep`` is patched to a no-op so the 30 s stabilization window never
+actually waits.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.googlefindmy.const import DOMAIN
+from custom_components.googlefindmy.fmdn_finder import bermuda_listener as bl
+from custom_components.googlefindmy.fmdn_finder.bermuda_listener import (
+    ATTR_AREA,
+    DATA_AREA_DEBOUNCE,
+    DATA_BERMUDA_UNSUBSCRIBE,
+    AreaDebounceState,
+    async_setup_bermuda_listener,
+    async_unload_bermuda_listener,
+)
+
+_ENTITY = "device_tracker.tag_bermuda_tracker_2"
+
+
+def _hass(debounce: dict[str, AreaDebounceState] | None = None) -> SimpleNamespace:
+    """Fake hass with a domain bucket and a task-swallowing create_task."""
+
+    def _create_task(coro, name=None):  # noqa: ANN001, ANN202
+        coro.close()  # avoid "coroutine never awaited" — we drive it directly
+        return Mock()
+
+    data = {DOMAIN: {DATA_AREA_DEBOUNCE: debounce if debounce is not None else {}}}
+    return SimpleNamespace(
+        data=data,
+        bus=SimpleNamespace(async_listen=Mock(return_value=Mock(name="unsub"))),
+        async_create_task=Mock(side_effect=_create_task),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _async_debounced_area_upload — five exits + H3 guard                         #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never actually wait the 30 s stabilization window."""
+    monkeypatch.setattr(bl.asyncio, "sleep", AsyncMock())
+
+
+@pytest.fixture
+def handle_mock(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Patch the terminal upload orchestrator to observe invocations."""
+    mock = AsyncMock()
+    monkeypatch.setattr(bl, "_async_handle_area_change", mock)
+    return mock
+
+
+async def _run_debounce(hass: SimpleNamespace, area: str, start: float) -> None:
+    await bl._async_debounced_area_upload(hass, _ENTITY, area, {ATTR_AREA: area}, start)
+
+
+@pytest.mark.asyncio
+async def test_debounce_skips_when_state_cleared(handle_mock: AsyncMock) -> None:
+    hass = _hass({})  # no state for the entity
+    await _run_debounce(hass, "Kitchen", start=100.0)
+    handle_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_debounce_skips_when_area_changed(handle_mock: AsyncMock) -> None:
+    state = AreaDebounceState(_ENTITY, "Hallway", first_seen=100.0, last_seen=100.0)
+    hass = _hass({_ENTITY: state})
+    await _run_debounce(hass, "Kitchen", start=100.0)  # expected Kitchen, state Hallway
+    handle_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_debounce_skips_when_superseded(handle_mock: AsyncMock) -> None:
+    state = AreaDebounceState(_ENTITY, "Kitchen", first_seen=200.0, last_seen=200.0)
+    hass = _hass({_ENTITY: state})
+    await _run_debounce(hass, "Kitchen", start=100.0)  # start != state.first_seen
+    handle_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_debounce_skips_when_already_scheduled(handle_mock: AsyncMock) -> None:
+    state = AreaDebounceState(
+        _ENTITY, "Kitchen", first_seen=100.0, last_seen=100.0, upload_scheduled=True
+    )
+    hass = _hass({_ENTITY: state})
+    await _run_debounce(hass, "Kitchen", start=100.0)
+    handle_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_debounce_success_uploads_and_marks_scheduled(
+    handle_mock: AsyncMock,
+) -> None:
+    state = AreaDebounceState(_ENTITY, "Kitchen", first_seen=100.0, last_seen=100.0)
+    hass = _hass({_ENTITY: state})
+    await _run_debounce(hass, "Kitchen", start=100.0)
+    handle_mock.assert_awaited_once()
+    assert state.upload_scheduled is True
+
+
+@pytest.mark.asyncio
+async def test_h3_identical_timestamp_still_uploads_once(
+    handle_mock: AsyncMock,
+) -> None:
+    """H3: two cycles sharing the same first_seen float upload only once.
+
+    The supersede check compares floats (``first_seen != debounce_start_time``);
+    with an identical ``time.time()`` value it cannot tell the two cycles apart,
+    so both pass that check. The ``upload_scheduled`` guard is the second line
+    of defence: the first cycle sets it, the second sees it and bails.
+    """
+    state = AreaDebounceState(_ENTITY, "Kitchen", first_seen=100.0, last_seen=100.0)
+    hass = _hass({_ENTITY: state})
+    await _run_debounce(hass, "Kitchen", start=100.0)  # cycle 1 -> uploads
+    await _run_debounce(hass, "Kitchen", start=100.0)  # cycle 2 -> guard bails
+    handle_mock.assert_awaited_once()  # exactly one upload despite equal timestamps
+
+
+# --------------------------------------------------------------------------- #
+# _bermuda_state_changed — filters and T-SAME / T-NEW transitions              #
+# --------------------------------------------------------------------------- #
+
+
+async def _capture_listener(hass: SimpleNamespace):  # noqa: ANN202
+    """Run setup and return the registered outer state-change callback."""
+    await async_setup_bermuda_listener(hass)
+    return hass.bus.async_listen.call_args[0][1]
+
+
+def _event(
+    entity_id: str | None, new_area: str | None, old_area: str | None = None
+) -> SimpleNamespace:
+    new_state = (
+        SimpleNamespace(attributes={ATTR_AREA: new_area} if new_area else {})
+        if entity_id is not None
+        else None
+    )
+    old_state = SimpleNamespace(attributes={ATTR_AREA: old_area}) if old_area else None
+    return SimpleNamespace(
+        data={"entity_id": entity_id, "new_state": new_state, "old_state": old_state}
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_registers_listener_and_inits_caches() -> None:
+    hass = _hass()
+    hass.data = {}  # start empty to verify setdefault init
+    await async_setup_bermuda_listener(hass)
+    hass_bucket = hass.data[DOMAIN]
+    assert DATA_AREA_DEBOUNCE in hass_bucket
+    assert DATA_BERMUDA_UNSUBSCRIBE in hass_bucket
+
+
+@pytest.mark.asyncio
+async def test_listener_ignores_non_bermuda_entity() -> None:
+    hass = _hass()
+    listener = await _capture_listener(hass)
+    listener(_event("device_tracker.some_phone", "Kitchen", old_area="Hall"))
+    hass.async_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_listener_ignores_missing_area() -> None:
+    hass = _hass()
+    listener = await _capture_listener(hass)
+    listener(_event(_ENTITY, None, old_area="Hall"))
+    hass.async_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_listener_ignores_unchanged_area() -> None:
+    hass = _hass()
+    listener = await _capture_listener(hass)
+    listener(_event(_ENTITY, "Kitchen", old_area="Kitchen"))
+    hass.async_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_listener_same_area_refreshes_without_new_task() -> None:
+    """T-SAME: an existing debounce for the same area only bumps last_seen."""
+    state = AreaDebounceState(_ENTITY, "Kitchen", first_seen=1.0, last_seen=1.0)
+    hass = _hass({_ENTITY: state})
+    listener = await _capture_listener(hass)
+    listener(_event(_ENTITY, "Kitchen", old_area="Hall"))
+    hass.async_create_task.assert_not_called()  # no new debounce task
+    assert state.last_seen > 1.0  # last_seen refreshed
+
+
+@pytest.mark.asyncio
+async def test_listener_area_change_spawns_debounce_task() -> None:
+    """T-NEW: an area change writes a fresh state and schedules a task."""
+    hass = _hass()
+    listener = await _capture_listener(hass)
+    listener(_event(_ENTITY, "Kitchen", old_area="Hall"))
+    hass.async_create_task.assert_called_once()
+    new_state = hass.data[DOMAIN][DATA_AREA_DEBOUNCE][_ENTITY]
+    assert new_state.area == "Kitchen"
+    assert new_state.upload_scheduled is False
+
+
+@pytest.mark.asyncio
+async def test_listener_missing_new_state_returns() -> None:
+    hass = _hass()
+    listener = await _capture_listener(hass)
+    listener(_event(None, None))  # entity_id None, new_state None
+    hass.async_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_listener_swallows_inner_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The outer callback must not propagate inner handler exceptions."""
+    hass = _hass()
+    listener = await _capture_listener(hass)
+    # A new_state whose ``attributes`` has no ``.get`` makes the inner handler
+    # raise AttributeError; the outer try/except must swallow it (event.data is
+    # still a real mapping so the error logger itself does not crash).
+    bad_event = SimpleNamespace(
+        data={
+            "entity_id": _ENTITY,
+            "new_state": SimpleNamespace(attributes=object()),
+            "old_state": None,
+        }
+    )
+    listener(bad_event)
+    hass.async_create_task.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# async_unload_bermuda_listener                                                #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_unload_calls_unsubscribe() -> None:
+    unsub = Mock()
+    hass = _hass()
+    hass.data[DOMAIN][DATA_BERMUDA_UNSUBSCRIBE] = unsub
+    await async_unload_bermuda_listener(hass)
+    unsub.assert_called_once()
+    assert DATA_BERMUDA_UNSUBSCRIBE not in hass.data[DOMAIN]
+
+
+@pytest.mark.asyncio
+async def test_unload_without_listener_is_noop() -> None:
+    hass = _hass()  # no DATA_BERMUDA_UNSUBSCRIBE registered
+    await async_unload_bermuda_listener(hass)  # must not raise (line 759 branch)

--- a/tests/test_ble_scanner_contracts.py
+++ b/tests/test_ble_scanner_contracts.py
@@ -1,0 +1,332 @@
+# tests/test_ble_scanner_contracts.py
+"""Contract tests for the optional HA-Bluetooth FMDN advertisement scanner.
+
+Covers ``custom_components/googlefindmy/fmdn_finder/ble_scanner.py``:
+
+* ``_is_fmdn_service_data`` payload-extraction invariants (the >=21 byte
+  length gate, FEAA-before-FE2C priority, boundary at exactly 21 bytes).
+* ``async_setup_ble_scanner`` terminal exits (import unavailable, domain
+  bucket not ready, successful registration) plus the nested advertisement
+  callback behaviour (no payload, no resolver, resolved match, rate-limited
+  unresolved log).
+* ``async_unload_ble_scanner`` terminal exits (bucket not ready, callable
+  unsub invoked, missing unsub).
+
+The HA ``bluetooth`` integration is not importable in the test environment
+(missing transitive deps), so the success path installs a minimal fake
+``homeassistant.components.bluetooth`` module and captures the registered
+callback for direct invocation (DoD: import path exercised only via patch).
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from custom_components.googlefindmy.const import DATA_EID_RESOLVER, DOMAIN
+from custom_components.googlefindmy.eid_resolver import (
+    FMDN_FRAME_TYPE,
+    MODERN_FRAME_TYPE,
+)
+from custom_components.googlefindmy.fmdn_finder import ble_scanner
+from custom_components.googlefindmy.fmdn_finder.ble_scanner import (
+    DATA_BLE_SCANNER_UNSUB,
+    FE2C_SERVICE_UUID,
+    FEAA_SERVICE_UUID,
+    MIN_FMDN_PAYLOAD_LENGTH,
+    _is_fmdn_service_data,
+    async_setup_ble_scanner,
+    async_unload_ble_scanner,
+)
+
+_BT_MODULE = "homeassistant.components.bluetooth"
+
+
+def _payload(
+    frame: int = FMDN_FRAME_TYPE, length: int = MIN_FMDN_PAYLOAD_LENGTH
+) -> bytes:
+    """Build a payload of ``length`` bytes starting with ``frame``."""
+    return bytes([frame]) + bytes(range(1, length))
+
+
+# --------------------------------------------------------------------------- #
+# _is_fmdn_service_data — payload extraction invariants                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_is_fmdn_feaa_at_min_length_returns_payload() -> None:
+    """Exactly 21 bytes under FEAA is accepted (length gate is >=, not >)."""
+    data = _payload(length=MIN_FMDN_PAYLOAD_LENGTH)
+    assert len(data) == 21
+    payload, uuid = _is_fmdn_service_data({FEAA_SERVICE_UUID: data})
+    assert payload == data
+    assert uuid == FEAA_SERVICE_UUID
+
+
+def test_is_fmdn_one_byte_below_min_is_rejected() -> None:
+    """20 bytes (one below the gate) is rejected — boundary invariant."""
+    data = _payload(length=MIN_FMDN_PAYLOAD_LENGTH - 1)
+    assert len(data) == 20
+    assert _is_fmdn_service_data({FEAA_SERVICE_UUID: data}) == (None, None)
+
+
+def test_is_fmdn_fe2c_when_feaa_absent() -> None:
+    """FE2C is used when FEAA is not present."""
+    data = _payload(length=25)
+    payload, uuid = _is_fmdn_service_data({FE2C_SERVICE_UUID: data})
+    assert payload == data
+    assert uuid == FE2C_SERVICE_UUID
+
+
+def test_is_fmdn_feaa_takes_priority_over_fe2c() -> None:
+    """When both UUIDs carry a valid payload, FEAA wins (iteration order)."""
+    feaa = _payload(frame=FMDN_FRAME_TYPE, length=21)
+    fe2c = _payload(frame=MODERN_FRAME_TYPE, length=30)
+    payload, uuid = _is_fmdn_service_data(
+        {FE2C_SERVICE_UUID: fe2c, FEAA_SERVICE_UUID: feaa}
+    )
+    assert uuid == FEAA_SERVICE_UUID
+    assert payload == feaa
+
+
+def test_is_fmdn_empty_service_data_returns_none() -> None:
+    """No matching UUID -> (None, None)."""
+    assert _is_fmdn_service_data({}) == (None, None)
+    assert _is_fmdn_service_data(
+        {"0000abcd-0000-1000-8000-00805f9b34fb": _payload()}
+    ) == (
+        None,
+        None,
+    )
+
+
+def test_is_fmdn_normalizes_bytearray_to_bytes() -> None:
+    """A bytearray payload is returned as immutable bytes."""
+    data = bytearray(_payload(length=21))
+    payload, _uuid = _is_fmdn_service_data({FEAA_SERVICE_UUID: data})
+    assert isinstance(payload, bytes)
+    assert not isinstance(payload, bytearray)
+
+
+# --------------------------------------------------------------------------- #
+# Fake bluetooth module + captured-callback fixture                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def fake_bluetooth(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Install a minimal fake ``homeassistant.components.bluetooth`` module.
+
+    Returns a namespace exposing the ``async_register_callback`` mock and a
+    ``captured`` dict that the test fills with the registered callback once
+    ``async_setup_ble_scanner`` runs.
+    """
+    captured: dict[str, object] = {}
+
+    def _register(
+        hass: object, callback: object, matcher: object, mode: object
+    ) -> Mock:
+        captured["callback"] = callback
+        captured["matcher"] = matcher
+        captured["mode"] = mode
+        return Mock(name="unsub")
+
+    register_mock = MagicMock(side_effect=_register)
+
+    module = ModuleType(_BT_MODULE)
+    module.BluetoothChange = object  # type: ignore[attr-defined]
+    module.BluetoothServiceInfoBleak = object  # type: ignore[attr-defined]
+    module.BluetoothScanningMode = SimpleNamespace(PASSIVE="passive")  # type: ignore[attr-defined]
+    module.async_register_callback = register_mock  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, _BT_MODULE, module)
+    return SimpleNamespace(register=register_mock, captured=captured)
+
+
+def _service_info(
+    service_data: dict[str, bytes],
+    address: str = "AA:BB:CC:DD:EE:FF",
+    rssi: int = -50,
+) -> SimpleNamespace:
+    return SimpleNamespace(service_data=service_data, address=address, rssi=rssi)
+
+
+# --------------------------------------------------------------------------- #
+# async_setup_ble_scanner — terminal exits                                     #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_setup_returns_false_when_bluetooth_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ImportError on the bluetooth import -> non-fatal False."""
+    # Setting the module to None in sys.modules forces ImportError on import.
+    monkeypatch.setitem(sys.modules, _BT_MODULE, None)
+    hass = SimpleNamespace(data={DOMAIN: {}})
+    assert await async_setup_ble_scanner(hass) is False
+
+
+@pytest.mark.asyncio
+async def test_setup_returns_false_when_domain_bucket_missing(
+    fake_bluetooth: SimpleNamespace,
+) -> None:
+    """A domain bucket that is not a dict aborts setup with False."""
+    hass = SimpleNamespace(data={})  # DOMAIN absent -> .get(DOMAIN) is None
+    assert await async_setup_ble_scanner(hass) is False
+    fake_bluetooth.register.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_setup_registers_callback_and_stores_unsub(
+    fake_bluetooth: SimpleNamespace,
+) -> None:
+    """Happy path: registers a PASSIVE callback and stores the unsub."""
+    bucket: dict[str, object] = {}
+    hass = SimpleNamespace(data={DOMAIN: bucket})
+    assert await async_setup_ble_scanner(hass) is True
+    fake_bluetooth.register.assert_called_once()
+    # PASSIVE mode requested (no active scan / no extra power draw).
+    assert fake_bluetooth.captured["mode"] == "passive"
+    # No matcher — the module filters inside the callback.
+    assert fake_bluetooth.captured["matcher"] is None
+    assert callable(bucket[DATA_BLE_SCANNER_UNSUB])
+
+
+# --------------------------------------------------------------------------- #
+# Nested advertisement callback behaviour                                      #
+# --------------------------------------------------------------------------- #
+
+
+async def _setup_and_capture(
+    fake_bluetooth: SimpleNamespace, resolver: object | None
+) -> tuple[dict[str, object], object]:
+    """Run setup with an optional resolver in the bucket; return callback."""
+    bucket: dict[str, object] = {}
+    if resolver is not None:
+        bucket[DATA_EID_RESOLVER] = resolver
+    hass = SimpleNamespace(data={DOMAIN: bucket})
+    assert await async_setup_ble_scanner(hass) is True
+    return bucket, fake_bluetooth.captured["callback"]
+
+
+@pytest.mark.asyncio
+async def test_callback_ignores_non_fmdn_advertisement(
+    fake_bluetooth: SimpleNamespace,
+) -> None:
+    """No FMDN payload -> callback returns without touching the resolver."""
+    resolver = Mock()
+    _bucket, callback = await _setup_and_capture(fake_bluetooth, resolver)
+    callback(_service_info({}), None)  # empty service_data -> payload None
+    resolver.resolve_eid.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_callback_returns_when_resolver_absent(
+    fake_bluetooth: SimpleNamespace,
+) -> None:
+    """A valid payload but no resolver in the bucket -> early return."""
+    _bucket, callback = await _setup_and_capture(fake_bluetooth, resolver=None)
+    # Must not raise even though there is no resolver.
+    callback(_service_info({FEAA_SERVICE_UUID: _payload()}), None)
+
+
+@pytest.mark.asyncio
+async def test_callback_resolves_match_with_ble_address(
+    fake_bluetooth: SimpleNamespace,
+) -> None:
+    """A resolvable advertisement calls resolve_eid with the BLE address."""
+    match = SimpleNamespace(device_id="device12345678", canonical_id="canon12345678")
+    resolver = Mock()
+    resolver.resolve_eid.return_value = match
+    _bucket, callback = await _setup_and_capture(fake_bluetooth, resolver)
+
+    payload = _payload(frame=MODERN_FRAME_TYPE, length=21)
+    callback(
+        _service_info({FEAA_SERVICE_UUID: payload}, address="11:22:33:44:55:66"), None
+    )
+
+    resolver.resolve_eid.assert_called_once()
+    args, kwargs = resolver.resolve_eid.call_args
+    assert args[0] == payload
+    assert kwargs["ble_address"] == "11:22:33:44:55:66"
+
+
+@pytest.mark.asyncio
+async def test_callback_handles_unknown_frame_type(
+    fake_bluetooth: SimpleNamespace,
+) -> None:
+    """A payload whose first byte is not a known frame type still resolves.
+
+    Exercises the ``frame_type is None`` branch (payload[0] not in the frame
+    set): resolution proceeds, the log falls back to frame 0.
+    """
+    match = SimpleNamespace(device_id="device12345678", canonical_id=None)
+    resolver = Mock()
+    resolver.resolve_eid.return_value = match
+    _bucket, callback = await _setup_and_capture(fake_bluetooth, resolver)
+
+    payload = _payload(frame=0x99, length=21)  # 0x99 is neither 0x40 nor 0x41
+    callback(_service_info({FEAA_SERVICE_UUID: payload}), None)
+    resolver.resolve_eid.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_rate_limits_unresolved_logs(
+    fake_bluetooth: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unresolved advertisements are logged at most once per interval prefix."""
+    resolver = Mock()
+    resolver.resolve_eid.return_value = None  # never resolves
+    _bucket, callback = await _setup_and_capture(fake_bluetooth, resolver)
+
+    debug = Mock()
+    monkeypatch.setattr(ble_scanner._LOGGER, "debug", debug)
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(ble_scanner.time, "monotonic", lambda: clock["t"])
+
+    info = _service_info({FEAA_SERVICE_UUID: _payload()})
+    callback(info, None)  # first sighting -> logs
+    first = debug.call_count
+    callback(info, None)  # immediately again -> suppressed
+    assert debug.call_count == first  # no new log within interval
+
+    clock["t"] += ble_scanner._UNRESOLVED_LOG_INTERVAL + 1.0
+    callback(info, None)  # interval elapsed -> logs again
+    assert debug.call_count == first + 1
+    assert resolver.resolve_eid.call_count == 3  # resolver hit every time
+
+
+# --------------------------------------------------------------------------- #
+# async_unload_ble_scanner — terminal exits                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_unload_returns_true_when_bucket_missing() -> None:
+    """No domain bucket -> nothing to do, return True."""
+    hass = SimpleNamespace(data={})
+    assert await async_unload_ble_scanner(hass) is True
+
+
+@pytest.mark.asyncio
+async def test_unload_invokes_callable_unsub() -> None:
+    """A callable unsub is popped and invoked exactly once."""
+    unsub = Mock()
+    bucket = {DATA_BLE_SCANNER_UNSUB: unsub}
+    hass = SimpleNamespace(data={DOMAIN: bucket})
+    assert await async_unload_ble_scanner(hass) is True
+    unsub.assert_called_once()
+    assert DATA_BLE_SCANNER_UNSUB not in bucket  # popped
+
+
+@pytest.mark.asyncio
+async def test_unload_tolerates_missing_unsub() -> None:
+    """No stored unsub -> return True without calling anything."""
+    bucket: dict[str, object] = {}
+    hass = SimpleNamespace(data={DOMAIN: bucket})
+    assert await async_unload_ble_scanner(hass) is True

--- a/tests/test_decrypt_locations_contracts.py
+++ b/tests/test_decrypt_locations_contracts.py
@@ -36,6 +36,21 @@ _PLAUSIBLE = 1_700_000_000.0  # slightly before _NOW
 _FAR_FUTURE = _NOW + 1_000_000_000.0  # ~31 years ahead -> exceeds drift window
 
 
+@pytest.fixture(autouse=True)
+def _isolate_eik_cache() -> object:
+    """Reset the module-global EIK cache/stats around each test.
+
+    The cache helpers below mutate module-global state; isolate it so a failing
+    assertion cannot leak an entry into later tests (parity with the token_cache
+    registry-isolation fixture).
+    """
+    d._eik_cache.clear()
+    d._eik_cache_stats.update(hits=0, misses=0)
+    yield
+    d._eik_cache.clear()
+    d._eik_cache_stats.update(hits=0, misses=0)
+
+
 # --------------------------------------------------------------------------- #
 # create_google_maps_link — 3 exits                                            #
 # --------------------------------------------------------------------------- #
@@ -327,7 +342,7 @@ def test_eik_cache_key_is_deterministic_and_flip_sensitive() -> None:
 def test_clear_and_stats_eik_cache() -> None:
     d._eik_cache["k"] = b"v"
     stats = d.get_eik_cache_stats()
-    assert stats["size"] >= 1
+    assert stats["size"] == 1  # isolated by the autouse fixture -> exactly one
     d.clear_eik_cache()
     assert d.get_eik_cache_stats()["size"] == 0
 

--- a/tests/test_decrypt_locations_contracts.py
+++ b/tests/test_decrypt_locations_contracts.py
@@ -1,0 +1,345 @@
+# tests/test_decrypt_locations_contracts.py
+"""Contract tests for the pure decode/normalize helpers of ``decrypt_locations``.
+
+Scope: the input-driven data-transformation helpers that are reachable without
+real crypto, network, or protobuf fixtures. The deep async crypto paths
+(``async_retrieve_identity_key``, ``async_decrypt_location_response_locations``)
+are covered by dedicated crypto tests and are out of scope here (see the W1
+plan negative protocol).
+
+Each helper is exercised across its enumerated ``return``/``raise`` exits
+(0-hit / error / plausible), following the AP-W1.1 counter discipline (CA-F8).
+
+H5 (bool-exclusion parity): ``_parse_epoch_seconds`` now rejects ``bool`` up
+front, matching ``normalize_pair_date_value`` /
+``normalize_creation_timestamp_value`` (which guard with
+``not isinstance(raw, bool)``). The parity is pinned below. Note: the observed
+return value for ``True``/``False`` was already ``None`` before the guard (via
+``float(True) == 1.0`` falling under the plausibility floor), so this is a
+type-parity / defense-in-depth fix, not a changed-output bug — the test pins
+the invariant rather than a red-before-green regression.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    decrypt_locations as d,
+)
+
+# A fixed "now" well after 2000-01-01 with headroom below the drift window.
+_NOW = 1_700_001_000.0  # 2023-11-14, plausible epoch seconds
+_PLAUSIBLE = 1_700_000_000.0  # slightly before _NOW
+_FAR_FUTURE = _NOW + 1_000_000_000.0  # ~31 years ahead -> exceeds drift window
+
+
+# --------------------------------------------------------------------------- #
+# create_google_maps_link — 3 exits                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_maps_link_valid_coordinates() -> None:
+    link = d.create_google_maps_link(52.5, 13.4)
+    assert link == "https://www.google.com/maps/search/?api=1&query=52.5,13.4"
+
+
+@pytest.mark.parametrize(
+    ("lat", "lon"),
+    [(90.1, 0.0), (-90.1, 0.0), (0.0, 180.1), (0.0, -180.1)],
+)
+def test_maps_link_out_of_bounds_returns_none(lat: float, lon: float) -> None:
+    assert d.create_google_maps_link(lat, lon) is None
+
+
+def test_maps_link_uncoercible_returns_none() -> None:
+    assert d.create_google_maps_link(None, 0.0) is None  # type: ignore[arg-type]
+    assert d.create_google_maps_link("abc", 0.0) is None  # type: ignore[arg-type]
+
+
+def test_maps_link_boundary_inclusive() -> None:
+    """Exact bounds (+/-90, +/-180) are inclusive."""
+    assert d.create_google_maps_link(90.0, 180.0) is not None
+    assert d.create_google_maps_link(-90.0, -180.0) is not None
+
+
+# --------------------------------------------------------------------------- #
+# _parse_epoch_seconds — full exit matrix (H5 carrier)                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_epoch_plausible_int() -> None:
+    assert d._parse_epoch_seconds(int(_PLAUSIBLE), _NOW) == _PLAUSIBLE
+
+
+def test_parse_epoch_string_is_sanitized() -> None:
+    """Leading/trailing whitespace, BOM and NBSP are stripped before float()."""
+    raw = f"﻿  {int(_PLAUSIBLE)}  "
+    assert d._parse_epoch_seconds(raw, _NOW) == _PLAUSIBLE
+
+
+def test_parse_epoch_valid_bytes() -> None:
+    assert d._parse_epoch_seconds(str(int(_PLAUSIBLE)).encode(), _NOW) == _PLAUSIBLE
+
+
+def test_parse_epoch_invalid_utf8_bytes_returns_none() -> None:
+    assert d._parse_epoch_seconds(b"\xff\xfe", _NOW) is None
+
+
+def test_parse_epoch_protobuf_time_object() -> None:
+    ts = SimpleNamespace(seconds=int(_PLAUSIBLE), nanos=500_000_000)
+    assert d._parse_epoch_seconds(ts, _NOW) == pytest.approx(_PLAUSIBLE + 0.5)
+
+
+def test_parse_epoch_protobuf_time_bad_field_returns_none() -> None:
+    ts = SimpleNamespace(seconds="not-a-number")
+    assert d._parse_epoch_seconds(ts, _NOW) is None
+
+
+def test_parse_epoch_millisecond_scaling() -> None:
+    assert d._parse_epoch_seconds(_PLAUSIBLE * 1e3, _NOW) == _PLAUSIBLE
+
+
+def test_parse_epoch_microsecond_scaling() -> None:
+    assert d._parse_epoch_seconds(_PLAUSIBLE * 1e6, _NOW) == _PLAUSIBLE
+
+
+def test_parse_epoch_non_finite_returns_none() -> None:
+    assert d._parse_epoch_seconds(float("nan"), _NOW) is None
+    assert d._parse_epoch_seconds(float("inf"), _NOW) is None
+
+
+def test_parse_epoch_too_old_returns_none() -> None:
+    assert d._parse_epoch_seconds(100.0, _NOW) is None  # before 2000-01-01
+
+
+def test_parse_epoch_too_far_future_returns_none() -> None:
+    assert d._parse_epoch_seconds(_FAR_FUTURE, _NOW) is None
+
+
+def test_parse_epoch_uncoercible_returns_none() -> None:
+    assert d._parse_epoch_seconds(object(), _NOW) is None
+
+
+# --------------------------------------------------------------------------- #
+# normalize_pair_date_value / normalize_creation_timestamp_value               #
+# --------------------------------------------------------------------------- #
+
+_NORMALIZERS = (
+    d.normalize_pair_date_value,
+    d.normalize_creation_timestamp_value,
+)
+
+
+@pytest.mark.parametrize("fn", _NORMALIZERS)
+def test_normalizer_plausible_numeric(fn) -> None:
+    assert fn(int(_PLAUSIBLE), now_wall=_NOW) == int(_PLAUSIBLE)
+
+
+@pytest.mark.parametrize("fn", _NORMALIZERS)
+def test_normalizer_millisecond_scaling(fn) -> None:
+    assert fn(_PLAUSIBLE * 1e3, now_wall=_NOW) == int(_PLAUSIBLE)
+
+
+@pytest.mark.parametrize("fn", _NORMALIZERS)
+def test_normalizer_microsecond_scaling(fn) -> None:
+    assert fn(_PLAUSIBLE * 1e6, now_wall=_NOW) == int(_PLAUSIBLE)
+
+
+@pytest.mark.parametrize("fn", _NORMALIZERS)
+def test_normalizer_non_finite_returns_none(fn) -> None:
+    assert fn(float("nan"), now_wall=_NOW) is None
+    assert fn(float("inf"), now_wall=_NOW) is None
+
+
+@pytest.mark.parametrize("fn", _NORMALIZERS)
+def test_normalizer_too_old_returns_none(fn) -> None:
+    assert fn(100, now_wall=_NOW) is None
+
+
+@pytest.mark.parametrize("fn", _NORMALIZERS)
+def test_normalizer_too_far_future_returns_none(fn) -> None:
+    assert fn(_FAR_FUTURE, now_wall=_NOW) is None
+
+
+@pytest.mark.parametrize("fn", _NORMALIZERS)
+def test_normalizer_string_delegates_to_parser(fn) -> None:
+    """A non-numeric (str) input delegates to _parse_epoch_seconds."""
+    assert fn(str(int(_PLAUSIBLE)), now_wall=_NOW) == int(_PLAUSIBLE)
+
+
+def test_normalize_pair_date_none_returns_none() -> None:
+    assert d.normalize_pair_date_value(None, now_wall=_NOW) is None
+
+
+# --------------------------------------------------------------------------- #
+# H5 — bool-exclusion parity across all three epoch parsers                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_h5_bool_exclusion_parity(flag: bool) -> None:
+    """A bool must never be interpreted as an epoch number by any parser.
+
+    All three parsers reject bool -> None. ``_parse_epoch_seconds`` now rejects
+    it via an explicit ``isinstance(value, bool)`` guard (parity with the two
+    numeric normalizers), rather than only accidentally via the plausibility
+    floor. The parity is the contract; the returned value was ``None`` already.
+    """
+    assert d._parse_epoch_seconds(flag, _NOW) is None
+    assert d.normalize_pair_date_value(flag, now_wall=_NOW) is None
+    assert d.normalize_creation_timestamp_value(flag, now_wall=_NOW) is None
+
+
+# --------------------------------------------------------------------------- #
+# _ensure_bytes — 3 exits                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_ensure_bytes_passthrough() -> None:
+    payload = b"\x01\x02"
+    assert d._ensure_bytes(payload) is payload
+
+
+def test_ensure_bytes_bytearray_is_copied_to_bytes() -> None:
+    result = d._ensure_bytes(bytearray(b"\x01\x02"))
+    assert isinstance(result, bytes) and not isinstance(result, bytearray)
+    assert result == b"\x01\x02"
+
+
+@pytest.mark.parametrize("value", ["str", 42, None, memoryview(b"x")])
+def test_ensure_bytes_rejects_other_types(value: object) -> None:
+    assert d._ensure_bytes(value) is None
+
+
+# --------------------------------------------------------------------------- #
+# _is_valid_latlon — 4 exits                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_is_valid_latlon_accepts_in_bounds() -> None:
+    assert d._is_valid_latlon(45.0, 9.0) is True
+    assert d._is_valid_latlon(0.0, 0.0) is True  # 0.0 is valid (not falsy-rejected)
+
+
+def test_is_valid_latlon_uncoercible_returns_false() -> None:
+    assert d._is_valid_latlon(None, 0.0) is False  # type: ignore[arg-type]
+
+
+def test_is_valid_latlon_non_finite_returns_false() -> None:
+    assert d._is_valid_latlon(float("nan"), 0.0) is False
+    assert d._is_valid_latlon(0.0, float("inf")) is False
+
+
+def test_is_valid_latlon_out_of_bounds_returns_false() -> None:
+    assert d._is_valid_latlon(91.0, 0.0) is False
+    assert d._is_valid_latlon(0.0, 181.0) is False
+
+
+# --------------------------------------------------------------------------- #
+# _extract_canonic_id — duck-typed protobuf                                    #
+# --------------------------------------------------------------------------- #
+
+
+def _canonic_proto(ids: list[object]) -> SimpleNamespace:
+    return SimpleNamespace(
+        deviceMetadata=SimpleNamespace(
+            identifierInformation=SimpleNamespace(
+                canonicIds=SimpleNamespace(canonicId=ids)
+            )
+        )
+    )
+
+
+def test_extract_canonic_id_returns_first_string() -> None:
+    proto = _canonic_proto([SimpleNamespace(id=""), SimpleNamespace(id="canonical-42")])
+    assert d._extract_canonic_id(proto) == "canonical-42"
+
+
+def test_extract_canonic_id_empty_list_returns_none() -> None:
+    assert d._extract_canonic_id(_canonic_proto([])) is None
+
+
+def test_extract_canonic_id_non_string_ids_returns_none() -> None:
+    assert d._extract_canonic_id(_canonic_proto([SimpleNamespace(id=123)])) is None
+
+
+def test_extract_canonic_id_missing_attribute_returns_none() -> None:
+    assert d._extract_canonic_id(object()) is None  # attribute chain raises
+
+
+# --------------------------------------------------------------------------- #
+# is_real_location_record / any_real_location_record — reauth-budget allowlist #
+# --------------------------------------------------------------------------- #
+
+
+def test_is_real_location_record_none_and_empty() -> None:
+    assert d.is_real_location_record(None) is False
+    assert d.is_real_location_record({}) is False
+
+
+def test_is_real_location_record_true_for_coordinates() -> None:
+    assert d.is_real_location_record({"latitude": 52.5, "longitude": 13.4}) is True
+
+
+def test_is_real_location_record_zero_coordinates_are_real() -> None:
+    """0.0/0.0 is a legitimate coordinate (``is not None``, not truthiness)."""
+    assert d.is_real_location_record({"latitude": 0.0, "longitude": 0.0}) is True
+
+
+def test_is_real_location_record_metadata_sentinel_is_false() -> None:
+    """SEMANTIC / metadata-only rows carry no coordinates -> not authenticated."""
+    assert (
+        d.is_real_location_record({"semantic_name": "Home", "latitude": None}) is False
+    )
+
+
+def test_any_real_location_record_mixed_list() -> None:
+    records = [
+        {"semantic_name": "Home", "latitude": None, "longitude": None},
+        {"latitude": 1.0, "longitude": 2.0},
+    ]
+    assert d.any_real_location_record(records) is True
+
+
+def test_any_real_location_record_none_empty_and_all_metadata() -> None:
+    assert d.any_real_location_record(None) is False
+    assert d.any_real_location_record([]) is False
+    assert d.any_real_location_record([{"latitude": None, "longitude": None}]) is False
+
+
+# --------------------------------------------------------------------------- #
+# EIK cache helpers                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_eik_cache_key_is_deterministic_and_flip_sensitive() -> None:
+    blob, version = b"identity-key-blob", 3
+    key_a = d._get_eik_cache_key(blob, version, False)
+    key_b = d._get_eik_cache_key(blob, version, False)
+    assert key_a == key_b  # deterministic
+    assert d._get_eik_cache_key(blob, version, True) != key_a  # flip_state matters
+    assert d._get_eik_cache_key(blob, version + 1, False) != key_a  # version matters
+
+
+def test_clear_and_stats_eik_cache() -> None:
+    d._eik_cache["k"] = b"v"
+    stats = d.get_eik_cache_stats()
+    assert stats["size"] >= 1
+    d.clear_eik_cache()
+    assert d.get_eik_cache_stats()["size"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Sync facade guard — running-loop rejection                                   #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sync_facade_rejects_running_loop() -> None:
+    """The sync facade must refuse to block a running event loop."""
+    with pytest.raises(RuntimeError):
+        # The running-loop guard fires before ``cache`` is touched.
+        d.decrypt_location_response_locations(object(), cache=SimpleNamespace())

--- a/tests/test_google_uploader_contracts.py
+++ b/tests/test_google_uploader_contracts.py
@@ -1,0 +1,285 @@
+# tests/test_google_uploader_contracts.py
+"""Contract tests for ``fmdn_finder/google_uploader`` (Coverage W1, AP-W1.4).
+
+The star is the H6 regression guard: ``FMDN_UPLOAD_ENABLED`` is the single
+switch standing between Home Assistant and a live gRPC upload attempt against
+Google. While it is ``False`` the transport path must never be reached. The
+remaining tests pin the public diagnostics API, every terminal exit of
+``_get_cache_from_hass`` and the still-uncovered exits of ``_try_grpc_upload``
+(success, gRPC status error, connection error). The two asyncio SSL-teardown
+exits are already covered by ``test_google_uploader_teardown.py`` and are not
+duplicated here.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.googlefindmy.fmdn_finder import google_uploader as gu
+from custom_components.googlefindmy.fmdn_finder.google_uploader import (
+    _get_cache_from_hass,
+    _try_grpc_upload,
+    async_upload_to_google_fmdn,
+    get_upload_status,
+    is_upload_enabled,
+)
+from custom_components.googlefindmy.SpotApi import spot_request as spot_request_module
+from custom_components.googlefindmy.SpotApi.spot_grpc_transport import SpotGrpcTransport
+
+_EID_HEX = "0011223344556677"
+
+
+# ---------------------------------------------------------------------------
+# H6: the disabled guard must fail closed and never touch the transport
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upload_disabled_returns_false_and_skips_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """H6: while FMDN_UPLOAD_ENABLED is False, no upload machinery runs."""
+    assert gu.FMDN_UPLOAD_ENABLED is False  # baseline invariant
+
+    grpc = AsyncMock()
+    cache_getter = AsyncMock()
+    monkeypatch.setattr(gu, "_try_grpc_upload", grpc)
+    monkeypatch.setattr(gu, "_get_cache_from_hass", cache_getter)
+
+    result = await async_upload_to_google_fmdn(
+        hass=SimpleNamespace(data={}),  # type: ignore[arg-type]
+        payload=b"payload-bytes",
+        truncated_eid_hex=_EID_HEX,
+    )
+
+    assert result is False
+    grpc.assert_not_called()
+    cache_getter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_enabled_success_returns_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gu, "FMDN_UPLOAD_ENABLED", True)
+    monkeypatch.setattr(gu, "_get_cache_from_hass", AsyncMock(return_value=object()))
+    grpc = AsyncMock(return_value=b"response-bytes")
+    monkeypatch.setattr(gu, "_try_grpc_upload", grpc)
+
+    result = await async_upload_to_google_fmdn(
+        hass=SimpleNamespace(data={}),  # type: ignore[arg-type]
+        payload=b"payload",
+        truncated_eid_hex=_EID_HEX,
+    )
+
+    assert result is True
+    grpc.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_enabled_failure_raises_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gu, "FMDN_UPLOAD_ENABLED", True)
+    monkeypatch.setattr(gu, "_get_cache_from_hass", AsyncMock(return_value=object()))
+    monkeypatch.setattr(
+        gu, "_try_grpc_upload", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+
+    with pytest.raises(ValueError, match="Upload failed"):
+        await async_upload_to_google_fmdn(
+            hass=SimpleNamespace(data={}),  # type: ignore[arg-type]
+            payload=b"payload",
+            truncated_eid_hex=_EID_HEX,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public diagnostics API
+# ---------------------------------------------------------------------------
+
+
+def test_is_upload_enabled_reflects_flag() -> None:
+    assert is_upload_enabled() is False
+
+
+def test_get_upload_status_reports_disabled_config() -> None:
+    status = get_upload_status()
+    assert status["enabled"] == "False"
+    assert status["blocker"] == "DroidGuard attestation required"
+    assert status["server"] == gu.FMDN_UPLOAD_SERVER
+
+
+# ---------------------------------------------------------------------------
+# _get_cache_from_hass: five terminal exits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_cache_raises_when_integration_not_loaded() -> None:
+    hass = SimpleNamespace(data={})
+    with pytest.raises(RuntimeError, match="not loaded"):
+        await _get_cache_from_hass(hass)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_get_cache_raises_when_no_entries() -> None:
+    hass = SimpleNamespace(data={"googlefindmy": {"entries": {}}})
+    with pytest.raises(RuntimeError, match="No GoogleFindMy entries"):
+        await _get_cache_from_hass(hass)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_get_cache_returns_token_cache_attribute() -> None:
+    sentinel = object()
+    entry = SimpleNamespace(token_cache=sentinel)
+    hass = SimpleNamespace(data={"googlefindmy": {"entries": {"e1": entry}}})
+    assert await _get_cache_from_hass(hass) is sentinel  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_get_cache_returns_dict_style_cache() -> None:
+    sentinel = object()
+    entry = {"cache": sentinel}  # dict-style entry, no token_cache attr
+    hass = SimpleNamespace(data={"googlefindmy": {"entries": {"e1": entry}}})
+    assert await _get_cache_from_hass(hass) is sentinel  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_get_cache_raises_when_cache_missing() -> None:
+    entry = SimpleNamespace(token_cache=None)  # attr present but None, not a dict
+    hass = SimpleNamespace(data={"googlefindmy": {"entries": {"e1": entry}}})
+    with pytest.raises(RuntimeError, match="TokenCache not available"):
+        await _get_cache_from_hass(hass)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _try_grpc_upload: remaining terminal exits (teardown races: see
+# test_google_uploader_teardown.py)
+# ---------------------------------------------------------------------------
+
+
+class _Stream:
+    def __init__(self, reply: Any = b"", exc: Exception | None = None) -> None:
+        self._reply = reply
+        self._exc = exc
+        self.sent: list[bytes] = []
+
+    async def __aenter__(self) -> _Stream:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    async def send_message(self, msg: bytes, end: bool = True) -> None:
+        self.sent.append(msg)
+
+    async def recv_message(self) -> Any:
+        if self._exc is not None:
+            raise self._exc
+        return self._reply
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch, stream: _Stream) -> None:
+    import grpclib.client  # noqa: PLC0415
+
+    class _StubMethod:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            return None
+
+        def open(self, metadata: Any = None, timeout: float | None = None) -> _Stream:
+            return stream
+
+    monkeypatch.setattr(grpclib.client, "UnaryUnaryMethod", _StubMethod)
+    monkeypatch.setattr(
+        spot_request_module,
+        "_pick_auth_token_async",
+        AsyncMock(return_value=("token", "kind", "user")),
+    )
+    monkeypatch.setattr(
+        SpotGrpcTransport, "get_channel", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(SpotGrpcTransport, "async_close", AsyncMock())
+
+
+async def _call_grpc() -> bytes:
+    return await _try_grpc_upload(
+        cache=object(),  # type: ignore[arg-type]
+        payload=b"payload",
+        server="spot-pa.googleapis.com",
+        service="google.internal.spot.v1.SpotService",
+        method="UploadLocationReports",
+    )
+
+
+@pytest.mark.asyncio
+async def test_grpc_upload_returns_reply_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream = _Stream(reply=b"the-reply")
+    _install_transport(monkeypatch, stream)
+    assert await _call_grpc() == b"the-reply"
+    assert stream.sent == [b"payload"]
+
+
+@pytest.mark.asyncio
+async def test_grpc_upload_empty_reply_becomes_empty_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_transport(monkeypatch, _Stream(reply=None))
+    assert await _call_grpc() == b""
+
+
+@pytest.mark.asyncio
+async def test_grpc_upload_grpc_error_becomes_spot_status_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import grpclib.const
+    import grpclib.exceptions
+
+    from custom_components.googlefindmy.SpotApi.spot_request import SpotGrpcStatusError
+
+    exc = grpclib.exceptions.GRPCError(grpclib.const.Status.UNIMPLEMENTED)
+    _install_transport(monkeypatch, _Stream(exc=exc))
+    with pytest.raises(SpotGrpcStatusError, match="DroidGuard attestation"):
+        await _call_grpc()
+
+
+@pytest.mark.asyncio
+async def test_grpc_upload_connection_error_becomes_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_transport(monkeypatch, _Stream(exc=ConnectionError("refused")))
+    with pytest.raises(ValueError, match="Connection to .* failed"):
+        await _call_grpc()
+
+
+@pytest.mark.asyncio
+async def test_grpc_upload_closes_transport_even_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stream = _Stream(reply=b"ok")
+    close_mock = AsyncMock()
+    _install_transport(monkeypatch, stream)
+    monkeypatch.setattr(SpotGrpcTransport, "async_close", close_mock)
+    await _call_grpc()
+    close_mock.assert_awaited()  # finally-block always tears the transport down
+
+
+@pytest.mark.asyncio
+async def test_grpc_upload_swallows_teardown_close_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failure while closing the transport must not mask the reply."""
+    stream = _Stream(reply=b"ok")
+    _install_transport(monkeypatch, stream)
+    monkeypatch.setattr(
+        SpotGrpcTransport,
+        "async_close",
+        AsyncMock(side_effect=RuntimeError("close race")),
+    )
+    assert await _call_grpc() == b"ok"

--- a/tests/test_main_cli_exit_paths.py
+++ b/tests/test_main_cli_exit_paths.py
@@ -1,0 +1,404 @@
+# tests/test_main_cli_exit_paths.py
+"""Contract tests for the standalone CLI exit and stale-token-purge paths.
+
+These pin the ``sys.exit(1)`` fail-closed exits and the stale-key purges in
+``main.py`` that the happy-path tests in ``test_main.py`` do not exercise:
+
+* ``_ensure_authenticated`` -- corrupt-secrets recovery, already-authenticated
+  short circuit, empty-email abort, stale derived-token purge.
+* ``_ensure_aas_token``    -- cached/absent short circuits and the
+  single-use-cookie exit.
+* ``_clear_stale_adm_token``        -- username guard + ADM key clearing.
+* ``_clear_stale_tokens_for_reauth`` -- file/dict/parse guards + key removal.
+
+The standalone FCM lead (``_setup_fcm_receiver``) is intentionally excluded
+(W0/E5 ``# pragma: no cover`` standalone lead).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+class _AsyncDictCache:
+    """Minimal async cache double: ``get``/``set`` over a plain dict.
+
+    ``set(name, None)`` pops the key, mirroring the real cache contract that
+    ``_clear_stale_adm_token`` relies on.
+    """
+
+    def __init__(self, initial: dict[str, Any] | None = None) -> None:
+        self.data: dict[str, Any] = dict(initial or {})
+
+    async def get(self, name: str) -> Any:
+        return self.data.get(name)
+
+    async def set(self, name: str, value: Any) -> None:
+        if value is None:
+            self.data.pop(name, None)
+        else:
+            self.data[name] = value
+
+
+# ---------------------------------------------------------------------------
+# _ensure_authenticated
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureAuthenticated:
+    """Auth-flow guards, abort and stale-purge on first-run login."""
+
+    def test_already_authenticated_short_circuits(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """When username *and* a token are present, the Chrome flow is never
+        triggered (early return, no browser)."""
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+        secrets = tmp_path / "Auth" / "secrets.json"
+        secrets.parent.mkdir(parents=True, exist_ok=True)
+        secrets.write_text(
+            json.dumps({"username": "u@example.com", "oauth_token": "tok"}),
+            encoding="utf-8",
+        )
+
+        from custom_components.googlefindmy.Auth import auth_flow
+
+        def _boom() -> tuple[str, str]:
+            raise AssertionError("Chrome flow must not run when authenticated")
+
+        monkeypatch.setattr(
+            auth_flow, "request_oauth_account_token_flow", _boom, raising=True
+        )
+
+        cli_main._ensure_authenticated()  # returns without touching auth_flow
+
+    def test_corrupt_secrets_treated_as_missing_and_continues(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:  # type: ignore[no-untyped-def]
+        """A secrets.json that fails to parse is logged and treated as missing;
+        the login flow then runs and persists fresh credentials."""
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+        secrets = tmp_path / "Auth" / "secrets.json"
+        secrets.parent.mkdir(parents=True, exist_ok=True)
+        secrets.write_text("{ not valid json", encoding="utf-8")
+
+        from custom_components.googlefindmy.Auth import auth_flow
+
+        monkeypatch.setattr(
+            auth_flow,
+            "request_oauth_account_token_flow",
+            lambda: ("fresh-oauth", "detected@example.com"),
+            raising=True,
+        )
+
+        with caplog.at_level("WARNING"):
+            cli_main._ensure_authenticated()
+
+        assert "treating as missing credentials" in caplog.text
+        written = json.loads(secrets.read_text(encoding="utf-8"))
+        assert written["oauth_token"] == "fresh-oauth"
+        assert written["username"] == "detected@example.com"
+
+    def test_empty_email_aborts_with_exit_one(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """When the Chrome session yields no e-mail and the interactive prompt
+        is left blank, the process exits 1 (fail closed, no partial write)."""
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+
+        from custom_components.googlefindmy.Auth import auth_flow
+
+        monkeypatch.setattr(
+            auth_flow,
+            "request_oauth_account_token_flow",
+            lambda: ("oauth-without-email", ""),
+            raising=True,
+        )
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "  ")
+
+        with pytest.raises(SystemExit) as excinfo:
+            cli_main._ensure_authenticated()
+
+        assert excinfo.value.code == 1
+        # No secrets file was written on the abort path.
+        assert not (tmp_path / "Auth" / "secrets.json").is_file()
+
+    def test_stale_derived_tokens_purged_before_write(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Existing derived ADM keys and a stale ``aas_token`` are dropped when
+        a fresh OAuth token is written, so they get regenerated from it."""
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+        secrets = tmp_path / "Auth" / "secrets.json"
+        secrets.parent.mkdir(parents=True, exist_ok=True)
+        # has_user True but has_token False (no oauth/aas token present) -> the
+        # login flow runs and the purge loop is reached. A present ``aas_token``
+        # would flip has_token True and short-circuit before the purge.
+        secrets.write_text(
+            json.dumps(
+                {
+                    "username": "u@example.com",
+                    "adm_token_u@example.com": "old",
+                    "adm_token_issued_at_u@example.com": "123",
+                    "adm_probe_x": "1",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        from custom_components.googlefindmy.Auth import auth_flow
+
+        monkeypatch.setattr(
+            auth_flow,
+            "request_oauth_account_token_flow",
+            lambda: ("new-oauth", "u@example.com"),
+            raising=True,
+        )
+
+        cli_main._ensure_authenticated()
+
+        written = json.loads(secrets.read_text(encoding="utf-8"))
+        assert written["oauth_token"] == "new-oauth"
+        assert "aas_token" not in written
+        assert not any(k.startswith(("adm_token_", "adm_probe_")) for k in written)
+
+
+# ---------------------------------------------------------------------------
+# _ensure_aas_token
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureAasToken:
+    """Eager OAuth->AAS exchange short circuits and fail-closed exit."""
+
+    @pytest.mark.asyncio
+    async def test_returns_when_aas_token_cached(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cached AAS token means nothing to do -- the retrieval module is
+        never imported/called."""
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.Auth import aas_token_retrieval
+
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise AssertionError("exchange must not run when AAS is cached")
+
+        monkeypatch.setattr(
+            aas_token_retrieval, "async_get_aas_token", _boom, raising=True
+        )
+        cache = _AsyncDictCache({"aas_token": "already-here", "oauth_token": "o"})
+
+        await cli_main._ensure_aas_token(cache)
+
+    @pytest.mark.asyncio
+    async def test_returns_when_no_oauth_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without an OAuth token there is nothing to exchange (auth not
+        needed) -- the exchange is skipped."""
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.Auth import aas_token_retrieval
+
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise AssertionError("exchange must not run without an OAuth token")
+
+        monkeypatch.setattr(
+            aas_token_retrieval, "async_get_aas_token", _boom, raising=True
+        )
+        cache = _AsyncDictCache({"oauth_token": "   "})  # blank -> treated absent
+
+        await cli_main._ensure_aas_token(cache)
+
+    @pytest.mark.asyncio
+    async def test_exchanges_when_oauth_present_and_aas_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A present OAuth token and absent AAS token trigger exactly one
+        exchange call and no exit."""
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.Auth import aas_token_retrieval
+
+        calls: list[Any] = []
+
+        async def _fake_exchange(*, cache: Any) -> None:
+            calls.append(cache)
+
+        monkeypatch.setattr(
+            aas_token_retrieval, "async_get_aas_token", _fake_exchange, raising=True
+        )
+        cache = _AsyncDictCache({"oauth_token": "fresh"})
+
+        await cli_main._ensure_aas_token(cache)
+
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_exchange_failure_exits_one_with_reauth_hint(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A failed exchange (stale single-use cookie) exits 1 with an
+        actionable re-authentication message on stderr."""
+        from custom_components.googlefindmy import main as cli_main
+        from custom_components.googlefindmy.Auth import aas_token_retrieval
+
+        async def _raise(*, cache: Any) -> None:
+            raise RuntimeError("BadAuthentication")
+
+        monkeypatch.setattr(
+            aas_token_retrieval, "async_get_aas_token", _raise, raising=True
+        )
+        cache = _AsyncDictCache({"oauth_token": "stale-cookie"})
+
+        with pytest.raises(SystemExit) as excinfo:
+            await cli_main._ensure_aas_token(cache)
+
+        assert excinfo.value.code == 1
+        assert "--reauth" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _clear_stale_adm_token
+# ---------------------------------------------------------------------------
+
+
+class TestClearStaleAdmToken:
+    """Per-session ADM token invalidation before the first CLI request."""
+
+    @pytest.mark.asyncio
+    async def test_no_username_is_a_noop(self) -> None:
+        """Without a username there is no namespaced ADM key to clear."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache({"username": "   "})  # blank
+        await cli_main._clear_stale_adm_token(cache)
+
+        assert cache.data == {"username": "   "}
+
+    @pytest.mark.asyncio
+    async def test_clears_namespaced_adm_keys_case_folded(self) -> None:
+        """The ADM token and its issued-at stamp are cleared under the
+        lower-cased username namespace."""
+        from custom_components.googlefindmy import main as cli_main
+
+        cache = _AsyncDictCache(
+            {
+                "username": "  User@Example.COM  ",
+                "adm_token_user@example.com": "tok",
+                "adm_token_issued_at_user@example.com": "999",
+                "keep_me": "yes",
+            }
+        )
+
+        await cli_main._clear_stale_adm_token(cache)
+
+        assert "adm_token_user@example.com" not in cache.data
+        assert "adm_token_issued_at_user@example.com" not in cache.data
+        assert cache.data["keep_me"] == "yes"
+
+
+# ---------------------------------------------------------------------------
+# _clear_stale_tokens_for_reauth
+# ---------------------------------------------------------------------------
+
+
+class TestClearStaleTokensForReauth:
+    """`--reauth` purge of all cached/derived tokens from secrets.json."""
+
+    def test_missing_file_is_a_noop(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+        cli_main._clear_stale_tokens_for_reauth()  # no Auth/secrets.json -> return
+
+    def test_non_dict_json_is_a_noop(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+        secrets = tmp_path / "Auth" / "secrets.json"
+        secrets.parent.mkdir(parents=True, exist_ok=True)
+        secrets.write_text(json.dumps(["a", "list"]), encoding="utf-8")
+
+        cli_main._clear_stale_tokens_for_reauth()
+
+        # File left untouched (still a list).
+        assert json.loads(secrets.read_text(encoding="utf-8")) == ["a", "list"]
+
+    def test_corrupt_json_is_a_noop(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+        secrets = tmp_path / "Auth" / "secrets.json"
+        secrets.parent.mkdir(parents=True, exist_ok=True)
+        secrets.write_text("{ broken", encoding="utf-8")
+
+        cli_main._clear_stale_tokens_for_reauth()
+
+        assert secrets.read_text(encoding="utf-8") == "{ broken"
+
+    def test_no_matching_keys_is_a_noop(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+        secrets = tmp_path / "Auth" / "secrets.json"
+        secrets.parent.mkdir(parents=True, exist_ok=True)
+        secrets.write_text(json.dumps({"username": "u@x"}), encoding="utf-8")
+
+        cli_main._clear_stale_tokens_for_reauth()
+
+        assert json.loads(secrets.read_text(encoding="utf-8")) == {"username": "u@x"}
+
+    def test_removes_all_token_families_and_keeps_username(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:  # type: ignore[no-untyped-def]
+        """Every ``oauth_token``/``aas_token``/derived key is removed while
+        non-token keys (username) survive; a count is reported."""
+        from custom_components.googlefindmy import main as cli_main
+
+        monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+        secrets = tmp_path / "Auth" / "secrets.json"
+        secrets.parent.mkdir(parents=True, exist_ok=True)
+        secrets.write_text(
+            json.dumps(
+                {
+                    "username": "u@x",
+                    "oauth_token": "o",
+                    "aas_token": "a",
+                    "adm_token_u@x": "d",
+                    "adm_token_issued_at_u@x": "1",
+                    "aas_token_issued_at_u@x": "2",
+                    "adm_probe_u@x": "p",
+                    "owner_key": "ok",
+                    "shared_key": "sk",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        cli_main._clear_stale_tokens_for_reauth()
+
+        remaining = json.loads(secrets.read_text(encoding="utf-8"))
+        assert remaining == {"username": "u@x"}

--- a/tests/test_services_handler_contracts.py
+++ b/tests/test_services_handler_contracts.py
@@ -323,11 +323,15 @@ class TestResolverDispatch:
 class TestRefreshUrlRedaction:
     @pytest.mark.asyncio
     async def test_redactor_receives_raw_token_url(
-        self, full_ctx: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+        self,
+        full_ctx: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """The refresh handler hands the *raw* token-bearing URL to
         ``ctx["redact_url_token"]``; the persisted configuration_url carries the
-        token, the redactor is what keeps it out of logs."""
+        token, and only the redactor's masked output reaches the log (the raw
+        token never appears in the emitted DEBUG record)."""
         entry = make_config_entry(entry_id="e1", title="Account")
         hass = _make_hass([entry])
 
@@ -350,14 +354,20 @@ class TestRefreshUrlRedaction:
         full_ctx["redact_url_token"] = redactor
         handlers = _register(hass, full_ctx)
 
-        await handlers[services.SERVICE_REFRESH_DEVICE_URLS](_FakeCall({}))
+        with caplog.at_level("DEBUG", logger=services._LOGGER.name):
+            await handlers[services.SERVICE_REFRESH_DEVICE_URLS](_FakeCall({}))
 
         # The device URL was updated with a token-bearing URL...
         update_mock.assert_called_once()
         written_url = update_mock.call_args.kwargs["configuration_url"]
         assert "/api/googlefindmy/map/CANON123?token=" in written_url
-        # ...and that exact raw URL is what the redactor was asked to mask.
+        # ...that exact raw URL is what the redactor was asked to mask...
         redactor.assert_called_once_with(written_url)
+        # ...and the raw token must not leak into the emitted log record; only
+        # the redactor's masked output is logged.
+        raw_token = written_url.split("token=", 1)[1]
+        assert raw_token not in caplog.text
+        assert "token=***" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -367,30 +377,39 @@ class TestRefreshUrlRedaction:
 
 class TestRebuildRegistryGuards:
     @pytest.mark.asyncio
-    async def test_invalid_entry_id_payload_returns_without_reload(
-        self, full_ctx: dict[str, Any]
+    async def test_non_iterable_entry_id_payload_hits_type_guard(
+        self, full_ctx: dict[str, Any], caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A structurally invalid ``entry_id`` payload is refused (early return,
-        no reload attempted)."""
+        """A non-iterable ``entry_id`` payload (e.g. an int) trips the payload
+        *type* guard specifically and returns without a reload.
+
+        A ``dict`` would be iterable and slip past the type guard into the
+        unresolvable-id branch, so an int is used to pin the type guard itself.
+        """
         reload_mock = mock.AsyncMock()
         hass = _make_hass()
         hass.config_entries.async_reload = reload_mock  # type: ignore[attr-defined]
         handlers = _register(hass, full_ctx)
-        await handlers[services.SERVICE_REBUILD_REGISTRY](
-            _FakeCall({"entry_id": {"nested": "dict"}})
-        )
+        with caplog.at_level("WARNING"):
+            await handlers[services.SERVICE_REBUILD_REGISTRY](
+                _FakeCall({"entry_id": 123})
+            )
         reload_mock.assert_not_awaited()
+        assert "Invalid entry_id payload type" in caplog.text
 
     @pytest.mark.asyncio
     async def test_invalid_device_ids_payload_returns_without_reload(
-        self, full_ctx: dict[str, Any]
+        self, full_ctx: dict[str, Any], caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A non-iterable ``device_ids`` payload is refused (early return)."""
+        """A non-iterable ``device_ids`` payload trips its type guard and returns
+        without a reload."""
         reload_mock = mock.AsyncMock()
         hass = _make_hass()
         hass.config_entries.async_reload = reload_mock  # type: ignore[attr-defined]
         handlers = _register(hass, full_ctx)
-        await handlers[services.SERVICE_REBUILD_REGISTRY](
-            _FakeCall({"device_ids": 123})
-        )
+        with caplog.at_level("WARNING"):
+            await handlers[services.SERVICE_REBUILD_REGISTRY](
+                _FakeCall({"device_ids": 123})
+            )
         reload_mock.assert_not_awaited()
+        assert "Invalid device_ids payload type" in caplog.text

--- a/tests/test_services_handler_contracts.py
+++ b/tests/test_services_handler_contracts.py
@@ -1,0 +1,396 @@
+# tests/test_services_handler_contracts.py
+"""Contract tests for the googlefindmy service handlers.
+
+``async_register_services(hass, ctx)`` wires seven service handlers as closures
+over an injected ``ctx`` (a 14-key context passed by ``__init__.py`` to avoid
+import cycles). These tests build that full ctx with mocked callables, capture
+the registered handlers, and pin:
+
+* input validation (``device_id`` / ``request_uuid`` type + emptiness guards),
+* the ``_resolve_runtime_for_device_id`` outcomes (no active entry, resolver
+  ``HomeAssistantError`` -> not-found, coordinator dispatch, suppressed ops),
+* token redaction in ``refresh_device_urls`` (the raw token-bearing URL is what
+  is handed to ``ctx["redact_url_token"]`` for logging),
+* the ``rebuild_registry`` payload-type guards (invalid entry_id / device_ids).
+
+Fixture note: ``dr.async_get`` and ``get_url`` are patched at the module level so
+handlers run without a live Home Assistant device registry / network helper.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from custom_components.googlefindmy import services
+from custom_components.googlefindmy.services import (
+    HomeAssistantError,
+    ServiceValidationError,
+)
+from tests.helpers.config_entries_stub import make_config_entry
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+class _FakeCall:
+    """Minimal ``ServiceCall`` double exposing only ``.data``."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self.data = data
+
+
+def _make_hass(entries: list[Any] | None = None) -> SimpleNamespace:
+    """Build a fake hass with a capturing service registry and entry list."""
+    entry_list = list(entries or [])
+    return SimpleNamespace(
+        services=SimpleNamespace(async_register=lambda *a, **k: None),
+        config_entries=SimpleNamespace(async_entries=lambda _domain: entry_list),
+        data={},
+    )
+
+
+@pytest.fixture
+def full_ctx() -> dict[str, Any]:
+    """A complete 14-key ctx with every callable stubbed.
+
+    Mirrors the keys documented on ``async_register_services``; every callable
+    is a ``Mock``/``AsyncMock`` so a handler that reaches for any of them gets a
+    benign stub rather than a ``KeyError``.
+    """
+    return {
+        "domain": services.DOMAIN,
+        "resolve_canonical": mock.Mock(return_value=("CANON", "Friendly Name")),
+        "is_active_entry": mock.Mock(return_value=True),
+        "primary_active_entry": mock.Mock(return_value=None),
+        "opt": mock.Mock(return_value=False),
+        "default_map_view_token_expiration": False,
+        "opt_map_view_token_expiration_key": "map_view_token_expiration",
+        "redact_url_token": mock.Mock(return_value="<redacted-url>"),
+        "soft_migrate_entry": mock.AsyncMock(),
+        "migrate_unique_ids": mock.AsyncMock(),
+        "relink_button_devices": mock.AsyncMock(),
+        "relink_subentry_entities": mock.AsyncMock(),
+        "coalesce_account_entries": mock.AsyncMock(),
+        "extract_normalized_email": mock.Mock(return_value=None),
+    }
+
+
+def _register(hass: SimpleNamespace, ctx: dict[str, Any]) -> dict[str, Any]:
+    """Register services and return {service_name: handler}.
+
+    ``async_register_services`` is declared ``async`` but its body performs only
+    synchronous work (defining closures + calling ``async_register``). Driving
+    the coroutine with a single ``send(None)`` runs it to completion without a
+    loop, so this works both in a plain fixture and inside a running event loop
+    (``asyncio.run`` would raise there).
+    """
+    handlers: dict[str, Any] = {}
+
+    def _capture(domain: str, name: str, handler: Any) -> None:
+        handlers[name] = handler
+
+    hass.services.async_register = _capture  # type: ignore[attr-defined]
+    coro = services.async_register_services(hass, ctx)
+    try:
+        coro.send(None)
+    except StopIteration:
+        pass
+    else:  # pragma: no cover - registration must not await
+        coro.close()
+        raise RuntimeError("async_register_services unexpectedly awaited")
+    return handlers
+
+
+@pytest.fixture
+def handlers(full_ctx: dict[str, Any]) -> dict[str, Any]:
+    """Handlers registered against a fake hass with no config entries."""
+    hass = _make_hass()
+    return _register(hass, full_ctx)
+
+
+# ---------------------------------------------------------------------------
+# Registration contract
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_all_seven_services_registered(self, handlers: dict[str, Any]) -> None:
+        """Every documented service name is wired exactly once."""
+        assert set(handlers) == {
+            services.SERVICE_LOCATE_DEVICE,
+            services.SERVICE_LOCATE_EXTERNAL,
+            services.SERVICE_PLAY_SOUND,
+            services.SERVICE_STOP_SOUND,
+            services.SERVICE_REFRESH_DEVICE_URLS,
+            services.SERVICE_REBUILD_DEVICE_REGISTRY,
+            services.SERVICE_REBUILD_REGISTRY,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Input validation (no resolver reached)
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceIdValidation:
+    """The three device-scoped handlers reject a missing/blank device_id."""
+
+    @pytest.mark.parametrize(
+        "service_const",
+        [
+            "SERVICE_LOCATE_DEVICE",
+            "SERVICE_LOCATE_EXTERNAL",
+            "SERVICE_PLAY_SOUND",
+            "SERVICE_STOP_SOUND",
+        ],
+    )
+    @pytest.mark.parametrize("bad", [None, "", 123, {"nested": 1}])
+    @pytest.mark.asyncio
+    async def test_missing_or_non_str_device_id_raises_not_found(
+        self, handlers: dict[str, Any], service_const: str, bad: Any
+    ) -> None:
+        handler = handlers[getattr(services, service_const)]
+        with pytest.raises(ServiceValidationError) as excinfo:
+            await handler(_FakeCall({"device_id": bad}))
+        assert excinfo.value.translation_key == "device_not_found"
+
+    @pytest.mark.asyncio
+    async def test_stop_sound_rejects_non_str_request_uuid(
+        self, handlers: dict[str, Any]
+    ) -> None:
+        """A non-string ``request_uuid`` fails closed before any dispatch."""
+        handler = handlers[services.SERVICE_STOP_SOUND]
+        with pytest.raises(ServiceValidationError) as excinfo:
+            await handler(_FakeCall({"device_id": "dev1", "request_uuid": 999}))
+        assert excinfo.value.translation_key == "stop_sound_failed"
+
+
+# ---------------------------------------------------------------------------
+# Resolver + dispatch contracts
+# ---------------------------------------------------------------------------
+
+
+def _hass_with_coordinator(coord: Any) -> SimpleNamespace:
+    """Fake hass whose single entry exposes ``runtime_data.coordinator``."""
+    runtime = SimpleNamespace(coordinator=coord)
+    entry = SimpleNamespace(entry_id="e1", runtime_data=runtime, title="Account")
+    return _make_hass([entry])
+
+
+class TestResolverDispatch:
+    @pytest.mark.asyncio
+    async def test_no_active_entry_raises(self, full_ctx: dict[str, Any]) -> None:
+        """With zero runtimes the handler raises the no_active_entry error."""
+        hass = _make_hass()  # no entries -> no runtimes
+        handlers = _register(hass, full_ctx)
+        with pytest.raises(ServiceValidationError) as excinfo:
+            await handlers[services.SERVICE_LOCATE_DEVICE](
+                _FakeCall({"device_id": "dev1"})
+            )
+        assert excinfo.value.translation_key == "no_active_entry"
+
+    @pytest.mark.asyncio
+    async def test_resolver_home_assistant_error_maps_to_not_found(
+        self, full_ctx: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``HomeAssistantError`` from the canonical resolver becomes a
+        translated device_not_found error."""
+        full_ctx["resolve_canonical"] = mock.Mock(
+            side_effect=HomeAssistantError("bad id")
+        )
+        coord = SimpleNamespace()
+        hass = _hass_with_coordinator(coord)
+        handlers = _register(hass, full_ctx)
+        with pytest.raises(ServiceValidationError) as excinfo:
+            await handlers[services.SERVICE_LOCATE_DEVICE](
+                _FakeCall({"device_id": "dev1"})
+            )
+        assert excinfo.value.translation_key == "device_not_found"
+
+    @pytest.mark.asyncio
+    async def test_locate_dispatches_to_coordinator(
+        self, full_ctx: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A resolvable device dispatches ``async_locate_device`` with the
+        canonical id from the resolver."""
+        coord = SimpleNamespace(
+            async_locate_device=mock.AsyncMock(),
+            get_device_display_name=mock.Mock(return_value="Tag"),
+        )
+        hass = _hass_with_coordinator(coord)
+        # No device-registry hit -> fall through to the coordinator scan.
+        monkeypatch.setattr(
+            services.dr,
+            "async_get",
+            lambda _h: SimpleNamespace(async_get=lambda _d: None),
+        )
+        handlers = _register(hass, full_ctx)
+        await handlers[services.SERVICE_LOCATE_DEVICE](_FakeCall({"device_id": "dev1"}))
+        coord.async_locate_device.assert_awaited_once_with("CANON")
+
+    @pytest.mark.asyncio
+    async def test_play_sound_suppressed_raises(
+        self, full_ctx: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A coordinator that returns ``False`` (suppressed) surfaces as a
+        play_sound_failed validation error."""
+        coord = SimpleNamespace(
+            async_play_sound=mock.AsyncMock(return_value=False),
+            get_device_display_name=mock.Mock(return_value="Tag"),
+        )
+        hass = _hass_with_coordinator(coord)
+        monkeypatch.setattr(
+            services.dr,
+            "async_get",
+            lambda _h: SimpleNamespace(async_get=lambda _d: None),
+        )
+        handlers = _register(hass, full_ctx)
+        with pytest.raises(ServiceValidationError) as excinfo:
+            await handlers[services.SERVICE_PLAY_SOUND](
+                _FakeCall({"device_id": "dev1"})
+            )
+        assert excinfo.value.translation_key == "play_sound_failed"
+
+    @pytest.mark.parametrize(
+        ("service_const", "coord_attr", "translation_key"),
+        [
+            ("SERVICE_LOCATE_DEVICE", "async_locate_device", "locate_failed"),
+            ("SERVICE_LOCATE_EXTERNAL", "async_locate_device", "locate_failed"),
+            ("SERVICE_PLAY_SOUND", "async_play_sound", "play_sound_failed"),
+            ("SERVICE_STOP_SOUND", "async_stop_sound", "stop_sound_failed"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_downstream_failure_wrapped_as_translated_error(
+        self,
+        full_ctx: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+        service_const: str,
+        coord_attr: str,
+        translation_key: str,
+    ) -> None:
+        """Any coordinator exception is surfaced as the handler's translated
+        ``*_failed`` error, never as a raw traceback."""
+        coord = SimpleNamespace(
+            **{coord_attr: mock.AsyncMock(side_effect=RuntimeError("boom"))},
+            get_device_display_name=mock.Mock(return_value="Tag"),
+        )
+        hass = _hass_with_coordinator(coord)
+        monkeypatch.setattr(
+            services.dr,
+            "async_get",
+            lambda _h: SimpleNamespace(async_get=lambda _d: None),
+        )
+        handlers = _register(hass, full_ctx)
+        with pytest.raises(ServiceValidationError) as excinfo:
+            await handlers[getattr(services, service_const)](
+                _FakeCall({"device_id": "dev1"})
+            )
+        assert excinfo.value.translation_key == translation_key
+
+    @pytest.mark.asyncio
+    async def test_stop_sound_passes_request_uuid_through(
+        self, full_ctx: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A valid ``request_uuid`` is forwarded verbatim to the coordinator."""
+        coord = SimpleNamespace(
+            async_stop_sound=mock.AsyncMock(return_value=True),
+            get_device_display_name=mock.Mock(return_value="Tag"),
+        )
+        hass = _hass_with_coordinator(coord)
+        monkeypatch.setattr(
+            services.dr,
+            "async_get",
+            lambda _h: SimpleNamespace(async_get=lambda _d: None),
+        )
+        handlers = _register(hass, full_ctx)
+        await handlers[services.SERVICE_STOP_SOUND](
+            _FakeCall({"device_id": "dev1", "request_uuid": "req-7"})
+        )
+        coord.async_stop_sound.assert_awaited_once_with("CANON", "req-7")
+
+
+# ---------------------------------------------------------------------------
+# Token redaction contract (refresh_device_urls)
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshUrlRedaction:
+    @pytest.mark.asyncio
+    async def test_redactor_receives_raw_token_url(
+        self, full_ctx: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The refresh handler hands the *raw* token-bearing URL to
+        ``ctx["redact_url_token"]``; the persisted configuration_url carries the
+        token, the redactor is what keeps it out of logs."""
+        entry = make_config_entry(entry_id="e1", title="Account")
+        hass = _make_hass([entry])
+
+        device = SimpleNamespace(
+            id="devid",
+            identifiers={(services.DOMAIN, "e1:CANON123")},
+            config_entries=["e1"],
+            serial_number=None,
+            name="Tag",
+            name_by_user=None,
+        )
+        update_mock = mock.Mock()
+        fake_reg = SimpleNamespace(
+            devices={"devid": device}, async_update_device=update_mock
+        )
+        monkeypatch.setattr(services.dr, "async_get", lambda _h: fake_reg)
+        monkeypatch.setattr(services, "get_url", lambda *a, **k: "http://ha.local:8123")
+
+        redactor = mock.Mock(return_value="http://ha.local:8123/...?token=***")
+        full_ctx["redact_url_token"] = redactor
+        handlers = _register(hass, full_ctx)
+
+        await handlers[services.SERVICE_REFRESH_DEVICE_URLS](_FakeCall({}))
+
+        # The device URL was updated with a token-bearing URL...
+        update_mock.assert_called_once()
+        written_url = update_mock.call_args.kwargs["configuration_url"]
+        assert "/api/googlefindmy/map/CANON123?token=" in written_url
+        # ...and that exact raw URL is what the redactor was asked to mask.
+        redactor.assert_called_once_with(written_url)
+
+
+# ---------------------------------------------------------------------------
+# rebuild_registry payload guards
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildRegistryGuards:
+    @pytest.mark.asyncio
+    async def test_invalid_entry_id_payload_returns_without_reload(
+        self, full_ctx: dict[str, Any]
+    ) -> None:
+        """A structurally invalid ``entry_id`` payload is refused (early return,
+        no reload attempted)."""
+        reload_mock = mock.AsyncMock()
+        hass = _make_hass()
+        hass.config_entries.async_reload = reload_mock  # type: ignore[attr-defined]
+        handlers = _register(hass, full_ctx)
+        await handlers[services.SERVICE_REBUILD_REGISTRY](
+            _FakeCall({"entry_id": {"nested": "dict"}})
+        )
+        reload_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_invalid_device_ids_payload_returns_without_reload(
+        self, full_ctx: dict[str, Any]
+    ) -> None:
+        """A non-iterable ``device_ids`` payload is refused (early return)."""
+        reload_mock = mock.AsyncMock()
+        hass = _make_hass()
+        hass.config_entries.async_reload = reload_mock  # type: ignore[attr-defined]
+        handlers = _register(hass, full_ctx)
+        await handlers[services.SERVICE_REBUILD_REGISTRY](
+            _FakeCall({"device_ids": 123})
+        )
+        reload_mock.assert_not_awaited()

--- a/tests/test_token_cache_contracts.py
+++ b/tests/test_token_cache_contracts.py
@@ -1,0 +1,268 @@
+# tests/test_token_cache_contracts.py
+"""Contract tests for the TokenCache facade, registry and default resolution.
+
+Covers ``custom_components/googlefindmy/Auth/token_cache.py``:
+
+* ``TokenCache.__init__`` validation guards (entry_id type/emptiness, missing
+  event loop).
+* ``get_or_set`` per-key lock (thundering-herd protection): the generator runs
+  at most once even under concurrent callers; coroutine generators are awaited.
+* Sync facades (``get_cached_value`` / ``set_cached_value`` /
+  ``get_cached_value_or_set``): the event-loop guard (RuntimeError when called
+  from inside a running loop) and the no-instance / with-instance branches.
+* ``_get_default_cache`` resolution order (provider, default entry, single
+  instance, ambiguity / absence RuntimeErrors).
+* Registry helpers (``get_cache_for_entry``, ``_set_default_entry_id``).
+
+Module-global registry state (``_INSTANCES`` / ``_STATE``) is snapshotted and
+restored around every test so ordering cannot leak state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from custom_components.googlefindmy.Auth import token_cache as tc
+from custom_components.googlefindmy.Auth.token_cache import TokenCache
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset the module-global registry/state around each test."""
+    monkeypatch.setattr(tc, "_INSTANCES", {}, raising=True)
+    monkeypatch.setattr(
+        tc,
+        "_STATE",
+        {"legacy_migration_done": False, "default_entry_id": None},
+        raising=True,
+    )
+
+
+def _fake_cache(
+    entry_id: str, data: dict[str, object] | None = None
+) -> SimpleNamespace:
+    """A lightweight stand-in registered directly into ``_INSTANCES``."""
+    return SimpleNamespace(entry_id=entry_id, _data=dict(data or {}))
+
+
+def _real_cache(monkeypatch: pytest.MonkeyPatch, entry_id: str = "e1") -> TokenCache:
+    """Build a real TokenCache with the Store patched out (no disk I/O)."""
+    monkeypatch.setattr(tc, "Store", Mock())
+    hass = SimpleNamespace(loop=asyncio.get_event_loop(), data={})
+    cache = TokenCache(hass, entry_id)
+    cache._store = Mock()  # async_delay_save / async_save are no-ops
+    return cache
+
+
+# --------------------------------------------------------------------------- #
+# __init__ validation guards                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_init_rejects_non_string_entry_id() -> None:
+    with pytest.raises(TypeError):
+        TokenCache(SimpleNamespace(loop=object()), 123)  # type: ignore[arg-type]
+
+
+def test_init_rejects_empty_entry_id() -> None:
+    with pytest.raises(ValueError):
+        TokenCache(SimpleNamespace(loop=object()), "   ")
+
+
+def test_init_requires_event_loop() -> None:
+    with pytest.raises(RuntimeError):
+        TokenCache(SimpleNamespace(loop=None), "e1")
+
+
+# --------------------------------------------------------------------------- #
+# get_or_set — thundering-herd per-key lock                                    #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_get_or_set_returns_existing_without_generator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _real_cache(monkeypatch)
+    cache._data["k"] = "cached"
+    gen = Mock()
+    assert await cache.get_or_set("k", gen) == "cached"
+    gen.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_or_set_awaits_coroutine_generator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _real_cache(monkeypatch)
+
+    async def gen() -> str:
+        return "computed"
+
+    assert await cache.get_or_set("k", gen) == "computed"
+    assert cache._data["k"] == "computed"
+
+
+@pytest.mark.asyncio
+async def test_get_or_set_runs_generator_once_under_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent callers must not all run the generator (per-key lock)."""
+    cache = _real_cache(monkeypatch)
+    calls = 0
+
+    async def gen() -> str:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0)  # yield so a second caller can enter the lock
+        return "once"
+
+    results = await asyncio.gather(
+        cache.get_or_set("k", gen),
+        cache.get_or_set("k", gen),
+        cache.get_or_set("k", gen),
+    )
+    assert results == ["once", "once", "once"]
+    assert calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# set() after close                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_set_after_close_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = _real_cache(monkeypatch)
+    await cache.close()
+    with pytest.raises(RuntimeError):
+        await cache.set("k", "v")
+
+
+# --------------------------------------------------------------------------- #
+# _get_default_cache — resolution order                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_default_cache_raises_when_no_instances() -> None:
+    with pytest.raises(RuntimeError, match="No TokenCache registered"):
+        tc._get_default_cache()
+
+
+def test_default_cache_returns_single_instance() -> None:
+    cache = _fake_cache("only")
+    tc._INSTANCES["only"] = cache
+    assert tc._get_default_cache() is cache
+
+
+def test_default_cache_uses_default_entry_id() -> None:
+    a, b = _fake_cache("a"), _fake_cache("b")
+    tc._INSTANCES.update({"a": a, "b": b})
+    tc._STATE["default_entry_id"] = "b"
+    assert tc._get_default_cache() is b
+
+
+def test_default_cache_ambiguous_without_default_raises() -> None:
+    tc._INSTANCES.update({"a": _fake_cache("a"), "b": _fake_cache("b")})
+    with pytest.raises(RuntimeError, match="Multiple config entries"):
+        tc._get_default_cache()
+
+
+def test_default_cache_prefers_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cache resolved via the nova_request provider wins over the registry."""
+    from custom_components.googlefindmy.NovaApi import nova_request
+
+    provided = _fake_cache("provided")
+    monkeypatch.setattr(
+        nova_request, "resolve_cache_from_provider", lambda: provided, raising=False
+    )
+    tc._INSTANCES["registry"] = _fake_cache("registry")
+    assert tc._get_default_cache() is provided
+
+
+# --------------------------------------------------------------------------- #
+# Registry helpers                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_get_cache_for_entry_hit_and_miss() -> None:
+    cache = _fake_cache("e1")
+    tc._INSTANCES["e1"] = cache
+    assert tc.get_cache_for_entry("e1") is cache
+    with pytest.raises(KeyError):
+        tc.get_cache_for_entry("missing")
+
+
+def test_set_default_entry_id_single_and_force() -> None:
+    tc._INSTANCES["e1"] = _fake_cache("e1")
+    tc._set_default_entry_id("e1")
+    assert tc._STATE["default_entry_id"] == "e1"
+    tc._set_default_entry_id("forced", force=True)
+    assert tc._STATE["default_entry_id"] == "forced"
+
+
+def test_set_default_entry_id_ambiguous_clears_default() -> None:
+    tc._INSTANCES.update({"a": _fake_cache("a"), "b": _fake_cache("b")})
+    tc._set_default_entry_id("a")  # >1 instances, not previously default -> None
+    assert tc._STATE["default_entry_id"] is None
+
+
+# --------------------------------------------------------------------------- #
+# Sync facades — event-loop guard + instance branches                          #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sync_getter_rejects_running_loop() -> None:
+    with pytest.raises(RuntimeError, match="inside event loop"):
+        tc.get_cached_value("k")
+
+
+@pytest.mark.asyncio
+async def test_sync_setter_rejects_running_loop() -> None:
+    with pytest.raises(RuntimeError, match="inside event loop"):
+        tc.set_cached_value("k", "v")
+
+
+@pytest.mark.asyncio
+async def test_sync_get_or_set_rejects_running_loop() -> None:
+    with pytest.raises(RuntimeError, match="inside event loop"):
+        tc.get_cached_value_or_set("k", lambda: "v")
+
+
+def test_sync_getter_returns_none_without_instances() -> None:
+    assert tc.get_cached_value("k") is None
+
+
+def test_sync_getter_reads_instance_data() -> None:
+    tc._INSTANCES["e1"] = _fake_cache("e1", {"k": "value"})
+    assert tc.get_cached_value("k") == "value"
+
+
+def test_sync_setter_writes_and_deletes_instance_data() -> None:
+    cache = _fake_cache("e1")
+    tc._INSTANCES["e1"] = cache
+    tc.set_cached_value("k", "v")
+    assert cache._data["k"] == "v"
+    tc.set_cached_value("k", None)  # None removes the key
+    assert "k" not in cache._data
+
+
+def test_sync_setter_without_instances_is_noop() -> None:
+    tc.set_cached_value("k", "v")  # only logs a warning, no raise
+
+
+def test_sync_get_or_set_without_instances_calls_generator() -> None:
+    assert tc.get_cached_value_or_set("k", lambda: "computed") == "computed"
+
+
+def test_sync_get_or_set_hit_and_store() -> None:
+    cache = _fake_cache("e1", {"present": "hit"})
+    tc._INSTANCES["e1"] = cache
+    assert tc.get_cached_value_or_set("present", lambda: "new") == "hit"
+    assert tc.get_cached_value_or_set("absent", lambda: "new") == "new"
+    assert cache._data["absent"] == "new"

--- a/tests/test_token_cache_contracts.py
+++ b/tests/test_token_cache_contracts.py
@@ -177,9 +177,7 @@ def test_default_cache_prefers_provider(monkeypatch: pytest.MonkeyPatch) -> None
     from custom_components.googlefindmy.NovaApi import nova_request
 
     provided = _fake_cache("provided")
-    monkeypatch.setattr(
-        nova_request, "resolve_cache_from_provider", lambda: provided, raising=False
-    )
+    monkeypatch.setattr(nova_request, "resolve_cache_from_provider", lambda: provided)
     tc._INSTANCES["registry"] = _fake_cache("registry")
     assert tc._get_default_cache() is provided
 

--- a/tests/test_token_refresh_contracts.py
+++ b/tests/test_token_refresh_contracts.py
@@ -1,0 +1,310 @@
+# tests/test_token_refresh_contracts.py
+"""Contract tests for ``Auth/token_refresh`` (Coverage W1, AP-W1.3).
+
+These pin the terminal exits of the manual token-regeneration helpers and the
+per-token-type cooldown key contract. The star is the H4 regression: the
+documented no-op of ``clear_cooldown`` when called without a ``token_type``
+(production only ever records typed ``entry_id:fcm`` / ``entry_id:adm`` keys),
+which a naive refactor would "fix" into a real wipe and silently reset the
+buttons' rate limits. One test per return/raise exit, assertions on the
+returned value and the cooldown state, no golden master.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.Auth import token_refresh
+from custom_components.googlefindmy.Auth.token_refresh import (
+    _cooldown_key,
+    _get_entry_id,
+    _record_refresh,
+    async_regenerate_adm_token,
+    async_regenerate_fcm_token,
+    clear_all_cooldowns,
+    clear_cooldown,
+    get_cooldown_remaining,
+    is_refresh_on_cooldown,
+)
+from custom_components.googlefindmy.const import DOMAIN
+
+_ENTRY = "entry-abc"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cooldowns() -> Any:
+    """Prevent global cooldown-state leaks between tests (W1-3 reset)."""
+    clear_all_cooldowns()
+    yield
+    clear_all_cooldowns()
+
+
+# ---------------------------------------------------------------------------
+# _cooldown_key: namespace isolation contract (:fcm != :adm)
+# ---------------------------------------------------------------------------
+
+
+def test_cooldown_key_none_type_is_legacy_entry_only() -> None:
+    assert _cooldown_key(_ENTRY, None) == _ENTRY
+    assert _cooldown_key(_ENTRY) == _ENTRY
+
+
+def test_cooldown_key_normalizes_case_and_whitespace() -> None:
+    # Case/whitespace fold together so "FCM" and "fcm " share one bucket.
+    assert _cooldown_key(_ENTRY, "FCM") == f"{_ENTRY}:fcm"
+    assert _cooldown_key(_ENTRY, "fcm ") == f"{_ENTRY}:fcm"
+    assert _cooldown_key(_ENTRY, "FCM") == _cooldown_key(_ENTRY, "fcm ")
+
+
+def test_cooldown_key_fcm_and_adm_are_isolated() -> None:
+    # The core invariant: the two buttons live on independent rate limits.
+    assert _cooldown_key(_ENTRY, "fcm") != _cooldown_key(_ENTRY, "adm")
+
+
+def test_recording_fcm_does_not_place_adm_on_cooldown() -> None:
+    _record_refresh(_ENTRY, "fcm")
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is True
+    assert is_refresh_on_cooldown(_ENTRY, "adm")[0] is False
+
+
+def test_get_cooldown_remaining_positive_after_record() -> None:
+    _record_refresh(_ENTRY, "adm")
+    remaining = get_cooldown_remaining(_ENTRY, "adm")
+    assert 0.0 < remaining <= token_refresh.TOKEN_REFRESH_COOLDOWN_S
+
+
+def test_is_refresh_on_cooldown_false_for_unknown_entry() -> None:
+    on_cd, remaining = is_refresh_on_cooldown("never-recorded", "fcm")
+    assert on_cd is False
+    assert remaining == 0.0
+
+
+# ---------------------------------------------------------------------------
+# H4 regression: clear_cooldown without a token_type is a documented no-op
+# ---------------------------------------------------------------------------
+
+
+def test_clear_cooldown_without_type_is_noop_against_typed_keys() -> None:
+    """H4: clearing the legacy entry-only key must NOT reset the typed key."""
+    _record_refresh(_ENTRY, "fcm")
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is True
+
+    clear_cooldown(_ENTRY)  # legacy key -> no-op against entry:fcm
+
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is True
+
+
+def test_clear_cooldown_with_matching_type_clears_it() -> None:
+    _record_refresh(_ENTRY, "fcm")
+    clear_cooldown(_ENTRY, "fcm")
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is False
+
+
+def test_clear_all_cooldowns_wipes_every_key() -> None:
+    _record_refresh(_ENTRY, "fcm")
+    _record_refresh(_ENTRY, "adm")
+    clear_all_cooldowns()
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is False
+    assert is_refresh_on_cooldown(_ENTRY, "adm")[0] is False
+
+
+# ---------------------------------------------------------------------------
+# _get_entry_id: three terminal exits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_entry_id_prefers_entry_id_attribute() -> None:
+    cache = SimpleNamespace(entry_id="from-attr", _namespace="ns")
+    assert await _get_entry_id(cache) == "from-attr"
+
+
+@pytest.mark.asyncio
+async def test_get_entry_id_falls_back_to_namespace() -> None:
+    cache = SimpleNamespace(entry_id=None, _namespace="ns-fallback")
+    assert await _get_entry_id(cache) == "ns-fallback"
+
+
+@pytest.mark.asyncio
+async def test_get_entry_id_defaults_when_nothing_present() -> None:
+    cache = SimpleNamespace(entry_id=None, _namespace=None)
+    assert await _get_entry_id(cache) == "default"
+
+
+# ---------------------------------------------------------------------------
+# async_regenerate_fcm_token: terminal exits
+# ---------------------------------------------------------------------------
+
+
+def _hass_with(bucket: Any) -> Any:
+    return SimpleNamespace(data={DOMAIN: bucket})
+
+
+class _Receiver:
+    def __init__(self, result: bool | Exception) -> None:
+        self._result = result
+        self.called_with: str | None = None
+
+    async def async_reregister_fcm(self, entry_id: str) -> bool:
+        self.called_with = entry_id
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_fcm_regen_blocked_on_cooldown() -> None:
+    _record_refresh(_ENTRY, "fcm")
+    hass = _hass_with({"fcm_receivers": {_ENTRY: _Receiver(True)}})
+    assert await async_regenerate_fcm_token(hass=hass, entry_id=_ENTRY) is False
+
+
+@pytest.mark.asyncio
+async def test_fcm_regen_fails_without_integration_data() -> None:
+    hass = SimpleNamespace(data={})  # bucket missing
+    assert await async_regenerate_fcm_token(hass=hass, entry_id=_ENTRY) is False
+
+
+@pytest.mark.asyncio
+async def test_fcm_regen_fails_when_no_receiver_found() -> None:
+    hass = _hass_with({"fcm_receivers": {}})  # no per-entry, no singleton
+    assert await async_regenerate_fcm_token(hass=hass, entry_id=_ENTRY) is False
+
+
+@pytest.mark.asyncio
+async def test_fcm_regen_uses_singleton_receiver_fallback() -> None:
+    receiver = _Receiver(True)
+    hass = _hass_with({"fcm_receivers": {}, "fcm_receiver": receiver})
+    assert await async_regenerate_fcm_token(hass=hass, entry_id=_ENTRY) is True
+    assert receiver.called_with == _ENTRY
+    # success records the typed cooldown
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is True
+
+
+@pytest.mark.asyncio
+async def test_fcm_regen_success_records_cooldown() -> None:
+    receiver = _Receiver(True)
+    hass = _hass_with({"fcm_receivers": {_ENTRY: receiver}})
+    assert await async_regenerate_fcm_token(hass=hass, entry_id=_ENTRY) is True
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is True
+    assert is_refresh_on_cooldown(_ENTRY, "adm")[0] is False
+
+
+@pytest.mark.asyncio
+async def test_fcm_regen_reregister_returns_false_no_cooldown() -> None:
+    hass = _hass_with({"fcm_receivers": {_ENTRY: _Receiver(False)}})
+    assert await async_regenerate_fcm_token(hass=hass, entry_id=_ENTRY) is False
+    # a failed regen must not arm the cooldown
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is False
+
+
+@pytest.mark.asyncio
+async def test_fcm_regen_swallows_receiver_exception() -> None:
+    hass = _hass_with({"fcm_receivers": {_ENTRY: _Receiver(RuntimeError("boom"))}})
+    assert await async_regenerate_fcm_token(hass=hass, entry_id=_ENTRY) is False
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is False
+
+
+# ---------------------------------------------------------------------------
+# async_regenerate_adm_token: terminal exits
+# ---------------------------------------------------------------------------
+
+
+class _Cache:
+    def __init__(self, entry_id: str = _ENTRY) -> None:
+        self.entry_id = entry_id
+        self.sets: list[tuple[str, Any]] = []
+
+    async def set(self, key: str, value: Any) -> None:
+        self.sets.append((key, value))
+
+
+def _patch_adm(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    token: Any,
+    username: str | None = "user@example.com",
+) -> None:
+    from unittest.mock import AsyncMock
+
+    import custom_components.googlefindmy.Auth.adm_token_retrieval as adm_mod
+    import custom_components.googlefindmy.Auth.username_provider as user_mod
+
+    monkeypatch.setattr(adm_mod, "async_get_adm_token", AsyncMock(return_value=token))
+    monkeypatch.setattr(
+        user_mod, "async_get_username", AsyncMock(return_value=username)
+    )
+
+
+@pytest.mark.asyncio
+async def test_adm_regen_blocked_on_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _record_refresh(_ENTRY, "adm")
+    _patch_adm(monkeypatch, token="new-token")
+    assert await async_regenerate_adm_token(cache=_Cache()) is False
+
+
+@pytest.mark.asyncio
+async def test_adm_regen_fails_without_username(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_adm(monkeypatch, token="new-token", username=None)
+    # username neither passed nor resolvable -> resolution branch + early exit
+    assert await async_regenerate_adm_token(cache=_Cache()) is False
+
+
+@pytest.mark.asyncio
+async def test_adm_regen_success_records_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_adm(monkeypatch, token="fresh-adm")
+    cache = _Cache()
+    assert (
+        await async_regenerate_adm_token(cache=cache, username="user@example.com")
+        is True
+    )
+    # ADM invalidated before regeneration
+    assert cache.sets and cache.sets[0][1] is None
+    assert is_refresh_on_cooldown(_ENTRY, "adm")[0] is True
+    # isolation: FCM stays free
+    assert is_refresh_on_cooldown(_ENTRY, "fcm")[0] is False
+
+
+@pytest.mark.asyncio
+async def test_adm_regen_empty_token_returns_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_adm(monkeypatch, token=None)  # regeneration yields empty token
+    assert (
+        await async_regenerate_adm_token(cache=_Cache(), username="user@example.com")
+        is False
+    )
+    assert is_refresh_on_cooldown(_ENTRY, "adm")[0] is False
+
+
+@pytest.mark.asyncio
+async def test_adm_regen_swallows_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import AsyncMock
+
+    import custom_components.googlefindmy.Auth.adm_token_retrieval as adm_mod
+    import custom_components.googlefindmy.Auth.username_provider as user_mod
+
+    monkeypatch.setattr(
+        user_mod, "async_get_username", AsyncMock(return_value="user@example.com")
+    )
+    monkeypatch.setattr(
+        adm_mod,
+        "async_get_adm_token",
+        AsyncMock(side_effect=RuntimeError("regen failed")),
+    )
+    assert (
+        await async_regenerate_adm_token(cache=_Cache(), username="user@example.com")
+        is False
+    )
+    assert is_refresh_on_cooldown(_ENTRY, "adm")[0] is False


### PR DESCRIPTION
## Coverage W1 follow-up: contract tests that catch bugs, floor 73 -> 74

Follow-up to #1183 (the W1 pilot). Continues Wave 1 of the coverage plan by
adding **contract tests** (one test per terminal exit, assertions on the
return value and on state) to the next high-contract modules, and raises the
coverage floor now that the gains are locked in. Priority is defect-catching
value over raw percentage.

This PR is opened early (still a work-in-progress for the remaining W1 modules)
to open the CI/review feedback channel; further modules land on this branch.

### Coverage floor 73 -> 74
Both gates move in lockstep, as enforced by `test_platinum_compliance`:
- `pyproject.toml` `[tool.coverage.report] fail_under = 74`
- `.github/workflows/ci.yml` `--cov-fail-under=74`

Measured full-suite total: **74.47 %** (~0.47 Pp headroom).

### AP-W1.3 `Auth/token_refresh` (reachable coverage ~100 %)
- Every terminal exit of `async_regenerate_fcm_token` (cooldown block, missing
  integration data, no receiver, singleton-receiver fallback, success,
  reregister-false, exception) and `async_regenerate_adm_token` (cooldown
  block, no username, success, empty token, exception).
- The `_cooldown_key` isolation contract: `:fcm` and `:adm` are independent
  rate limits; recording one never places the sibling on cooldown.
- **H4 regression (star):** `clear_cooldown` without a `token_type` is a
  *documented no-op* against the typed keys production actually records. A
  naive refactor into a real wipe would silently reset the buttons' rate
  limits; this test freezes the intended behavior.

### AP-W1.4 `fmdn_finder/google_uploader` (reachable coverage ~100 %)
- **H6 guard (star):** while `FMDN_UPLOAD_ENABLED` is `False`,
  `async_upload_to_google_fmdn` fails closed and never reaches the gRPC
  transport or the cache lookup (the single switch guarding against a live
  upload attempt to Google).
- Public diagnostics API, all five `_get_cache_from_hass` exits, and the
  remaining `_try_grpc_upload` exits (success, empty reply, gRPC status error,
  connection error, teardown swallow). The SSL-teardown races remain in
  `test_google_uploader_teardown.py` and are not duplicated.

### Notes
- New async tests carry an explicit `@pytest.mark.asyncio` marker
  (`test_guard_async_test_marker` requirement; not added to the legacy
  allowlist).
- Full suite green, `ruff format`/`check` clean, `coverage.json` not committed.
- Only unreachable lines remain in the two modules: the `TYPE_CHECKING`
  import blocks and the `grpclib`-missing `ImportError` guard (unreachable
  with `grpclib` installed).

### Still to come on this branch (Wave 1 remainder)
W1.1 `decrypt_locations` (H5 property parity), W1.5 `ble_scanner`,
W1.6 `bermuda_listener` (H3), W1.7 `token_cache`, W1.8 `services`,
W1.9 `main` CLI exit paths.
