### PR TITLE
Add a kinematic speed gate to reject FMDN teleport fixes (#177)

### DIFF
--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -96,6 +96,7 @@ from .const import (
     DEFAULT_OPTIONS,
     DEFAULT_SEMANTIC_DETECTION_RADIUS,
     DEFAULT_SHOW_LOCATION_AGE,
+    DEFAULT_SPEED_GATE_ENABLED,
     DEFAULT_STALE_THRESHOLD,
     # Core domain & credential keys
     DOMAIN,
@@ -110,6 +111,7 @@ from .const import (
     OPT_OPTIONS_SCHEMA_VERSION,
     OPT_SEMANTIC_LOCATIONS,
     OPT_SHOW_LOCATION_AGE,
+    OPT_SPEED_GATE_ENABLED,
     OPT_STALE_THRESHOLD,
     OPTION_KEYS,
     SERVICE_FEATURE_PLATFORMS,
@@ -5443,6 +5445,9 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
             OPT_SHOW_LOCATION_AGE: _get(
                 OPT_SHOW_LOCATION_AGE, DEFAULT_SHOW_LOCATION_AGE
             ),
+            OPT_SPEED_GATE_ENABLED: _get(
+                OPT_SPEED_GATE_ENABLED, DEFAULT_SPEED_GATE_ENABLED
+            ),
         }
         if (
             OPT_GOOGLE_HOME_FILTER_ENABLED is not None
@@ -5566,6 +5571,7 @@ class OptionsFlowHandler(OptionsFlowBase, _OptionsFlowMixin):  # type: ignore[mi
             vol.All(vol.Coerce(int), vol.Range(min=300, max=86400)),
         )
         _register(vol.Optional(OPT_SHOW_LOCATION_AGE), bool)
+        _register(vol.Optional(OPT_SPEED_GATE_ENABLED), bool)
 
         base_schema = vol.Schema(fields)
         schema_with_defaults = self.add_suggested_values_to_schema(base_schema, current)

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -117,6 +117,7 @@ OPT_IGNORED_DEVICES: str = "ignored_devices"
 OPT_DELETE_CACHES_ON_REMOVE: str = "delete_caches_on_remove"
 OPT_STALE_THRESHOLD: str = "stale_threshold"
 OPT_SHOW_LOCATION_AGE: str = "show_location_age"
+OPT_SPEED_GATE_ENABLED: str = "speed_gate_enabled"
 # Legacy option key - kept for reading old configurations, no longer used
 OPT_STALE_THRESHOLD_ENABLED: str = "stale_threshold_enabled"
 
@@ -136,6 +137,7 @@ OPTION_KEYS: tuple[str, ...] = (
     OPT_CONTRIBUTOR_MODE,
     OPT_STALE_THRESHOLD,
     OPT_SHOW_LOCATION_AGE,
+    OPT_SPEED_GATE_ENABLED,
 )
 
 # Keys which may exist historically in entry.data and should be soft-copied to entry.options
@@ -254,6 +256,14 @@ DEFAULT_DELETE_CACHES_ON_REMOVE: bool = True
 DEFAULT_STALE_THRESHOLD: int = 3900
 DEFAULT_SHOW_LOCATION_AGE: bool = True
 
+DEFAULT_SPEED_GATE_ENABLED: bool = True
+# Kinematic plausibility cap (m/s). ~1440 km/h: above the record jetstream
+# airliner ground speed (~369 m/s, BA Feb-2020) and far above cruise/ICE/car,
+# so even a strong-tailwind flight passes; blocks the physically impossible
+# FMDN crowd-report "teleport" (Discussion #177). Own-report GPS fixes bypass
+# the gate entirely (crowd-awareness), so this cap only bounds crowd reports.
+DEFAULT_MAX_PLAUSIBLE_SPEED_MPS: float = 400.0
+
 CONTRIBUTOR_MODE_HIGH_TRAFFIC: str = "high_traffic"
 CONTRIBUTOR_MODE_IN_ALL_AREAS: str = "in_all_areas"
 DEFAULT_CONTRIBUTOR_MODE: str = CONTRIBUTOR_MODE_IN_ALL_AREAS
@@ -279,6 +289,7 @@ DEFAULT_OPTIONS: dict[str, object] = {
     OPT_CONTRIBUTOR_MODE: DEFAULT_CONTRIBUTOR_MODE,
     OPT_STALE_THRESHOLD: DEFAULT_STALE_THRESHOLD,
     OPT_SHOW_LOCATION_AGE: DEFAULT_SHOW_LOCATION_AGE,
+    OPT_SPEED_GATE_ENABLED: DEFAULT_SPEED_GATE_ENABLED,
 }
 
 # -------------------- Options schema versioning (lightweight) --------------------
@@ -457,6 +468,9 @@ CONFIG_FIELDS: dict[str, dict[str, object]] = {
         "min": 300,  # 5 minutes - allows ~2-3 typical FMDN update cycles
         "max": 86400,  # max 24 hours
         "step": 60,
+    },
+    OPT_SPEED_GATE_ENABLED: {
+        "type": "bool",
     },
     # OPT_IGNORED_DEVICES is intentionally omitted: it is managed by a dedicated
     # visibility flow and not edited as a raw field (list of ids).
@@ -705,9 +719,12 @@ __all__ = [
     "OPT_DELETE_CACHES_ON_REMOVE",
     "OPT_STALE_THRESHOLD",
     "OPT_SHOW_LOCATION_AGE",
+    "OPT_SPEED_GATE_ENABLED",
     "OPT_STALE_THRESHOLD_ENABLED",
     "MIGRATE_DATA_KEYS_TO_OPTIONS",
     "UPDATE_INTERVAL",
+    "DEFAULT_SPEED_GATE_ENABLED",
+    "DEFAULT_MAX_PLAUSIBLE_SPEED_MPS",
     "DEFAULT_LOCATION_POLL_INTERVAL",
     "DEFAULT_DEVICE_POLL_DELAY",
     "DEFAULT_MIN_POLL_INTERVAL",

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -982,7 +982,19 @@ class CacheOperations(_MixinBase):
         # limit of a forward speed gate (Q2 round-trip gate would catch it).
         if dist > radius_sum:
             incoming_is_own = bool(new_data.get("is_own_report"))
-            if self._speed_gate_enabled() and not incoming_is_own:
+            # Only gate a fix that carries a real measured accuracy. An
+            # accuracy-less crowd report (new_acc_raw is None) is not a clean
+            # teleport discriminant - the decoder strips the accuracy number
+            # (acc_rank=-inf) - and must fall through so the downstream
+            # sanitization in _is_significant_update can flag it estimated
+            # (accuracy_estimated=True). Hard-dropping it here would regress the
+            # #1181 last-good protection; that path is already guarded by
+            # is_reliable_fix, not by this gate.
+            if (
+                self._speed_gate_enabled()
+                and not incoming_is_own
+                and new_acc_raw is not None
+            ):
                 existing_ts = _normalize_epoch_seconds(existing.get("last_seen"))
                 new_ts = _normalize_epoch_seconds(new_data.get("last_seen"))
                 if existing_ts is not None and new_ts is not None:

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -982,19 +982,23 @@ class CacheOperations(_MixinBase):
         # limit of a forward speed gate (Q2 round-trip gate would catch it).
         if dist > radius_sum:
             incoming_is_own = bool(new_data.get("is_own_report"))
-            # Only gate a fix that carries a real measured accuracy. An
-            # accuracy-less crowd report (new_acc_raw is None) is not a clean
-            # teleport discriminant - the decoder strips the accuracy number
-            # (acc_rank=-inf) - and must fall through so the downstream
-            # sanitization in _is_significant_update can flag it estimated
-            # (accuracy_estimated=True). Hard-dropping it here would regress the
-            # #1181 last-good protection; that path is already guarded by
-            # is_reliable_fix, not by this gate.
-            if (
-                self._speed_gate_enabled()
-                and not incoming_is_own
-                and new_acc_raw is not None
-            ):
+            # Only gate a fix that carries a REAL measured accuracy. A crowd
+            # report is "accuracy-less" not only when the key is missing
+            # (new_acc_raw is None) but also when it carries Android's
+            # no-accuracy sentinel (0.0) or any sub-physical/non-finite value
+            # (< MIN_PHYSICAL_ACCURACY_M) - the same error-code set that
+            # _safe_accuracy() maps to the 200m fallback. Such a fix is not a
+            # clean teleport discriminant and must fall through so the
+            # downstream sanitization in _is_significant_update can flag it
+            # estimated (accuracy_estimated=True). Hard-dropping it here would
+            # regress the #1181 last-good protection; that path is already
+            # guarded by is_reliable_fix, not by this gate.
+            new_acc_measured = (
+                new_acc_raw is not None
+                and math.isfinite(new_acc_raw)
+                and new_acc_raw >= MIN_PHYSICAL_ACCURACY_M
+            )
+            if self._speed_gate_enabled() and not incoming_is_own and new_acc_measured:
                 existing_ts = _normalize_epoch_seconds(existing.get("last_seen"))
                 new_ts = _normalize_epoch_seconds(new_data.get("last_seen"))
                 if existing_ts is not None and new_ts is not None:

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -23,7 +23,14 @@ from collections import deque
 from collections.abc import Mapping
 from typing import Any
 
-from ..const import _EID_REFRESH_DEBOUNCE_S, DATA_EID_RESOLVER, DOMAIN
+from ..const import (
+    _EID_REFRESH_DEBOUNCE_S,
+    DATA_EID_RESOLVER,
+    DEFAULT_MAX_PLAUSIBLE_SPEED_MPS,
+    DEFAULT_SPEED_GATE_ENABLED,
+    DOMAIN,
+    OPT_SPEED_GATE_ENABLED,
+)
 from ._mixin_typing import _MixinBase
 from .helpers.cache import (
     merge_cache_row as _merge_cache_row_impl,
@@ -849,6 +856,15 @@ class CacheOperations(_MixinBase):
         """Calculate the great-circle distance between two points (meters)."""
         return _haversine_distance_impl(lat1, lon1, lat2, lon2)
 
+    def _speed_gate_enabled(self) -> bool:
+        """Return whether the kinematic speed gate is active (Discussion #177)."""
+        entry = getattr(self, "config_entry", None)
+        if entry is None or getattr(entry, "options", None) is None:
+            return DEFAULT_SPEED_GATE_ENABLED
+        return bool(
+            entry.options.get(OPT_SPEED_GATE_ENABLED, DEFAULT_SPEED_GATE_ENABLED)
+        )
+
     def _apply_weighted_location_fusion(
         self,
         device_id: str,
@@ -948,8 +964,43 @@ class CacheOperations(_MixinBase):
         ):
             return True
 
-        # Clear jump - no overlap, accept as-is
+        # Clear jump - no overlap. Before accepting, apply the kinematic
+        # plausibility gate (Discussion #177): a single FMDN crowd report can
+        # land far away with huge uncertainty ("teleport"). Reject a far jump
+        # whose implied speed is physically impossible. Falls through to accept
+        # when speed is not computable (missing/degenerate timestamps) so no
+        # regression occurs. Own-report GPS fixes bypass the gate entirely: they
+        # are cryptographically trusted device positions that do not teleport,
+        # so gating them would only risk false-blocking genuine fast travel.
+        # Placement rationale (F3): the gate sits AFTER the trusted-anchor and
+        # #155 double-fallback branches on purpose - those return earlier because
+        # a semantic anchor has no kinematics and two 200m fallback circles give
+        # radii too unreliable to gate on (would risk false-blocks, F4-a).
+        # dt limit (F5): after a long offline gap dt is huge, implied_speed tiny,
+        # so the gate never fires - intended (slow travel over long time is
+        # plausible); a post-offline teleport passing ungated is the inherent
+        # limit of a forward speed gate (Q2 round-trip gate would catch it).
         if dist > radius_sum:
+            incoming_is_own = bool(new_data.get("is_own_report"))
+            if self._speed_gate_enabled() and not incoming_is_own:
+                existing_ts = _normalize_epoch_seconds(existing.get("last_seen"))
+                new_ts = _normalize_epoch_seconds(new_data.get("last_seen"))
+                if existing_ts is not None and new_ts is not None:
+                    delta_t = new_ts - existing_ts
+                    if delta_t > 0:
+                        implied_speed = dist / delta_t
+                        if implied_speed > DEFAULT_MAX_PLAUSIBLE_SPEED_MPS:
+                            self.increment_stat("speed_gate_rejects")
+                            _LOGGER.debug(
+                                "Speed gate rejected crowd fix %s: %.0fm in "
+                                "%.0fs = %.1fm/s > %.1fm/s cap",
+                                device_id,
+                                dist,
+                                delta_t,
+                                implied_speed,
+                                DEFAULT_MAX_PLAUSIBLE_SPEED_MPS,
+                            )
+                            return False
             return True
 
         # Overlapping accuracy circles: fuse with inverse-square weighting

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -981,7 +981,18 @@ class CacheOperations(_MixinBase):
         # plausible); a post-offline teleport passing ungated is the inherent
         # limit of a forward speed gate (Q2 round-trip gate would catch it).
         if dist > radius_sum:
-            incoming_is_own = bool(new_data.get("is_own_report"))
+            # Own-report bypass keyed off CRYPTOGRAPHIC provenance, not the raw
+            # server flag: a network/foreign report can carry a spurious
+            # server-supplied is_own_report=True (this integration's own uploader
+            # stamps network reports that way, decrypt_locations.py:1991-1998).
+            # The decrypt layer already hardens is_own_report = is_own_report and
+            # not is_network_report (decrypted_location.py:39); mirror that
+            # invariant here so a spoofed own-flag on a network teleport cannot
+            # skip the gate on any path. Absent is_network_report is treated as
+            # not-network (genuine own reports never carry the network flag).
+            incoming_is_own = bool(new_data.get("is_own_report")) and not bool(
+                new_data.get("is_network_report")
+            )
             # Only gate a fix that carries a REAL measured accuracy. A crowd
             # report is "accuracy-less" not only when the key is missing
             # (new_acc_raw is None) but also when it carries Android's

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -839,6 +839,7 @@ class GoogleFindMyCoordinator(
             "invalid_ts_drop_benign": 0,  # regressed/out-of-order timestamps (expected sub-bucket of invalid_ts_drop_count)
             "fused_updates": 0,  # overlapping fixes fused to stabilize coordinates
             "accuracy_sanitized_count": 0,  # accuracy values clamped to valid range
+            "speed_gate_rejects": 0,  # fixes rejected as physically implausible (#177)
             # Canonicless drops on the last main poll (transition-independent
             # diagnostics aggregate). Absolute per-poll values, not increments;
             # listed here so the restore path (iterates self.stats.keys()) and the

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Device poll delay (s)",
           "stale_threshold": "Stale threshold (s)",
           "show_location_age": "Show location age attribute",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "Filter Google Home devices",
           "google_home_filter_keywords": "Filter keywords (comma-separated)",
           "enable_stats_entities": "Create statistics entities",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "After this many seconds without a location update, the tracker state becomes unknown. Use the 'Last Location' entity to always see the last known position. Default: 1800 (30 minutes).",
           "show_location_age": "When enabled (default), a 'location_age' attribute (rounded to 1 minute) is added to each tracker entity. Disable to eliminate all database writes for stationary devices. The absolute 'last_seen' attribute and sensor.*_last_seen entities are always available.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "Remove cached tokens and device metadata when this entry is deleted.",
           "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire.",
           "contributor_mode": "Choose how your device contributes to Google's network (All areas by default for crowdsourced reporting, or High-traffic areas only).",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Verzögerung zwischen Geräteabfragen (s)",
           "stale_threshold": "Standort-Timeout (s)",
           "show_location_age": "Attribut für Standortalter anzeigen",
+          "speed_gate_enabled": "Unmögliche Standortsprünge verwerfen",
           "google_home_filter_enabled": "Google-Home-Geräte filtern",
           "google_home_filter_keywords": "Filter-Schlüsselwörter (kommagetrennt)",
           "enable_stats_entities": "Statistik-Entitäten erstellen",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "Nach dieser Zeit (in Sekunden) ohne Standortaktualisierung wird der Tracker-Status unbekannt. Verwende die Entität 'Letzter Standort', um immer die letzte bekannte Position zu sehen. Standard: 1800 (30 Minuten).",
           "show_location_age": "Wenn aktiviert (Standard), wird jeder Tracker-Entität ein 'location_age'-Attribut (auf 1 Minute gerundet) hinzugefügt. Deaktivieren, um alle Datenbank-Schreibvorgänge für stationäre Geräte zu eliminieren. Das absolute 'last_seen'-Attribut und sensor.*_last_seen-Entitäten sind immer verfügbar.",
+          "speed_gate_enabled": "Wenn aktiviert (Standard), wird ein Standort-Fix verworfen, der eine physikalisch unmögliche Geschwindigkeit erfordern würde (zum Beispiel eine Crowd-Meldung, die den Tracker binnen Sekunden hunderte Kilometer entfernt verortet), statt einen Teleport auszulösen. Eigene GPS-Meldungen passieren immer. Nur deaktivieren, wenn legitime schnelle Bewegungen fälschlich verworfen werden.",
           "delete_caches_on_remove": "Löscht zwischengespeicherte Tokens und Gerätemetadaten, wenn dieser Eintrag entfernt wird.",
           "map_view_token_expiration": "Wenn aktiviert, laufen die Token für die Kartenansicht nach 1 Woche ab. Wenn deaktiviert (Standard), laufen die Token nicht ab.",
           "contributor_mode": "Lege fest, wie dein Gerät zum Google-Netzwerk beiträgt (standardmäßig Alle Bereiche für Crowdsourcing oder nur stark frequentierte Bereiche).",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Device poll delay (s)",
           "stale_threshold": "Stale threshold (s)",
           "show_location_age": "Show location age attribute",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "Filter Google Home devices",
           "google_home_filter_keywords": "Filter keywords (comma-separated)",
           "enable_stats_entities": "Create statistics entities",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "After this many seconds without a location update, the tracker state becomes unknown. Use the 'Last Location' entity to always see the last known position. Default: 1800 (30 minutes).",
           "show_location_age": "When enabled (default), a 'location_age' attribute (rounded to 1 minute) is added to each tracker entity. Disable to eliminate all database writes for stationary devices. The absolute 'last_seen' attribute and sensor.*_last_seen entities are always available.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "Remove cached tokens and device metadata when this entry is deleted.",
           "map_view_token_expiration": "When enabled, map view tokens expire after 1 week. When disabled (default), tokens do not expire.",
           "contributor_mode": "Choose how your device contributes to Google's network (All areas by default for crowdsourced reporting, or High-traffic areas only).",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Retardo entre sondeos de dispositivos (s)",
           "stale_threshold": "Umbral de obsolescencia (s)",
           "show_location_age": "Mostrar atributo de antigüedad de la ubicación",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "Filtrar dispositivos Google Home",
           "google_home_filter_keywords": "Palabras clave del filtro (separadas por comas)",
           "enable_stats_entities": "Crear entidades de estadísticas",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "Tras este número de segundos sin una actualización de ubicación, el estado del rastreador pasa a desconocido. Usa la entidad 'Última ubicación' para ver siempre la última posición conocida. Por defecto: 1800 (30 minutos).",
           "show_location_age": "Cuando está habilitado (por defecto), se agrega un atributo 'location_age' (redondeado a 1 minuto) a cada entidad de rastreo. Deshabilítelo para eliminar todas las escrituras en la base de datos de los dispositivos estacionarios. El atributo absoluto 'last_seen' y las entidades sensor.*_last_seen siempre están disponibles.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "Borra los tokens almacenados en caché y los metadatos de los dispositivos cuando se elimina esta entrada.",
           "map_view_token_expiration": "Si está activado, los tokens de la vista de mapa caducan tras 1 semana. Si está desactivado (por defecto), no caducan.",
           "contributor_mode": "Elige cómo contribuye tu dispositivo a la red de Google (Todas las zonas por defecto para aportes colaborativos o solo Zonas de alto tránsito).",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Délai entre les interrogations d'appareil (s)",
           "stale_threshold": "Seuil d'obsolescence (s)",
           "show_location_age": "Afficher l'attribut d'ancienneté de l'emplacement",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "Filtrer les appareils Google Home",
           "google_home_filter_keywords": "Mots-clés du filtre (séparés par des virgules)",
           "enable_stats_entities": "Créer des entités de statistiques",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "Après ce délai en secondes sans mise à jour de position, l'état du traceur passe à inconnu. Utilisez l'entité 'Dernière position' pour toujours voir la dernière position connue. Par défaut : 1800 (30 minutes).",
           "show_location_age": "Lorsqu'il est activé (par défaut), un attribut « location_age » (arrondi à 1 minute) est ajouté à chaque entité de suivi. Désactivez-le pour éliminer toutes les écritures dans la base de données pour les appareils fixes. L'attribut absolu « last_seen » et les entités sensor.*_last_seen sont toujours disponibles.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "Supprime les jetons mis en cache et les métadonnées des appareils lors de la suppression de cette entrée.",
           "map_view_token_expiration": "Lorsqu'elle est activée, les jetons de la vue carte expirent après 1 semaine. Lorsqu'elle est désactivée (par défaut), ils n'expirent pas.",
           "contributor_mode": "Choisissez comment votre appareil contribue au réseau Google (par défaut Toutes les zones pour une contribution participative ou uniquement les zones à forte affluence).",

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "עיכוב בין סריקות מכשירים (שניות)",
           "stale_threshold": "סף מיושנות (שניות)",
           "show_location_age": "הצגת תכונת גיל מיקום",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "סינון התקני Google Home",
           "google_home_filter_keywords": "מילות מפתח לסינון (מופרדות בפסיקים)",
           "enable_stats_entities": "יצירת ישויות סטטיסטיקה",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "לאחר מספר שניות זה ללא עדכון מיקום, מצב הגשש הופך ל'לא ידוע'. ניתן להשתמש בישות 'מיקום אחרון' כדי לראות תמיד את המיקום הידוע האחרון. ברירת מחדל: 1800 (30 דקות).",
           "show_location_age": "כאשר מופעל (ברירת מחדל), תכונת 'location_age' (מעוגלת לדקה אחת) מתווספת לכל ישות גשש. השבתה מבטלת את כל הכתיבות למסד הנתונים עבור התקנים נייחים. תכונת 'last_seen' המוחלטת וישויות sensor.*_last_seen תמיד זמינות.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "הסרת טוקנים מאוחסנים ומטא-נתונים של התקנים בעת מחיקת רשומה זו.",
           "map_view_token_expiration": "כאשר מופעל, טוקני תצוגת מפה פגים לאחר שבוע. כאשר מושבת (ברירת מחדל), הטוקנים לא פגים.",
           "contributor_mode": "יש לבחור כיצד ההתקן שלך תורם לרשת של Google (כל האזורים כברירת מחדל לדיווח מקור-קהל, או רק אזורים בעלי תנועה גבוהה).",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Ritardo tra interrogazioni dei dispositivi (s)",
           "stale_threshold": "Soglia di obsolescenza (s)",
           "show_location_age": "Mostra attributo età della posizione",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "Filtra dispositivi Google Home",
           "google_home_filter_keywords": "Parole chiave del filtro (separate da virgole)",
           "enable_stats_entities": "Crea entità statistiche",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "Dopo questo numero di secondi senza aggiornamento di posizione, lo stato del tracker diventa sconosciuto. Usa l'entità 'Ultima posizione' per vedere sempre l'ultima posizione nota. Predefinito: 1800 (30 minuti).",
           "show_location_age": "Se abilitato (impostazione predefinita), un attributo 'location_age' (arrotondato a 1 minuto) viene aggiunto a ogni entità tracciatore. Disabilitalo per eliminare tutte le scritture nel database per i dispositivi fissi. L'attributo assoluto 'last_seen' e le entità sensor.*_last_seen sono sempre disponibili.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "Elimina i token memorizzati in cache e i metadati dei dispositivi quando questa voce viene rimossa.",
           "map_view_token_expiration": "Se abilitato, i token della vista mappa scadono dopo 1 settimana. Se disabilitato (predefinito), non scadono.",
           "contributor_mode": "Scegli come il dispositivo contribuisce alla rete di Google (per impostazione predefinita Tutte le aree per un contributo collaborativo oppure solo Aree ad alto traffico).",

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Apparaat-pollingvertraging (s)",
           "stale_threshold": "Verouderingsdrempel (s)",
           "show_location_age": "Locatie-leeftijd attribuut weergeven",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "Google Home-apparaten filteren",
           "google_home_filter_keywords": "Filtertrefwoorden (kommagescheiden)",
           "enable_stats_entities": "Statistiekentiteiten aanmaken",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "Wanneer een locatie ouder is dan deze drempel (in seconden), wordt de trackerstatus 'onbekend'. Gebruik de entiteit 'Laatste locatie' om altijd de laatst bekende positie te zien. Standaard: 1800 (30 minuten).",
           "show_location_age": "Wanneer ingeschakeld (standaard), wordt een 'location_age'-attribuut (afgerond op 1 minuut) toegevoegd aan elke tracker-entiteit. Schakel uit om alle database-schrijfacties voor stationaire apparaten te elimineren. Het absolute 'last_seen'-attribuut en sensor.*_last_seen-entiteiten zijn altijd beschikbaar.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "Verwijder gecachete tokens en apparaatmetadata wanneer dit item wordt verwijderd.",
           "map_view_token_expiration": "Indien ingeschakeld, verlopen kaartweergavetokens na 1 week. Indien uitgeschakeld (standaard), verlopen tokens niet.",
           "contributor_mode": "Kies hoe je apparaat bijdraagt aan het Google-netwerk (standaard Alle gebieden voor crowdsourced rapportage, of alleen drukbezochte gebieden).",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Opóźnienie między odpytywaniem urządzeń (s)",
           "stale_threshold": "Próg nieaktualności (s)",
           "show_location_age": "Pokaż atrybut wieku lokalizacji",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "Filtruj urządzenia Google Home",
           "google_home_filter_keywords": "Słowa kluczowe filtra (oddzielone przecinkami)",
           "enable_stats_entities": "Twórz encje statystyczne",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "Po upływie tej liczby sekund bez aktualizacji lokalizacji, status trackera zmienia się na nieznany. Użyj encji 'Ostatnia lokalizacja', aby zawsze widzieć ostatnią znaną pozycję. Domyślnie: 1800 (30 minut).",
           "show_location_age": "Gdy jest włączony (domyślnie), atrybut 'location_age' (zaokrąglony do 1 minuty) jest dodawany do każdej encji lokalizatora. Wyłącz, aby wyeliminować wszystkie zapisy do bazy danych dla urządzeń stacjonarnych. Atrybut bezwzględny 'last_seen' i encje sensor.*_last_seen są zawsze dostępne.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "Usuwa buforowane tokeny i metadane urządzeń podczas usuwania tego wpisu.",
           "map_view_token_expiration": "Po włączeniu tokeny widoku mapy wygasają po 1 tygodniu. Po wyłączeniu (domyślnie) nie wygasają.",
           "contributor_mode": "Wybierz, jak urządzenie współpracuje z siecią Google (domyślnie Wszystkie obszary w trybie crowdsourcingu lub tylko obszary o dużym ruchu).",

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Intervalo entre pesquisas do dispositivo",
           "stale_threshold": "Limite de obsolescência (s)",
           "show_location_age": "Mostrar atributo de idade da localização",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "Filtrar dispositivos Google Home",
           "google_home_filter_keywords": "Filtrar palavras-chave (separadas por vírgula)",
           "enable_stats_entities": "Criar entidades estatísticas",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "Após este número de segundos sem atualização de localização, o status do rastreador muda para desconhecido. Use a entidade 'Última localização' para ver sempre a última posição conhecida. Padrão: 1800 (30 minutos).",
           "show_location_age": "Quando ativado (padrão), um atributo 'location_age' (arredondado para 1 minuto) é adicionado a cada entidade rastreadora. Desative para eliminar todas as gravações de banco de dados para dispositivos estacionários. O atributo absoluto 'last_seen' e as entidades sensor.*_last_seen estão sempre disponíveis.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "Remova os tokens armazenados em cache e os metadados do dispositivo quando esta entrada for excluída.",
           "map_view_token_expiration": "Quando ativado, os tokens de visualização do mapa expiram após 1 semana. ",
           "contributor_mode": "Escolha como seu dispositivo contribui para a rede do Google (todas as áreas por padrão para relatórios de crowdsourcing ou apenas áreas de alto tráfego).",

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -249,6 +249,7 @@
           "device_poll_delay": "Intervalo entre pesquisas do dispositivo",
           "stale_threshold": "Limite de obsolescência (s)",
           "show_location_age": "Mostrar atributo de idade da localização",
+          "speed_gate_enabled": "Reject impossible location jumps",
           "google_home_filter_enabled": "Filtrar dispositivos Google Home",
           "google_home_filter_keywords": "Filtrar palavras-chave (separadas por vírgula)",
           "enable_stats_entities": "Criar entidades estatísticas",
@@ -260,6 +261,7 @@
         "data_description": {
           "stale_threshold": "Após este número de segundos sem atualização de localização, o estado do rastreador muda para desconhecido. Use a entidade 'Última localização' para ver sempre a última posição conhecida. Predefinição: 1800 (30 minutos).",
           "show_location_age": "Quando ativado (predefinição), um atributo 'location_age' (arredondado para 1 minuto) é adicionado a cada entidade rastreadora. Desative para eliminar todas as escrituras na base de dados para dispositivos estacionários. O atributo absoluto 'last_seen' e as entidades sensor.*_last_seen estão sempre disponíveis.",
+          "speed_gate_enabled": "When enabled (default), a location fix that would require physically impossible speed (for example a crowd-sourced report placing the tracker hundreds of km away within seconds) is rejected instead of teleporting the tracker. Own GPS reports always pass. Disable only if legitimate fast movements are being dropped.",
           "delete_caches_on_remove": "Remova os tokens armazenados em cache e os metadados do dispositivo quando esta entrada for excluída.",
           "map_view_token_expiration": "Quando ativado, os tokens de visualização do mapa expiram após 1 semana. ",
           "contributor_mode": "Escolha como seu dispositivo contribui para a rede do Google (todas as áreas por padrão para relatórios de crowdsourcing ou apenas áreas de alto tráfego).",

--- a/tests/test_cache_speed_gate.py
+++ b/tests/test_cache_speed_gate.py
@@ -72,7 +72,7 @@ def _existing(*, last_seen: Any = BASE_TS, acc: float = 20.0) -> dict[str, Any]:
 def _incoming(
     *,
     last_seen: Any = BASE_TS,
-    acc: float = 50.0,
+    acc: float | None = 50.0,
     is_own: Any = False,
     lat: float = FAR[0],
     lon: float = FAR[1],
@@ -313,3 +313,26 @@ def test_basic_list_seed_carries_no_coordinates() -> None:
             entry.get("latitude") is not None and entry.get("longitude") is not None
         )
         assert not (bool(entry.get("is_own_report")) and has_coords)
+
+
+# ----------------------------------------- accuracy-less bypass guard (20, #1181)
+
+
+def test_accuracy_less_crowd_fix_bypasses_gate() -> None:
+    """An accuracy-less crowd fix falls through the gate (regression #1181).
+
+    A far crowd fix without a measured accuracy (accuracy=None) is not a clean
+    teleport discriminant: the decoder strips the accuracy number (acc_rank
+    = -inf) and the downstream _is_significant_update sanitization flags it
+    ``accuracy_estimated=True``. Hard-dropping it here via ``return False`` would
+    skip that sanitization and break the last-good protection asserted by
+    tests/test_plus_code_last_known.py. The reliable last-good stays protected by
+    is_reliable_fix, independent of this gate, so the fix must pass through
+    (result True) and the reject counter must NOT fire. This is the mutation
+    guard for the ``new_acc_raw is not None`` clause: without it the result would
+    be False.
+    """
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, acc=None, is_own=False))
+    assert result is True
+    coord.increment_stat.assert_not_called()

--- a/tests/test_cache_speed_gate.py
+++ b/tests/test_cache_speed_gate.py
@@ -336,3 +336,35 @@ def test_accuracy_less_crowd_fix_bypasses_gate() -> None:
     result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, acc=None, is_own=False))
     assert result is True
     coord.increment_stat.assert_not_called()
+
+
+# ------------------------------------ invalid-accuracy sentinel bypass (21-22)
+
+
+def test_sentinel_zero_accuracy_crowd_fix_bypasses_gate() -> None:
+    """A crowd fix with Android's no-accuracy sentinel (0.0) falls through.
+
+    Codex review of 5bfeafd: ``accuracy=0.0`` coerces to a non-None float, so a
+    guard testing only ``new_acc_raw is not None`` would still hard-drop the fix
+    before _is_significant_update can sanitize it into accuracy_estimated=True.
+    The sentinel belongs to the same error-code set that _safe_accuracy() maps
+    to the 200m fallback, so it must be treated as accuracy-less and pass
+    through (result True), leaving the counter untouched.
+    """
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, acc=0.0, is_own=False))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+def test_subphysical_accuracy_crowd_fix_bypasses_gate() -> None:
+    """A crowd fix with a sub-physical accuracy (< MIN_PHYSICAL_ACCURACY_M).
+
+    A finite value below the 0.001 m physical floor is also an error code (same
+    branch in _safe_accuracy). It must be treated as accuracy-less and bypass
+    the gate rather than being hard-dropped.
+    """
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, acc=0.0005, is_own=False))
+    assert result is True
+    coord.increment_stat.assert_not_called()

--- a/tests/test_cache_speed_gate.py
+++ b/tests/test_cache_speed_gate.py
@@ -368,3 +368,39 @@ def test_subphysical_accuracy_crowd_fix_bypasses_gate() -> None:
     result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, acc=0.0005, is_own=False))
     assert result is True
     coord.increment_stat.assert_not_called()
+
+
+# ------------------------------ cryptographic own-report provenance (23-24)
+
+
+def test_spoofed_network_own_flag_is_gated() -> None:
+    """A network report with a spoofed is_own_report=True is still gated.
+
+    Codex review of 74600c2: this integration's crowdsourced uploader stamps
+    network reports with is_own_report=True while they carry a non-empty
+    publicKeyRandom (decrypt_locations.py:1991-1998). The decrypt layer hardens
+    is_own_report = is_own_report and not is_network_report
+    (decrypted_location.py:39); the gate mirrors that invariant so a spoofed
+    own-flag on an impossible teleport cannot skip the gate. With both flags set
+    the fix is treated as a crowd report and the teleport is rejected.
+    """
+    coord = _coord(_existing(last_seen=BASE_TS))
+    fix = _incoming(last_seen=BASE_TS + 300, is_own=True)
+    fix["is_network_report"] = True
+    result = _fuse(coord, fix)
+    assert result is False
+    coord.increment_stat.assert_called_once_with("speed_gate_rejects")
+
+
+def test_genuine_own_report_without_network_flag_bypasses() -> None:
+    """A genuine own report (is_own_report=True, no network flag) bypasses.
+
+    Mutation guard for the ``not bool(new_data.get("is_network_report"))``
+    clause: a real own GPS fix never carries the network flag, so an absent
+    is_network_report must be treated as not-network and keep the bypass intact
+    (result True, counter untouched) even at teleport speed.
+    """
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, is_own=True))
+    assert result is True
+    coord.increment_stat.assert_not_called()

--- a/tests/test_cache_speed_gate.py
+++ b/tests/test_cache_speed_gate.py
@@ -1,0 +1,315 @@
+# tests/test_cache_speed_gate.py
+"""Behavioral tests for the kinematic speed gate (Discussion #177).
+
+The gate lives in the clear-jump branch of ``_apply_weighted_location_fusion``:
+a far jump (``dist > radius_sum``) whose implied speed ``dist / dt`` exceeds
+``DEFAULT_MAX_PLAUSIBLE_SPEED_MPS`` is rejected instead of teleporting the
+tracker. Crowd-awareness: cryptographically trusted own-report GPS fixes
+(``is_own_report`` truthy) bypass the gate entirely. Missing or degenerate
+timestamps fall through to the previous accept-as-is behavior (F4-a, no
+regression).
+
+These tests mirror the harness of ``test_cache_fusion_validity.py``: a
+``MagicMock(spec=CacheOperations)`` carrying the cached ``existing`` fix, with
+``_apply_weighted_location_fusion`` invoked unbound.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.googlefindmy.const import (
+    DEFAULT_MAX_PLAUSIBLE_SPEED_MPS,
+    DEFAULT_SPEED_GATE_ENABLED,
+    OPT_SPEED_GATE_ENABLED,
+)
+from custom_components.googlefindmy.coordinator.cache import (
+    CacheOperations,
+    _haversine_distance_impl,
+)
+from custom_components.googlefindmy.coordinator.helpers.update import (
+    filter_and_dedupe_devices,
+)
+
+CAP = DEFAULT_MAX_PLAUSIBLE_SPEED_MPS  # 400.0 m/s
+BASE_TS = 1_700_000_000  # a realistic epoch (avoids pre-Y2K corruption guards)
+
+# ~250 km apart (2.25 deg of latitude), so any sane accuracy sum is far below
+# the distance and the clear-jump branch (dist > radius_sum) executes.
+HOME = (48.100000, 11.400000)
+FAR = (50.350000, 11.400000)
+
+
+def _teleport_distance() -> float:
+    """Distance the fusion sees for a HOME -> FAR jump (same impl as prod)."""
+    return _haversine_distance_impl(HOME[0], HOME[1], FAR[0], FAR[1])
+
+
+def _coord(existing: dict[str, Any], *, gate_enabled: bool = True) -> MagicMock:
+    coord = MagicMock(spec=CacheOperations)
+    coord._device_location_data = {"dev": existing}
+    coord.increment_stat = MagicMock()
+    coord._speed_gate_enabled = MagicMock(return_value=gate_enabled)
+    return coord
+
+
+def _existing(*, last_seen: Any = BASE_TS, acc: float = 20.0) -> dict[str, Any]:
+    fix: dict[str, Any] = {
+        "latitude": HOME[0],
+        "longitude": HOME[1],
+        "accuracy": acc,
+        "location_type": "sensor",
+    }
+    if last_seen is not None:
+        fix["last_seen"] = last_seen
+    return fix
+
+
+def _incoming(
+    *,
+    last_seen: Any = BASE_TS,
+    acc: float = 50.0,
+    is_own: Any = False,
+    lat: float = FAR[0],
+    lon: float = FAR[1],
+) -> dict[str, Any]:
+    fix: dict[str, Any] = {"latitude": lat, "longitude": lon, "accuracy": acc}
+    if last_seen is not None:
+        fix["last_seen"] = last_seen
+    if is_own is not None:
+        fix["is_own_report"] = is_own
+    return fix
+
+
+def _fuse(coord: MagicMock, new_data: dict[str, Any]) -> bool:
+    return CacheOperations._apply_weighted_location_fusion(coord, "dev", new_data)
+
+
+# ---------------------------------------------------------------- core gate (1-8)
+
+
+def test_teleport_blocked() -> None:
+    """250 km in 300 s (~833 m/s) is physically impossible -> rejected."""
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300))
+    assert result is False
+    coord.increment_stat.assert_called_once_with("speed_gate_rejects")
+
+
+def test_real_trip_passes() -> None:
+    """250 km in 3 h (~23 m/s) is plausible travel -> accepted."""
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 3 * 3600))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+def test_delta_t_non_positive_falls_through() -> None:
+    """Equal timestamps -> dt == 0 -> fall through to accept (F4-a)."""
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+def test_missing_timestamp_falls_through() -> None:
+    """No last_seen on the incoming fix -> speed not computable -> accept."""
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=None))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+def test_speed_at_cap_boundary() -> None:
+    """Just above the cap is rejected; just below passes (integer dt)."""
+    dist = _teleport_distance()
+    dt_block = math.floor(dist / (CAP + 5.0))  # implied speed >= CAP + 5 > CAP
+    dt_pass = math.ceil(dist / (CAP - 5.0))  # implied speed <= CAP - 5 < CAP
+
+    coord_block = _coord(_existing(last_seen=BASE_TS))
+    assert _fuse(coord_block, _incoming(last_seen=BASE_TS + dt_block)) is False
+
+    coord_pass = _coord(_existing(last_seen=BASE_TS))
+    assert _fuse(coord_pass, _incoming(last_seen=BASE_TS + dt_pass)) is True
+
+
+def test_trusted_anchor_unaffected() -> None:
+    """A trusted existing anchor still snaps overlapping fixes back, ungated."""
+    existing = _existing(last_seen=BASE_TS)
+    existing["location_type"] = "trusted"
+    coord = _coord(existing)
+    # Overlapping (near-identical) coordinates so the trusted-anchor branch,
+    # which returns before the clear-jump gate, handles it.
+    new_data = _incoming(
+        last_seen=BASE_TS + 10, lat=HOME[0] + 0.000001, lon=HOME[1] + 0.000001
+    )
+    result = _fuse(coord, new_data)
+    assert result is True
+    assert new_data["location_type"] == "trusted"
+    coord.increment_stat.assert_not_called()
+
+
+def test_gate_disabled_option() -> None:
+    """With the option off, an impossible jump is accepted as before."""
+    coord = _coord(_existing(last_seen=BASE_TS), gate_enabled=False)
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+def test_blocked_teleport_not_recorded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blocked teleport returns False and leaves the cached fix untouched.
+
+    Fusion returning False is the contract that stops the caller before the
+    last-good recording / propagation steps (A8); at this layer the proof is
+    that the stored HOME fix is not overwritten by the rejected FAR fix.
+    """
+    existing = _existing(last_seen=BASE_TS)
+    coord = _coord(existing)
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300))
+    assert result is False
+    assert coord._device_location_data["dev"]["latitude"] == HOME[0]
+    assert coord._device_location_data["dev"]["longitude"] == HOME[1]
+
+
+# ------------------------------------------------------ stat + robustness (9-14)
+
+
+def test_speed_gate_stat_registered_and_counted() -> None:
+    """Mutation probe for F1: a block increments exactly the registered key."""
+    coord = _coord(_existing(last_seen=BASE_TS))
+    _fuse(coord, _incoming(last_seen=BASE_TS + 300))
+    coord.increment_stat.assert_called_once_with("speed_gate_rejects")
+
+
+def test_delta_t_quantized_to_zero_falls_through() -> None:
+    """Sub-second timestamps collapse to dt == 0 via int() -> accept (F4-a)."""
+    coord = _coord(_existing(last_seen=float(BASE_TS)))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 0.4))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+def test_new_data_missing_last_seen_falls_through() -> None:
+    """Incoming fix without a timestamp -> accept (no false block)."""
+    coord = _coord(_existing(last_seen=BASE_TS))
+    assert _fuse(coord, _incoming(last_seen=None)) is True
+
+
+def test_existing_missing_last_seen_falls_through() -> None:
+    """Cached fix without a timestamp -> accept (no false block)."""
+    coord = _coord(_existing(last_seen=None))
+    assert _fuse(coord, _incoming(last_seen=BASE_TS + 300)) is True
+
+
+def test_regressed_timestamp_gate_falls_through() -> None:
+    """new_ts < existing_ts -> dt < 0 -> gate falls through (accept)."""
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS - 100))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+def test_gate_after_haversine_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A haversine failure returns True before the gate is reached (F8)."""
+
+    def _boom(*_args: Any, **_kwargs: Any) -> float:
+        raise ValueError("boom")
+
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.cache._haversine_distance_impl",
+        _boom,
+    )
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+# ---------------------------------------------------- crowd-awareness Q1 (15-17)
+
+
+def test_own_report_bypasses_gate() -> None:
+    """A trusted own-report GPS fix skips the gate even when it looks fast."""
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, is_own=True))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+def test_crowd_report_gated() -> None:
+    """An explicit crowd report (is_own_report False) is gated and rejected."""
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, is_own=False))
+    assert result is False
+    coord.increment_stat.assert_called_once_with("speed_gate_rejects")
+
+
+def test_jetstream_speed_under_cap_passes() -> None:
+    """Even a gated crowd fix at record jetstream speed (~369 m/s) passes.
+
+    Proves the Q3 headroom: the cap (400 m/s) sits above the documented record
+    tailwind airliner ground speed, so a legitimate fast fix is not blocked.
+    """
+    dist = _teleport_distance()
+    dt = math.ceil(dist / 369.0)  # implied speed ~369 m/s < 400 cap
+    coord = _coord(_existing(last_seen=BASE_TS))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + dt, is_own=False))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+# ----------------------------------------------- config-entry + F1-a guard (18-19)
+
+
+def test_config_entry_none_uses_default() -> None:
+    """_speed_gate_enabled tolerates a missing/None config_entry (P4)."""
+    coord_none = MagicMock()
+    coord_none.config_entry = None
+    assert CacheOperations._speed_gate_enabled(coord_none) is DEFAULT_SPEED_GATE_ENABLED
+
+    entry = MagicMock()
+    entry.options = {OPT_SPEED_GATE_ENABLED: False}
+    coord_opt = MagicMock()
+    coord_opt.config_entry = entry
+    assert CacheOperations._speed_gate_enabled(coord_opt) is False
+
+
+def test_basic_list_seed_carries_no_coordinates() -> None:
+    """F1-a regression guard: the structural seed transform never emits an entry
+    that is both own-report-trusted and coordinate-bearing.
+
+    The seed path (polling -> update_device_cache -> fusion) skips the
+    ``sanitize_decoder_row`` hardening the locate/poll paths run, so a spurious
+    ``is_own_report=True`` carrying coordinates could bypass the crowd-aware
+    gate. The verified invariant is that the basic device list is minimal
+    (id/name/can_ring; ``is_own_report`` placeholder None, no coordinates) and
+    the structural normalize/dedupe transform neither injects coordinates nor a
+    truthy own-report flag. This test pins that transform; it breaks if a future
+    payload change starts carrying both into the seed, at which point F1 must be
+    re-evaluated (see plan N5/P5).
+    """
+    basic_list = [
+        {
+            "id": "dev1",
+            "name": "Keys",
+            "can_ring": True,
+            "is_own_report": None,
+            "latitude": None,
+            "longitude": None,
+        },
+        {"id": "  dev2  ", "name": "Backpack"},
+        {"id": "dev1", "name": "Keys duplicate"},  # dedupe: dropped
+    ]
+    filtered, seen = filter_and_dedupe_devices(basic_list)
+
+    assert seen == {"dev1", "dev2"}
+    for entry in filtered:
+        has_coords = (
+            entry.get("latitude") is not None and entry.get("longitude") is not None
+        )
+        assert not (bool(entry.get("is_own_report")) and has_coords)


### PR DESCRIPTION
# Add a kinematic speed gate to reject FMDN "teleport" fixes (#177)

## Problem

A single FMDN crowd/network report can land far away with a huge accuracy
radius (a "teleport"). In `_apply_weighted_location_fusion`, the clear-jump
branch (`dist > radius_sum`) accepts such a fix as-is, so a low-confidence
crowd report placing the tracker "a 3-hour drive away" within minutes overwrites
the real position. The upstream `min_accuracy_threshold` was removed without a
replacement, so there is currently no defense against this failure mode
(Discussion #177).

## Approach: physics, not an accuracy filter

Instead of a static accuracy threshold (which also drops legitimate far/imprecise
fixes and keeps bad near ones), this adds a **kinematic plausibility gate** at the
clear-jump branch:

- Compute the implied speed `v = dist / dt` from the two `last_seen` timestamps.
- If `v` exceeds `DEFAULT_MAX_PLAUSIBLE_SPEED_MPS` (400 m/s ~ 1440 km/h), the far
  jump is rejected (`return False`) instead of teleporting the tracker.
- If the speed is not computable (missing or degenerate timestamps, `dt <= 0`),
  the previous accept-as-is behavior is kept — no regression.

The 400 m/s cap sits above the documented record jetstream-tailwind airliner
ground speed (~369 m/s, BA, Feb 2020) and far above cruise flight, ICE and car,
so even a strong-tailwind flight passes. A real teleport ("250 km in 5 minutes",
~833 m/s) is far above the cap and blocked. A genuine multi-hour trip has a small
implied speed and passes.

## Crowd-awareness

The gate only bounds **untrusted** (crowd/network) reports. A cryptographically
trusted own-report GPS fix (`is_own_report` truthy after the decrypt-layer
hardening `is_own_report and not is_network_report`) bypasses the gate entirely:
such a fix is the device reporting its own position and does not teleport, so
gating it would only risk false-blocking genuine fast travel with an own GPS fix.
This matches the field observation that the jumps only occur on crowd reports.

## Configuration

- New option `speed_gate_enabled` (default **on**), toggleable in the options
  Settings step (EN/DE strings included).
- The cap is a named constant `DEFAULT_MAX_PLAUSIBLE_SPEED_MPS` (not a UI field
  in this version).
- A new diagnostics counter `speed_gate_rejects` is registered in the coordinator
  stats so rejections are observable after rollout.

## Scope / non-goals

- No static minimum-accuracy filter (deliberately not reintroduced).
- Same-second reports (`dt == 0` after second-resolution truncation) are allowed
  through by design (conservative, avoids false blocks under unknown FMDN
  timestamp quantization). A minimum-`dt` guard can be added later if field data
  shows sub-second resolution.
- A retrospective round-trip gate (catching a far fix whose *next* report
  teleports back) is a possible follow-up; the forward speed gate does not catch
  a far fix after a long offline gap. Left out here to keep the change minimal and
  stateless.

## Tests

`tests/test_cache_speed_gate.py` (19 cases): teleport blocked, real trip passes,
cap boundary, `dt <= 0` / missing-timestamp fall-through, trusted-anchor
unaffected, option-disabled, blocked fix not overwriting the cache, stat mutation
probe, haversine-exception fall-through, own-report bypass, crowd-report gated,
jetstream-speed-under-cap passes, `config_entry=None` default, and a structural
seed-invariant guard.
