### PR TITLE
fix(nova): redact device name and drop misleading cause list in manual-locate diagnostic

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -707,11 +707,22 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
                 canonic_device_id, callback
             )
             if not fcm_token:
-                _LOGGER.error(
-                    "Failed to get FCM token for %s: "
-                    "see previous warnings for details (client/token unavailable or no coordinator)",
-                    name,
+                # ``async_register_for_location_updates`` has already logged a
+                # specific WARNING naming the exact cause (missing canonical id,
+                # no coordinator, unavailable client/token, or a fail-closed
+                # reconnect that never reached STARTED). Re-stating a hard-coded
+                # closed set of causes here was misleading: the list was
+                # incomplete and, when the real cause was the reconnect/STARTED
+                # timeout, actively pointed at the wrong thing. A second ERROR
+                # also overstated a self-healing, fail-closed outcome that the
+                # next poll recovers from. Defer to that authoritative record and
+                # keep the raw device name at DEBUG only (R6, AGENTS.md Section 5
+                # redaction; mirrors the outer surfacing handler below).
+                _LOGGER.warning(
+                    "Manual locate skipped: no FCM token available "
+                    "(see the preceding warning for the specific cause)",
                 )
+                _LOGGER.debug("No FCM token for %s; skipping this locate", name)
                 return []
             registered = True
             _LOGGER.debug("FCM token obtained for %s (len=%d)", name, len(fcm_token))

--- a/tests/test_location_request_surfacing_diagnostics.py
+++ b/tests/test_location_request_surfacing_diagnostics.py
@@ -356,9 +356,7 @@ async def test_missing_fcm_token_surfacing_redacts_name_and_defers_to_warning(
         location_request, "_make_location_callback", _fake_make_callback
     )
     receiver = _NoTokenFcmReceiver()
-    monkeypatch.setattr(
-        location_request, "_FCM_ReceiverGetter", lambda *_a: receiver
-    )
+    monkeypatch.setattr(location_request, "_FCM_ReceiverGetter", lambda *_a: receiver)
 
     caplog.set_level(logging.DEBUG, logger=location_request.__name__)
 

--- a/tests/test_location_request_surfacing_diagnostics.py
+++ b/tests/test_location_request_surfacing_diagnostics.py
@@ -306,3 +306,88 @@ async def test_format_cause_chain_breaks_on_cyclic_cause() -> None:
     rendered = location_request._format_cause_chain(first)
 
     assert rendered == "RuntimeError: first -> ValueError: second"
+
+
+class _NoTokenFcmReceiver:
+    """Receiver whose registration yields no token (returns a falsy string).
+
+    In production every falsy return from ``async_register_for_location_updates``
+    is preceded by its own specific WARNING (missing coordinator, unavailable
+    client/token, or a fail-closed reconnect that never reached STARTED), so the
+    caller must defer to that record instead of re-guessing the cause.
+    """
+
+    async def async_register_for_location_updates(
+        self, device_id: str, callback: Callable[[str, str], None]
+    ) -> str:
+        return ""
+
+    async def async_unregister_for_location_updates(self, device_id: str) -> None:
+        return None
+
+
+async def test_missing_fcm_token_surfacing_redacts_name_and_defers_to_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """R6 + honest diagnostics for the ``not fcm_token`` branch.
+
+    When ``async_register_for_location_updates`` yields no token, the caller must
+    (1) keep the raw device name out of any user-facing (>= WARNING) record and
+    expose it only at DEBUG (R6, AGENTS.md Section 5), and (2) NOT re-guess the
+    cause with the old misleading closed set (``client/token unavailable or no
+    coordinator``) -- the specific cause is already logged by the receiver
+    immediately before. The duplicate report is a WARNING, not a second ERROR,
+    because the outcome is fail-closed and self-heals on the next poll.
+
+    RED before the fix: the branch logged ``"Failed to get FCM token for %s: ...
+    (client/token unavailable or no coordinator)"`` with the raw name at ERROR.
+    """
+
+    def _fake_make_callback(
+        *, ctx: Any, canonic_device_id: str, **_: Any
+    ) -> Callable[[str, str], None]:
+        def _callback(_response_canonic_id: str, _hex: str) -> None:
+            return None
+
+        return _callback
+
+    monkeypatch.setattr(
+        location_request, "_make_location_callback", _fake_make_callback
+    )
+    receiver = _NoTokenFcmReceiver()
+    monkeypatch.setattr(
+        location_request, "_FCM_ReceiverGetter", lambda *_a: receiver
+    )
+
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+
+    result = await location_request.get_location_data_for_device(
+        canonic_device_id="device-xyz",
+        name=_SENTINEL_NAME,
+        session=None,
+        username="user@example.com",
+        cache=_FakeTokenCache(),
+    )
+    assert result == []
+
+    user_facing = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
+    assert user_facing, "expected a user-facing record for the skipped locate"
+    for rec in user_facing:
+        message = rec.getMessage()
+        # R6: no raw device name in a WARNING/ERROR record.
+        assert _SENTINEL_NAME not in message
+        # D1: the misleading hard-coded cause enumeration must be gone.
+        assert "no coordinator" not in message
+        assert "client/token unavailable" not in message
+
+    # The skipped-locate record is surfaced and defers to the preceding warning.
+    assert any("no FCM token available" in rec.getMessage() for rec in user_facing)
+    # Severity: the duplicate report is a WARNING, not a second ERROR.
+    assert all(rec.levelno == logging.WARNING for rec in user_facing)
+
+    # The name stays available for debugging -- at DEBUG only.
+    debug_text = " ".join(
+        rec.getMessage() for rec in caplog.records if rec.levelno == logging.DEBUG
+    )
+    assert _SENTINEL_NAME in debug_text


### PR DESCRIPTION
# Summary

The `not fcm_token` branch of `get_location_data_for_device` logged a user-facing **ERROR** that (a) leaked the raw device display name and (b) enumerated a hard-coded, incomplete set of causes that could point readers at the wrong thing. This PR makes that one diagnostic honest and R6-compliant and adds a regression test.

- Type: ☑ fix
- Scope/Area: nova / LocateTracker diagnostic logging
- Linked issues: —

## Motivation

A user saw exactly one log line and no obviously-related warning:

```
ERROR ...LocateTracker.location_request
Failed to get FCM token for samsung SM-S938B:
see previous warnings for details (client/token unavailable or no coordinator)
```

Root-causing against the log showed the incident was a **self-healing, fail-closed** manual locate: a forced first-locate reconnect did not reach `STARTED` within the readiness budget, so `async_register_for_location_updates` returned falsy after already emitting its own specific, entry-scoped WARNING:

```
WARNING ...Auth.fcm_receiver_ha [entry=01K...]
Forced reconnect did not reach STARTED after 22.0s;
aborting manual locate registration (fail-closed)
```

The device was located successfully moments earlier on the same entry; this ERROR was the delayed failure of a superseded attempt. No functional defect exists in the locate path, and there is **no silent `None`** — every falsy return from `async_register_for_location_updates` (and its `_reconnect_and_refresh_token` helper) is preceded by a specific WARNING.

Two real defects remained in the caller's ERROR line itself:

1. **R6 redaction (AGENTS.md Section 5).** The raw device name (`samsung SM-S938B`) leaked into a user-facing ERROR record. The rest of this module already keeps device names at DEBUG only (see the outer `except Exception` surfacing handler in the same function, PR #1129).
2. **Misleading diagnostics.** The closed set `(client/token unavailable or no coordinator)` was incomplete: it omitted the actual cause here (reconnect never reached STARTED) and sent the reader on false trails. AGENTS.md §11.5 requires a *specific* cause, and the specific cause is already logged immediately before by the receiver.

---

## Change Log (human-readable)

- `custom_components/.../LocateTracker/location_request.py`: in the `not fcm_token` branch, replace the ERROR that re-guessed the cause and printed the device name with:
  - a redacted **WARNING** that defers to the authoritative preceding warning (no device name, no misleading cause list),
  - the device name kept at **DEBUG** only (mirrors the module's existing R6 pattern),
  - **WARNING instead of ERROR**, because the outcome is fail-closed and self-heals on the next poll (a second ERROR duplicated and overstated the already-logged specific WARNING).
- `tests/test_location_request_surfacing_diagnostics.py`: add a regression test that is RED on the old behavior (name at ERROR, enumeration present) and GREEN with the fix.

## Behavior change note

This lowers the severity of that one duplicate record from ERROR to WARNING. Called out explicitly so it is easy to push back on if you prefer to keep ERROR; the redaction and the removal of the misleading enumeration stand independently of the level choice.

## Testing

- `python -m py_compile` and `ruff check` pass on both changed files locally.
- The repository's pytest suite requires Python 3.13 + HA stubs and could **not** be run in my local environment (Python 3.11, no `homeassistant`); I am relying on CI to execute the regression test. The test is constructed as a mutation gate: it asserts the sentinel device name is absent from every `>= WARNING` record, that `"no coordinator"` / `"client/token unavailable"` are gone, that the record is at WARNING level, and that the name is present at DEBUG — all four fail on the pre-fix code.

## Out of scope (proposed follow-up)

Other user-facing (`>= WARNING`) sites in `location_request.py` still log the raw device name and are the same R6 class, but each also carries an exception/rate/auth detail that needs per-site judgment, so they are intentionally left for a focused follow-up rather than silently bundled here:

- `location_request.py`: `except Exception as fcm_error` (FCM registration failed, ERROR), rate-limited (WARNING), authentication error (WARNING), network/client error (WARNING), `Nova API request failed` (ERROR), FCM-unregister failure in `finally` (WARNING).
- `_make_location_callback`: parse/process/cache-provider failures (ERROR) and `No location data found after decryption` (WARNING).

Happy to send that R6-completion sweep as a separate PR if desired.