### PR TITLE
docs: sync README with code (stale_threshold default, Plus Code + BLE battery sensors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Accessible via the ⚙️ cogwheel button on the main Google Find My Device Inte
 | `semantic_locations` | none | - | User-defined semantic location zones (managed via a dedicated options flow step). |
 | `delete_caches_on_remove` | true | toggle | Removes stored authentication caches when the integration is deleted. |
 | `contributor_mode` | in_all_areas | selection | Chooses whether Google shares aggregated network-only data (`high_traffic`) or participates in full crowdsourced reporting (`in_all_areas`). |
-| `stale_threshold` | 1800 | seconds | After this many seconds (default: 30 minutes) without a location update, the tracker state becomes `unknown`. Use the "Last Location" entity to always see the last known position. |
+| `stale_threshold` | 3900 | seconds | After this many seconds (default: 65 minutes) without a location update, the tracker state becomes `unknown`. Use the "Last Location" entity to always see the last known position. |
 | `show_location_age` | true | toggle | Adds a `location_age` attribute (in seconds, rounded to 60s) to each tracker entity. Excluded from Recorder history to keep DB size predictable. |
 
 ### Google Home filter behavior
@@ -291,7 +291,7 @@ The integration provides a couple of Home Assistant Actions for use with automat
 ## Supported devices and functions
 
 - **Device coverage:** Phones, tablets, Wear OS devices, earbuds, and compatible Bluetooth trackers surfaced in the Google Find My Device network.  Any device that appears in the official Google Find My interface is eligible to be imported.
-- **Entities created:** Each tracked device exposes a `device_tracker` entity for live location, a binary sensor for connection state, and optional helper entities (statistics, sound trigger button) depending on device capabilities.
+- **Entities created:** Each tracked device exposes a `device_tracker` entity for live location, a binary sensor for connection state, a "last seen" timestamp sensor, and a Plus Code (Open Location Code) sensor. Optional helper entities (statistics, sound trigger button) are added depending on options and device capabilities, and a BLE battery sensor is added when the device is matched to a local Bermuda BLE tracker that reports battery.
 - **Action support:** Sound playback is available on hardware that exposes the native "Play sound" action within Google's ecosystem.  The integration hides the button on devices that do not advertise support, aligning with [Home Assistant action documentation](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/docs-supported-functions/).
 
 ## Data updates and background behavior


### PR DESCRIPTION
## Summary

Documentation-only sync of `README.md` against the current `1.7` code. Two verified drifts:

1. **`stale_threshold` default.** The Configuration Options table listed `1800` seconds ("30 minutes"). The default was retuned to **3900 s (65 minutes)** in #1175 (`const.py` `DEFAULT_STALE_THRESHOLD = 3900`). Table value and prose updated.
2. **Missing user-visible entities.** The "Entities created" list omitted two sensors the integration actually ships:
   - **Plus Code (Open Location Code) sensor** — created for every tracker (#1179, `sensor.py` ~L556, "always, alongside LastSeen").
   - **BLE battery sensor** — created conditionally when a device is matched to a local Bermuda BLE tracker that reports battery (`sensor.py` ~L569-586).
   The "last seen" timestamp sensor (always created) was also made explicit.

## Verification

- Options table (14 keys), 7 services, 13 Make targets, min HA `2025.9.1`, FMDN flags, vendored Open-Location-Code commit hash, SECP160r1/P-256 crypto, `google_device_id` attribute, `crypto.*` diagnostics keys and `script/` helpers were all cross-checked against the code and found accurate — only the two items above drifted.
- No source or test code changed; no version bump (`docs:` type, no semantic-release impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)