### PR TITLE
test(auth): reach 100% coverage on token_retrieval, drop born-dead _format_android_id

### DIFF
--- a/custom_components/googlefindmy/Auth/token_retrieval.py
+++ b/custom_components/googlefindmy/Auth/token_retrieval.py
@@ -83,12 +83,6 @@ def _is_invalid_aas_error_text(text: str, *, allow_http_generic: bool = False) -
 _CLIENT_SIG: str = "38918a453d07199354f8b19af05ec6562ced5788"
 
 
-def _format_android_id(android_id: int) -> str:
-    """Return a canonical hex string for an Android ID."""
-
-    return f"0x{android_id:016x}"
-
-
 def _extract_android_id_from_credentials(fcm_creds: Any) -> int | None:
     """Parse the android_id from an FCM credential bundle."""
 

--- a/tests/test_token_retrieval.py
+++ b/tests/test_token_retrieval.py
@@ -17,8 +17,11 @@ import pytest
 from custom_components.googlefindmy.Auth import token_retrieval
 from custom_components.googlefindmy.Auth.token_retrieval import (
     InvalidAasTokenError,
+    _coerce_android_id,
+    _extract_android_id_from_credentials,
     _is_invalid_aas_error_text,
 )
+from custom_components.googlefindmy.exceptions import MissingTokenCacheError
 
 # ---------------------------------------------------------------------------
 # _is_invalid_aas_error_text: HTTP-generic gating
@@ -209,3 +212,260 @@ def test_typed_channel_absent_http_only_stays_retryable(
             android_id=0x1234,
         )
     assert not isinstance(excinfo.value, InvalidAasTokenError)
+
+
+# ---------------------------------------------------------------------------
+# _is_invalid_aas_error_text: "invalid" without credential vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_without_credential_vocabulary_is_not_a_match() -> None:
+    """ "invalid" alone (no token/auth/credential word) must NOT be treated as an
+    invalid-AAS signal, even when the HTTP-generic gate is opened."""
+    assert _is_invalid_aas_error_text("invalid request payload") is False
+    assert (
+        _is_invalid_aas_error_text("invalid request payload", allow_http_generic=True)
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# _extract_android_id_from_credentials
+# ---------------------------------------------------------------------------
+
+
+def test_extract_android_id_returns_int_from_gcm_block() -> None:
+    """A numeric android_id in the FCM gcm block is returned unchanged."""
+    assert (
+        _extract_android_id_from_credentials({"gcm": {"android_id": 0xABCDEF}})
+        == 0xABCDEF
+    )
+
+
+def test_extract_android_id_non_numeric_string_returns_none() -> None:
+    """A non-numeric string android_id is rejected (returns None)."""
+    assert (
+        _extract_android_id_from_credentials({"gcm": {"android_id": "not-a-number"}})
+        is None
+    )
+
+
+def test_extract_android_id_unsupported_type_returns_none() -> None:
+    """An android_id of an unsupported type (e.g. float) is rejected."""
+    assert _extract_android_id_from_credentials({"gcm": {"android_id": 3.14}}) is None
+
+
+# ---------------------------------------------------------------------------
+# _coerce_android_id
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_android_id_parses_hex_string() -> None:
+    """A "0x"-prefixed hex string cached value is coerced to its integer form."""
+    assert _coerce_android_id("0x1000", "cache") == 0x1000
+
+
+def test_coerce_android_id_non_numeric_string_returns_none() -> None:
+    """A non-numeric cached string yields None instead of raising."""
+    assert _coerce_android_id("bogus", "cache") is None
+
+
+def test_coerce_android_id_unsupported_type_returns_none() -> None:
+    """A cached value of an unsupported type (e.g. float) yields None."""
+    assert _coerce_android_id(3.14, "cache") is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_android_id: defensive cache-failure branches
+# ---------------------------------------------------------------------------
+
+
+class _AllRaisingCache:
+    """Async cache whose every get/set raises, to exercise defensive branches."""
+
+    async def get(self, name: str) -> Any:
+        raise RuntimeError(f"cache get failed: {name}")
+
+    async def set(self, name: str, value: Any) -> None:
+        raise RuntimeError(f"cache set failed: {name}")
+
+
+class _FcmIntThenSetRaisesCache:
+    """Returns a valid FCM android_id on read but fails every write."""
+
+    def __init__(self, android_id: int) -> None:
+        self._android_id = android_id
+
+    async def get(self, name: str) -> Any:
+        if name == "fcm_credentials":
+            return {"gcm": {"android_id": self._android_id}}
+        return None
+
+    async def set(self, name: str, value: Any) -> None:
+        raise RuntimeError(f"cache set failed: {name}")
+
+
+@pytest.mark.asyncio
+async def test_resolve_android_id_survives_all_cache_failures() -> None:
+    """When every cache read/write fails, a fresh android_id is still generated
+    and returned; the defensive branches must swallow the cache errors."""
+    cache = _AllRaisingCache()
+    result = await token_retrieval._resolve_android_id(
+        cache=cache, username="user@example.com"
+    )
+    assert isinstance(result, int)
+    # Generated fallback lies in the documented range (see _resolve_android_id).
+    assert 0x1000000000000000 <= result < 0x1000000000000000 + 0xF000000000000000
+
+
+@pytest.mark.asyncio
+async def test_resolve_android_id_returns_fcm_id_even_if_persist_fails() -> None:
+    """The FCM-derived android_id is returned even when persisting it raises."""
+    cache = _FcmIntThenSetRaisesCache(0xABCDEF)
+    result = await token_retrieval._resolve_android_id(
+        cache=cache, username="user@example.com"
+    )
+    assert result == 0xABCDEF
+
+
+# ---------------------------------------------------------------------------
+# _perform_oauth_sync: empty response and legacy "Auth" fallback
+# ---------------------------------------------------------------------------
+
+
+def test_empty_gpsoauth_response_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty gpsoauth response surfaces as a retryable RuntimeError (not an
+    InvalidAasTokenError, so the AAS token is preserved)."""
+
+    def _empty(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    _install_fake_gpsoauth(monkeypatch, _empty)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        token_retrieval._perform_oauth_sync(
+            "user@example.com",
+            "aas_et/fake",
+            "android_device_manager",
+            False,
+            android_id=0x1234,
+        )
+    assert not isinstance(excinfo.value, InvalidAasTokenError)
+    assert "No response" in str(excinfo.value)
+
+
+def test_legacy_auth_field_used_when_token_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When gpsoauth omits "Token" but returns the legacy "Auth" field, the
+    legacy value is used as the OAuth token."""
+
+    def _legacy(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"Auth": "ya29.legacy-token"}
+
+    _install_fake_gpsoauth(monkeypatch, _legacy)
+
+    result = token_retrieval._perform_oauth_sync(
+        "user@example.com",
+        "aas_et/fake",
+        "android_device_manager",
+        False,
+        android_id=0x1234,
+    )
+    assert result == "ya29.legacy-token"
+
+
+# ---------------------------------------------------------------------------
+# request_token (sync entry point): guards and happy path
+# ---------------------------------------------------------------------------
+
+
+class _SimpleAsyncCache:
+    """Minimal async cache backed by a plain dict (reads/writes never raise)."""
+
+    def __init__(self, initial: dict[str, Any] | None = None) -> None:
+        self._data: dict[str, Any] = dict(initial or {})
+
+    async def get(self, name: str) -> Any:
+        return self._data.get(name)
+
+    async def set(self, name: str, value: Any) -> None:
+        self._data[name] = value
+
+
+def test_request_token_without_cache_raises_missing_cache() -> None:
+    """Called with no running loop and no cache, request_token must raise
+    MissingTokenCacheError (the multi-account isolation guard)."""
+    with pytest.raises(MissingTokenCacheError):
+        token_retrieval.request_token("user@example.com", "android_device_manager")
+
+
+@pytest.mark.asyncio
+async def test_request_token_inside_event_loop_is_rejected() -> None:
+    """request_token is blocking and must refuse to run inside a live event loop,
+    directing callers to the async variant instead."""
+    with pytest.raises(RuntimeError, match="event loop is running"):
+        token_retrieval.request_token("user@example.com", "android_device_manager")
+
+
+def test_request_token_happy_path_with_injected_aas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With an injected AAS token and a cached android_id, request_token resolves
+    the OAuth token via the blocking gpsoauth exchange."""
+
+    def _ok(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"Token": "ya29.sync-ok"}
+
+    _install_fake_gpsoauth(monkeypatch, _ok)
+    cache = _SimpleAsyncCache({"android_id_user@example.com": 0x99})
+
+    result = token_retrieval.request_token(
+        "user@example.com",
+        "android_device_manager",
+        aas_token="aas_et/fake",
+        cache=cache,
+    )
+    assert result == "ya29.sync-ok"
+
+
+# ---------------------------------------------------------------------------
+# async_request_token: cache guard and default AAS provider fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_request_token_without_cache_raises() -> None:
+    """async_request_token requires a cache for multi-account isolation."""
+    with pytest.raises(MissingTokenCacheError):
+        await token_retrieval.async_request_token(
+            "user@example.com", "android_device_manager", cache=None
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_request_token_uses_default_aas_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With neither an injected token nor a provider, async_request_token falls
+    back to the default async_get_aas_token provider."""
+
+    async def _fake_get_aas(*, cache: Any) -> str:
+        return "aas_et/default"
+
+    monkeypatch.setattr(token_retrieval, "async_get_aas_token", _fake_get_aas)
+
+    def _ok(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"Token": "ya29.async-default"}
+
+    _install_fake_gpsoauth(monkeypatch, _ok)
+    cache = _SimpleAsyncCache({"android_id_user@example.com": 0x5})
+
+    result = await token_retrieval.async_request_token(
+        "user@example.com",
+        "android_device_manager",
+        cache=cache,
+    )
+    assert result == "ya29.async-default"


### PR DESCRIPTION
## What

Brings `custom_components/googlefindmy/Auth/token_retrieval.py` to **100% line and branch coverage** and removes a dead private helper found along the way.

## Bug found: dead code `_format_android_id`

While verifying reachability of the uncovered lines, `_format_android_id()` turned out to have **zero callers across the entire git history** (born dead since #1097).

- It was intended as the write-side counterpart to the android_id read coercers (store android_id canonically as a `0x…` hex string, parse it back on read). But `_resolve_android_id` persists raw ints (`cache.set(cache_key, android_id)`), so the encoder was never wired in.
- **Not a latent bug:** `gpsoauth` expects an `int` and receives exactly that. Wiring the encoder back in would be wrong, so removal is the correct root-cause fix.
- **Not an upstream inheritance:** real GoogleFindMyTools has no such helper and passes the android_id through raw.

## Tests added (16 behaviour-asserting cases)

- `_is_invalid_aas_error_text`: `"invalid"` without credential vocabulary is not a match (even with the HTTP-generic gate open)
- `_extract_android_id_from_credentials`: int passthrough; non-numeric / unsupported type rejected
- `_coerce_android_id`: hex-string parse; non-numeric / unsupported type -> `None`
- `_resolve_android_id`: survives an all-raising cache (fresh id generated); returns the FCM id even when persisting it fails
- `_perform_oauth_sync`: empty gpsoauth response stays a retryable `RuntimeError` (AAS token preserved); legacy `"Auth"` field used when `"Token"` is absent
- `request_token`: missing-cache guard, event-loop-running guard, injected-AAS happy path
- `async_request_token`: missing-cache guard, default AAS provider fallback

Async tests use `async def` + `@pytest.mark.asyncio` (no `asyncio.run`, per `tests/AGENTS.md`).

## Verification

- Target file: **100.0%** (149/149 lines, 0 missing branches), measured on the current tree
- `tests/test_token_retrieval.py`: 26 passed (10 existing + 16 new)
- `ruff check` + `ruff format`: clean

## Known nits (non-blocking, P3)

Two new tests assert on error-message substrings (`"No response"` and `match="event loop is running"`). These are string-sensitive and could drift if the messages change; kept for now since the messages are stable.

No behaviour change to production code beyond the dead-code removal.