### PR TITLE
ci: branch-neutral semantic-release + three-file version sync

### DIFF
--- a/.github/workflows/release-stamp.yml
+++ b/.github/workflows/release-stamp.yml
@@ -65,8 +65,8 @@ jobs:
         # step stamps the exact published tag regardless. Keep both regexes in sync.
         run: |
           set -euo pipefail
-          if ! printf '%s' "$TAG_NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?(\.[0-9]+)?$'; then
-            echo "::error::tag_name '$TAG_NAME' violates tag_format='{version}'; expected X.Y.Z[bN][.N], no 'v' prefix"
+          if ! printf '%s' "$TAG_NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?([ab][0-9]+)?$'; then
+            echo "::error::tag_name '$TAG_NAME' violates tag_format='{version}'; expected X.Y.Z[.N][bN], no 'v' prefix"
             exit 1
           fi
           # target_commitish may be a raw commit SHA (release made from a tag
@@ -132,7 +132,14 @@ jobs:
       - name: Rebuild and upload the HACS ZIP from the stamped tree
         run: |
           set -euo pipefail
-          cd custom_components
-          zip -r ../googlefindmy.zip googlefindmy
-          cd ..
+          # hacs.json sets zip_release=true + filename=googlefindmy.zip, so HACS
+          # installs THIS asset and extracts it directly into
+          # custom_components/googlefindmy/. manifest.json MUST therefore sit at
+          # the ZIP root -- zip the domain *contents* (`.` from inside the domain
+          # dir), never the googlefindmy/ directory from its parent (that would
+          # nest one level too deep and hide the integration -> broken installs).
+          # Locked by tests/test_hacs_validation.py (ZIP-structure guard).
+          cd custom_components/googlefindmy
+          zip -r ../../googlefindmy.zip .
+          cd ../..
           gh release upload "$TAG_NAME" googlefindmy.zip --clobber

--- a/.github/workflows/release-stamp.yml
+++ b/.github/workflows/release-stamp.yml
@@ -47,7 +47,6 @@ jobs:
 
     env:
       TAG_NAME: ${{ github.event.release.tag_name }}
-      TARGET_BRANCH: ${{ github.event.release.target_commitish }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -111,7 +110,9 @@ jobs:
           # target_commitish is an unreliable hint: GitHub documents it as unused
           # once the git tag already exists, defaulting to the repo default branch
           # (which only coincidentally equals the maintenance line on some forks).
-          # So resolve the branch from the tag commit itself, and fast-forward only.
+          # So resolve the branch solely from the tag commit itself and never trust
+          # the event hint as a tiebreaker: stamp only when exactly one branch owns
+          # the tag, and fast-forward only.
           git fetch origin '+refs/heads/*:refs/remotes/origin/*' --quiet
           TAG_SHA="$(git rev-list -n1 "refs/tags/${TAG_NAME}")"
           mapfile -t CANDIDATES < <(
@@ -121,8 +122,6 @@ jobs:
           )
           if [ "${#CANDIDATES[@]}" -eq 0 ]; then
             STAMP_BRANCH=""
-          elif printf '%s\n' "${CANDIDATES[@]}" | grep -qxF "$TARGET_BRANCH"; then
-            STAMP_BRANCH="$TARGET_BRANCH"          # event hint is a real owning branch; honor it
           elif [ "${#CANDIDATES[@]}" -eq 1 ]; then
             STAMP_BRANCH="${CANDIDATES[0]}"        # unambiguous single owner
           else

--- a/.github/workflows/release-stamp.yml
+++ b/.github/workflows/release-stamp.yml
@@ -57,8 +57,12 @@ jobs:
 
       - name: Validate published tag
         # Early, human-readable abort. The canonical regex (SSOT) lives in
-        # script/stamp_version.py (VERSION_RE); this guard mirrors it so a
-        # malformed tag never reaches the stamp/commit steps. Keep both in sync.
+        # script/stamp_version.py (VERSION_RE); this guard mirrors it byte-for-byte
+        # (locked by tests/test_stamp_version.py). The shape is deliberately PEP
+        # 440-broad (bN/aN betas, four-segment .N) so hand-picked maintenance tags
+        # stamp cleanly. semantic-release cannot *propose* for those lines (see
+        # release.yml Workflow A, which opens a hand-tag draft there instead); this
+        # step stamps the exact published tag regardless. Keep both regexes in sync.
         run: |
           set -euo pipefail
           if ! printf '%s' "$TAG_NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?(\.[0-9]+)?$'; then

--- a/.github/workflows/release-stamp.yml
+++ b/.github/workflows/release-stamp.yml
@@ -1,0 +1,134 @@
+name: Release Stamp
+
+# Workflow B of the "manual release -> code stamp" handshake.
+#
+# Fires AFTER a GitHub release is published (whether from the Release workflow's
+# draft or a hand-made releases/new release). It writes the exact published tag
+# into the three version literals (script/stamp_version.py), commits the result
+# with [skip ci], and pushes it protection-aware. The delivered HACS ZIP is
+# rebuilt from the stamped tree so the installed artifact always carries the
+# right number, independent of the (older) tree the git tag points at.
+#
+# Security: values derived from the release event (tag_name, target branch) are
+# passed to shell exclusively via env: indirection and quoted "$VARS" -- never
+# interpolated as ${{ ... }} inside run: blocks (shell-injection hardening).
+#
+# Loop safety: the stamp commit carries [skip ci], and this workflow triggers
+# only on `release: published`, never on `push`. A push made with GITHUB_TOKEN
+# does not, by GitHub design, trigger further workflow runs either.
+
+on:
+  release:
+    types: [published]
+
+# Least-privilege: contents for the stamp push + ZIP upload; pull-requests only
+# for the dormant protected-branch fallback leg (see "Protection-aware push").
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  stamp:
+    name: Stamp published version into code
+    runs-on: ubuntu-latest
+    # Only run on the maintainer forks, not on downstream forks.
+    if: github.repository_owner == 'jleinenbach' || github.repository_owner == 'BSkando'
+    concurrency:
+      group: release-stamp
+      cancel-in-progress: false
+
+    env:
+      TAG_NAME: ${{ github.event.release.tag_name }}
+      TARGET_BRANCH: ${{ github.event.release.target_commitish }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Check out the release target branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Validate published tag
+        # Early, human-readable abort. The canonical regex (SSOT) lives in
+        # script/stamp_version.py (VERSION_RE); this guard mirrors it so a
+        # malformed tag never reaches the stamp/commit steps. Keep both in sync.
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$TAG_NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?(\.[0-9]+)?$'; then
+            echo "::error::tag_name '$TAG_NAME' violates tag_format='{version}'; expected X.Y.Z[bN][.N], no 'v' prefix"
+            exit 1
+          fi
+          # target_commitish may be a raw commit SHA (release made from a tag
+          # rather than a branch); we must not create a SHA-named branch.
+          if printf '%s' "$TARGET_BRANCH" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::release target_commitish '$TARGET_BRANCH' is a commit SHA, not a branch; cannot stamp-and-push. Publish releases from a branch."
+            exit 1
+          fi
+          echo "tag=$TAG_NAME target=$TARGET_BRANCH"
+
+      - name: Stamp version into the three literals
+        run: |
+          set -euo pipefail
+          python script/stamp_version.py --version "$TAG_NAME"
+
+      - name: Commit the stamp
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "nothing to stamp (version already current); skipping commit"
+            echo "STAMP_COMMITTED=false" >> "$GITHUB_ENV"
+          else
+            git add -A
+            git commit -m "chore(release): ${TAG_NAME} [skip ci]"
+            echo "STAMP_COMMITTED=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Protection-aware push
+        if: env.STAMP_COMMITTED == 'true'
+        run: |
+          set -euo pipefail
+          # Preferred path: direct push. Works today because 1.7 / BSkando are
+          # unprotected. If a future branch protection rejects the direct push
+          # (only then), fall back to a short-lived PR + auto-merge.
+          #
+          # Dormant fallback caveats:
+          #   * Auto-merge needs the repo switch allow_auto_merge=true.
+          #   * If the future protection requires a REVIEW, GITHUB_TOKEN cannot
+          #     approve its own PR -> the stamp PR waits for one maintainer
+          #     click per release. If it requires only status checks, auto-merge
+          #     lands it after CI.
+          if git push origin "HEAD:${TARGET_BRANCH}" 2> push_err.log; then
+            echo "direct push to ${TARGET_BRANCH} succeeded"
+          else
+            if grep -qiE 'protected branch|\b403\b|GH006' push_err.log; then
+              echo "direct push blocked by branch protection; using PR fallback"
+              FB_BRANCH="release-stamp/${TAG_NAME}"
+              git push origin "HEAD:${FB_BRANCH}"
+              gh pr create --base "${TARGET_BRANCH}" --head "${FB_BRANCH}" \
+                --title "chore(release): ${TAG_NAME}" \
+                --body "Automated version stamp for release ${TAG_NAME}. [skip ci]"
+              gh pr merge --auto --squash "${FB_BRANCH}" \
+                || echo "::warning::auto-merge unavailable (allow_auto_merge=false?); PR left open for manual merge"
+            else
+              echo "::error::push failed for a non-protection reason:"
+              cat push_err.log
+              exit 1
+            fi
+          fi
+
+      - name: Rebuild and upload the HACS ZIP from the stamped tree
+        run: |
+          set -euo pipefail
+          cd custom_components
+          zip -r ../googlefindmy.zip googlefindmy
+          cd ..
+          gh release upload "$TAG_NAME" googlefindmy.zip --clobber

--- a/.github/workflows/release-stamp.yml
+++ b/.github/workflows/release-stamp.yml
@@ -3,26 +3,34 @@ name: Release Stamp
 # Workflow B of the "manual release -> code stamp" handshake.
 #
 # Fires AFTER a GitHub release is published (whether from the Release workflow's
-# draft or a hand-made releases/new release). It writes the exact published tag
-# into the three version literals (script/stamp_version.py), commits the result
-# with [skip ci], and pushes it protection-aware. The delivered HACS ZIP is
-# rebuilt from the stamped tree so the installed artifact always carries the
-# right number, independent of the (older) tree the git tag points at.
+# draft or a hand-made releases/new release). It checks out the *published tag*,
+# writes that exact tag into the three version literals (script/stamp_version.py),
+# commits with [skip ci], and pushes the stamp to the branch that owns the tag.
+# The delivered HACS ZIP is rebuilt from this stamped tag tree, so the installed
+# artifact always matches the released commit.
 #
-# Security: values derived from the release event (tag_name, target branch) are
-# passed to shell exclusively via env: indirection and quoted "$VARS" -- never
-# interpolated as ${{ ... }} inside run: blocks (shell-injection hardening).
+# Tag vs. branch: we check out github.event.release.tag_name, NOT target_commitish.
+# GitHub documents target_commitish as unused once the git tag already exists (it
+# then defaults to the repo default branch), so trusting it would stamp and package
+# the wrong branch on a maintenance line. The branch that receives the stamp push
+# is resolved from the tag commit itself (git branch -r --contains) and pushed
+# fast-forward only; if the tag is behind the branch tip, the branch stamp is
+# skipped -- the ZIP asset already carries the correct version.
 #
-# Loop safety: the stamp commit carries [skip ci], and this workflow triggers
-# only on `release: published`, never on `push`. A push made with GITHUB_TOKEN
-# does not, by GitHub design, trigger further workflow runs either.
+# Security: values derived from the release event (tag_name, target branch) reach
+# shell exclusively via env: indirection and quoted "$VARS" -- never interpolated
+# as ${{ ... }} inside run: blocks (shell-injection hardening).
+#
+# Loop safety: the stamp commit carries [skip ci], and this workflow triggers only
+# on `release: published`, never on `push`. A push made with GITHUB_TOKEN does not,
+# by GitHub design, trigger further workflow runs either.
 
 on:
   release:
     types: [published]
 
 # Least-privilege: contents for the stamp push + ZIP upload; pull-requests only
-# for the dormant protected-branch fallback leg (see "Protection-aware push").
+# for the dormant protected-branch fallback leg (see "Resolve the owning branch").
 permissions:
   contents: write
   pull-requests: write
@@ -43,10 +51,13 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - name: Check out the release target branch
+      - name: Check out the published tag
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.release.target_commitish }}
+          # Pin the exact published commit. target_commitish is unreliable once
+          # the tag already exists (see header); the tag ref always points at the
+          # released commit, so the stamped tree and the HACS ZIP match the release.
+          ref: ${{ github.event.release.tag_name }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -69,13 +80,7 @@ jobs:
             echo "::error::tag_name '$TAG_NAME' violates tag_format='{version}'; expected X.Y.Z[.N][bN], no 'v' prefix"
             exit 1
           fi
-          # target_commitish may be a raw commit SHA (release made from a tag
-          # rather than a branch); we must not create a SHA-named branch.
-          if printf '%s' "$TARGET_BRANCH" | grep -qE '^[0-9a-f]{40}$'; then
-            echo "::error::release target_commitish '$TARGET_BRANCH' is a commit SHA, not a branch; cannot stamp-and-push. Publish releases from a branch."
-            exit 1
-          fi
-          echo "tag=$TAG_NAME target=$TARGET_BRANCH"
+          echo "validated tag=$TAG_NAME"
 
       - name: Stamp version into the three literals
         run: |
@@ -96,37 +101,66 @@ jobs:
             echo "STAMP_COMMITTED=true" >> "$GITHUB_ENV"
           fi
 
-      - name: Protection-aware push
+      - name: Resolve the owning branch and push the stamp
         if: env.STAMP_COMMITTED == 'true'
         run: |
           set -euo pipefail
-          # Preferred path: direct push. Works today because 1.7 / BSkando are
-          # unprotected. If a future branch protection rejects the direct push
-          # (only then), fall back to a short-lived PR + auto-merge.
+          # The stamp commit sits on top of the *published tag* (we checked the tag
+          # out, not a branch). It is pushed to the branch that owns the tag.
           #
-          # Dormant fallback caveats:
-          #   * Auto-merge needs the repo switch allow_auto_merge=true.
-          #   * If the future protection requires a REVIEW, GITHUB_TOKEN cannot
-          #     approve its own PR -> the stamp PR waits for one maintainer
-          #     click per release. If it requires only status checks, auto-merge
-          #     lands it after CI.
-          if git push origin "HEAD:${TARGET_BRANCH}" 2> push_err.log; then
-            echo "direct push to ${TARGET_BRANCH} succeeded"
+          # target_commitish is an unreliable hint: GitHub documents it as unused
+          # once the git tag already exists, defaulting to the repo default branch
+          # (which only coincidentally equals the maintenance line on some forks).
+          # So resolve the branch from the tag commit itself, and fast-forward only.
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' --quiet
+          TAG_SHA="$(git rev-list -n1 "refs/tags/${TAG_NAME}")"
+          mapfile -t CANDIDATES < <(
+            git branch -r --contains "$TAG_SHA" --format='%(refname:short)' \
+              | grep -vE '(^|/)HEAD$' \
+              | sed 's#^origin/##'
+          )
+          if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+            STAMP_BRANCH=""
+          elif printf '%s\n' "${CANDIDATES[@]}" | grep -qxF "$TARGET_BRANCH"; then
+            STAMP_BRANCH="$TARGET_BRANCH"          # event hint is a real owning branch; honor it
+          elif [ "${#CANDIDATES[@]}" -eq 1 ]; then
+            STAMP_BRANCH="${CANDIDATES[0]}"        # unambiguous single owner
           else
-            if grep -qiE 'protected branch|\b403\b|GH006' push_err.log; then
-              echo "direct push blocked by branch protection; using PR fallback"
-              FB_BRANCH="release-stamp/${TAG_NAME}"
-              git push origin "HEAD:${FB_BRANCH}"
-              gh pr create --base "${TARGET_BRANCH}" --head "${FB_BRANCH}" \
-                --title "chore(release): ${TAG_NAME}" \
-                --body "Automated version stamp for release ${TAG_NAME}. [skip ci]"
-              gh pr merge --auto --squash "${FB_BRANCH}" \
-                || echo "::warning::auto-merge unavailable (allow_auto_merge=false?); PR left open for manual merge"
-            else
-              echo "::error::push failed for a non-protection reason:"
-              cat push_err.log
-              exit 1
-            fi
+            STAMP_BRANCH=""                        # multiple owners; do not guess
+          fi
+          if [ -z "$STAMP_BRANCH" ]; then
+            echo "::notice::could not unambiguously resolve the branch owning tag ${TAG_NAME} (candidates: ${CANDIDATES[*]:-none}); the HACS ZIP asset is already stamped and uploaded, so the branch stamp is skipped"
+            exit 0
+          fi
+          echo "stamping onto branch: ${STAMP_BRANCH}"
+          # Push order of the error classification matters: protection rejections
+          # ("remote rejected", GH006) also contain the word "rejected", so the
+          # protected-branch check MUST precede the non-fast-forward check.
+          if git push origin "HEAD:${STAMP_BRANCH}" 2> push_err.log; then
+            echo "direct push to ${STAMP_BRANCH} succeeded"
+          elif grep -qiE 'protected branch|\b403\b|GH006' push_err.log; then
+            # Dormant fallback for a future branch protection: a short-lived PR +
+            # auto-merge. Needs the repo switch allow_auto_merge=true. If the future
+            # protection requires a REVIEW, GITHUB_TOKEN cannot approve its own PR
+            # -> the stamp PR waits for one maintainer click. If it requires only
+            # status checks, auto-merge lands it after CI.
+            echo "direct push blocked by branch protection; using PR fallback"
+            FB_BRANCH="release-stamp/${TAG_NAME}"
+            git push origin "HEAD:${FB_BRANCH}"
+            gh pr create --base "${STAMP_BRANCH}" --head "${FB_BRANCH}" \
+              --title "chore(release): ${TAG_NAME}" \
+              --body "Automated version stamp for release ${TAG_NAME}. [skip ci]"
+            gh pr merge --auto --squash "${FB_BRANCH}" \
+              || echo "::warning::auto-merge unavailable (allow_auto_merge=false?); PR left open for manual merge"
+          elif grep -qiE 'non-fast-forward|fetch first|tip of your current branch is behind' push_err.log; then
+            # The tag is behind the branch tip; the stamp would rewrite history.
+            # Skip it -- the HACS asset already carries the version, and we never
+            # force-push a maintenance branch.
+            echo "::notice::tag ${TAG_NAME} is behind ${STAMP_BRANCH}; branch stamp skipped (HACS asset already carries the version)"
+          else
+            echo "::error::push failed for a non-protection reason:"
+            cat push_err.log
+            exit 1
           fi
 
       - name: Rebuild and upload the HACS ZIP from the stamped tree

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,32 +74,78 @@ jobs:
           poetry run semantic-release --noop version
           poetry run semantic-release --noop changelog
 
-      - name: Propose next version and open a draft release
+      - name: Propose a version and open a draft release
         if: github.event.inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # The branch this workflow was dispatched on (main or an X.Y line).
-          # Passed via env indirection and used as the draft's --target so the
-          # eventual tag lands on THIS line, not on the repo default branch.
+          # Passed via env indirection and used only as the draft's --target so
+          # the eventual tag lands on THIS line, never as a hard-wired decision.
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          # --print only computes and prints the next version; it does not touch
-          # the working tree, tag, or publish (proposal only).
-          PROPOSED="$(poetry run semantic-release version --print)"
-          if [ -z "$PROPOSED" ]; then
-            echo "::error::semantic-release produced no version (is this a release branch matching branches.release?); no draft created"
-            exit 1
+
+          # --- Can semantic-release propose for THIS line? --------------------
+          # semantic-release only understands SemVer. This project's maintenance
+          # lines are tagged PEP 440 (beta `bN`, four-segment `.N`), which PSR
+          # silently skips -- so on those lines its "last release" view drifts
+          # from the real newest tag and any proposal derives from a stale base.
+          # Detect that branch-name-agnostically by comparing PSR's view with the
+          # real topological line tip. Fail-safe: on a false mismatch the
+          # maintainer just hand-tags; no wrong number is ever proposed/stamped.
+          # `|| true` keeps a semantic-release crash (e.g. a bad pyproject) from
+          # aborting here: an empty PSR_LAST just routes to the hand-tag draft
+          # (safe). Real PSR errors still surface loudly in the dry-run preview
+          # step above (`--noop version`), which is the diagnostic path.
+          REAL_TIP="$(git describe --tags --abbrev=0 HEAD 2>/dev/null || true)"
+          PSR_LAST="$(poetry run semantic-release version --print-last-released 2>/dev/null || true)"
+
+          MODE=propose
+          if [ -n "$REAL_TIP" ] && [ "$REAL_TIP" != "$PSR_LAST" ]; then
+            # PSR is blind to this line's tag scheme -> hand-tag draft.
+            MODE=hand
+            echo "::notice::semantic-release cannot propose for ${REF_NAME}: last-release view (${PSR_LAST:-none}) != real tip (${REAL_TIP}). Opening an empty hand-tag draft."
+          else
+            # --print prints the CURRENT version (not a new one) when no releasing
+            # commit exists since the last tag; guard against drafting a stale
+            # release for an already-released version.
+            PROPOSED="$(poetry run semantic-release version --print 2>/dev/null || true)"
+            if [ -z "$PROPOSED" ] || [ "$PROPOSED" = "$PSR_LAST" ]; then
+              echo "::notice::No release due on ${REF_NAME}: no releasing commits since ${PSR_LAST:-the last tag}. Nothing to draft."
+              exit 0
+            fi
           fi
-          echo "Proposed next version: $PROPOSED (target branch: $REF_NAME)"
-          # Open a DRAFT release the maintainer can edit (tag and/or notes) before
-          # publishing. --target pins the draft to the dispatched branch so the tag
-          # is created there (not on the default branch). GitHub generates starter
-          # notes; the maintainer refines them. Publishing the draft triggers
-          # release-stamp.yml to stamp the code.
-          if ! gh release create "$PROPOSED" --draft --target "$REF_NAME" \
-              --generate-notes --title "$PROPOSED"; then
-            echo "::error::gh release create failed (does a draft/tag '$PROPOSED' already exist?)"
-            exit 1
+
+          # --- Open the draft --------------------------------------------------
+          # A DRAFT release's tag is editable in the UI before publishing; the tag
+          # is only created when the draft is published, which fires
+          # release-stamp.yml (Workflow B) to stamp the code.
+          if [ "$MODE" = "propose" ]; then
+            echo "Proposed next version: $PROPOSED (target: $REF_NAME)"
+            if ! gh release create "$PROPOSED" --draft --target "$REF_NAME" \
+                --generate-notes --title "$PROPOSED"; then
+              echo "::error::gh release create failed (does a draft/release '$PROPOSED' already exist?)"
+              exit 1
+            fi
+            echo "Draft created for $PROPOSED on $REF_NAME. Edit and publish it to stamp the code."
+          else
+            # Hand-tag draft: a placeholder tag the maintainer replaces with the
+            # intended version (e.g. 1.7.14b1) before publishing. If published
+            # unchanged, release-stamp.yml's VERSION_RE guard rejects the
+            # placeholder, so a bad stamp can never land.
+            PLACEHOLDER="set-release-tag"
+            # Collision guard. A transient view error (auth/API) is treated as
+            # "absent" and falls through to `gh release create` below, which then
+            # surfaces its own error -- safe, never a silent wrong action.
+            if gh release view "$PLACEHOLDER" >/dev/null 2>&1; then
+              echo "::error::a '$PLACEHOLDER' draft already exists; publish or delete it, then re-run."
+              exit 1
+            fi
+            if ! gh release create "$PLACEHOLDER" --draft --target "$REF_NAME" \
+                --generate-notes \
+                --title "DRAFT - replace tag with your version (e.g. 1.7.14 or 1.7.14b1) before publishing"; then
+              echo "::error::gh release create failed for the hand-tag draft"
+              exit 1
+            fi
+            echo "Empty hand-tag draft created on $REF_NAME. Set the tag to your version and publish to stamp the code."
           fi
-          echo "Draft release created for proposed version $PROPOSED on $REF_NAME. Edit and publish it to stamp the code."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,36 @@
 name: Release
 
 on:
-  # Release is triggered manually via the Actions UI ("Run workflow"), which lets you
-  # pick the branch (main or any X.Y maintenance line) at run time -- no branch name
-  # is hard-wired here. semantic-release derives the version from git tags plus the
-  # Conventional Commits since the last tag, never from the branch name
-  # (see pyproject.toml [tool.semantic_release]).
+  # Workflow A of the "manual release -> code stamp" handshake.
+  #
+  # Triggered manually via the Actions UI ("Run workflow"), which lets you pick
+  # the branch (main or any X.Y maintenance line) at run time -- no branch name
+  # is hard-wired here. It only PROPOSES the next version and opens a DRAFT
+  # release; it never stamps code, tags, or publishes. semantic-release derives
+  # the proposed version from git tags plus the Conventional Commits since the
+  # last tag, never from the branch name (see pyproject.toml [tool.semantic_release]).
+  #
+  # The maintainer then edits the draft (tag and/or body) and publishes it. That
+  # publish fires release-stamp.yml (Workflow B), which writes the exact chosen
+  # tag into the three version literals. Nothing releases automatically.
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Dry run (no actual release)"
+        description: "Dry run (preview only, do not create a draft)"
         required: false
         default: "false"
         type: boolean
 
+# Least-privilege: contents:write is all that "gh release create --draft" and
+# the dry-run preview need. Publishing / PR work happens in release-stamp.yml.
 permissions:
   contents: write
-  issues: write
-  pull-requests: write
 
 jobs:
   release:
-    name: Semantic Release
+    name: Propose version and open draft release
     runs-on: ubuntu-latest
-    # Only run on main repo, not forks
+    # Only run on the maintainer forks, not on downstream forks.
     if: github.repository_owner == 'jleinenbach' || github.repository_owner == 'BSkando'
     concurrency:
       group: release
@@ -56,34 +63,43 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Semantic Release (dry run)
+      - name: Preview (dry run)
         if: github.event.inputs.dry_run == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          poetry run semantic-release version --noop
-          poetry run semantic-release changelog --noop
+          set -euo pipefail
+          # Global --noop MUST precede the subcommand in python-semantic-release
+          # v10 (`version --noop` / `changelog --noop` are not valid options).
+          poetry run semantic-release --noop version
+          poetry run semantic-release --noop changelog
 
-      - name: Semantic Release
+      - name: Propose next version and open a draft release
         if: github.event.inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The branch this workflow was dispatched on (main or an X.Y line).
+          # Passed via env indirection and used as the draft's --target so the
+          # eventual tag lands on THIS line, not on the repo default branch.
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          poetry run semantic-release version
-          poetry run semantic-release publish
-
-      - name: Create HACS ZIP asset
-        if: github.event.inputs.dry_run != 'true'
-        run: |
-          # Get the latest tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$LATEST_TAG" ]; then
-            echo "Creating ZIP for release $LATEST_TAG"
-            cd custom_components
-            zip -r ../googlefindmy.zip googlefindmy
-            cd ..
-            # Upload to the release if it exists
-            gh release upload "$LATEST_TAG" googlefindmy.zip --clobber || true
+          set -euo pipefail
+          # --print only computes and prints the next version; it does not touch
+          # the working tree, tag, or publish (proposal only).
+          PROPOSED="$(poetry run semantic-release version --print)"
+          if [ -z "$PROPOSED" ]; then
+            echo "::error::semantic-release produced no version (is this a release branch matching branches.release?); no draft created"
+            exit 1
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "Proposed next version: $PROPOSED (target branch: $REF_NAME)"
+          # Open a DRAFT release the maintainer can edit (tag and/or notes) before
+          # publishing. --target pins the draft to the dispatched branch so the tag
+          # is created there (not on the default branch). GitHub generates starter
+          # notes; the maintainer refines them. Publishing the draft triggers
+          # release-stamp.yml to stamp the code.
+          if ! gh release create "$PROPOSED" --draft --target "$REF_NAME" \
+              --generate-notes --title "$PROPOSED"; then
+            echo "::error::gh release create failed (does a draft/tag '$PROPOSED' already exist?)"
+            exit 1
+          fi
+          echo "Draft release created for proposed version $PROPOSED on $REF_NAME. Edit and publish it to stamp the code."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  # Release is triggered manually via the Actions UI ("Run workflow"), which lets you
+  # pick the branch (main or any X.Y maintenance line) at run time -- no branch name
+  # is hard-wired here. semantic-release derives the version from git tags plus the
+  # Conventional Commits since the last tag, never from the branch name
+  # (see pyproject.toml [tool.semantic_release]).
   workflow_dispatch:
     inputs:
       dry_run:

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -37,13 +37,17 @@ updates like the subentry unload reminder easy to place without scrolling throug
 The integration version lives in **three** places that MUST be bumped together on every release:
 `manifest.json` `"version"`, `const.py` `INTEGRATION_VERSION` (the latter feeds diagnostics,
 device `sw_version`, and logs), and `pyproject.toml` `[tool.poetry] version` (the distribution
-version; `semantic-release` rewrites it automatically on the `main` branch via
-`[tool.semantic_release] version_toml`, but on release branches such as `1.7` it must be bumped by
-hand alongside the other two — this is exactly how `pyproject.toml` silently drifted to `1.7.1`
-while the integration shipped `1.7.4`). `manifest.json` is strict JSON validated by hassfest, so it
-cannot carry an inline cross-reference comment or an extra key; this note is the canonical anchor for
-the manifest side. `const.py` and `pyproject.toml` carry reciprocal cross-reference comments naming
-the other two files. A release that bumps only some files ships an inconsistent version string.
+version). `semantic-release` now rewrites **all three** automatically on any release line
+(`main` and every `X.Y` maintenance branch, e.g. `1.7`) via `[tool.semantic_release] version_toml`
+(pyproject) plus `version_variables` (`const.py` + `manifest.json`); a manual three-file bump is
+only a fallback for out-of-band edits. Historically, before `version_variables` was wired up,
+`pyproject.toml` silently drifted to `1.7.1` while the integration shipped `1.7.4`. `manifest.json`
+is strict JSON validated by hassfest, so it cannot carry an inline cross-reference comment or an
+extra key; this note is the canonical anchor for the manifest side. `const.py` and `pyproject.toml`
+carry reciprocal cross-reference comments naming the other two files. Note: `const.py`'s
+`INTEGRATION_VERSION` deliberately has **no** `: str` annotation, because the `version_variables`
+regex matches `NAME = "x"` but not `NAME: str = "x"`; do not re-add the annotation.
+A release that bumps only some files ships an inconsistent version string.
 Before tagging a release, grep all three:
 `git grep -nE '"version"|INTEGRATION_VERSION|^version = ' custom_components/googlefindmy/manifest.json custom_components/googlefindmy/const.py pyproject.toml`.
 

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -23,11 +23,15 @@ DATA_EID_RESOLVER: Final[Literal["eid_resolver"]] = "eid_resolver"
 CONFIG_ENTRY_VERSION: int = 2
 # Integration version. MUST be bumped together with manifest.json "version" and
 # pyproject.toml [tool.poetry] version on every release; the three are a coupled
-# triple. manifest.json is strict JSON (hassfest-validated) and cannot carry this
-# cross-reference, so the manifest side is anchored in this directory's AGENTS.md
-# ("Version bump touches three files"). pyproject.toml carries the reverse reference
-# in a TOML comment.
-INTEGRATION_VERSION: str = "1.7.13"
+# triple, kept in sync automatically by semantic-release (pyproject.toml
+# [tool.semantic_release] version_variables). manifest.json is strict JSON
+# (hassfest-validated) and cannot carry this cross-reference, so the manifest side is
+# anchored in this directory's AGENTS.md ("Version bump touches three files").
+# pyproject.toml carries the reverse reference in a TOML comment.
+# NOTE: no ": str" annotation on purpose -- semantic-release's version_variables
+# regex only matches `NAME = "x"`, not `NAME: str = "x"`. Re-adding the annotation
+# would silently skip this file on the automated version bump.
+INTEGRATION_VERSION = "1.7.13"
 
 # --------------------------------------------------------------------------------------
 # Shared textual constants

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,7 @@
   "name": "Google Find My Device",
   "homeassistant": "2025.9.1",
   "content_in_root": false,
+  "zip_release": true,
+  "filename": "googlefindmy.zip",
   "render_readme": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,10 @@ name = "googlefindmy-ha"
 # Integration version: coupled triple. MUST be bumped together with
 # custom_components/googlefindmy/const.py INTEGRATION_VERSION and
 # custom_components/googlefindmy/manifest.json "version" on every release.
-# semantic-release manages this value on the `main` branch (see
-# [tool.semantic_release] version_toml below); on release branches it MUST be
-# bumped by hand alongside the other two. Canonical anchor:
+# semantic-release keeps all three in sync automatically on any release line
+# (main and every X.Y maintenance branch) via [tool.semantic_release] version_toml
+# + version_variables below; a manual three-file bump is only a fallback. Canonical
+# anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
 version = "1.7.13"
 description = "Home Assistant integration for Google's Find My Device network."
@@ -517,10 +518,26 @@ confidence = "low"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:tool.poetry.version"]
-branch = "main"
+# const.py and manifest.json are stamped via version_variables. NOTE: const.py's
+# INTEGRATION_VERSION carries NO type annotation on purpose -- the version_variables
+# regex only matches `NAME = "x"`, not `NAME: str = "x"` (a word token between the
+# name and `=` breaks the match). Do not re-add the annotation.
+version_variables = [
+    "custom_components/googlefindmy/const.py:INTEGRATION_VERSION",
+    "custom_components/googlefindmy/manifest.json:version",
+]
+# Release from any X.Y maintenance line (or main); no hard-wired branch name. The
+# version comes from the last matching git tag (tag_format) plus the Conventional
+# Commits since it, never from the branch name. tag_format has no `v` prefix, matching
+# the recent no-prefix tag convention rather than the ancient `v1.0.x` tags.
+tag_format = "{version}"
 upload_to_pypi = false
 upload_to_release = true
 build_command = "poetry build"
+
+[tool.semantic_release.branches.release]
+# Matches `main` AND any X.Y maintenance line (1.7, 1.8, ...) without naming one.
+match = "^(main|[0-9]+\\.[0-9]+)$"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]

--- a/script/stamp_version.py
+++ b/script/stamp_version.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# script/stamp_version.py
+"""Deterministically stamp a released version into the three version literals.
+
+This is the code-writing half of the "manual release -> code stamp" handshake
+(see .github/workflows/release-stamp.yml). It takes the *exact* version the
+maintainer published (``--version``, e.g. ``1.7.14`` or a beta ``1.7.14b1``)
+and writes it verbatim into the three places that must move together:
+
+* ``pyproject.toml``            -> ``[tool.poetry] version``
+* ``custom_components/googlefindmy/const.py`` -> ``INTEGRATION_VERSION`` (no
+  type annotation on purpose; ``version_variables`` and the guard tests both
+  require the annotationless ``NAME = "x"`` form)
+* ``custom_components/googlefindmy/manifest.json`` -> top-level ``"version"``
+
+It never *computes* a version (that is semantic-release's job in the proposal
+step) -- it only mirrors the tag the maintainer chose, so a hand-picked or beta
+tag is honoured exactly. Each substitution must hit exactly one literal; zero or
+multiple hits abort with a non-zero exit so a mis-anchored write can never land.
+
+Usage (preview the effect on a clean worktree, then inspect ``git diff``)::
+
+    python script/stamp_version.py --version 1.7.14
+    python script/stamp_version.py --version 1.7.14b1 --repo-root /path/to/repo
+
+The tag is validated against the ``tag_format = "{version}"`` convention
+(no ``v`` prefix): ``X.Y.Z`` with an optional ``bN``/``aN`` prerelease and an
+optional ``.N`` fourth segment (covers 1.7.14, 1.7.14b1, 1.7.9b1, 1.7.13.1).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+# Canonical tag/version shape (SSOT). tag_format = "{version}" means the git tag
+# IS the version, so a leading `v` is rejected. Mirrors the real tag set on 1.7.
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?(\.[0-9]+)?$")
+
+CONST_REL = "custom_components/googlefindmy/const.py"
+MANIFEST_REL = "custom_components/googlefindmy/manifest.json"
+PYPROJECT_REL = "pyproject.toml"
+
+
+class StampError(RuntimeError):
+    """Raised when a literal cannot be stamped exactly once."""
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _write(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def stamp_pyproject(text: str, version: str) -> str:
+    """Replace ``version = "..."`` inside the ``[tool.poetry]`` table only.
+
+    Table-scoped so a dependency spec or another table's ``version`` can never
+    be hit. Exactly one match is required.
+    """
+    lines = text.splitlines(keepends=True)
+    in_poetry = False
+    hits = 0
+    version_line = re.compile(r'^(version\s*=\s*)"[^"]*"(.*)$')
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_poetry = stripped == "[tool.poetry]"
+            continue
+        if in_poetry:
+            m = version_line.match(line)
+            if m:
+                lines[i] = f'{m.group(1)}"{version}"{m.group(2)}\n'
+                hits += 1
+    if hits != 1:
+        raise StampError(
+            f"{PYPROJECT_REL}: expected exactly 1 [tool.poetry] version line, "
+            f"found {hits}"
+        )
+    return "".join(lines)
+
+
+def stamp_const(text: str, version: str) -> str:
+    """Replace the annotationless ``INTEGRATION_VERSION`` literal, canonicalising.
+
+    The match is deliberately as permissive as the loosest guard test
+    (test_hypothesis_properties.py: flexible whitespace, single or double
+    quotes), so a valid-per-test const.py never makes the stamp fail. The
+    written form is always the canonical ``INTEGRATION_VERSION = "x"`` (single
+    spaces, double quotes) that test_hacs_validation.py requires -- so stamping
+    also normalises the literal and never re-introduces a type annotation.
+    """
+    pattern = re.compile(
+        r"""^INTEGRATION_VERSION\s*=\s*["'][^"']*["']\s*$""", re.MULTILINE
+    )
+    new_text, hits = pattern.subn(f'INTEGRATION_VERSION = "{version}"', text)
+    if hits != 1:
+        raise StampError(
+            f"{CONST_REL}: expected exactly 1 INTEGRATION_VERSION literal "
+            f'(form INTEGRATION_VERSION = "x"), found {hits}'
+        )
+    return new_text
+
+
+def stamp_manifest(text: str, version: str) -> str:
+    """Replace the top-level ``"version"`` value with a minimal one-line diff.
+
+    JSON is parsed to confirm a single top-level ``version`` key exists, then a
+    targeted regex rewrites only that value (avoids reordering/reformatting the
+    manifest, which hassfest is sensitive to). Exactly one match is required.
+    """
+    data = json.loads(text)
+    if not isinstance(data, dict) or "version" not in data:
+        raise StampError(f"{MANIFEST_REL}: no top-level 'version' key")
+    pattern = re.compile(r'("version"\s*:\s*)"[^"]*"')
+    new_text, hits = pattern.subn(rf'\g<1>"{version}"', text)
+    if hits != 1:
+        raise StampError(
+            f'{MANIFEST_REL}: expected exactly 1 "version" field, found {hits}'
+        )
+    # Cross-check: the rewritten value round-trips and equals the target.
+    if json.loads(new_text).get("version") != version:
+        raise StampError(f"{MANIFEST_REL}: post-stamp version mismatch")
+    return new_text
+
+
+def stamp_all(repo_root: Path, version: str) -> list[Path]:
+    """Stamp all three files. Returns the list of changed paths (sorted)."""
+    targets = {
+        repo_root / PYPROJECT_REL: stamp_pyproject,
+        repo_root / CONST_REL: stamp_const,
+        repo_root / MANIFEST_REL: stamp_manifest,
+    }
+    changed: list[Path] = []
+    for path, stamper in targets.items():
+        if not path.is_file():
+            raise StampError(f"{path}: file not found")
+        original = _read(path)
+        stamped = stamper(original, version)
+        if stamped != original:
+            _write(path, stamped)
+            changed.append(path)
+    return sorted(changed)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Stamp the exact released version into pyproject.toml, const.py and "
+            "manifest.json. Does not compute a version; mirrors --version verbatim."
+        )
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Exact version to stamp, e.g. 1.7.14 or 1.7.14b1 (no 'v' prefix).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: current working directory).",
+    )
+    args = parser.parse_args()
+
+    version = args.version.strip()
+    if not VERSION_RE.match(version):
+        parser.error(
+            f"version {version!r} violates tag_format='{{version}}'; expected "
+            "X.Y.Z with optional bN/aN and optional .N (no 'v' prefix)"
+        )
+
+    try:
+        changed = stamp_all(args.repo_root, version)
+    except StampError as exc:
+        print(f"stamp_version: ERROR: {exc}")
+        return 1
+
+    for path in changed:
+        print(f"stamped {path} -> {version}")
+    print(f"stamp_version: OK, {len(changed)} file(s) set to {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/stamp_version.py
+++ b/script/stamp_version.py
@@ -24,8 +24,10 @@ Usage (preview the effect on a clean worktree, then inspect ``git diff``)::
     python script/stamp_version.py --version 1.7.14b1 --repo-root /path/to/repo
 
 The tag is validated against the ``tag_format = "{version}"`` convention
-(no ``v`` prefix): ``X.Y.Z`` with an optional ``bN``/``aN`` prerelease and an
-optional ``.N`` fourth segment (covers 1.7.14, 1.7.14b1, 1.7.9b1, 1.7.13.1).
+(no ``v`` prefix): ``X.Y.Z`` with an optional ``.N`` fourth segment followed by
+an optional ``bN``/``aN`` prerelease (covers 1.7.14, 1.7.14b1, 1.7.13.1,
+1.7.13.1b1). The segment order is PEP 440: the numeric release tuple precedes
+the prerelease, so ``1.7.14.1b1`` is valid but ``1.7.14b1.1`` is not.
 """
 
 from __future__ import annotations
@@ -44,7 +46,7 @@ from pathlib import Path
 # of proposing a stale number; the stamp path here still honours the exact chosen
 # tag verbatim. The shell guard in release-stamp.yml MUST stay byte-equal to this
 # pattern (locked by tests/test_stamp_version.py).
-VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?(\.[0-9]+)?$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?([ab][0-9]+)?$")
 
 CONST_REL = "custom_components/googlefindmy/const.py"
 MANIFEST_REL = "custom_components/googlefindmy/manifest.json"
@@ -183,7 +185,8 @@ def main() -> int:
     if not VERSION_RE.match(version):
         parser.error(
             f"version {version!r} violates tag_format='{{version}}'; expected "
-            "X.Y.Z with optional bN/aN and optional .N (no 'v' prefix)"
+            "X.Y.Z[.N][bN] (optional .N fourth segment then optional bN/aN, "
+            "no 'v' prefix)"
         )
 
     try:

--- a/script/stamp_version.py
+++ b/script/stamp_version.py
@@ -36,7 +36,14 @@ import re
 from pathlib import Path
 
 # Canonical tag/version shape (SSOT). tag_format = "{version}" means the git tag
-# IS the version, so a leading `v` is rejected. Mirrors the real tag set on 1.7.
+# IS the version, so a leading `v` is rejected. Mirrors the real tag set on 1.7,
+# which is PEP 440 (`bN`/`aN` betas, four-segment `.N`) -- deliberately broader
+# than SemVer so hand-picked maintenance tags stamp cleanly. Consequence:
+# semantic-release (SemVer-only) cannot compute a trustworthy *proposal* for such
+# lines, so release.yml (Workflow A) opens an empty hand-tag draft there instead
+# of proposing a stale number; the stamp path here still honours the exact chosen
+# tag verbatim. The shell guard in release-stamp.yml MUST stay byte-equal to this
+# pattern (locked by tests/test_stamp_version.py).
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+([ab][0-9]+)?(\.[0-9]+)?$")
 
 CONST_REL = "custom_components/googlefindmy/const.py"
@@ -93,9 +100,14 @@ def stamp_const(text: str, version: str) -> str:
     written form is always the canonical ``INTEGRATION_VERSION = "x"`` (single
     spaces, double quotes) that test_hacs_validation.py requires -- so stamping
     also normalises the literal and never re-introduces a type annotation.
+
+    The trailing match is ``[ \\t]*$`` (horizontal whitespace only), not
+    ``\\s*$``: a greedy ``\\s*$`` would also swallow the newline(s) after the
+    literal and delete the blank line that follows it in const.py on every
+    stamp. Restricting to spaces/tabs keeps the surrounding layout intact.
     """
     pattern = re.compile(
-        r"""^INTEGRATION_VERSION\s*=\s*["'][^"']*["']\s*$""", re.MULTILINE
+        r"""^INTEGRATION_VERSION\s*=\s*["'][^"']*["'][ \t]*$""", re.MULTILINE
     )
     new_text, hits = pattern.subn(f'INTEGRATION_VERSION = "{version}"', text)
     if hits != 1:

--- a/tests/test_hacs_validation.py
+++ b/tests/test_hacs_validation.py
@@ -63,3 +63,52 @@ def test_no_micro_sign_in_integration_files(
         if "\u00b5" in text:
             offenders.append(str(path.relative_to(integration_root)))
     assert not offenders, f"micro sign detected in: {offenders}"
+
+
+def test_hacs_zip_release_declares_filename(
+    hacs_metadata: dict[str, object],
+) -> None:
+    """When zip_release is enabled, a ``.zip`` release asset must be declared.
+
+    HACS then installs that asset instead of the git source archive, so the
+    version-stamped ZIP built by release-stamp.yml actually reaches users. The
+    two only line up if hacs.json names the asset; guard that here.
+    """
+
+    if hacs_metadata.get("zip_release"):
+        filename = hacs_metadata.get("filename")
+        assert isinstance(filename, str) and filename.endswith(".zip"), (
+            "zip_release=true requires a '.zip' 'filename' entry in hacs.json"
+        )
+
+
+def test_release_zip_places_manifest_at_root() -> None:
+    """release-stamp.yml must zip the domain *contents*, not the domain dir.
+
+    With zip_release=true HACS extracts the asset straight into
+    ``custom_components/googlefindmy/`` (verified against HACS ``extractall``
+    semantics), so ``manifest.json`` has to sit at the ZIP root. Building the ZIP
+    from the parent (``zip -r ../googlefindmy.zip googlefindmy``) nests it one
+    level too deep and hides the integration -- a broken install for everyone.
+    This guard locks the fixed ``cd <domain> && zip . `` form so the regression
+    cannot silently return.
+    """
+
+    workflow = Path(".github/workflows/release-stamp.yml").read_text(encoding="utf-8")
+    filename = json.loads(Path("hacs.json").read_text(encoding="utf-8")).get("filename")
+    assert filename, "hacs.json must declare the release asset filename"
+    assert "cd custom_components/googlefindmy" in workflow, (
+        "ZIP must be built from inside the integration domain directory"
+    )
+    assert f"zip -r ../../{filename} ." in workflow, (
+        f"ZIP step must run 'zip -r ../../{filename} .' from the domain dir "
+        "so the asset root is the domain root"
+    )
+    # Regression guard: the pre-fix form nested the domain dir inside the asset.
+    assert "zip -r ../googlefindmy.zip googlefindmy" not in workflow, (
+        "found the pre-fix ZIP form that nests custom_components/googlefindmy/ "
+        "inside the asset (breaks the HACS install)"
+    )
+    assert f'gh release upload "$TAG_NAME" {filename} --clobber' in workflow, (
+        f"workflow must upload the declared hacs.json asset name {filename!r}"
+    )

--- a/tests/test_hacs_validation.py
+++ b/tests/test_hacs_validation.py
@@ -43,8 +43,11 @@ def test_hacs_metadata_matches_manifest(
     assert hacs_metadata["name"] == manifest["name"]
 
     const_text = (integration_root / "const.py").read_text(encoding="utf-8")
-    match = re.search(r'INTEGRATION_VERSION: str = "([^"]+)"', const_text)
-    assert match, "INTEGRATION_VERSION constant missing"
+    # No type annotation: semantic-release's version_variables regex only matches
+    # `NAME = "x"`, not `NAME: str = "x"` (see const.py / AGENTS.md). This pattern
+    # therefore doubles as a guard against re-introducing the annotation.
+    match = re.search(r'INTEGRATION_VERSION = "([^"]+)"', const_text)
+    assert match, "INTEGRATION_VERSION constant missing (or has a type annotation)"
     assert manifest["version"] == INTEGRATION_VERSION == match.group(1)
     assert "homeassistant" not in manifest
 

--- a/tests/test_hypothesis_properties.py
+++ b/tests/test_hypothesis_properties.py
@@ -306,8 +306,10 @@ def test_integration_version_matches_manifest() -> None:
 
     # Extract version from const.py
     const_content = const_path.read_text()
+    # No type annotation on purpose: semantic-release's version_variables regex only
+    # matches `NAME = "x"`, not `NAME: str = "x"` (see const.py / AGENTS.md).
     const_match = re.search(
-        r'INTEGRATION_VERSION:\s*str\s*=\s*["\']([^"\']+)["\']', const_content
+        r'INTEGRATION_VERSION\s*=\s*["\']([^"\']+)["\']', const_content
     )
     assert const_match, "INTEGRATION_VERSION not found in const.py"
     const_version = const_match.group(1)

--- a/tests/test_stamp_version.py
+++ b/tests/test_stamp_version.py
@@ -166,7 +166,8 @@ def test_workflow_guard_regex_matches_version_re() -> None:
     wf = (_REPO_ROOT / ".github/workflows/release-stamp.yml").read_text(
         encoding="utf-8"
     )
-    # The workflow also carries a 40-hex SHA guard; pick the version-shaped one.
+    # The push step also greps to classify errors, but only with ``-qiE``/``-qxF``;
+    # pick the sole ``grep -qE`` carrying a ``^[0-9]`` version-shaped pattern.
     patterns = re.findall(r"grep -qE '([^']+)'", wf)
     tag_patterns = [p for p in patterns if p.startswith(r"^[0-9]+\.")]
     assert len(tag_patterns) == 1, (
@@ -174,4 +175,37 @@ def test_workflow_guard_regex_matches_version_re() -> None:
     )
     assert tag_patterns[0] == VERSION_RE.pattern, (
         f"guard drift: workflow {tag_patterns[0]!r} != VERSION_RE {VERSION_RE.pattern!r}"
+    )
+
+
+# --- Tag-vs-branch: checkout must pin the published tag ---------------------
+
+
+def test_workflow_checks_out_published_tag() -> None:
+    """The stamp workflow must check out the published TAG, not target_commitish.
+
+    GitHub documents ``release.target_commitish`` as unused once the git tag
+    already exists -- it then defaults to the repo default branch, which only
+    coincidentally equals the maintenance line on some forks. Checking that out
+    would stamp and package the wrong branch. Pinning ``tag_name`` guarantees the
+    stamped tree and the uploaded HACS ZIP always match the exact published
+    commit. Regression guard for the tag-vs-branch confusion
+    (CA-WORKFLOW-EVENT-PAYLOAD-CONTRACT-001).
+    """
+    wf = (_REPO_ROOT / ".github/workflows/release-stamp.yml").read_text(
+        encoding="utf-8"
+    )
+    # The checkout ref must reference the published tag ...
+    assert "ref: ${{ github.event.release.tag_name }}" in wf, (
+        "checkout step must pin the published tag as ref"
+    )
+    # ... and never the stale target_commitish.
+    assert "ref: ${{ github.event.release.target_commitish }}" not in wf, (
+        "checkout must not use target_commitish (stale for pre-existing tags)"
+    )
+    # The stamp push must resolve the owning branch from the tag commit, so a
+    # stale/wrong target_commitish cannot send the stamp to the wrong branch.
+    assert "git branch -r --contains" in wf, (
+        "stamp push must resolve the owning branch from the tag commit, "
+        "not trust the stale target_commitish"
     )

--- a/tests/test_stamp_version.py
+++ b/tests/test_stamp_version.py
@@ -209,3 +209,12 @@ def test_workflow_checks_out_published_tag() -> None:
         "stamp push must resolve the owning branch from the tag commit, "
         "not trust the stale target_commitish"
     )
+    # The resolution must NOT fall back to the stale event hint as a tiebreaker:
+    # when the tag sits on several branches (e.g. main + 1.7 on a non-diverged
+    # maintenance line) the stale target_commitish could steer the stamp to the
+    # wrong branch. Only an unambiguous single owner is stamped; zero or several
+    # owners skip safely (CA-WORKFLOW-EVENT-PAYLOAD-CONTRACT-001).
+    assert "TARGET_BRANCH" not in wf, (
+        "branch resolution must not use the stale target_commitish hint at all; "
+        "the tiebreaker could pick the wrong branch when the tag has several owners"
+    )

--- a/tests/test_stamp_version.py
+++ b/tests/test_stamp_version.py
@@ -1,0 +1,175 @@
+# tests/test_stamp_version.py
+"""Regression tests for ``script/stamp_version.py`` (the release-stamp writer).
+
+Covers three things the code-architekt review flagged as unguarded (Z1/Z2):
+
+* ``VERSION_RE`` against the *real* 1.7 tag matrix -- plain SemVer releases plus
+  the PEP 440 forms the maintainer actually uses (beta ``bN``, four-segment
+  ``.N``) -- and the invalid forms that must be rejected (``v`` prefix, the
+  Workflow-A hand-tag placeholder, ``rc`` prereleases, etc.).
+* the three per-file stampers: exact-one-hit accounting, table/key scoping so a
+  dependency spec or sibling key is never touched, and const canonicalisation.
+* a byte-parity guard between ``VERSION_RE`` and the shell regex mirrored in
+  ``.github/workflows/release-stamp.yml`` -- so the two guards can never drift
+  apart silently.
+
+The suite is CI-authoritative: ``tests/conftest.py`` hard-requires the real
+``homeassistant`` package at collection time, so it is not locally collectable
+without it. The stamp logic itself is pure stdlib and imported directly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from script.stamp_version import (  # noqa: E402  (path bootstrap must precede import)
+    VERSION_RE,
+    StampError,
+    stamp_const,
+    stamp_manifest,
+    stamp_pyproject,
+)
+
+# --- VERSION_RE: the real tag matrix on the 1.7 line -----------------------
+
+VALID_TAGS = [
+    "1.7.14",  # plain SemVer patch release
+    "1.7.9",  # plain SemVer
+    "1.8.0",  # plain SemVer minor
+    "1.7.14b1",  # PEP 440 beta (maintainer's hand-tag scheme)
+    "1.7.9b1",  # PEP 440 beta
+    "1.7.13b2",  # PEP 440 beta, real tag on 1.7
+    "1.7.14a1",  # PEP 440 alpha
+    "1.7.13.1",  # four-segment maintenance tag, real tag on 1.7
+    "1.7.13.0",  # four-segment maintenance tag
+]
+
+INVALID_TAGS = [
+    "v1.7.14",  # leading v prefix violates tag_format = "{version}"
+    "1.7",  # too few segments
+    "1.7.14-rc1",  # SemVer-style prerelease, not this scheme
+    "1.7.14rc1",  # rc is not in the [ab] prerelease set
+    "1.7.14.1.2",  # five segments
+    "1.7.14 ",  # trailing whitespace
+    " 1.7.14",  # leading whitespace
+    "",  # empty
+    "set-release-tag",  # Workflow A hand-mode placeholder MUST be rejected
+]
+
+
+@pytest.mark.parametrize("tag", VALID_TAGS)
+def test_version_re_accepts_real_tags(tag: str) -> None:
+    assert VERSION_RE.match(tag), f"{tag!r} should be accepted by VERSION_RE"
+
+
+@pytest.mark.parametrize("tag", INVALID_TAGS)
+def test_version_re_rejects_bad_tags(tag: str) -> None:
+    assert not VERSION_RE.match(tag), f"{tag!r} should be rejected by VERSION_RE"
+
+
+# --- stamp_pyproject: [tool.poetry] table scoping --------------------------
+
+
+def test_stamp_pyproject_hits_only_tool_poetry() -> None:
+    text = (
+        "[tool.poetry]\n"
+        'version = "1.7.13"\n'
+        'name = "x"\n'
+        "\n"
+        "[tool.poetry.dependencies]\n"
+        'somelib = { version = "2.0.0" }\n'
+        "\n"
+        "[tool.other]\n"
+        'version = "9.9.9"\n'
+    )
+    out = stamp_pyproject(text, "1.7.14b1")
+    assert 'version = "1.7.14b1"' in out
+    # Dependency spec and the unrelated table are untouched.
+    assert 'somelib = { version = "2.0.0" }' in out
+    assert 'version = "9.9.9"' in out
+    # Exactly one literal changed.
+    assert out.count('"1.7.14b1"') == 1
+
+
+def test_stamp_pyproject_zero_hits_raises() -> None:
+    with pytest.raises(StampError):
+        stamp_pyproject('[tool.other]\nversion = "1.0.0"\n', "1.7.14")
+
+
+# --- stamp_const: annotationless literal, canonicalisation -----------------
+
+
+def test_stamp_const_canonicalises_loose_form() -> None:
+    # Loosest guard-valid form: single quotes and extra whitespace.
+    text = "INTEGRATION_VERSION  =  '1.7.13'\n"
+    out = stamp_const(text, "1.7.14b1")
+    # Written form is always the canonical double-quote single-space shape.
+    assert out == 'INTEGRATION_VERSION = "1.7.14b1"\n'
+
+
+def test_stamp_const_double_quote_form() -> None:
+    text = 'INTEGRATION_VERSION = "1.7.13"\n'
+    assert stamp_const(text, "1.7.14") == 'INTEGRATION_VERSION = "1.7.14"\n'
+
+
+def test_stamp_const_preserves_following_blank_line() -> None:
+    # Mirrors the real const.py layout: the literal is followed by a blank line.
+    # A greedy `\s*$` match would swallow that newline and delete the blank line
+    # on every stamp; the horizontal-whitespace match must leave it intact.
+    text = 'INTEGRATION_VERSION = "1.7.13"\n\n# next section\n'
+    out = stamp_const(text, "1.7.14")
+    assert out == 'INTEGRATION_VERSION = "1.7.14"\n\n# next section\n'
+
+
+def test_stamp_const_zero_hits_raises() -> None:
+    with pytest.raises(StampError):
+        stamp_const("OTHER = 1\n", "1.7.14")
+
+
+# --- stamp_manifest: single top-level "version" ----------------------------
+
+
+def test_stamp_manifest_replaces_only_version() -> None:
+    text = '{\n  "domain": "googlefindmy",\n  "version": "1.7.13",\n  "name": "x"\n}\n'
+    out = stamp_manifest(text, "1.7.14b1")
+    parsed = json.loads(out)
+    assert parsed["version"] == "1.7.14b1"
+    assert parsed["domain"] == "googlefindmy"  # untouched
+
+
+def test_stamp_manifest_no_version_key_raises() -> None:
+    with pytest.raises(StampError):
+        stamp_manifest('{"domain": "x"}', "1.7.14")
+
+
+# --- Z2: byte-parity between VERSION_RE and the shell guard -----------------
+
+
+def test_workflow_guard_regex_matches_version_re() -> None:
+    """release-stamp.yml's tag guard must mirror VERSION_RE byte-for-byte.
+
+    The two live in different languages (Python ``re`` vs POSIX ERE via
+    ``grep -qE``) but are kept textually identical so a change to one without
+    the other is caught here instead of at release time.
+    """
+    wf = (_REPO_ROOT / ".github/workflows/release-stamp.yml").read_text(
+        encoding="utf-8"
+    )
+    # The workflow also carries a 40-hex SHA guard; pick the version-shaped one.
+    patterns = re.findall(r"grep -qE '([^']+)'", wf)
+    tag_patterns = [p for p in patterns if p.startswith(r"^[0-9]+\.")]
+    assert len(tag_patterns) == 1, (
+        f"expected exactly one tag guard, found {tag_patterns}"
+    )
+    assert tag_patterns[0] == VERSION_RE.pattern, (
+        f"guard drift: workflow {tag_patterns[0]!r} != VERSION_RE {VERSION_RE.pattern!r}"
+    )

--- a/tests/test_stamp_version.py
+++ b/tests/test_stamp_version.py
@@ -51,6 +51,7 @@ VALID_TAGS = [
     "1.7.14a1",  # PEP 440 alpha
     "1.7.13.1",  # four-segment maintenance tag, real tag on 1.7
     "1.7.13.0",  # four-segment maintenance tag
+    "1.7.14.1b1",  # PEP 440 order: four-segment release THEN prerelease
 ]
 
 INVALID_TAGS = [
@@ -59,6 +60,7 @@ INVALID_TAGS = [
     "1.7.14-rc1",  # SemVer-style prerelease, not this scheme
     "1.7.14rc1",  # rc is not in the [ab] prerelease set
     "1.7.14.1.2",  # five segments
+    "1.7.14b1.1",  # prerelease before the fourth segment (not PEP 440 order)
     "1.7.14 ",  # trailing whitespace
     " 1.7.14",  # leading whitespace
     "",  # empty


### PR DESCRIPTION
## What

Make `python-semantic-release` (PSR 10.6.1) release **branch-independently** without a hard-wired branch name, and make a single release stamp **all three** coupled version literals in sync.

Today the version lives in three coupled places (`pyproject.toml` `[tool.poetry] version`, `custom_components/googlefindmy/const.py` `INTEGRATION_VERSION`, `custom_components/googlefindmy/manifest.json` `"version"`), but the PSR config only manages the first one and is pinned to `branch = "main"`, so releases from the `1.7` maintenance line are unmanaged and the three files drift by hand.

## Changes

- **`pyproject.toml` `[tool.semantic_release]`**
  - Replace the v7-style `branch = "main"` with a PSR 10 branch group `[tool.semantic_release.branches.release]` whose `match = "^(main|[0-9]+\.[0-9]+)$"` accepts `main` **and any `X.Y` maintenance line** without naming a single branch.
  - Add `tag_format = "{version}"`. The default `v{version}` only matched the ancient `v1.0.x` tags and computed a wrong `1.1.0`; the no-prefix format anchors on the recent tag convention (e.g. `1.7.13.1`).
  - Add `version_variables` for `const.py:INTEGRATION_VERSION` and `manifest.json:version` so one release stamps all three files.
- **`const.py`**: drop the `: str` annotation on `INTEGRATION_VERSION`. PSR's `version_variables` regex (`\s*(:=|==|[:=@ ])\s*`, see `declarations/pattern.py`) cannot match `NAME: str = "x"` (a word token between the name and `=`). A comment documents why the annotation must not be re-added.
- **`release.yml`**: make the trigger `workflow_dispatch`-only. The manual "Run workflow" button lets you pick the branch at run time, so no branch name is hard-wired in the trigger, and merges no longer risk an accidental release. (The old `push: branches: [main]` auto-trigger was effectively dead, since releases are cut from `1.7`, not `main`.)
- **`AGENTS.md`** + reciprocal comments: updated to describe the automated three-file sync instead of "bump by hand on release branches".

## Version source is the tag, not the branch

PSR derives the next version from the last matching git tag plus the Conventional Commits since it, read from `HEAD` at run time. Nothing encodes a branch name in the version. Release from `1.7`, `1.8`, or `main` and each line counts from its own tag.

## Proof (`--noop`, PSR 10.6.1, against this exact diff)

On an `X.Y` branch carrying this config:

```
INFO  Using group 'release' options
The next version is: 1.8.0!
```

A `semantic-release version --no-commit --no-tag --no-push` run stamps exactly three files to the same version:

```
 custom_components/googlefindmy/const.py
 custom_components/googlefindmy/manifest.json
 pyproject.toml
```

(Next version is `1.8.0` because a `feat(cache):` commit has landed since `1.7.13`; that is the Conventional-Commits semantics, driven by commit type, not by this PR.)

## Notes

- No production code changes; config, docs, and two guard tests only. `INTEGRATION_VERSION` stays a frozen string literal in `const.py`, so `_async_check_restart_required` (in-memory vs. on-disk manifest comparison) is unaffected.
- Two source-parsing guard tests (`test_hacs_validation`, `test_hypothesis_properties`) hard-coded the annotated form `INTEGRATION_VERSION: str = "..."`; they are updated to the annotation-free form and now double as a guard against re-introducing the annotation (which would silently break the automated stamp).
- Not addressed here (out of scope): the `changelog.changelog_file` deprecation warning and normalizing the historical inconsistent tag prefixes.
