### PR TITLE
fix(nova): redact device name across remaining manual-locate log sites (R6)

### DIFF
--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -298,11 +298,13 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                 decrypt_module = _import_decrypt_locations_module()
                 eid_info_module = _import_eid_info_module()
             except ImportError as import_error:
+                # R6 (AGENTS.md Section 5): keep the raw device name out of the
+                # user-facing ERROR; expose it at DEBUG only.
                 _LOGGER.error(
-                    "Failed to import decoder/decrypt functions in callback for %s: %s",
-                    name,
+                    "Failed to import decoder/decrypt functions in callback: %s",
                     import_error,
                 )
+                _LOGGER.debug("Decoder/decrypt import failed in callback for %s", name)
                 ctx.data = cast(list[dict[str, Any]], [])
                 ctx.event.set()
                 return
@@ -334,10 +336,13 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                     getattr(eid_info_module, "SpotApiEmptyResponseError"),
                 )
             except AttributeError as import_error:
+                # R6 (AGENTS.md Section 5): device name to DEBUG only.
                 _LOGGER.error(
-                    "Failed to load decoder/decrypt attributes in callback for %s: %s",
-                    name,
+                    "Failed to load decoder/decrypt attributes in callback: %s",
                     import_error,
+                )
+                _LOGGER.debug(
+                    "Decoder/decrypt attribute load failed in callback for %s", name
                 )
                 ctx.data = cast(list[dict[str, Any]], [])
                 ctx.event.set()
@@ -347,9 +352,9 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
             try:
                 device_update = parse_device_update_protobuf(hex_response)
             except Exception as parse_exc:
-                _LOGGER.error(
-                    "Failed to parse device update for %s: %s", name, parse_exc
-                )
+                # R6 (AGENTS.md Section 5): device name to DEBUG only.
+                _LOGGER.error("Failed to parse device update: %s", parse_exc)
+                _LOGGER.debug("Device update parse failed for %s", name)
                 ctx.data = cast(list[dict[str, Any]], [])
                 ctx.event.set()
                 return
@@ -411,16 +416,15 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                     # (SpotApiEmptyResponseError, SpotAuthPermanentError) keep ERROR
                     # severity because they themselves drive reauth. ctx.error and
                     # the propagation are unchanged in every case.
+                    # R6 (AGENTS.md Section 5): device name to DEBUG only; the
+                    # visible record carries the failure and its cause.
                     if isinstance(
                         err, (SpotApiEmptyResponseError, SpotAuthPermanentError)
                     ):
-                        _LOGGER.error(
-                            "Failed to process location data for %s: %s", name, err
-                        )
+                        _LOGGER.error("Failed to process location data: %s", err)
                     else:
-                        _LOGGER.warning(
-                            "Failed to process location data for %s: %s", name, err
-                        )
+                        _LOGGER.warning("Failed to process location data: %s", err)
+                    _LOGGER.debug("Location data processing failed for %s", name)
                     ctx.error = err
                     ctx.event.set()
                     return
@@ -443,12 +447,13 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                     ctx.event.set()
                     return
                 except Exception as err:
+                    # R6 (AGENTS.md Section 5): device name to DEBUG only.
                     _LOGGER.error(
-                        "Unexpected error during async decryption for %s (%s): %s",
-                        name,
+                        "Unexpected error during async decryption (%s): %s",
                         type(err).__name__,
                         err,
                     )
+                    _LOGGER.debug("Async decryption error for %s", name)
                     _LOGGER.debug("Traceback: %s", traceback.format_exc())
                     ctx.data = cast(list[dict[str, Any]], [])
                     ctx.event.set()
@@ -474,9 +479,9 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
                     location_data[0]["canonic_id"] = response_canonic_id.lower()
                     ctx.data = location_data
                 else:
-                    _LOGGER.warning(
-                        "No location data found after decryption for %s", name
-                    )
+                    # R6 (AGENTS.md Section 5): device name to DEBUG only.
+                    _LOGGER.warning("No location data found after decryption")
+                    _LOGGER.debug("No decrypted location data for %s", name)
                     ctx.data = cast(list[dict[str, Any]], [])
                 ctx.event.set()
 
@@ -484,9 +489,9 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
             asyncio.run_coroutine_threadsafe(_decrypt_and_store(), loop)
 
         except Exception as callback_error:
-            _LOGGER.error(
-                "Error processing FCM callback for %s: %s", name, callback_error
-            )
+            # R6 (AGENTS.md Section 5): device name to DEBUG only.
+            _LOGGER.error("Error processing FCM callback: %s", callback_error)
+            _LOGGER.debug("FCM callback processing error for %s", name)
             _LOGGER.debug("FCM callback traceback: %s", traceback.format_exc())
             ctx.data = cast(list[dict[str, Any]], [])
             ctx.event.set()
@@ -727,7 +732,9 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
             registered = True
             _LOGGER.debug("FCM token obtained for %s (len=%d)", name, len(fcm_token))
         except Exception as fcm_error:
-            _LOGGER.error("FCM registration failed for %s: %s", name, fcm_error)
+            # R6 (AGENTS.md Section 5): device name to DEBUG only.
+            _LOGGER.error("FCM registration failed: %s", fcm_error)
+            _LOGGER.debug("FCM registration failed for %s", name)
             _LOGGER.debug("FCM registration traceback: %s", traceback.format_exc())
             return []
 
@@ -758,33 +765,34 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         except asyncio.CancelledError:
             raise
         except NovaRateLimitError as e:
-            _LOGGER.warning(
-                "Rate limited while requesting location for %s: %s", name, e
-            )
+            # R6 (AGENTS.md Section 5): device name to DEBUG only.
+            _LOGGER.warning("Rate limited while requesting location: %s", e)
+            _LOGGER.debug("Rate limited while requesting location for %s", name)
             return []
         except NovaHTTPError as e:
+            # R6 (AGENTS.md Section 5): device name to DEBUG only.
             _LOGGER.warning(
-                "Server error (%s) while requesting location for %s: %s",
-                e.status,
-                name,
-                e,
+                "Server error (%s) while requesting location: %s", e.status, e
             )
+            _LOGGER.debug("Server error while requesting location for %s", name)
             return []
         except NovaAuthError as e:
             # Re-raise auth errors so api.py can convert to ConfigEntryAuthFailed
             # and trigger re-authentication flow. Previously this was swallowed,
             # causing users to see only "No location data" without re-auth prompt.
-            _LOGGER.warning(
-                "Authentication error while requesting location for %s: %s", name, e
-            )
+            # R6 (AGENTS.md Section 5): device name to DEBUG only.
+            _LOGGER.warning("Authentication error while requesting location: %s", e)
+            _LOGGER.debug("Authentication error while requesting location for %s", name)
             raise
         except aiohttp.ClientError as e:
-            _LOGGER.warning(
-                "Network/client error while requesting location for %s: %s", name, e
-            )
+            # R6 (AGENTS.md Section 5): device name to DEBUG only.
+            _LOGGER.warning("Network/client error while requesting location: %s", e)
+            _LOGGER.debug("Network/client error while requesting location for %s", name)
             return []
         except Exception as e:
-            _LOGGER.error("Nova API request failed for %s: %s", name, e)
+            # R6 (AGENTS.md Section 5): device name to DEBUG only.
+            _LOGGER.error("Nova API request failed: %s", e)
+            _LOGGER.debug("Nova API request failed for %s", name)
             return []
 
         # For this RPC the server often returns HTTP 200 with empty body (FCM delivers the data).
@@ -834,10 +842,11 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         if not data:
             _LOGGER.debug("No location data found for %s after decryption", name)
         else:
+            # R6 (AGENTS.md Section 5): device name to DEBUG only.
             _LOGGER.warning(
-                "Received location data for unexpected device in %s flow; ignoring.",
-                name,
+                "Received location data for an unexpected device; ignoring."
             )
+            _LOGGER.debug("Unexpected-device mismatch in locate flow for %s", name)
         return []
 
     except asyncio.CancelledError:
@@ -891,9 +900,9 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
                     canonic_device_id
                 )
         except Exception as cleanup_error:
-            _LOGGER.warning(
-                "Error during FCM unregister for %s: %s", name, cleanup_error
-            )
+            # R6 (AGENTS.md Section 5): device name to DEBUG only.
+            _LOGGER.warning("Error during FCM unregister: %s", cleanup_error)
+            _LOGGER.debug("FCM unregister failed for %s", name)
 
 
 if __name__ == "__main__":

--- a/tests/test_location_request_r6_name_sweep.py
+++ b/tests/test_location_request_r6_name_sweep.py
@@ -1,0 +1,373 @@
+# tests/test_location_request_r6_name_sweep.py
+"""R6 device-name redaction sweep for the remaining locate-request log sites.
+
+PR #1193 redacted the raw device display name in the single ``not fcm_token``
+diagnostic. This sweep completes the same R6 class (AGENTS.md Section 5): every
+remaining *user-facing* (``>= WARNING``) record in ``location_request`` must state
+the failure and its cause without the raw device name, and expose the name only
+at DEBUG. The mirror of the established Count@WARNING / Name@DEBUG pattern.
+
+Each test is a mutation gate: the sentinel display name is passed *only* via
+``name=`` (never inside an exception's message), so the sole way it can appear in
+a ``>= WARNING`` record is the pre-fix ``... for %s`` argument. It is RED on the
+old code (name at WARNING/ERROR) and GREEN with the redaction.
+
+Two groups are covered:
+
+* ``get_location_data_for_device`` -- the FCM-registration failure, the Nova
+  request exception ladder (rate-limit / HTTP / auth / network / generic), and the
+  ``finally`` FCM-unregister failure.
+* ``_make_location_callback`` -- the parse failure, the per-device decrypt
+  failure (warning and error severities), and the empty-after-decrypt path.
+
+The flows are exercised through the same stubbing style the sibling suites use
+(no ``asyncio.run`` in tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import aiohttp
+import pytest
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    location_request,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+    OwnerKeyLookupTransientError,
+    StaleOwnerKeyError,
+)
+from custom_components.googlefindmy.NovaApi.nova_request import (
+    NovaAuthError,
+    NovaHTTPError,
+    NovaRateLimitError,
+)
+from custom_components.googlefindmy.SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
+    SpotApiEmptyResponseError,
+)
+from custom_components.googlefindmy.SpotApi.spot_request import SpotAuthPermanentError
+
+pytestmark = pytest.mark.asyncio
+
+_SENTINEL_NAME = "Jens-Privat-Tracker-SENTINEL-7Q"
+_CANONIC = "device-canonic-id"
+
+
+class _FakeTokenCache:
+    """Minimal entry-scoped cache stub for the locate flow."""
+
+    def __init__(self, label: str = "entry-r6-sweep") -> None:
+        self.entry_id = label
+        self.values: dict[str, Any] = {}
+
+    async def async_get_cached_value(self, key: str) -> Any:
+        return self.values.get(key)
+
+    async def async_set_cached_value(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+    async def get(self, key: str) -> Any:
+        return self.values.get(key)
+
+    async def set(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+
+class _TokenReceiver:
+    """Receiver whose registration yields a token (the locate fails downstream)."""
+
+    def __init__(self, *, unregister_exc: Exception | None = None) -> None:
+        self._unregister_exc = unregister_exc
+
+    async def async_register_for_location_updates(
+        self, device_id: str, callback: Callable[[str, str], None]
+    ) -> str:
+        return "fcm-token"
+
+    async def async_unregister_for_location_updates(self, device_id: str) -> None:
+        if self._unregister_exc is not None:
+            raise self._unregister_exc
+
+
+def _assert_name_only_at_debug(caplog: pytest.LogCaptureFixture) -> None:
+    """The sentinel name is absent from every ``>= WARNING`` record, present at DEBUG."""
+    user_facing = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
+    assert user_facing, "expected at least one user-facing (>= WARNING) record"
+    for rec in user_facing:
+        assert _SENTINEL_NAME not in rec.getMessage(), (
+            f"R6 leak: device name in {logging.getLevelName(rec.levelno)} record: "
+            f"{rec.getMessage()!r}"
+        )
+    debug_text = " ".join(
+        rec.getMessage() for rec in caplog.records if rec.levelno == logging.DEBUG
+    )
+    assert _SENTINEL_NAME in debug_text, "device name must stay available at DEBUG"
+
+
+# ---------------------------------------------------------------------------
+# Group 1: get_location_data_for_device
+# ---------------------------------------------------------------------------
+def _wire_nova_raises(monkeypatch: pytest.MonkeyPatch, *, nova_exc: Exception) -> None:
+    """Stub the flow so ``async_nova_request`` raises ``nova_exc``.
+
+    Registration and request build succeed, so control reaches the Nova-request
+    exception ladder; the FCM callback is never fired.
+    """
+    receiver = _TokenReceiver()
+    monkeypatch.setattr(location_request, "_FCM_ReceiverGetter", lambda *_a: receiver)
+
+    def _fake_make_callback(**_: Any) -> Callable[[str, str], None]:
+        return lambda *_a: None
+
+    monkeypatch.setattr(
+        location_request, "_make_location_callback", _fake_make_callback
+    )
+    monkeypatch.setattr(
+        location_request, "create_location_request", lambda *a, **k: "deadbeef"
+    )
+
+    async def _raise_nova(*_a: object, **_k: object) -> bytes:
+        raise nova_exc
+
+    monkeypatch.setattr(location_request, "async_nova_request", _raise_nova)
+
+
+@pytest.mark.parametrize(
+    "nova_exc",
+    [
+        # Note: no exception message contains the sentinel name, so any sentinel
+        # in a >= WARNING record can only come from the pre-fix ``name`` arg.
+        NovaRateLimitError("upstream quota exceeded"),
+        NovaHTTPError(503, "backend unavailable"),
+        aiohttp.ClientError("connection reset"),
+        RuntimeError("unclassified nova failure"),
+    ],
+)
+async def test_nova_request_ladder_redacts_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    nova_exc: Exception,
+) -> None:
+    """RED pre-fix: rate-limit / HTTP / network / generic Nova failures logged the
+    raw device name at WARNING/ERROR. The name must move to DEBUG only."""
+    _wire_nova_raises(monkeypatch, nova_exc=nova_exc)
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+
+    result = await location_request.get_location_data_for_device(
+        canonic_device_id=_CANONIC,
+        name=_SENTINEL_NAME,
+        session=None,
+        username="user@example.com",
+        cache=_FakeTokenCache(),
+    )
+    assert result == []
+    _assert_name_only_at_debug(caplog)
+
+
+async def test_nova_auth_error_redacts_name_and_reraises(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The auth path logs a WARNING (then re-raises for the reauth flow); the raw
+    device name must not ride along in that user-facing record."""
+    _wire_nova_raises(monkeypatch, nova_exc=NovaAuthError(401, "token rejected"))
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+
+    with pytest.raises(NovaAuthError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id=_CANONIC,
+            name=_SENTINEL_NAME,
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
+    _assert_name_only_at_debug(caplog)
+
+
+async def test_fcm_registration_failure_redacts_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED pre-fix: a failing FCM registration logged the raw device name at ERROR."""
+
+    class _RaisingReceiver:
+        async def async_register_for_location_updates(
+            self, device_id: str, callback: Callable[[str, str], None]
+        ) -> str:
+            raise RuntimeError("registration backend down")
+
+        async def async_unregister_for_location_updates(self, device_id: str) -> None:
+            return None
+
+    monkeypatch.setattr(
+        location_request, "_FCM_ReceiverGetter", lambda *_a: _RaisingReceiver()
+    )
+    monkeypatch.setattr(
+        location_request,
+        "_make_location_callback",
+        lambda **_k: lambda *_a: None,
+    )
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+
+    result = await location_request.get_location_data_for_device(
+        canonic_device_id=_CANONIC,
+        name=_SENTINEL_NAME,
+        session=None,
+        username="user@example.com",
+        cache=_FakeTokenCache(),
+    )
+    assert result == []
+    _assert_name_only_at_debug(caplog)
+
+
+async def test_unregister_failure_in_finally_redacts_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED pre-fix: a failing FCM unregister in ``finally`` logged the raw name.
+
+    ``create_location_request`` is forced to raise so the flow lands in the broad
+    surfacing handler (already R6-clean since PR #1129) and then runs ``finally``,
+    where the raising unregister exercises the swept WARNING.
+    """
+    receiver = _TokenReceiver(unregister_exc=RuntimeError("unregister backend down"))
+    monkeypatch.setattr(location_request, "_FCM_ReceiverGetter", lambda *_a: receiver)
+    monkeypatch.setattr(
+        location_request,
+        "_make_location_callback",
+        lambda **_k: lambda *_a: None,
+    )
+
+    def _boom(*_a: object, **_k: object) -> str:
+        raise RuntimeError("payload build failed")
+
+    monkeypatch.setattr(location_request, "create_location_request", _boom)
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+
+    result = await location_request.get_location_data_for_device(
+        canonic_device_id=_CANONIC,
+        name=_SENTINEL_NAME,
+        session=None,
+        username="user@example.com",
+        cache=_FakeTokenCache(),
+    )
+    assert result == []
+    assert any(
+        "Error during FCM unregister" in rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    ), "expected the unregister WARNING to be exercised"
+    _assert_name_only_at_debug(caplog)
+
+
+# ---------------------------------------------------------------------------
+# Group 2: _make_location_callback
+# ---------------------------------------------------------------------------
+def _patch_callback_imports(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    parse: Callable[[str], Any] | None = None,
+    decrypt: Callable[..., Any] | None = None,
+) -> None:
+    """Stub the callback's lazy module imports with configurable parse/decrypt.
+
+    Defaults: parse returns an identity sentinel, decrypt returns an empty list.
+    The real exception classes are wired so the production ``except`` tuple and the
+    severity ``isinstance`` check behave identically.
+    """
+
+    async def _default_decrypt(*_: Any, **__: Any) -> list[dict[str, Any]]:
+        return []
+
+    decoder_module = SimpleNamespace(
+        parse_device_update_protobuf=parse or (lambda _hex: object())
+    )
+    decrypt_module = SimpleNamespace(
+        async_decrypt_location_response_locations=decrypt or _default_decrypt,
+        DecryptionError=DecryptionError,
+        StaleOwnerKeyError=StaleOwnerKeyError,
+        OwnerKeyLookupTransientError=OwnerKeyLookupTransientError,
+    )
+    eid_module = SimpleNamespace(SpotApiEmptyResponseError=SpotApiEmptyResponseError)
+
+    monkeypatch.setattr(
+        location_request, "_import_decoder_module", lambda: decoder_module
+    )
+    monkeypatch.setattr(
+        location_request, "_import_decrypt_locations_module", lambda: decrypt_module
+    )
+    monkeypatch.setattr(location_request, "_import_eid_info_module", lambda: eid_module)
+
+
+async def _fire_callback(caplog: pytest.LogCaptureFixture) -> None:
+    """Build the real callback with the sentinel name and drive it once."""
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+    ctx = location_request._CallbackContext()
+    callback = location_request._make_location_callback(
+        name=_SENTINEL_NAME,
+        canonic_device_id=_CANONIC,
+        ctx=ctx,
+        loop=asyncio.get_running_loop(),
+        cache=MagicMock(),
+    )
+    callback(_CANONIC, "00")
+    await asyncio.wait_for(ctx.event.wait(), timeout=2.0)
+
+
+async def test_callback_parse_failure_redacts_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED pre-fix: a protobuf parse failure logged the raw name at ERROR."""
+
+    def _raise_parse(_hex: str) -> Any:
+        raise ValueError("malformed protobuf")
+
+    _patch_callback_imports(monkeypatch, parse=_raise_parse)
+    await _fire_callback(caplog)
+    _assert_name_only_at_debug(caplog)
+
+
+@pytest.mark.parametrize(
+    "decrypt_exc",
+    [
+        DecryptionError("own reports predate current identity key"),  # WARNING
+        SpotAuthPermanentError("invalid session"),  # ERROR
+    ],
+)
+async def test_callback_decrypt_failure_redacts_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    decrypt_exc: Exception,
+) -> None:
+    """RED pre-fix: a per-device decrypt failure logged the raw name (warning and
+    error severities alike)."""
+
+    async def _raise_decrypt(*_: Any, **__: Any) -> list[dict[str, Any]]:
+        raise decrypt_exc
+
+    _patch_callback_imports(monkeypatch, decrypt=_raise_decrypt)
+    await _fire_callback(caplog)
+    _assert_name_only_at_debug(caplog)
+
+
+async def test_callback_empty_after_decrypt_redacts_name(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """RED pre-fix: the empty-after-decrypt path logged the raw name at WARNING."""
+    _patch_callback_imports(monkeypatch)  # default decrypt returns []
+    await _fire_callback(caplog)
+    assert any(
+        "No location data found after decryption" in rec.getMessage()
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    ), "expected the empty-after-decrypt WARNING to be exercised"
+    _assert_name_only_at_debug(caplog)


### PR DESCRIPTION
# Summary

Follow-up to #1193. That PR redacted the raw device display name in the single `not fcm_token` diagnostic and I noted the remaining same-class sites as an out-of-scope follow-up. This PR completes the sweep: every remaining **user-facing (`>= WARNING`)** record in `location_request.py` that logged the raw device name via a `... for %s` argument now defers the name to **DEBUG only**, stating the failure and its cause at the visible level. This mirrors the module's established Count@WARNING / Name@DEBUG pattern (#1129 / #1193).

- Type: ☑ fix
- Scope/Area: nova / LocateTracker diagnostic logging
- Linked issues: follow-up to #1193

## Motivation

**R6 (AGENTS.md Section 5).** Derived identifiers such as user-assigned device names must not leak into user-facing WARNING/ERROR records. The `not fcm_token` line fixed in #1193 was one instance of a broader class; the rest of `location_request.py` still printed `name` at WARNING/ERROR on every failure branch.

## Swept sites (16)

**`get_location_data_for_device`**
- `except Exception as fcm_error` — FCM registration failure (ERROR)
- Nova request ladder: `NovaRateLimitError` (WARNING), `NovaHTTPError` server error (WARNING), `NovaAuthError` (WARNING, then re-raises), `aiohttp.ClientError` (WARNING), generic `Exception` (ERROR)
- unexpected-device mismatch (WARNING)
- FCM unregister failure in `finally` (WARNING)

**`_make_location_callback`**
- decoder/decrypt import failure + attribute-load failure (ERROR)
- protobuf parse failure (ERROR)
- per-device decrypt failure — ERROR for session/auth (`SpotApiEmptyResponseError` / `SpotAuthPermanentError`), WARNING for the per-device offline-phone case
- unexpected async-decryption error (ERROR)
- empty-after-decrypt (WARNING)
- outer callback failure (ERROR)

Two sites go slightly beyond #1193's enumerated follow-up list — the `NovaHTTPError` server-error WARNING and the unexpected-device-mismatch WARNING — because they are the **same R6 class**. A partial sweep would leave the class inconsistent, so they are included and called out here.

## Design notes

- Transformation is uniform and minimal: the visible WARNING/ERROR keeps the failure description and the exception cause (`%s` of the exception, which carries the actionable detail per §11.5); the `name` argument is dropped from the visible record and re-emitted on a following `_LOGGER.debug(... for %s, name)`.
- **Visible message prefixes are preserved** so existing filters keep matching — e.g. `test_location_request_decrypt_log_severity.py` filters on `"Failed to process location data"`, which is unchanged (only the trailing `for <name>` is removed), and the added DEBUG line uses a distinct wording so the `len == 1` severity assertion still holds.
- Lazy `%`-formatting throughout (no G004 f-strings on `warning`/`error`).

## Out of scope (deliberately not touched)

- `INFO`/`DEBUG` records that mention `name` (e.g. "Requesting location data for %s") — R6 targets user-facing `>= WARNING` records; INFO/DEBUG are not shown at default HA log level and redacting them would be large, noisy churn without a privacy benefit.
- The canonic-device-id mismatch WARNING (`FCM callback received data for %s, but we requested %s`) logs canonical **IDs**, not the display name — a separate (device-ID) redaction question the module currently treats as DEBUG-loggable elsewhere. Left for a distinct decision if desired.

## Testing

- Local: `python -m py_compile`, `ruff check`, and `ruff format --check` pass on both changed files. An AST sweep confirms **zero** `_LOGGER.warning/error` calls in the file still reference a bare `name`.
- The repo's pytest suite needs Python 3.13 + HA stubs and can't run in my local env (Python 3.11); relying on CI for execution.
- New regression suite `tests/test_location_request_r6_name_sweep.py` is a **mutation gate**: the sentinel device name is injected only via `name=` (never inside an exception message), so it can only reach a `>= WARNING` record through the pre-fix `... for %s` argument. Each test asserts the sentinel is absent from every `>= WARNING` record and present at DEBUG — RED on the old code, GREEN with the redaction. Covers the caller ladder (rate-limit/HTTP/auth/network/generic, FCM-registration, `finally` unregister) and the callback branches (parse, decrypt warning + error, empty-after-decrypt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)