### PR TITLE
fix(cache): defer round-trip anchor mutation past significance gate (Fund A) + release-tip VERSION_RE guard (Fund B)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,17 @@ jobs:
           # (safe). Real PSR errors still surface loudly in the dry-run preview
           # step above (`--noop version`), which is the diagnostic path.
           REAL_TIP="$(git describe --tags --abbrev=0 HEAD 2>/dev/null || true)"
+          # Gate REAL_TIP against the canonical PEP 440 version shape (SSOT:
+          # script/stamp_version.py VERSION_RE, byte-mirrored in release-stamp.yml).
+          # A foreign, non-version tag (e.g. `set-release-tag`, `nightly`, `v2`)
+          # is not a valid line tip: it must NOT poison the PSR_LAST != REAL_TIP
+          # comparison below and spuriously route to the hand-tag draft. PEP 440
+          # beta/four-segment tags DO match VERSION_RE, so they are kept and still
+          # trigger MODE=hand on a real stale-base mismatch -- the intended guard.
+          if [ -n "$REAL_TIP" ] && ! printf '%s' "$REAL_TIP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?([ab][0-9]+)?$'; then
+            echo "::notice::ignoring non-PEP-440 line tip '${REAL_TIP}' for PSR routing (not a version tag)."
+            REAL_TIP=""
+          fi
           PSR_LAST="$(poetry run semantic-release version --print-last-released 2>/dev/null || true)"
 
           MODE=propose

--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -483,6 +483,13 @@ class CacheOperations(_MixinBase):
         # this payload (early return @512), the anchor is intentionally NOT
         # touched (F-CODEX-7): a discarded own-report must not invalidate it.
         supersede_anchor = bool(slot.pop("_supersede_round_trip_anchor", False))
+        # Same deferral discipline for the round-trip anchor consume/seed intents
+        # set mid-fusion: pop them HERE (before sanitize/merge/commit) so they never
+        # leak into the cached row, and apply them only AFTER the payload commits
+        # (post-@580). A payload the significance gate rejects (early return @512)
+        # thus never consumes or seeds an anchor - the ordering fix (Fund A).
+        anchor_seed = slot.pop("_round_trip_anchor_seed", None)
+        anchor_consume = bool(slot.pop("_round_trip_anchor_consume", False))
 
         status = slot.get("status")
 
@@ -594,6 +601,25 @@ class CacheOperations(_MixinBase):
             _anchors = getattr(self, "_round_trip_anchors", None)
             if _anchors:
                 _anchors.pop(device_id, None)
+
+        # Round-trip anchor consume/seed (Fund A, ordering-vs-commit): applied here
+        # POST-commit and POST-significance-gate, symmetric to the supersede pop
+        # above. Consume and seed are mutually exclusive per report: the recovery
+        # path leaves the fusion via ``return True`` (only sets consume), while the
+        # accept path seeds and leaves via its own ``return True`` (only sets seed).
+        # So at most one of the two markers is ever present on a committed payload.
+        if anchor_consume and self._round_trip_confirm_enabled():
+            _anchors = getattr(self, "_round_trip_anchors", None)
+            if _anchors:
+                _anchors.pop(device_id, None)
+        if anchor_seed is not None and self._round_trip_confirm_enabled():
+            # Lazy-init mirroring _record_last_good_location so a __new__-built
+            # coordinator needs no extra wiring (moved here from the fusion).
+            _anchors = getattr(self, "_round_trip_anchors", None)
+            if _anchors is None:
+                _anchors = {}
+                self._round_trip_anchors = _anchors
+            _anchors[device_id] = anchor_seed
 
         # FIX #155: Only count background_updates for non-poll sources
         # to avoid double-counting with polled_updates.
@@ -1147,7 +1173,15 @@ class CacheOperations(_MixinBase):
                                         # recovered fix leaves via THIS return, not
                                         # the accept-path return below, so it never
                                         # sets a new anchor of its own.
-                                        anchors.pop(device_id, None)
+                                        # F-CODEX-7/ordering: defer the store
+                                        # mutation. Mutating _round_trip_anchors here
+                                        # (mid-fusion) consumes the anchor BEFORE the
+                                        # significance gate/commit; a payload the
+                                        # gate later rejects (early return @512) would
+                                        # then have burnt the anchor. Mark the intent
+                                        # on new_data and pop the anchor only AFTER
+                                        # the commit (mirrors _supersede handling).
+                                        new_data["_round_trip_anchor_consume"] = True
                                         self.increment_stat("round_trip_recoveries")
                                         _LOGGER.debug(
                                             "Round-trip recovery %s: returned "
@@ -1219,13 +1253,16 @@ class CacheOperations(_MixinBase):
                         if self._round_trip_confirm_enabled() and is_reliable_fix(
                             existing
                         ):
-                            # Lazy-init mirroring _record_last_good_location so a
-                            # __new__-built coordinator needs no extra wiring.
-                            anchors = getattr(self, "_round_trip_anchors", None)
-                            if anchors is None:
-                                anchors = {}
-                                self._round_trip_anchors = anchors
-                            anchors[device_id] = {
+                            # F-CODEX-7/ordering: defer the store mutation. Seeding
+                            # the anchor here (mid-fusion) writes _round_trip_anchors
+                            # BEFORE the significance gate/commit; a payload the gate
+                            # later rejects (early return @512) would then leave a
+                            # phantom anchor behind. Mark the intent on new_data and
+                            # let update_device_cache lazy-init the store and seed the
+                            # anchor only AFTER the commit (mirrors _supersede). The
+                            # anchored COORDINATES stay A's (existing_lat/lon); ts is
+                            # new_ts per the F-CODEX-5 TTL-clock reasoning above.
+                            new_data["_round_trip_anchor_seed"] = {
                                 "lat": existing_lat,
                                 "lon": existing_lon,
                                 "ts": new_ts,

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1966,6 +1966,15 @@ class PollingOperations(_MixinBase):
                             # action; production always routes through
                             # update_device_cache, which does.
                             location.pop("_supersede_round_trip_anchor", None)
+                            # Fund A: same hygiene for the deferred round-trip anchor
+                            # consume/seed markers. Semantic divergence vs. the real
+                            # update_device_cache path: production pops AND applies
+                            # these post-commit (consume/seed the anchor); this
+                            # test-double fallback only strips them so they cannot
+                            # leak into the cached row, and intentionally performs no
+                            # anchor mutation.
+                            location.pop("_round_trip_anchor_seed", None)
+                            location.pop("_round_trip_anchor_consume", None)
                             location.pop("_report_hint", None)
                             location.setdefault("last_updated", wall_now)
                             merged_location = self._merge_with_existing_cache_row(

--- a/tests/test_cache_round_trip.py
+++ b/tests/test_cache_round_trip.py
@@ -19,6 +19,7 @@ These tests mirror the harness of ``test_cache_speed_gate.py``: a
 
 from __future__ import annotations
 
+import time
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -105,13 +106,16 @@ def test_far_jump_accept_sets_anchor() -> None:
     coord = _coord(_fix(HOME, last_seen=BASE_TS))
     # dt = 3 h -> implied speed ~23 m/s -> plausible -> accepted (not gated).
     b_ts = BASE_TS + 3 * 3600
-    result = _fuse(coord, _fix(FAR, last_seen=b_ts, acc=50.0))
+    nd = _fix(FAR, last_seen=b_ts, acc=50.0)
+    result = _fuse(coord, nd)
     assert result is True
-    assert coord._round_trip_anchors["dev"] == {
+    # Fund A: store mutation deferred to update_device_cache; assert the intent marker
+    assert nd["_round_trip_anchor_seed"] == {
         "lat": HOME[0],
         "lon": HOME[1],
         "ts": float(b_ts),
     }
+    assert "dev" not in coord._round_trip_anchors  # store untouched by unbound fusion
 
 
 def test_stale_offline_jump_then_return_recovers() -> None:
@@ -127,15 +131,24 @@ def test_stale_offline_jump_then_return_recovers() -> None:
     b_ts = BASE_TS + 3 * 3600  # B seen 3 h after A's (stale) last_seen
     coord = _coord(_fix(HOME, last_seen=BASE_TS, acc=50.0))
     # A->B accepted (low implied speed over 3 h) -> A remembered as anchor.
-    assert _fuse(coord, _fix(FAR, last_seen=b_ts, acc=50.0)) is True
+    seed_nd = _fix(FAR, last_seen=b_ts, acc=50.0)
+    assert _fuse(coord, seed_nd) is True
+    # Fund A: store mutation deferred to update_device_cache; assert the intent marker.
     # Anchor ts is the accept time (B), not A's stale last_seen.
-    assert coord._round_trip_anchors["dev"]["ts"] == float(b_ts)
+    assert seed_nd["_round_trip_anchor_seed"]["ts"] == float(b_ts)
+    # The unbound fusion does not seed the store; for the recovery step to read the
+    # anchor, apply the deferred seed manually (stands in for update_device_cache).
+    coord._round_trip_anchors["dev"] = seed_nd["_round_trip_anchor_seed"]
     # The device now sits at B; a correction back near A arrives 300 s after B
     # (well within the 900 s TTL) but is a kinematic teleport B->A -> recover.
     coord._device_location_data["dev"] = _fix(FAR, last_seen=b_ts)
-    result = _fuse(coord, _fix(HOME, last_seen=b_ts + 300, acc=50.0))
+    return_nd = _fix(HOME, last_seen=b_ts + 300, acc=50.0)
+    result = _fuse(coord, return_nd)
     assert result is True
-    assert "dev" not in coord._round_trip_anchors  # one-shot consumed
+    # Fund A: consume is deferred; the intent marker is set and the anchor survives
+    # the unbound fusion (update_device_cache would pop it post-commit).
+    assert return_nd["_round_trip_anchor_consume"] is True
+    assert "dev" in coord._round_trip_anchors  # not popped by unbound fusion
 
 
 def test_anchor_not_set_for_estimated_existing() -> None:
@@ -236,10 +249,14 @@ def test_return_within_radius_recovers() -> None:
     coord = _coord(_fix(FAR, last_seen=BASE_TS), anchors=anchors)
     # existing is B (FAR); a fix back at A (HOME) 5 min later would be gated
     # (~833 m/s) but lands on the anchor -> recovered.
-    result = _fuse(coord, _fix(HOME, last_seen=BASE_TS + 300, acc=50.0))
+    nd = _fix(HOME, last_seen=BASE_TS + 300, acc=50.0)
+    result = _fuse(coord, nd)
     assert result is True
     coord.increment_stat.assert_called_once_with("round_trip_recoveries")
-    assert "dev" not in coord._round_trip_anchors  # one-shot consumed
+    # Fund A: store mutation deferred to update_device_cache; assert the intent marker.
+    # The consume is deferred, so the anchor survives the unbound fusion.
+    assert nd["_round_trip_anchor_consume"] is True
+    assert "dev" in coord._round_trip_anchors  # not popped by unbound fusion
 
 
 def test_return_just_inside_200m_recovers() -> None:
@@ -273,10 +290,14 @@ def test_recovery_does_not_reset_anchor() -> None:
     """A recovered return fix sets no new anchor (DF-1 ping-pong bollwerk)."""
     anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(BASE_TS)}}
     coord = _coord(_fix(FAR, last_seen=BASE_TS), anchors=anchors)
-    result = _fuse(coord, _fix(HOME, last_seen=BASE_TS + 300, acc=50.0))
+    nd = _fix(HOME, last_seen=BASE_TS + 300, acc=50.0)
+    result = _fuse(coord, nd)
     assert result is True
-    # Anchor consumed and NOT replaced by a fresh one for the returning fix.
-    assert coord._round_trip_anchors == {}
+    # Fund A: store mutation deferred to update_device_cache; assert the intent marker.
+    # The returning fix marks a consume (one-shot) and NEVER a fresh seed for
+    # itself (DF-1 ping-pong bollwerk): the seed marker must be absent.
+    assert nd["_round_trip_anchor_consume"] is True
+    assert "_round_trip_anchor_seed" not in nd
 
 
 def test_recovery_ignores_incoming_reliability() -> None:
@@ -408,10 +429,14 @@ def test_out_of_order_echo_then_forward_return_recovers() -> None:
     # of B (delta_t = 300 s -> ~833 m/s, gated) and now after the anchor ts
     # (delta_anchor = 240 s, within the 900 s TTL, on the anchor) -> recovered
     # and consumed one-shot.
-    result = _fuse(coord, _fix(HOME, last_seen=BASE_TS + 300, acc=50.0))
+    return_nd = _fix(HOME, last_seen=BASE_TS + 300, acc=50.0)
+    result = _fuse(coord, return_nd)
     assert result is True
     coord.increment_stat.assert_called_with("round_trip_recoveries")
-    assert "dev" not in coord._round_trip_anchors  # one-shot consumed
+    # Fund A: store mutation deferred to update_device_cache; assert the intent marker.
+    # The consume is deferred, so the anchor survives the unbound fusion.
+    assert return_nd["_round_trip_anchor_consume"] is True
+    assert "dev" in coord._round_trip_anchors  # not popped by unbound fusion
 
 
 # ------------------------------------------- supersede detection (F-FABLE-2, AP-2)
@@ -592,6 +617,164 @@ def test_supersede_not_triggered_when_significance_rejects() -> None:
     # The payload was dropped: cached position stays at B, anchor A survives.
     assert coord._device_location_data["dev"]["latitude"] == pytest.approx(FAR[0])
     assert coord._round_trip_anchors["dev"]["lat"] == HOME[0]
+
+
+# ------------------- seed/consume ordering vs. significance gate (Fund A, AP-2)
+
+# Significance-reject axis choice (Fund A ordering tests). Both the anchor SEED
+# and CONSUME markers are set only INSIDE the speed gate's ``delta_t > 0`` block
+# (crowd, forward-of-cache). The timestamp-REGRESSION reject axis (``new_ts <
+# cached last_seen``) forces ``delta_t < 0``, so the gate never fires and NO
+# marker is ever set - a regression-based ordering test would be VACUOUS (it
+# would not exercise the deferred store mutation at all; verified empirically).
+# The only significance-reject axis compatible with ``delta_t > 0`` is the
+# FUTURE-DRIFT guard (``new_ts > time.time() + 7200`` in _is_significant_update):
+# a forward, plausible jump sets the marker in fusion, then the future-drift
+# check discards the payload before the post-commit apply. These two tests
+# therefore anchor everything to ``time.time()`` and add a STRUCTURAL guard
+# (implied_speed vs. cap / delta vs. TTL) so the behavioral premise stays pinned
+# regardless of wall-clock jitter.
+_FUTURE_DRIFT_S = 7200  # _is_significant_update's local MAX_ACCEPTED..._DRIFT_S
+_SPEED_CAP_MPS = 400.0  # DEFAULT_MAX_PLAUSIBLE_SPEED_MPS
+
+
+def test_seed_not_applied_when_significance_rejects() -> None:
+    """Fund A ordering: a seed marker set mid-fusion must NOT reach the store when
+    the significance gate rejects the payload (via ``update_device_cache``).
+
+    An anchorless coordinator takes a crowd clear-jump A->B whose implied speed is
+    plausible (accept path -> seed marker set), but whose ``last_seen`` sits past
+    the future-drift horizon so ``_is_significant_update`` discards it (early
+    return @520, before the post-commit seed apply). The deferred seed must never
+    land: no phantom anchor, cache position unchanged.
+
+    Axis note: the regression axis is unusable here (it forces ``delta_t < 0`` so
+    the gate never fires and no seed marker is set at all - a vacuous test); the
+    future-drift axis is the only significance-reject compatible with the
+    ``delta_t > 0`` accept path that seeds. A structural guard pins the accept
+    (``implied_speed < cap``) so the premise cannot silently rot.
+
+    Mutation cross-check: revert cache.py's seed to a direct
+    ``anchors[device_id]=...`` mid-fusion -> the anchor appears despite the
+    rejected payload -> this test goes red.
+    """
+    now = time.time()
+    a_ts = now  # cached A's last_seen
+    # B seen far in the future -> significance future-drift reject; delta_t huge
+    # but positive so the gate fires and the accept path seeds.
+    b_ts = now + _FUTURE_DRIFT_S + 800.0
+    coord = _make_update_coordinator(_fix(HOME, last_seen=a_ts, acc=20.0))
+    # Structural guard: the jump is a plausible ACCEPT (seed path), not a reject.
+    implied_speed = _haversine_distance_impl(*HOME, *FAR) / (b_ts - a_ts)
+    assert implied_speed < _SPEED_CAP_MPS
+
+    coord.update_device_cache("dev", _fix(FAR, last_seen=b_ts, acc=20.0))
+
+    # Significance rejected the payload: no seed reached the store, cache unchanged.
+    assert "dev" not in coord._round_trip_anchors  # no phantom anchor
+    assert coord._device_location_data["dev"]["latitude"] == pytest.approx(HOME[0])
+
+
+def test_consume_not_applied_when_significance_rejects() -> None:
+    """Fund A ordering: a consume marker set mid-fusion must NOT pop the anchor when
+    the significance gate rejects the payload (via ``update_device_cache``).
+
+    A coordinator holds anchor A (seeded low, TTL-valid) with the device cached at
+    B. A crowd return lands on A: it is gated as a teleport (implied speed > cap)
+    but within TTL+radius of the anchor, so the recovery path fires and sets the
+    consume marker. Its ``last_seen`` is past the future-drift horizon, so
+    ``_is_significant_update`` discards the payload (early return @520) before the
+    post-commit consume apply. The anchor must SURVIVE and the cache stay at B.
+
+    Geometry: recovery requires ``delta_t > 0`` (gate fires), ``0 <= delta_anchor
+    <= TTL`` and ``return_dist <= radius``; the future-drift reject needs
+    ``new_ts > now + 7200``. Anchor ts is set 600 s below new_ts (TTL-valid,
+    delta_anchor >= 0) and cached B's last_seen 300 s below new_ts (delta_t > 0,
+    ~833 m/s > cap). A structural guard pins ``delta <= ROUND_TRIP_TTL_S``.
+
+    Axis note: the regression axis would force ``delta_t < 0`` so the recovery path
+    never fires and no consume marker is set (vacuous); future-drift is the only
+    reject axis compatible with the ``delta_t > 0`` recovery path.
+
+    Mutation cross-check: revert cache.py's consume to a direct
+    ``anchors.pop(device_id, None)`` mid-fusion -> the anchor is consumed despite
+    the rejected payload -> this test goes red.
+    """
+    now = time.time()
+    new_ts = now + _FUTURE_DRIFT_S + 800.0  # future-drift reject; forward of cache
+    cached_b_ts = new_ts - 300.0  # delta_t = 300 s -> ~833 m/s > cap (gate fires)
+    anchor_ts = new_ts - 600.0  # delta_anchor = 600 s: TTL-valid and >= 0
+    # Structural guard: the return sits inside the anchor TTL (recovery path live).
+    delta = new_ts - anchor_ts
+    assert delta <= ROUND_TRIP_TTL_S
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": anchor_ts}}
+    coord = _make_update_coordinator(
+        _fix(FAR, last_seen=cached_b_ts, acc=20.0), anchors=anchors
+    )
+
+    # A crowd return onto A: recovery-consume marker set in fusion, then the
+    # payload is future-drift rejected before the post-commit consume apply.
+    coord.update_device_cache("dev", _fix(HOME, last_seen=new_ts, acc=20.0))
+
+    # The anchor survives (consume never applied) and the cache stays at B.
+    assert coord._round_trip_anchors["dev"]["lat"] == pytest.approx(HOME[0])
+    assert coord._device_location_data["dev"]["latitude"] == pytest.approx(FAR[0])
+
+
+def test_seed_applied_when_significance_accepts() -> None:
+    """Fund A ordering (positive control to test_seed_not_applied...): an ACCEPTED
+    crowd clear-jump seeds the anchor post-commit via ``update_device_cache``.
+
+    An anchorless coordinator takes a plausible A->B jump (dt = 3 h -> ~23 m/s <
+    cap, accept path -> seed marker) that the significance gate ACCEPTS (B is a
+    large, significant move from A). The post-commit apply then seeds the anchor
+    with A's coordinates and the accept-time (B's) ts. This exercises the
+    post-commit seed block including the lazy-init branch: ``_round_trip_anchors``
+    is forced to ``None`` beforehand (the harness would otherwise pre-init ``{}``
+    and the lazy-init would never fire), covering cache.py 615-622.
+    """
+    b_ts = BASE_TS + 3 * 3600  # dt = 3 h -> implied ~23 m/s < cap -> accept
+    coord = _make_update_coordinator(_fix(HOME, last_seen=BASE_TS, acc=20.0))
+    # Force the lazy-init branch of the post-commit seed apply (cache.py 619-621).
+    coord._round_trip_anchors = None
+
+    coord.update_device_cache("dev", _fix(FAR, last_seen=b_ts, acc=20.0))
+
+    # Seed applied post-commit through the lazy-init path; cache advanced to B.
+    assert coord._round_trip_anchors["dev"] == {
+        "lat": HOME[0],
+        "lon": HOME[1],
+        "ts": float(b_ts),
+    }
+    assert coord._device_location_data["dev"]["latitude"] == pytest.approx(FAR[0])
+
+
+def test_consume_applied_when_significance_accepts() -> None:
+    """Fund A ordering (positive control to test_consume_not_applied...): an
+    ACCEPTED recovery return pops the anchor post-commit via ``update_device_cache``.
+
+    A coordinator holds anchor A (TTL-valid) with the device cached at B. A crowd
+    return lands on A within TTL+radius: it is gated as a teleport (implied speed >
+    cap) yet recovers on the anchor, so the recovery path sets the consume marker.
+    Its ``last_seen`` is forward of cached B (no regression) and near-present (no
+    future-drift), so the significance gate ACCEPTS the payload. The post-commit
+    apply then pops the one-shot anchor, covering cache.py 611-614.
+    """
+    cached_b_ts = BASE_TS  # cached B's last_seen
+    anchor_ts = BASE_TS  # delta_anchor = 300 s -> TTL-valid and >= 0
+    new_ts = BASE_TS + 300  # delta_t = 300 s -> ~833 m/s > cap; > cached B -> accept
+    # Structural guard: the return sits inside the anchor TTL (recovery path live).
+    assert new_ts - anchor_ts <= ROUND_TRIP_TTL_S
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(anchor_ts)}}
+    coord = _make_update_coordinator(
+        _fix(FAR, last_seen=cached_b_ts, acc=20.0), anchors=anchors
+    )
+
+    coord.update_device_cache("dev", _fix(HOME, last_seen=new_ts, acc=20.0))
+
+    # Consume applied post-commit: the one-shot anchor is popped; cache moved to A.
+    assert "dev" not in coord._round_trip_anchors
+    assert coord._device_location_data["dev"]["latitude"] == pytest.approx(HOME[0])
 
 
 # ---------------------- anchor survival across estimated-existing skip (F2, AP-3)

--- a/tests/test_stamp_version.py
+++ b/tests/test_stamp_version.py
@@ -157,25 +157,58 @@ def test_stamp_manifest_no_version_key_raises() -> None:
 
 
 def test_workflow_guard_regex_matches_version_re() -> None:
-    """release-stamp.yml's tag guard must mirror VERSION_RE byte-for-byte.
+    """Both release workflows' tag guards must mirror VERSION_RE byte-for-byte.
 
-    The two live in different languages (Python ``re`` vs POSIX ERE via
-    ``grep -qE``) but are kept textually identical so a change to one without
-    the other is caught here instead of at release time.
+    The guards live in different languages (Python ``re`` vs POSIX ERE via
+    ``grep -qE``) but are kept textually identical across ``release-stamp.yml``
+    (the tag guard) and ``release.yml`` (the REAL_TIP line-tip gate) so a change
+    to one without the others is caught here instead of at release time.
     """
-    wf = (_REPO_ROOT / ".github/workflows/release-stamp.yml").read_text(
-        encoding="utf-8"
-    )
-    # The push step also greps to classify errors, but only with ``-qiE``/``-qxF``;
-    # pick the sole ``grep -qE`` carrying a ``^[0-9]`` version-shaped pattern.
-    patterns = re.findall(r"grep -qE '([^']+)'", wf)
-    tag_patterns = [p for p in patterns if p.startswith(r"^[0-9]+\.")]
-    assert len(tag_patterns) == 1, (
-        f"expected exactly one tag guard, found {tag_patterns}"
-    )
-    assert tag_patterns[0] == VERSION_RE.pattern, (
-        f"guard drift: workflow {tag_patterns[0]!r} != VERSION_RE {VERSION_RE.pattern!r}"
-    )
+    for wf_name in (
+        ".github/workflows/release-stamp.yml",
+        ".github/workflows/release.yml",
+    ):
+        wf = (_REPO_ROOT / wf_name).read_text(encoding="utf-8")
+        # Other steps also grep to classify errors, but only with ``-qiE``/``-qxF``;
+        # pick the sole ``grep -qE`` carrying a ``^[0-9]`` version-shaped pattern.
+        patterns = re.findall(r"grep -qE '([^']+)'", wf)
+        tag_patterns = [p for p in patterns if p.startswith(r"^[0-9]+\.")]
+        assert len(tag_patterns) == 1, (
+            f"expected exactly one tag guard in {wf_name}, found {tag_patterns}"
+        )
+        assert tag_patterns[0] == VERSION_RE.pattern, (
+            f"guard drift in {wf_name}: {tag_patterns[0]!r} != "
+            f"VERSION_RE {VERSION_RE.pattern!r}"
+        )
+
+
+def test_real_tip_gate_blanks_foreign_tag_keeps_pep440() -> None:
+    """release.yml REAL_TIP gate: foreign tips blanked, PEP 440 tips kept.
+
+    The gate re-uses VERSION_RE (the SSOT) to decide whether the topological
+    line tip is a valid version. A foreign, non-version tag (Workflow-A hand-tag
+    placeholder, ``nightly``, ``v2``) must be blanked so it cannot spuriously
+    route PSR to the hand-tag draft; a genuine PEP 440 beta/four-segment tag must
+    be kept so a real stale-base mismatch still fires ``MODE=hand``. This mirrors
+    the shell condition
+    ``[ -n "$REAL_TIP" ] && ! printf '%s' "$REAL_TIP" | grep -qE '<VERSION_RE>'``.
+
+    Mutation cross-check (re-runnable): replace ``gate``'s body with a bare
+    ``return real_tip`` (no gating) and the three foreign-tag assertions turn red.
+    """
+
+    def gate(real_tip: str) -> str:
+        # Faithful Python mirror of the release.yml shell gate.
+        return real_tip if VERSION_RE.match(real_tip) else ""
+
+    # foreign / non-version tips are blanked -> no spurious MODE=hand
+    assert gate("set-release-tag") == ""
+    assert gate("nightly") == ""
+    assert gate("v2") == ""
+    # genuine PEP 440 line tips are kept -> MODE=hand still fires on a mismatch
+    assert gate("1.7.14b1") == "1.7.14b1"
+    assert gate("1.7.14.0") == "1.7.14.0"
+    assert gate("1.7.13") == "1.7.13"
 
 
 # --- Tag-vs-branch: checkout must pin the published tag ---------------------


### PR DESCRIPTION
## Round-trip anchor ordering-vs-commit fix (Fund A) + release-tip VERSION_RE hardening (Fund B)

Follow-up to the round-trip anchor lifecycle work (#1197/#1198) and the release automation (#1199), addressing two Codex findings raised on the cross-fork PR (BSkando #205).

### Fund A (real): round-trip anchor seed/consume mutated the store before commit

`_apply_weighted_location_fusion` seeded (accept path) and consumed (recovery path) the round-trip anchor store **inside the fusion**, i.e. before the significance gate (`_is_significant_update`) and before the payload commits. A payload the significance gate later rejects (early return) therefore left behind:

* a **phantom anchor** from a jump that was never committed (seed path), or
* a **prematurely burnt anchor** from a recovery that was never committed (consume path, the symmetric D1 case).

**Fix:** defer both mutations, exactly mirroring the existing `_supersede_round_trip_anchor` pattern. The fusion now records the intent as a marker on `new_data` (`_round_trip_anchor_seed` / `_round_trip_anchor_consume`); `update_device_cache` pops the markers early (before sanitize/merge, so they never leak into the cached row) and applies them only **after** the commit and the significance gate. A rejected payload thus never touches the anchor store, and the F-CODEX-7 semantics (a discarded own-report must not invalidate the anchor) hold automatically because the early return skips the post-commit block.

The preapply paths (`locate.py`, `polling.py`) share the same `slot` object reference through to `update_device_cache`, so the marker survives without extra plumbing; the polling test-double fallback strips the markers for hygiene.

**Test-blind-spot addressed:** the entire existing round-trip suite called `_apply_weighted_location_fusion` *unbound*, so the fusion-then-significance ordering was never exercised and no test could catch the bug. New integration tests drive `update_device_cache` for both axes (seed + consume), each asserting the ordering invariant (rejected payload -> no store mutation) plus a positive control (accepted payload -> mutation applied post-commit), with a re-runnable mutation cross-check documented in each docstring. The existing unbound-fusion tests were converted to assert the intent marker on `new_data`.

### Fund B (false positive) + class-wide hardening

Codex flagged `gh release create ... --draft` as leaving a real git tag that `git describe --tags` would later misread. This premise is **empirically false**: a live, non-destructive test on this fork showed a `--draft` release creates **no** git tag (`git ls-remote --tags` empty, the tag ref returns `Not Found`, GitHub stores an `untagged-...` draft instead). No code fix of the alleged path is made.

Independently, `release.yml` now gates `REAL_TIP` (`git describe --tags`) against the canonical PEP 440 `VERSION_RE` (SSOT `script/stamp_version.py`, byte-mirrored in `release-stamp.yml`), so a foreign, non-version tag on the line tip (e.g. a stray `set-release-tag`, `nightly`, `v2`) can no longer poison the PSR routing comparison and spuriously open a hand-tag draft. PEP 440 beta/four-segment tags still match `VERSION_RE`, so the intended `MODE=hand` protection for PSR-unparseable version tags is preserved. The byte-parity guard test was extended to cover both workflows, plus a deterministic gate-behaviour test (foreign tip blanked, PEP 440 tip kept).

### Scope

Runtime: `coordinator/cache.py` (deferred markers), `coordinator/polling.py` (fallback hygiene). Workflow: `.github/workflows/release.yml` (REAL_TIP gate). Tests: `tests/test_cache_round_trip.py`, `tests/test_stamp_version.py`. No behaviour change on the accepted-payload path; the fix only removes mutations caused by payloads that never commit.
