### PR TITLE
fix: symmetric padding for the map filter panel controls

### DIFF
--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -741,11 +741,15 @@ class GoogleFindMyMapView(HomeAssistantView):
             border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.2);
             max-width: 300px; backdrop-filter: blur(5px);
         }}
-        /* Scoped border-box reset: the full-width inputs/button carry their own
-           padding+border, so without this they overflow the panel's 15px right
-           padding (content-box adds padding+border ON TOP of width:100%), which
-           made the right gap collapse to ~3px while the left stayed at 15px. */
-        .controls *, .controls *::before, .controls *::after {{ box-sizing: border-box; }}
+        /* Scoped border-box for the full-width form controls only: the inputs
+           and button carry width:100% plus their own padding+border, so under
+           content-box they overflow the panel's 15px right padding (padding+
+           border added ON TOP of width:100%), collapsing the right gap to ~3px
+           while the left stayed at 15px. Targeting exactly these elements (not a
+           `.controls *` descendant reset) leaves the summary on its intended
+           content-box geometry, whose 12px padding + 20px min-height deliberately
+           sums to a 44px WCAG tap target. */
+        .controls input, .controls button {{ box-sizing: border-box; }}
         .controls h3 {{ margin: 0 0 10px; font-size: 16px; line-height: 1.2; }}
         .control-group {{ margin-bottom: 10px; }}
         label {{ display: block; font-size: 12px; font-weight: bold; color: #333; margin-bottom: 4px; }}

--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -741,6 +741,11 @@ class GoogleFindMyMapView(HomeAssistantView):
             border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.2);
             max-width: 300px; backdrop-filter: blur(5px);
         }}
+        /* Scoped border-box reset: the full-width inputs/button carry their own
+           padding+border, so without this they overflow the panel's 15px right
+           padding (content-box adds padding+border ON TOP of width:100%), which
+           made the right gap collapse to ~3px while the left stayed at 15px. */
+        .controls *, .controls *::before, .controls *::after {{ box-sizing: border-box; }}
         .controls h3 {{ margin: 0 0 10px; font-size: 16px; line-height: 1.2; }}
         .control-group {{ margin-bottom: 10px; }}
         label {{ display: block; font-size: 12px; font-weight: bold; color: #333; margin-bottom: 4px; }}

--- a/tests/test_map_view_controls_panel.py
+++ b/tests/test_map_view_controls_panel.py
@@ -160,6 +160,29 @@ def test_input_ids_are_unchanged_so_apply_filters_still_binds() -> None:
     assert "getElementById('accuracy')" in html
 
 
+# ------------------- Defect 3: right-edge padding symmetry ------------------
+
+
+def test_full_width_controls_use_border_box_sizing() -> None:
+    """Full-width inputs/button must not overflow the panel's right padding.
+
+    The date inputs, the range slider and the apply button all carry
+    ``width: 100%`` together with their own ``padding`` and a ``1px`` border.
+    Under the default ``content-box`` model that padding+border is added ON TOP
+    of the 100% content width, so the elements grew ~12px past the panel's 15px
+    right padding: the right gap collapsed to a few pixels while the left gap
+    stayed at 15px (visible asymmetry reported on the rendered map). A scoped
+    ``box-sizing: border-box`` reset folds padding+border back INTO the 100%,
+    restoring the symmetric 15px gutter on both sides.
+
+    Mutation check: dropping the reset re-introduces the overflow, so this
+    assertion goes red — it pins the fix, not merely the presence of a string.
+    """
+    html = _render()
+    assert ".controls *, .controls *::before, .controls *::after {" in html
+    assert "box-sizing: border-box;" in html
+
+
 def test_style_and_details_tags_are_balanced_and_ordered() -> None:
     """Guard against unclosed tags after the CSS/HTML rewrite.
 

--- a/tests/test_map_view_controls_panel.py
+++ b/tests/test_map_view_controls_panel.py
@@ -179,8 +179,26 @@ def test_full_width_controls_use_border_box_sizing() -> None:
     assertion goes red — it pins the fix, not merely the presence of a string.
     """
     html = _render()
-    assert ".controls *, .controls *::before, .controls *::after {" in html
+    assert ".controls input, .controls button {" in html
     assert "box-sizing: border-box;" in html
+
+
+def test_border_box_reset_does_not_touch_the_summary_tap_target() -> None:
+    """The border-box reset must stay off the summary (regression guard).
+
+    The summary's 44px tap target is computed on ``content-box`` geometry
+    (20px min-height + 2x12px padding). A broad ``.controls *`` descendant
+    reset would silently re-measure that min-height on the border box and
+    shrink the handle to ~41px, below the documented WCAG 2.5.5 target. The
+    reset is therefore restricted to the full-width form controls and must not
+    reach the summary via a universal descendant selector.
+
+    Mutation check: widening the selector back to ``.controls *`` makes this
+    assertion red — it pins the *scope* of the reset, not just its presence.
+    """
+    html = _render()
+    assert ".controls *, .controls *::before" not in html
+    assert "box-sizing: border-box;" in html  # reset still present, just scoped
 
 
 def test_style_and_details_tags_are_balanced_and_ordered() -> None:


### PR DESCRIPTION
## What

Follow-up to #1185: the map filter panel had too little padding on its right edge. The full-width controls (date fields, accuracy slider, "Apply filters" button) reached almost to the right border while the left kept its 15px gap.

## Cause

Those controls carry `width: 100%` together with their own `padding` and a `1px` border, but the panel had no `box-sizing` reset. Under the default `content-box` model, padding+border are added ON TOP of the 100% content width, so the controls ran ~12px past the panel's 15px right padding — leaving ~3px on the right versus 15px on the left.

## Fix

A `box-sizing: border-box` reset **scoped to exactly the full-width form controls** (`.controls input, .controls button`), which folds padding+border back INTO the 100% and restores a symmetric 15px gutter on both sides.

Scoping it to the form controls (instead of a broad `.controls *` descendant reset) deliberately leaves the collapsible `<summary>` on its intended `content-box` geometry: its `12px` vertical padding + `20px` min-height sum to a 44px WCAG 2.5.5 tap target, which a border-box reset would have re-measured on the border box and shrunk to ~41px (**Codex P2**, addressed).

## Tests

Two regression tests in the existing `test_map_view_controls_panel.py`, both mutation-verified:
- `test_full_width_controls_use_border_box_sizing` — dropping the reset re-introduces the overflow (assertion goes red).
- `test_border_box_reset_does_not_touch_the_summary_tap_target` — widening the selector back to `.controls *` re-triggers the summary tap-target regression (assertion goes red). The pre-existing tap-target test only asserted the string ingredients (`min-height: 20px`, `padding: 12px 0`), not the effective box model, which is why it stayed green through the original regression.

Only a scoped CSS one-liner + comment and two tests, no logic change. `ruff` green, full panel suite (13 tests) green.