### PR TITLE
fix(cache): propagate round-trip anchor seed to shared trackers (Fund A) + release-tip false-positive (Fund B)

### DIFF
--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -633,7 +633,10 @@ class CacheOperations(_MixinBase):
             if callable(register_fn):
                 register_fn(device_id, effective_identity_key)
             self._propagate_location_to_shared_devices(
-                device_id, slot, supersede_anchors=supersede_anchor
+                device_id,
+                slot,
+                supersede_anchors=supersede_anchor,
+                seed_anchors=anchor_seed,
             )
 
         # Trigger resolver refresh if identity changed
@@ -650,6 +653,7 @@ class CacheOperations(_MixinBase):
         source_device_id: str,
         location: dict[str, Any],
         supersede_anchors: bool = False,
+        seed_anchors: dict[str, Any] | None = None,
     ) -> None:
         """Propagate location updates to devices sharing the same tracker.
 
@@ -664,6 +668,10 @@ class CacheOperations(_MixinBase):
                 stale round-trip anchor (F-CODEX-9), symmetric to the
                 source-device pop, so a later crowd echo near the old anchor
                 cannot roll a shared target back to the stale position.
+            seed_anchors: When not None, also seed each adopting target's
+                round-trip anchor with this (source-A) anchor as an independent
+                copy, so a B-to-A return under a sibling device_id finds an
+                anchor and recovers, symmetric to the source-device seed (@622).
         """
         if not location:
             return
@@ -738,6 +746,25 @@ class CacheOperations(_MixinBase):
                 _anchors = getattr(self, "_round_trip_anchors", None)
                 if _anchors:
                     _anchors.pop(target_id, None)
+
+            # SA-8: seed and supersede are propagation-symmetric (one physical
+            # tracker, one home A), so both ride this loop. The recovery CONSUME
+            # pop (@611-614) is deliberately NOT propagated: a B-to-A return on
+            # one sibling would otherwise delete another sibling's still-legitimate
+            # A-anchor, which that sibling needs for its own return. Only seed +
+            # supersede propagate. Seed and supersede are mutually exclusive per
+            # report (accept-path seed vs own-report supersede), so this never
+            # double-mutates a target.
+            if seed_anchors is not None and self._round_trip_confirm_enabled():
+                # No lazy-init needed here: a non-None seed_anchors means the
+                # source post-commit seed block (@615-622, same confirm guard)
+                # already ran and initialized the store before this propagation
+                # call. Mirror the supersede sibling's getattr guard above; use
+                # ``is not None`` (not truthiness) so an initialized-but-empty
+                # store still seeds the adopting target.
+                _anchors = getattr(self, "_round_trip_anchors", None)
+                if _anchors is not None:
+                    _anchors[target_id] = dict(seed_anchors)
 
             _LOGGER.debug(
                 "Propagated location from %s to %s (shared tracker, source=%s)",

--- a/tests/test_cache_round_trip.py
+++ b/tests/test_cache_round_trip.py
@@ -997,3 +997,113 @@ def test_supersede_clears_shared_anchor_when_source_has_no_anchor() -> None:
     assert echo_ts - BASE_TS <= ROUND_TRIP_TTL_S
     coord.update_device_cache("dev_b", _fix(HOME, last_seen=echo_ts, acc=20.0))
     assert coord._device_location_data["dev_b"]["latitude"] == pytest.approx(C[0])
+
+
+# ------------- shared-device anchor SEED propagation (SA-8, Fund A shared sweep)
+
+
+def test_seed_propagates_to_shared_target_enables_sibling_return() -> None:
+    """SA-8: an accepted A->B clear jump on ``dev_a`` seeds the round-trip anchor
+    of every ADOPTING shared sibling with A's coordinates, so a later B->A return
+    that arrives under a sibling device id finds an anchor and recovers instead of
+    stranding at B.
+
+    Sequence over the real ``update_device_cache`` commit path:
+    1. Both siblings start cached near A (HOME) with ``dev_b`` OLDER than the
+       incoming A->B report, and the anchor store is emptied so the seed is born
+       fresh. A crowd clear jump A(HOME)->B(FAR) over 3 h (plausible, under cap)
+       is accepted on ``dev_a``: fusion sets the accept-path seed marker with A's
+       coordinates, and the post-commit apply seeds ``dev_a``'s anchor.
+    2. That fresh B location propagates to the older ``dev_b`` (freshness gate
+       passes), and the SA-8 seed block copies A's anchor onto ``dev_b`` too.
+    3. A B->A return arriving ONLY on ``dev_b`` within TTL+radius rides the seeded
+       anchor and recovers ``dev_b`` back onto A rather than being gated as a
+       teleport.
+
+    Mutation guard: removing the AP-1 seed-propagation block (the ``seed_anchors``
+    branch in ``_propagate_location_to_shared_devices``) leaves ``dev_b`` without
+    an anchor, so (a) the ``dev_b`` anchor-coordinate assertions fail and (b) the
+    step-3 B->A return finds no anchor, is gated as a teleport, and ``dev_b``
+    strands at FAR instead of recovering to HOME -> this test goes red.
+    """
+    ik = b"\x44" * 32
+    coord = _make_shared_update_coordinator(ik=ik)
+    # Empty the anchor store so the propagated seed is born fresh (not inherited
+    # from the harness pre-seed), exercising the SA-8 lazy-init + copy path.
+    coord._round_trip_anchors = {}
+    # Both siblings start near A (HOME) so the accept-path seed anchors A's
+    # coordinates; dev_b is OLDER than the coming A->B report so it adopts it.
+    b_ts = BASE_TS + 3 * 3600  # dt = 3 h -> implied ~23 m/s < cap -> accept path
+    coord._device_location_data["dev_a"] = {
+        **_fix(HOME, last_seen=BASE_TS, acc=20.0),
+        "identity_key": ik,
+    }
+    coord._device_location_data["dev_b"] = {
+        **_fix(HOME, last_seen=BASE_TS - 10, acc=20.0),
+        "identity_key": ik,
+    }
+
+    # Step 1+2: accepted A->B clear jump on dev_a (non-own, measured accuracy).
+    # Seeds dev_a at A post-commit and propagates the seed to the adopting dev_b.
+    coord.update_device_cache(
+        "dev_a",
+        {**_fix(FAR, last_seen=b_ts, acc=20.0), "identity_key": ik},
+    )
+
+    # The seed carries A's coordinates (HOME), NOT the FAR target-cache position,
+    # on BOTH the source and the propagated sibling.
+    assert coord._round_trip_anchors["dev_a"]["lat"] == pytest.approx(HOME[0])
+    assert coord._round_trip_anchors["dev_b"]["lat"] == pytest.approx(HOME[0])
+    assert coord._round_trip_anchors["dev_b"]["lon"] == pytest.approx(HOME[1])
+    # dev_b adopted the fresh B location.
+    assert coord._device_location_data["dev_b"]["latitude"] == pytest.approx(FAR[0])
+
+    # Step 3: a B->A return arriving ONLY on dev_b within TTL+radius rides the
+    # seeded anchor and recovers dev_b onto A (structural TTL guard live).
+    anchor_ts = b_ts  # accept-time ts of the seeded anchor
+    return_ts = b_ts + 300
+    assert (return_ts) - anchor_ts <= ROUND_TRIP_TTL_S
+    coord.update_device_cache("dev_b", _fix(HOME, last_seen=return_ts, acc=20.0))
+    assert coord._device_location_data["dev_b"]["latitude"] == pytest.approx(HOME[0])
+
+
+def test_seed_not_propagated_to_fresher_shared_target() -> None:
+    """SA-8 scoping: a shared target that is FRESHER than the A->B report (its
+    propagation skipped by the freshness gate) receives NEITHER the location NOR
+    the anchor seed.
+
+    The seed rides the propagation data-flow, so a target that never adopts the
+    superseding location must not inherit the anchor either - the seed block sits
+    AFTER the freshness-gate ``continue``, so only adopting siblings are seeded.
+
+    Mutation guard: hoisting the seed BEFORE the freshness gate (Option A) would
+    seed the fresher ``dev_b`` with A even though it skipped the location update,
+    so the ``dev_b not in anchors`` assertion fails -> this test goes red.
+    """
+    ik = b"\x55" * 32
+    coord = _make_shared_update_coordinator(ik=ik)
+    coord._round_trip_anchors = {}
+    # Both siblings start near A (HOME); make dev_b FRESHER than the coming report
+    # so the freshness gate skips its propagation (and thus its seed).
+    coord._device_location_data["dev_a"] = {
+        **_fix(HOME, last_seen=BASE_TS, acc=20.0),
+        "identity_key": ik,
+    }
+    coord._device_location_data["dev_b"] = {
+        **_fix(HOME, last_seen=BASE_TS + 10 * 3600, acc=20.0),
+        "identity_key": ik,
+    }
+
+    b_ts = BASE_TS + 3 * 3600  # OLDER than dev_b's fresh_ts -> propagation skipped
+    coord.update_device_cache(
+        "dev_a",
+        {**_fix(FAR, last_seen=b_ts, acc=20.0), "identity_key": ik},
+    )
+
+    # dev_b did NOT adopt the fresh location (still at HOME, its own value)...
+    assert coord._device_location_data["dev_b"]["latitude"] == pytest.approx(HOME[0])
+    assert coord._device_location_data["dev_b"]["latitude"] != pytest.approx(FAR[0])
+    # ...and received NO seed (the seed rides the propagation data-flow only).
+    assert "dev_b" not in coord._round_trip_anchors
+    # The source itself was still seeded (positive control).
+    assert coord._round_trip_anchors["dev_a"]["lat"] == pytest.approx(HOME[0])


### PR DESCRIPTION
## Summary

Follow-up to the merged #1200 (anchor ordering-vs-commit fix). Addresses two Codex review findings on the cross-fork PR #205 (`jleinenbach:1.7` -> `BSkando:1.7`), reviewed commit `7756ee7ca`.

**Finding A (runtime, cache.py) is real and fixed here. Finding B (release.yml draft tag) is a false positive and is answered, not changed.**

### Finding A: round-trip anchor seed not propagated to shared trackers (fixed)

When two device ids share one physical tracker (same `identity_key`), an accepted A->B jump on the source seeds a round-trip anchor at the pre-jump position A, but only for the source `device_id` (`_anchors[device_id] = anchor_seed`). `_propagate_location_to_shared_devices` then adopts the fresh B row for every sibling, and (since #1198/F-CODEX-9) propagates the supersede-pop, but it never propagated the **seed**. The recovery read keys hard on `device_id` (`anchors.get(device_id)`), so a later B->A return arriving under a sibling id finds no anchor, the speed gate rejects it as a teleport, and the shared tracker is stranded at B.

This is the exact mirror of the already-merged F-CODEX-9 supersede propagation. The fix rides the same propagation data-flow: a new `seed_anchors` parameter on `_propagate_location_to_shared_devices` seeds each **adopting** sibling (past the freshness gate) with an independent copy of the source-A anchor (`_anchors[target_id] = dict(anchor_seed)`), symmetric to the supersede block right above it.

Design note (SA-8 breadth sweep, beyond the flagged line): the recovery **consume** pop is deliberately NOT propagated. A B->A return on one sibling must not delete another sibling's still-legitimate A-anchor, which that sibling needs for its own return. Only seed and supersede are propagation-symmetric (one physical tracker, one home A). Seed and supersede are mutually exclusive per report (accept-path seed vs own-report supersede), so a target is never double-mutated.

Provenance is preserved: the propagated seed is the source-A anchor, which already passed `is_reliable_fix`/the speed gate; a per-sibling `target_cache` value would bypass that guard, so option (a) is used.

Tests: a mutation-sharp integration test drives `update_device_cache` for an A->B accept on `dev_a`, asserts `dev_b` receives the source-A anchor, and proves a B->A return arriving only on `dev_b` recovers (instead of stranding at B). A scoping test proves a fresher sibling that skips the freshness gate does NOT inherit the seed. Both carry a re-runnable mutation counter-proof.

### Finding B: draft-only release tag (false positive, no change)

Codex flags `gh release create "$PROPOSED" --draft` as creating a stale git tag on an abandoned draft. This is the same premise a prior live test already refuted: a `--draft` release creates NO git tag (GitHub stores an `untagged-...` draft; `git ls-remote --tags` is empty; the tag ref returns `Not Found`). The in-code comment "the tag is only created when the draft is published" is correct.

Independently, `release.yml` already gates `REAL_TIP` (`git describe --tags`) against the canonical PEP 440 `VERSION_RE` (SSOT `script/stamp_version.py`, byte-mirrored in `release-stamp.yml`, merged in #1200), so a foreign non-version tip cannot poison PSR routing. A stale draft whose name is a valid version collides on the next run and is caught by the existing `if ! gh release create ... exit 1` fail-safe, not left as a silent wrong action. No code change is made; the finding is answered with this evidence.

## Scope

- `custom_components/googlefindmy/coordinator/cache.py`: `seed_anchors` param on `_propagate_location_to_shared_devices` + propagation block (additive, mirrors the F-CODEX-9 supersede block).
- `tests/test_cache_round_trip.py`: two new integration tests + mutation counter-proofs.
- No `.github/workflows/` change (Finding B is a false positive).

## Risk

Low. Additive, default `seed_anchors=None` keeps every existing caller unchanged; the new block fires only on an accept-path seed for an adopting sibling. RAM-only anchor, no schema change. Both behaviours remain switchable via the existing round-trip option.
