### PR TITLE
fix(cache): expire round-trip anchor only on TTL, not on unrelated far rejects

### DIFF
--- a/custom_components/googlefindmy/coordinator/cache.py
+++ b/custom_components/googlefindmy/coordinator/cache.py
@@ -1220,17 +1220,23 @@ class CacheOperations(_MixinBase):
                                             ROUND_TRIP_TTL_S,
                                         )
                                         return True
-                                    # Anchor expired or the fix landed too far
-                                    # from A: drop it (housekeeping) and let the
-                                    # gate reject as usual. Guard on
-                                    # delta_anchor >= 0 (F-FABLE-1): a delayed
-                                    # out-of-order report near A can carry a
-                                    # last_seen between A and B, making
-                                    # delta_anchor < 0 (new_ts before the anchor
-                                    # ts). That is not an expiry - popping here
-                                    # would destroy the anchor and strand a later
-                                    # genuine return. Only house-keep forward.
-                                    if delta_anchor >= 0:
+                                    # House-keep the anchor ONLY on a genuine TTL
+                                    # expiry (delta_anchor > ROUND_TRIP_TTL_S); the
+                                    # gate rejects as usual. Two non-expiry cases
+                                    # deliberately LEAVE the anchor in place so a
+                                    # later genuine B->A return within the original
+                                    # window still recovers:
+                                    #  - a within-TTL far reject (return_dist >
+                                    #    ROUND_TRIP_ANCHOR_RADIUS_M): an unrelated
+                                    #    noisy crowd fix between the trip legs must
+                                    #    not burn the still-valid anchor.
+                                    #  - an out-of-order report (delta_anchor < 0):
+                                    #    a delayed fix near A whose last_seen sits
+                                    #    between A and B is not an expiry.
+                                    # The single "> TTL" test subsumes the old
+                                    # F-FABLE-1 ">= 0" guard: every negative
+                                    # delta_anchor is <= TTL, so it never pops.
+                                    if delta_anchor > ROUND_TRIP_TTL_S:
                                         anchors.pop(device_id, None)
                             self.increment_stat("speed_gate_rejects")
                             _LOGGER.debug(

--- a/tests/test_cache_round_trip.py
+++ b/tests/test_cache_round_trip.py
@@ -439,6 +439,69 @@ def test_out_of_order_echo_then_forward_return_recovers() -> None:
     assert "dev" in coord._round_trip_anchors  # not popped by unbound fusion
 
 
+def test_within_ttl_far_reject_preserves_anchor() -> None:
+    """A within-TTL reject outside the return radius must NOT drop the anchor.
+
+    An active A->B anchor can receive an UNRELATED rejected crowd fix C that
+    lands within the TTL window (0 <= delta_anchor <= TTL) but outside the return
+    radius (return_dist > ROUND_TRIP_ANCHOR_RADIUS_M). That is not an expiry: the
+    anchor has not aged out and must survive, so a later genuine B->A return in
+    the original window still recovers. Only a genuine TTL expiry
+    (delta_anchor > TTL) house-keeps the anchor.
+
+    Mutation guard: revert the pop condition to ``if delta_anchor >= 0:``. Then
+    delta_anchor = 300 >= 0 pops the still-valid anchor here, and the
+    ``"dev" in coord._round_trip_anchors`` assertion below turns red.
+    """
+    far = _point_north(HOME, 5000.0)  # 5 km north of A, far outside the 200 m radius
+    assert _haversine_distance_impl(HOME[0], HOME[1], *far) > ROUND_TRIP_ANCHOR_RADIUS_M
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(BASE_TS)}}
+    coord = _coord(_fix(FAR, last_seen=BASE_TS), anchors=anchors)
+    # delta_t = 300 > 0 (gated teleport), delta_anchor = 300 (0 <= 300 <= 900 TTL),
+    # return_dist = 5000 m > radius -> unrelated within-TTL far reject.
+    result = _fuse(coord, _fix(far, last_seen=BASE_TS + 300, acc=50.0))
+    assert result is False
+    coord.increment_stat.assert_called_once_with("speed_gate_rejects")
+    # The still-valid anchor survives the unrelated far reject (TTL-only expiry).
+    assert "dev" in coord._round_trip_anchors
+    assert coord._round_trip_anchors["dev"] == {
+        "lat": HOME[0],
+        "lon": HOME[1],
+        "ts": float(BASE_TS),
+    }
+
+
+def test_far_reject_then_genuine_return_recovers() -> None:
+    """A genuine return recovers after a within-TTL far reject preserved the anchor.
+
+    End-to-end for the housekeeping fix: an unrelated noisy crowd fix arriving
+    between the trip legs (within TTL, outside radius) must not burn the anchor,
+    so the subsequent genuine B->A return within TTL + radius still recovers and
+    consumes it one-shot.
+
+    Mutation guard: revert the pop condition to ``if delta_anchor >= 0:``. Then
+    step 1 pops the anchor, step 2 finds no anchor, is gated, and ``result is
+    False`` instead of True (the defeated-recovery bug this fix closes).
+    """
+    far = _point_north(HOME, 5000.0)
+    anchors = {"dev": {"lat": HOME[0], "lon": HOME[1], "ts": float(BASE_TS)}}
+    coord = _coord(_fix(FAR, last_seen=BASE_TS), anchors=anchors)
+
+    # Step 1: an unrelated within-TTL far reject at BASE_TS + 120 (delta_anchor =
+    # 120 <= 900 TTL, return_dist = 5000 m > radius). Anchor must survive.
+    assert _fuse(coord, _fix(far, last_seen=BASE_TS + 120, acc=50.0)) is False
+    assert "dev" in coord._round_trip_anchors  # alive after the noisy reject
+
+    # Step 2: a genuine forward return near A at BASE_TS + 300 (delta_anchor =
+    # 300, within TTL; return_dist = 0 <= radius) -> recovered and consumed.
+    assert (BASE_TS + 300) - float(BASE_TS) <= ROUND_TRIP_TTL_S  # structural guard
+    return_nd = _fix(HOME, last_seen=BASE_TS + 300, acc=50.0)
+    result = _fuse(coord, return_nd)
+    assert result is True
+    coord.increment_stat.assert_called_with("round_trip_recoveries")
+    assert return_nd["_round_trip_anchor_consume"] is True
+
+
 # ------------------------------------------- supersede detection (F-FABLE-2, AP-2)
 
 


### PR DESCRIPTION
## Summary

Fixes the Codex finding on #205 ("Preserve anchors on unrelated rejected fixes").

The speed-gate reject branch house-kept the round-trip recovery anchor whenever
`delta_anchor >= 0`, which conflated two distinct cases:

- a genuine TTL expiry (`delta_anchor > ROUND_TRIP_TTL_S`), and
- an unrelated rejected crowd fix that landed **within** the TTL window but
  **outside** the return radius (`0 <= delta_anchor <= TTL` and
  `return_dist > ROUND_TRIP_ANCHOR_RADIUS_M`).

The second case is a noisy report arriving between the trip legs. It dropped a
still-valid A->B anchor, so a later genuine B->A return within the original
15-minute window found no anchor, was speed-gated, and the recovery feature was
defeated.

## Fix

Gate the housekeeping pop on a genuine TTL expiry (`delta_anchor > ROUND_TRIP_TTL_S`).
A within-TTL far reject and an out-of-order report (`delta_anchor < 0`) both leave
the anchor in place; it expires naturally by TTL. The single `> TTL` test subsumes
the old F-FABLE-1 `>= 0` guard (every negative `delta_anchor` is `<= TTL`, so it
never pops).

## Why this is safe (no ping-pong regression)

Recovery stays double-gated: a return is only recovered when `return_dist <= RADIUS`
**and** `delta_anchor <= TTL`, and the anchor is consumed one-shot post-commit. A
longer-lived anchor outside radius/TTL is inert. The supersede invalidation
(F-CODEX-9 / F-FABLE-2) still pops the anchor on a trusted own-report clear jump.
The anchor is RAM-only, one entry per device.

## Scope (SA-8 breadth sweep)

Point defect at a single site (the housekeeping pop). The other anchor mutation
sites delete for orthogonal, correct reasons (own-report supersede pop, one-shot
consume pop, shared-device propagation of supersede+seed, device purge) and do
**not** carry the expiry-vs-unrelated-reject confusion. The defective housekeeping
pop sits in the crowd-reject path and is never propagated to shared siblings.

## Tests

Two new behavioral tests in `tests/test_cache_round_trip.py`:

- `test_within_ttl_far_reject_preserves_anchor`: an unrelated within-TTL out-of-radius
  reject leaves the anchor in place.
- `test_far_reject_then_genuine_return_recovers`: the subsequent genuine near-A return
  then recovers.

Each carries a re-runnable mutation check (revert the guard to `>= 0` -> both go red).
Existing genuine-expiry pop (`test_expired_anchor_is_popped_on_reject`) and out-of-order
preservation tests stay green.

Anchor-lifecycle family: #1198 / #1200 / #1201. Flows upstream via the open cross-fork PR #205 once merged into `1.7`.
