### PR TITLE
fix(cache): round-trip anchor lifecycle + symmetric speed-gate guard (#1196 follow-up)

### DIFF
--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -606,7 +606,9 @@ class CacheOperations(_MixinBase):
             register_fn = getattr(self, "_register_identity_key", None)
             if callable(register_fn):
                 register_fn(device_id, effective_identity_key)
-            self._propagate_location_to_shared_devices(device_id, slot)
+            self._propagate_location_to_shared_devices(
+                device_id, slot, supersede_anchors=supersede_anchor
+            )
 
         # Trigger resolver refresh if identity changed
         if resolver_refresh_needed:
@@ -621,6 +623,7 @@ class CacheOperations(_MixinBase):
         self,
         source_device_id: str,
         location: dict[str, Any],
+        supersede_anchors: bool = False,
     ) -> None:
         """Propagate location updates to devices sharing the same tracker.
 
@@ -631,6 +634,10 @@ class CacheOperations(_MixinBase):
         Args:
             source_device_id: The device that received the update.
             location: The location data to propagate.
+            supersede_anchors: When True, also drop each propagated target's
+                stale round-trip anchor (F-CODEX-9), symmetric to the
+                source-device pop, so a later crowd echo near the old anchor
+                cannot roll a shared target back to the stale position.
         """
         if not location:
             return
@@ -690,6 +697,21 @@ class CacheOperations(_MixinBase):
             self._device_location_data[target_id] = merged
             # Coordinator last-good for the shared target, same non-poison gate.
             self._record_last_good_location(target_id, merged)
+
+            # F-CODEX-9: the superseding clear-jump was propagated to this
+            # shared target, so invalidate its stale round-trip anchor too -
+            # symmetric to the source-device pop after the commit. Otherwise a
+            # later crowd echo near the old anchor could take the round-trip
+            # recovery path and roll this propagated target back to the stale
+            # position, even though the trusted location was already propagated
+            # here (SA-8d data-flow breadth). Rides the exact propagation
+            # data-flow: only targets that actually adopted the fresh location
+            # (past the freshness gate above) are cleared; a fresher target
+            # that skipped propagation keeps its own anchor.
+            if supersede_anchors and self._round_trip_confirm_enabled():
+                _anchors = getattr(self, "_round_trip_anchors", None)
+                if _anchors:
+                    _anchors.pop(target_id, None)
 
             _LOGGER.debug(
                 "Propagated location from %s to %s (shared tracker, source=%s)",
@@ -1038,10 +1060,16 @@ class CacheOperations(_MixinBase):
             # a stale anchor can survive on those paths too. Deferred, not fixed
             # here (scope discipline at this iterated locus); a later crowd echo
             # is still TTL- and radius-bounded.
+            # F-CODEX-9: the marker is set unconditionally for an own clear-jump,
+            # NOT only when THIS source device holds an anchor. A shared tracker
+            # propagates this fresh trusted position to sibling device ids (same
+            # identity_key) post-commit, and a sibling may hold a stale anchor
+            # even when the source does not. The post-commit handling pops the
+            # source anchor AND every propagated target's anchor; all pops are
+            # idempotent (pop(key, None)), so marking without a source anchor is a
+            # harmless no-op on the source side while still clearing the siblings.
             if incoming_is_own and self._round_trip_confirm_enabled():
-                _anchors = getattr(self, "_round_trip_anchors", None)
-                if _anchors and _anchors.get(device_id) is not None:
-                    new_data["_supersede_round_trip_anchor"] = True
+                new_data["_supersede_round_trip_anchor"] = True
             # Only gate a fix that carries a REAL measured accuracy. A crowd
             # report is "accuracy-less" not only when the key is missing
             # (new_acc_raw is None) but also when it carries Android's

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -477,6 +477,12 @@ class CacheOperations(_MixinBase):
             return
 
         fused_applied = slot.pop("_fused_applied", False)
+        # F-FABLE-2: pop the supersede marker early (before sanitize/merge/commit)
+        # so it never leaks into the cached row, but defer the action until AFTER
+        # the payload commits (post-@580). If the significance gate below rejects
+        # this payload (early return @512), the anchor is intentionally NOT
+        # touched (F-CODEX-7): a discarded own-report must not invalidate it.
+        supersede_anchor = bool(slot.pop("_supersede_round_trip_anchor", False))
 
         status = slot.get("status")
 
@@ -578,6 +584,16 @@ class CacheOperations(_MixinBase):
         # so a sanitized accuracy-less update never overwrites the last reliable
         # position the Plus Code display accessors fall back to (non-poison).
         self._record_last_good_location(device_id, slot)
+
+        # F-FABLE-2 (post-commit): now that the trusted own-report clear-jump has
+        # been committed, invalidate any stale round-trip anchor so a later crowd
+        # echo near the old anchor cannot roll the tracker back. Placed AFTER the
+        # commit and the significance gate (early return @512) so a rejected
+        # payload never triggers it - F-CODEX-7 semantics preserved automatically.
+        if supersede_anchor and self._round_trip_confirm_enabled():
+            _anchors = getattr(self, "_round_trip_anchors", None)
+            if _anchors:
+                _anchors.pop(device_id, None)
 
         # FIX #155: Only count background_updates for non-poll sources
         # to avoid double-counting with polled_updates.
@@ -1004,6 +1020,28 @@ class CacheOperations(_MixinBase):
             incoming_is_own = bool(new_data.get("is_own_report")) and not bool(
                 new_data.get("is_network_report")
             )
+            # Round-trip anchor supersede (F-FABLE-2): a trusted own-report that
+            # is itself a clear jump (dist > radius_sum, this branch) away from
+            # the previous position is a genuine relocation B->C. An anchor A
+            # that survived from an earlier gated crowd jump A->B is now stale -
+            # a later crowd echo near A must not roll the tracker off the trusted
+            # current position back to A. Mark the slot so the anchor is
+            # invalidated AFTER this payload commits (see supersede handling in
+            # update_device_cache): an own-report bypasses the gate below
+            # (not incoming_is_own) and never seeds/consumes, so a surviving
+            # anchor is strictly pre-existing. DF-A4: keyed on the clear-jump
+            # own-report only - an own-report near B never reaches this branch,
+            # so the legitimate B->A return stays protected.
+            # Known gap (F-3, TTL/radius-bounded): the trusted-return accept
+            # paths above (trusted new_data, trusted existing, #155 dual 200m
+            # fallback) return before this branch and never set the marker, so
+            # a stale anchor can survive on those paths too. Deferred, not fixed
+            # here (scope discipline at this iterated locus); a later crowd echo
+            # is still TTL- and radius-bounded.
+            if incoming_is_own and self._round_trip_confirm_enabled():
+                _anchors = getattr(self, "_round_trip_anchors", None)
+                if _anchors and _anchors.get(device_id) is not None:
+                    new_data["_supersede_round_trip_anchor"] = True
             # Only gate a fix that carries a REAL measured accuracy. A crowd
             # report is "accuracy-less" not only when the key is missing
             # (new_acc_raw is None) but also when it carries Android's
@@ -1020,7 +1058,27 @@ class CacheOperations(_MixinBase):
                 and math.isfinite(new_acc_raw)
                 and new_acc_raw >= MIN_PHYSICAL_ACCURACY_M
             )
-            if self._speed_gate_enabled() and not incoming_is_own and new_acc_measured:
+            # Symmetric cached-endpoint guard (F-CODEX-1): also require the
+            # cached point ``existing`` to be a reliable fix. If it is an
+            # estimated/accuracy-less row (the 200 m fallback carries
+            # accuracy_estimated=True), implied_speed would be measured against
+            # an unreliable reference and reject the incoming report against a
+            # phantom position, stranding the tracker on the estimate. Mirrors
+            # the incoming-side new_acc_measured check so the gate fires only when
+            # BOTH endpoints carry real measured accuracy; is_reliable_fix is the
+            # same predicate that guards anchor seeding below (@1125).
+            # Trade-off (F-2): when ``existing`` is estimated, the ENTIRE gate
+            # block below (incl. round-trip recovery, housekeeping and reject) is
+            # skipped, so a measured crowd teleport is accepted ungated for that
+            # one step. This is deliberate - gating against a phantom reference is
+            # the worse failure (F-CODEX-1 stranding). Follow-up candidate: gate
+            # against the last-good location instead of skipping entirely.
+            if (
+                self._speed_gate_enabled()
+                and not incoming_is_own
+                and new_acc_measured
+                and is_reliable_fix(existing)
+            ):
                 existing_ts = _normalize_epoch_seconds(existing.get("last_seen"))
                 new_ts = _normalize_epoch_seconds(new_data.get("last_seen"))
                 if existing_ts is not None and new_ts is not None:
@@ -1075,8 +1133,16 @@ class CacheOperations(_MixinBase):
                                         return True
                                     # Anchor expired or the fix landed too far
                                     # from A: drop it (housekeeping) and let the
-                                    # gate reject as usual.
-                                    anchors.pop(device_id, None)
+                                    # gate reject as usual. Guard on
+                                    # delta_anchor >= 0 (F-FABLE-1): a delayed
+                                    # out-of-order report near A can carry a
+                                    # last_seen between A and B, making
+                                    # delta_anchor < 0 (new_ts before the anchor
+                                    # ts). That is not an expiry - popping here
+                                    # would destroy the anchor and strand a later
+                                    # genuine return. Only house-keep forward.
+                                    if delta_anchor >= 0:
+                                        anchors.pop(device_id, None)
                             self.increment_stat("speed_gate_rejects")
                             _LOGGER.debug(
                                 "Speed gate rejected crowd fix %s: %.0fm in "

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1960,6 +1960,12 @@ class PollingOperations(_MixinBase):
                             self.update_device_cache(dev_id, location, source="poll")
                         else:
                             location.pop("_fusion_preapplied", None)
+                            # F-1: strip the supersede marker so it can never leak
+                            # into the cached row. This test-double fallback commits
+                            # directly and does NOT run the post-commit supersede
+                            # action; production always routes through
+                            # update_device_cache, which does.
+                            location.pop("_supersede_round_trip_anchor", None)
                             location.pop("_report_hint", None)
                             location.setdefault("last_updated", wall_now)
                             merged_location = self._merge_with_existing_cache_row(

--- a/tests/test_cache_round_trip.py
+++ b/tests/test_cache_round_trip.py
@@ -22,10 +22,13 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from custom_components.googlefindmy.const import (
     ROUND_TRIP_ANCHOR_RADIUS_M,
     ROUND_TRIP_TTL_S,
 )
+from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from custom_components.googlefindmy.coordinator.cache import (
     CacheOperations,
     _haversine_distance_impl,
@@ -345,11 +348,17 @@ def test_no_anchor_when_speed_gate_disabled() -> None:
     assert coord._round_trip_anchors == {}
 
 
-def test_out_of_order_return_not_recovered() -> None:
-    """A return whose timestamp precedes the anchor (delta < 0) is not recovered.
+def test_out_of_order_echo_preserves_anchor() -> None:
+    """An out-of-order echo (delta_anchor < 0) must NOT drop the anchor (F-FABLE-1).
 
-    Guards against a rewound/out-of-order timestamp being read as an instant
-    round trip; the anchor is dropped and the gate rejects as usual.
+    A delayed/out-of-order report near A can carry a last_seen BETWEEN A and B,
+    so its new_ts precedes the anchor ts (delta_anchor < 0). That is not an
+    expiry: popping the anchor here would destroy it and strand a later genuine
+    return. The echo is still gated (rejected as a teleport), but the anchor
+    survives for a later legitimate forward return.
+
+    Mutation guard: on the pre-fix code the housekeeping pop was unconditional,
+    so the anchor was dropped here and this ``"dev" in anchors`` assertion failed.
     """
     anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(BASE_TS + 600)}}
     coord = _coord(_fix(FAR, last_seen=BASE_TS), anchors=anchors)
@@ -357,4 +366,284 @@ def test_out_of_order_return_not_recovered() -> None:
     result = _fuse(coord, _fix(HOME, last_seen=BASE_TS + 300, acc=50.0))
     assert result is False
     coord.increment_stat.assert_called_once_with("speed_gate_rejects")
-    assert "dev" not in coord._round_trip_anchors  # housekeeping pop
+    # The anchor is preserved (forward-only housekeeping); still keyed on "dev".
+    assert coord._round_trip_anchors["dev"] == {
+        "lat": HOME[0],
+        "lon": HOME[1],
+        "ts": float(BASE_TS + 600),
+    }
+
+
+def test_out_of_order_echo_then_forward_return_recovers() -> None:
+    """A genuine forward return recovers after an out-of-order echo preserved the
+    anchor (F-FABLE-1 end-to-end).
+
+    The speed gate only evaluates a jump when the incoming fix is forward of the
+    cached endpoint (``new_ts > existing_ts``). To exercise a gated out-of-order
+    echo whose new_ts still precedes the anchor ts (delta_anchor < 0), the anchor
+    ts must sit AFTER the cached endpoint's last_seen - the realistic case where
+    the cached row is an older B fix while the anchor was seeded at the later
+    accept time. Both echo and forward return are gated (teleport B->A); the echo
+    (delta_anchor < 0) must LEAVE the anchor alive, and the later forward return
+    (delta_anchor >= 0, within TTL + radius) then recovers and consumes it.
+
+    Mutation guard: on the pre-fix code the out-of-order echo popped the anchor
+    unconditionally, so the later forward return finds no anchor, is gated, and
+    ``result is False`` (the stranded-return bug this guard closes).
+    """
+    anchor_ts = BASE_TS + 60
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(anchor_ts)}}
+    # Cached endpoint B carries an OLDER last_seen than the anchor ts, so a fix
+    # between the two is forward of B (gate fires) yet before the anchor.
+    coord = _coord(_fix(FAR, last_seen=BASE_TS), anchors=anchors)
+
+    # Step 1: an out-of-order echo near A at BASE_TS + 30: forward of B
+    # (delta_t = 30 s -> ~8333 m/s, gated) but before the anchor ts
+    # (delta_anchor = 30 - 60 = -30 < 0). It must be rejected AND preserve the
+    # anchor.
+    assert _fuse(coord, _fix(HOME, last_seen=BASE_TS + 30, acc=50.0)) is False
+    assert coord._round_trip_anchors["dev"]["ts"] == float(anchor_ts)  # alive
+
+    # Step 2: a legitimate forward return near A at BASE_TS + 300: still forward
+    # of B (delta_t = 300 s -> ~833 m/s, gated) and now after the anchor ts
+    # (delta_anchor = 240 s, within the 900 s TTL, on the anchor) -> recovered
+    # and consumed one-shot.
+    result = _fuse(coord, _fix(HOME, last_seen=BASE_TS + 300, acc=50.0))
+    assert result is True
+    coord.increment_stat.assert_called_with("round_trip_recoveries")
+    assert "dev" not in coord._round_trip_anchors  # one-shot consumed
+
+
+# ------------------------------------------- supersede detection (F-FABLE-2, AP-2)
+
+
+def test_own_report_clear_jump_marks_supersede_with_anchor() -> None:
+    """An own-report clear jump with a surviving anchor marks the slot (F-FABLE-2).
+
+    A trusted own-report that is itself a clear jump (dist > radius_sum) away
+    from the previous position is a genuine relocation B->C. A pre-existing
+    anchor A (from an earlier gated crowd jump) is now stale, so fusion marks
+    ``_supersede_round_trip_anchor`` on ``new_data`` for update_device_cache to
+    consume post-commit. The own-report itself still bypasses the speed gate and
+    is accepted (result True), never seeding or consuming the anchor here.
+    """
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(BASE_TS)}}
+    coord = _coord(_fix(FAR, last_seen=BASE_TS, acc=50.0), anchors=anchors)
+    new_data = _fix(HOME, last_seen=BASE_TS + 300, acc=50.0, is_own=True)
+    # HOME vs cached FAR is a clear jump; own-report -> gate bypassed.
+    result = _fuse(coord, new_data)
+    assert result is True
+    assert new_data.get("_supersede_round_trip_anchor") is True
+    # Fusion neither consumes nor seeds the anchor: the action is deferred.
+    assert coord._round_trip_anchors == anchors
+
+
+def test_own_report_clear_jump_without_anchor_sets_no_marker() -> None:
+    """Without a surviving anchor an own-report clear jump sets no marker."""
+    coord = _coord(_fix(FAR, last_seen=BASE_TS, acc=50.0))  # no anchors
+    new_data = _fix(HOME, last_seen=BASE_TS + 300, acc=50.0, is_own=True)
+    result = _fuse(coord, new_data)
+    assert result is True
+    assert "_supersede_round_trip_anchor" not in new_data
+
+
+def test_crowd_clear_jump_sets_no_supersede_marker() -> None:
+    """A crowd (non-own) clear jump never marks supersede, even with an anchor.
+
+    The marker is keyed on ``incoming_is_own``: a crowd report is not a trusted
+    relocation, so it must not invalidate the anchor. (This particular crowd fix
+    lands on the anchor and is recovered, which is the anchor's whole purpose.)
+    """
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(BASE_TS)}}
+    coord = _coord(_fix(FAR, last_seen=BASE_TS, acc=50.0), anchors=anchors)
+    new_data = _fix(HOME, last_seen=BASE_TS + 300, acc=50.0)  # is_own absent
+    _fuse(coord, new_data)
+    assert "_supersede_round_trip_anchor" not in new_data
+
+
+def test_own_report_clear_jump_disabled_toggle_sets_no_marker() -> None:
+    """With the round-trip toggle off, no supersede marker is set."""
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(BASE_TS)}}
+    coord = _coord(
+        _fix(FAR, last_seen=BASE_TS, acc=50.0), rt_enabled=False, anchors=anchors
+    )
+    new_data = _fix(HOME, last_seen=BASE_TS + 300, acc=50.0, is_own=True)
+    result = _fuse(coord, new_data)
+    assert result is True
+    assert "_supersede_round_trip_anchor" not in new_data
+
+
+# ------------------------------- supersede action via update_device_cache (AP-2)
+
+
+def _make_update_coordinator(
+    existing: dict[str, Any],
+    *,
+    anchors: dict[str, dict[str, Any]] | None = None,
+    gate_enabled: bool = True,
+    rt_enabled: bool = True,
+) -> Any:
+    """A coordinator wired for the real ``update_device_cache`` path.
+
+    Mirrors ``tests/test_plus_code_last_known.py::_make_update_coordinator`` but
+    also wires the round-trip anchor store and the two feature toggles the
+    supersede handling reads, so the F-FABLE-2 post-commit action runs through
+    the production commit sequence.
+    """
+    coord = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coord._device_location_data = {"dev": dict(existing)}
+    coord._device_names = {}
+    coord._device_update_history = {}
+    coord._round_trip_anchors = {} if anchors is None else anchors
+    coord.increment_stat = lambda *_a, **_k: None
+    coord._apply_report_type_cooldown = lambda *_a, **_k: None
+    coord._is_on_hass_loop = lambda: True
+    coord._run_on_hass_loop = lambda *_a, **_k: None
+    coord._speed_gate_enabled = lambda: gate_enabled
+    coord._round_trip_confirm_enabled = lambda: rt_enabled
+    # Seed the reliable fix as the current last-good.
+    coord._record_last_good_location("dev", existing)
+    return coord
+
+
+def test_supersede_action_invalidates_anchor_after_commit() -> None:
+    """F-FABLE-2 action end-to-end: an own-report clear jump B->C invalidates a
+    stale anchor A after committing, so a later stale crowd echo near A cannot
+    roll the tracker back.
+
+    Sequence over the real ``update_device_cache`` commit path:
+    1. A crowd jump A->B is accepted and seeds anchor A (ts = accept time of B).
+    2. An own-report clear jump B->C commits and the post-commit supersede action
+       pops anchor A (device no longer in ``_round_trip_anchors``).
+    3. A later stale crowd echo near A is gated (no anchor to recover on) and is
+       dropped by fusion, so the cached position stays at C.
+
+    Mutation guard: neutralizing the post-commit pop leaves anchor A alive, so
+    step 3's crowd echo recovers onto A and the ``device not in anchors``
+    assertion (and the position-stays-at-C assertion) fail.
+    """
+    # C is a third location, a clear jump north of both HOME (A) and FAR (B).
+    C = (46.000000, 11.400000)
+    t0 = BASE_TS
+    # Step 1: crowd jump A(HOME) -> B(FAR) over 3 h (plausible) seeds anchor A.
+    coord = _make_update_coordinator(_fix(HOME, last_seen=t0, acc=20.0))
+    b_ts = t0 + 3 * 3600
+    coord.update_device_cache("dev", _fix(FAR, last_seen=b_ts, acc=20.0))
+    assert coord._round_trip_anchors["dev"]["lat"] == HOME[0]
+    assert coord._device_location_data["dev"]["latitude"] == FAR[0]
+
+    # Step 2: own-report clear jump B(FAR) -> C over 3 h (own bypasses the gate,
+    # commits) -> post-commit supersede pops anchor A.
+    c_ts = b_ts + 3 * 3600
+    coord.update_device_cache("dev", _fix(C, last_seen=c_ts, acc=20.0, is_own=True))
+    assert coord._device_location_data["dev"]["latitude"] == pytest.approx(C[0])
+    assert "dev" not in coord._round_trip_anchors  # anchor invalidated
+
+    # Step 3: a stale crowd echo near A arrives quickly after C (teleport speed).
+    # With the anchor gone it cannot recover; fusion rejects it and the cached
+    # position stays at C.
+    coord.update_device_cache("dev", _fix(HOME, last_seen=c_ts + 300, acc=20.0))
+    assert coord._device_location_data["dev"]["latitude"] == pytest.approx(C[0])
+
+
+def test_supersede_not_triggered_when_significance_rejects() -> None:
+    """F-CODEX-7 non-recurrence: an own-report clear jump that is REJECTED by the
+    significance gate (timestamp regression) must NOT invalidate the anchor.
+
+    The supersede marker is popped early (pre-commit) but the action runs only
+    AFTER the significance gate and the commit. A rejected payload (early return
+    @512) therefore never reaches the pop, so a discarded own-report leaves the
+    anchor intact.
+
+    Mutation guard: moving the pop BEFORE the significance gate (pre-commit)
+    would invalidate the anchor even though the payload is discarded, so this
+    ``anchor survives`` assertion fails.
+    """
+    t0 = BASE_TS
+    # Seed anchor A and place the device at B via a plausible crowd jump.
+    coord = _make_update_coordinator(_fix(HOME, last_seen=t0, acc=20.0))
+    b_ts = t0 + 3 * 3600
+    coord.update_device_cache("dev", _fix(FAR, last_seen=b_ts, acc=20.0))
+    assert coord._round_trip_anchors["dev"]["lat"] == HOME[0]
+
+    # An own-report clear jump to C but with a REGRESSED timestamp (before B):
+    # fusion marks supersede (own clear jump + surviving anchor), yet the
+    # significance gate rejects the payload (new_ts < cached B ts) -> early
+    # return, so the post-commit supersede action never runs.
+    C = (46.000000, 11.400000)
+    regressed_ts = b_ts - 1000  # < cached B last_seen -> significance rejects
+    coord.update_device_cache(
+        "dev", _fix(C, last_seen=regressed_ts, acc=20.0, is_own=True)
+    )
+    # The payload was dropped: cached position stays at B, anchor A survives.
+    assert coord._device_location_data["dev"]["latitude"] == pytest.approx(FAR[0])
+    assert coord._round_trip_anchors["dev"]["lat"] == HOME[0]
+
+
+# ---------------------- anchor survival across estimated-existing skip (F2, AP-3)
+
+
+def test_anchor_surviving_estimated_skip_expires_by_ttl() -> None:
+    """An anchor that survives an estimated-``existing`` gate skip stays bounded
+    by the existing TTL/radius; it does not become permanently consumable (F2).
+
+    F-CODEX-1 makes the whole gate block fall through when ``existing`` is an
+    estimated fallback (is_reliable_fix False). No consume and no housekeeping pop
+    run on that path, so a pre-existing anchor simply survives UNTOUCHED - it must
+    not thereby gain an extended life. This test pins that the surviving anchor is
+    still only recoverable within ROUND_TRIP_TTL_S: a later return that lands on
+    the anchor coordinates but arrives past the TTL is NOT recovered (it is gated
+    as a normal teleport), proving the survival does not widen the TTL window.
+
+    Mutation guard: none of the AP-3 production edits are asserted positively here
+    (this is a bounding/regression guard); it documents that the estimated-skip
+    path leaves the anchor's TTL semantics unchanged.
+    """
+    anchor_ts = BASE_TS
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(anchor_ts)}}
+
+    # Step 1: a fast crowd fix against an ESTIMATED cached endpoint. F-CODEX-1
+    # makes the gate block fall through entirely (no consume, no pop), so the
+    # anchor survives untouched. existing is FAR/estimated; incoming lands far
+    # from the anchor (at FAR) so even if the gate ran it would not recover.
+    coord = _coord(
+        _fix(FAR, last_seen=BASE_TS, acc=200.0, estimated=True), anchors=anchors
+    )
+    assert _fuse(coord, _fix(FAR, last_seen=BASE_TS + 300, acc=50.0)) is True
+    assert coord._round_trip_anchors["dev"]["ts"] == float(anchor_ts)  # untouched
+
+    # Step 2: the device is now at a RELIABLE B; a return lands exactly on the
+    # anchor coordinates but PAST the TTL (delta_anchor > ROUND_TRIP_TTL_S). The
+    # surviving anchor must not recover it: it is gated as a normal teleport.
+    expired_return_ts = anchor_ts + ROUND_TRIP_TTL_S + 120
+    gated_b_seen = expired_return_ts - 300  # keeps ~833 m/s > cap on the return
+    coord._device_location_data["dev"] = _fix(FAR, last_seen=gated_b_seen, acc=20.0)
+    result = _fuse(coord, _fix(HOME, last_seen=expired_return_ts, acc=50.0))
+    assert result is False
+    coord.increment_stat.assert_called_with("speed_gate_rejects")
+
+
+def test_anchor_surviving_estimated_skip_radius_bounded() -> None:
+    """The anchor that survived an estimated-existing skip is also still
+    radius-bounded: a within-TTL return OUTSIDE the anchor radius does NOT recover
+    (companion to the TTL bound, F2).
+    """
+    anchor_ts = BASE_TS
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(anchor_ts)}}
+    coord = _coord(
+        _fix(FAR, last_seen=BASE_TS, acc=200.0, estimated=True), anchors=anchors
+    )
+    # Estimated-existing skip leaves the anchor untouched.
+    assert _fuse(coord, _fix(FAR, last_seen=BASE_TS + 300, acc=50.0)) is True
+
+    # Device now at a reliable B; a within-TTL return that lands just OUTSIDE the
+    # 200 m radius of the anchor is not recovered.
+    outside = _point_north(HOME, 260.0)
+    assert (
+        _haversine_distance_impl(HOME[0], HOME[1], *outside)
+        > ROUND_TRIP_ANCHOR_RADIUS_M
+    )
+    coord._device_location_data["dev"] = _fix(FAR, last_seen=BASE_TS, acc=20.0)
+    result = _fuse(coord, _fix(outside, last_seen=BASE_TS + 300, acc=50.0))
+    assert result is False
+    coord.increment_stat.assert_called_with("speed_gate_rejects")

--- a/tests/test_cache_round_trip.py
+++ b/tests/test_cache_round_trip.py
@@ -438,13 +438,27 @@ def test_own_report_clear_jump_marks_supersede_with_anchor() -> None:
     assert coord._round_trip_anchors == anchors
 
 
-def test_own_report_clear_jump_without_anchor_sets_no_marker() -> None:
-    """Without a surviving anchor an own-report clear jump sets no marker."""
-    coord = _coord(_fix(FAR, last_seen=BASE_TS, acc=50.0))  # no anchors
+def test_own_report_clear_jump_marks_supersede_even_without_source_anchor() -> None:
+    """An own-report clear jump marks supersede even when THIS device holds no
+    anchor (F-CODEX-9).
+
+    The marker no longer keys on the source device's own anchor: a shared tracker
+    propagates this fresh trusted position to sibling device ids post-commit, and
+    a sibling may hold a stale anchor even when the source does not. Marking
+    unconditionally lets the post-commit handling clear those propagated siblings;
+    the source-side pop stays a harmless idempotent no-op when the source has no
+    anchor.
+
+    Mutation guard: re-gating the marker on ``_anchors.get(device_id)`` (the old
+    source-anchor condition) leaves the marker unset here, so this assertion
+    fails - and, via update_device_cache, a propagated sibling's stale anchor
+    would survive.
+    """
+    coord = _coord(_fix(FAR, last_seen=BASE_TS, acc=50.0))  # no source anchor
     new_data = _fix(HOME, last_seen=BASE_TS + 300, acc=50.0, is_own=True)
     result = _fuse(coord, new_data)
     assert result is True
-    assert "_supersede_round_trip_anchor" not in new_data
+    assert new_data.get("_supersede_round_trip_anchor") is True
 
 
 def test_crowd_clear_jump_sets_no_supersede_marker() -> None:
@@ -647,3 +661,156 @@ def test_anchor_surviving_estimated_skip_radius_bounded() -> None:
     result = _fuse(coord, _fix(outside, last_seen=BASE_TS + 300, acc=50.0))
     assert result is False
     coord.increment_stat.assert_called_with("speed_gate_rejects")
+
+
+# ---------------- shared-device anchor propagation (F-CODEX-9, AP-3 sweep)
+
+
+def _make_shared_update_coordinator(
+    *,
+    ik: bytes,
+    rt_enabled: bool = True,
+) -> Any:
+    """A coordinator wired for ``update_device_cache`` with two devices sharing
+    one identity key, both carrying a stale round-trip anchor at HOME (A).
+
+    ``dev_a`` is the source that receives the own-report clear jump; ``dev_b``
+    shares the physical tracker via ``identity_key`` and holds an OLDER cached
+    position so the post-commit propagation adopts the fresh location.
+    """
+    coord = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coord._device_location_data = {
+        "dev_a": {**_fix(FAR, last_seen=BASE_TS, acc=20.0), "identity_key": ik},
+        "dev_b": {**_fix(FAR, last_seen=BASE_TS - 10, acc=20.0), "identity_key": ik},
+    }
+    coord._device_names = {}
+    coord._device_update_history = {}
+    coord._identity_key_to_devices = {ik: {"dev_a", "dev_b"}}
+    coord._round_trip_anchors = {
+        "dev_a": {"lat": HOME[0], "lon": HOME[1], "ts": BASE_TS},
+        "dev_b": {"lat": HOME[0], "lon": HOME[1], "ts": BASE_TS},
+    }
+    coord.increment_stat = lambda *_a, **_k: None
+    coord._apply_report_type_cooldown = lambda *_a, **_k: None
+    coord._is_on_hass_loop = lambda: True
+    coord._run_on_hass_loop = lambda *_a, **_k: None
+    coord._speed_gate_enabled = lambda: True
+    coord._round_trip_confirm_enabled = lambda: rt_enabled
+    coord._record_last_good_location("dev_a", coord._device_location_data["dev_a"])
+    coord._record_last_good_location("dev_b", coord._device_location_data["dev_b"])
+    return coord
+
+
+def test_supersede_invalidates_propagated_shared_anchor() -> None:
+    """F-CODEX-9: a trusted own-report clear jump on a shared tracker invalidates
+    the round-trip anchor of every propagated shared target, not just the source.
+
+    Two device ids share one physical tracker (identity key). Both hold a stale
+    anchor at A. An own-report clear jump B->C on ``dev_a`` commits, pops its own
+    anchor, and propagates C to ``dev_b``. The post-commit supersede action must
+    ride that same propagation and drop ``dev_b``'s stale anchor too, otherwise a
+    later crowd echo near A on ``dev_b`` would take the round-trip recovery path
+    and roll the propagated target back to the stale A position.
+
+    Mutation guard: dropping ``supersede_anchors`` in the propagation loop leaves
+    ``dev_b``'s anchor alive, so (a) the ``dev_b not in anchors`` assertion fails
+    and (b) the step-3 crowd echo, still WITHIN the anchor TTL, recovers ``dev_b``
+    back onto A. The geometry keeps the echo inside ROUND_TRIP_TTL_S so (b) is a
+    live guard, not a vacuous TTL-expiry pass.
+    """
+    ik = b"\x11" * 32
+    coord = _make_shared_update_coordinator(ik=ik)
+
+    # Own-report clear jump B(FAR) -> C on dev_a. C is a clear jump far from both
+    # HOME (A) and FAR (B). c_ts is newer than dev_b's cached B ts (propagation
+    # adopts C) and close to the anchor ts (BASE_TS) so the step-3 echo lands
+    # within ROUND_TRIP_TTL_S of the anchor - the behavioral guard stays live.
+    C = (46.000000, 11.400000)
+    c_ts = BASE_TS + 300
+    coord.update_device_cache(
+        "dev_a",
+        {**_fix(C, last_seen=c_ts, acc=20.0, is_own=True), "identity_key": ik},
+    )
+
+    # Source anchor popped (existing F-FABLE-2 behavior).
+    assert "dev_a" not in coord._round_trip_anchors
+    # Fresh location propagated to the shared target...
+    assert coord._device_location_data["dev_b"]["latitude"] == pytest.approx(C[0])
+    # ...and its stale anchor invalidated with it (F-CODEX-9, the fix).
+    assert "dev_b" not in coord._round_trip_anchors
+
+    # Behavioral proof: a later crowd echo near A on dev_b, arriving WITHIN the
+    # anchor TTL (delta_anchor = 600 s <= ROUND_TRIP_TTL_S), is now gated (no
+    # anchor to recover on) and dropped, so dev_b stays at C. With the anchor
+    # still alive (mutation) it would recover onto A.
+    echo_ts = c_ts + 300  # BASE_TS + 600, delta from anchor ts (BASE_TS) < 900
+    assert echo_ts - BASE_TS <= ROUND_TRIP_TTL_S
+    coord.update_device_cache("dev_b", _fix(HOME, last_seen=echo_ts, acc=20.0))
+    assert coord._device_location_data["dev_b"]["latitude"] == pytest.approx(C[0])
+
+
+def test_supersede_preserves_fresher_shared_target_anchor() -> None:
+    """F-CODEX-9 precision: a shared target that is FRESHER than the superseding
+    location (propagation skipped by the freshness gate) keeps its own anchor.
+
+    The invalidation rides the propagation data-flow, so a target that never
+    adopts the superseding location must not lose its anchor - the fix clears
+    only what it actually propagated (SA-8d scoping).
+
+    Mutation guard: clearing anchors unconditionally (before the freshness gate,
+    Option A) would drop the fresher target's anchor, so this ``anchor survives``
+    assertion fails.
+    """
+    ik = b"\x22" * 32
+    coord = _make_shared_update_coordinator(ik=ik)
+    # Make dev_b FRESHER than the incoming own-report so propagation is skipped.
+    fresh_ts = BASE_TS + 10 * 3600
+    coord._device_location_data["dev_b"]["last_seen"] = fresh_ts
+
+    C = (46.000000, 11.400000)
+    c_ts = BASE_TS + 3 * 3600  # OLDER than dev_b's fresh_ts -> propagation skipped
+    coord.update_device_cache(
+        "dev_a",
+        {**_fix(C, last_seen=c_ts, acc=20.0, is_own=True), "identity_key": ik},
+    )
+
+    # dev_b did NOT adopt C (it is fresher) -> its anchor stays intact.
+    assert coord._device_location_data["dev_b"]["latitude"] == pytest.approx(FAR[0])
+    assert coord._round_trip_anchors["dev_b"]["lat"] == pytest.approx(HOME[0])
+
+
+def test_supersede_clears_shared_anchor_when_source_has_no_anchor() -> None:
+    """F-CODEX-9 (R1): a shared target's stale anchor is cleared even when the
+    SOURCE device holds no anchor of its own.
+
+    The supersede marker is set on any trusted own clear-jump, not only when the
+    source holds an anchor, so a propagated sibling that still carries a stale
+    anchor is invalidated too. Without this, an own clear-jump on an anchorless
+    source would propagate the fresh position but leave the sibling's anchor
+    alive, keeping the F-CODEX-9 rollback reachable.
+
+    Mutation guard: re-gating the marker on the source anchor (the old condition)
+    leaves ``dev_b``'s anchor alive; (a) the ``dev_b not in anchors`` assertion
+    fails and (b) the within-TTL crowd echo recovers ``dev_b`` onto A.
+    """
+    ik = b"\x33" * 32
+    coord = _make_shared_update_coordinator(ik=ik)
+    # Source dev_a holds NO anchor; only the shared target dev_b does.
+    del coord._round_trip_anchors["dev_a"]
+    assert coord._round_trip_anchors["dev_b"]["lat"] == pytest.approx(HOME[0])
+
+    C = (46.000000, 11.400000)
+    c_ts = BASE_TS + 300
+    coord.update_device_cache(
+        "dev_a",
+        {**_fix(C, last_seen=c_ts, acc=20.0, is_own=True), "identity_key": ik},
+    )
+    # Fresh location propagated and the sibling's stale anchor cleared.
+    assert coord._device_location_data["dev_b"]["latitude"] == pytest.approx(C[0])
+    assert "dev_b" not in coord._round_trip_anchors
+
+    # Behavioral proof: a within-TTL crowd echo near A on dev_b is now dropped.
+    echo_ts = c_ts + 300
+    assert echo_ts - BASE_TS <= ROUND_TRIP_TTL_S
+    coord.update_device_cache("dev_b", _fix(HOME, last_seen=echo_ts, acc=20.0))
+    assert coord._device_location_data["dev_b"]["latitude"] == pytest.approx(C[0])

--- a/tests/test_cache_speed_gate.py
+++ b/tests/test_cache_speed_gate.py
@@ -57,7 +57,9 @@ def _coord(existing: dict[str, Any], *, gate_enabled: bool = True) -> MagicMock:
     return coord
 
 
-def _existing(*, last_seen: Any = BASE_TS, acc: float = 20.0) -> dict[str, Any]:
+def _existing(
+    *, last_seen: Any = BASE_TS, acc: float = 20.0, estimated: bool = False
+) -> dict[str, Any]:
     fix: dict[str, Any] = {
         "latitude": HOME[0],
         "longitude": HOME[1],
@@ -66,6 +68,10 @@ def _existing(*, last_seen: Any = BASE_TS, acc: float = 20.0) -> dict[str, Any]:
     }
     if last_seen is not None:
         fix["last_seen"] = last_seen
+    if estimated:
+        # Mark the cached endpoint as the 200 m estimated fallback (is_reliable_fix
+        # False), the reference F-CODEX-1 protects the incoming report against.
+        fix["accuracy_estimated"] = True
     return fix
 
 
@@ -404,3 +410,38 @@ def test_genuine_own_report_without_network_flag_bypasses() -> None:
     result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, is_own=True))
     assert result is True
     coord.increment_stat.assert_not_called()
+
+
+# ----------------------------- symmetric cached-endpoint guard (F-CODEX-1, AP-3)
+
+
+def test_fast_report_against_estimated_existing_not_gated() -> None:
+    """F-CODEX-1 symmetry: a fast crowd fix against an ESTIMATED cached endpoint
+    is NOT gated (the gate requires BOTH endpoints to be reliable).
+
+    If ``existing`` is the 200 m estimated fallback (accuracy_estimated=True,
+    is_reliable_fix False), the implied speed would be measured against an
+    unreliable phantom reference and strand the tracker on the estimate. The
+    symmetric guard makes the gate fall through, so the incoming report is
+    accepted (result True) and the reject counter stays untouched.
+
+    Mutation guard: removing the ``and is_reliable_fix(existing)`` clause gates
+    this jump again, so ``result is False`` and the counter fires.
+    """
+    coord = _coord(_existing(last_seen=BASE_TS, acc=200.0, estimated=True))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, is_own=False))
+    assert result is True
+    coord.increment_stat.assert_not_called()
+
+
+def test_fast_report_against_reliable_existing_still_gated() -> None:
+    """Regression guard for F-CODEX-1: the SAME fast crowd fix against a reliable
+    (measured, non-estimated) cached endpoint is still gated and rejected.
+
+    Proves the symmetric guard narrows the gate only for estimated references and
+    does not weaken the core speed gate when both endpoints carry real accuracy.
+    """
+    coord = _coord(_existing(last_seen=BASE_TS, acc=20.0, estimated=False))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, is_own=False))
+    assert result is False
+    coord.increment_stat.assert_called_once_with("speed_gate_rejects")


### PR DESCRIPTION
## Summary

Follow-up to #1196 (the stateful round-trip escape hatch, now in `1.7` via #1197). Three coherent fixes in the round-trip / speed-gate region of `cache.py`, each dual-audited and mutation-tested.

| Fix | Change | Locus |
|-----|--------|-------|
| **F-FABLE-1** | Guard the anchor housekeeping pop on `delta_anchor >= 0`. A delayed out-of-order report (last_seen between anchor A and B) yields `delta_anchor < 0`; popping there destroys the anchor and strands a later genuine return. Only house-keep forward. | `cache.py` housekeeping pop |
| **F-FABLE-2** | Invalidate a stale round-trip anchor **after** a trusted own-report clear-jump commits. Detection sets a slot marker; it is popped early (before sanitize/merge, no cache leak) and the anchor is popped only after the payload commits and passes the significance gate, so a rejected payload never triggers it (F-CODEX-7 preserved by placement). Polling test-double fallback strips the marker too. | `cache.py` clear-jump + post-commit, `polling.py` fallback |
| **F-CODEX-1 residual** | Extend the speed gate with `is_reliable_fix(existing)` so it fires only when **both** endpoints carry real measured accuracy. Gating against an estimated 200 m fallback endpoint would reject the incoming fix against a phantom position and strand the tracker on the estimate. This is the symmetric cached-endpoint half of the incoming-side `new_acc_measured` check. | `cache.py` gate condition |

## Tests

12 new cases across `test_cache_round_trip.py` and `test_cache_speed_gate.py`, each with a **mutation counter-proof**: reverting the fix turns the paired test red (verified locally for all three). Full suite green locally; CI authoritative.

## Reviews

- **code-architekt `[REVIEW:DIFF]`**: PASS on all hunks (F-CODEX-7 freedom, no marker leak, correct kinematic reference, no second gate asymmetry, no concurrency issues).
- **Fable adversarial**: "tenable with conditions" (no blocking defect). Conditions folded in as in-code documentation.

## Known bounded trade-offs (documented in-code, deferred)

- **F-2 (Medium)**: when the cached `existing` is estimated, the whole gate block is skipped, so a measured crowd teleport is accepted ungated for that one step. Deliberate (gating against a phantom reference is the worse failure). Follow-up candidate: gate against the last-good location instead of skipping entirely.
- **F-3 (Low-Medium)**: the trusted-return accept paths never set the supersede marker, so a stale anchor can survive there too. TTL/radius-bounded; deferred for scope discipline at this iterated locus.
- **F-1 (Low)**: the polling test-double fallback pops the marker but does not run the supersede action (production always routes through `update_device_cache`).

All three are TTL/radius-bounded and cannot strand indefinitely.
