### PR TITLE
docs(pyproject): correct version-sync comment for PEP 440 maintenance lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,13 @@ name = "googlefindmy-ha"
 # Integration version: coupled triple. MUST be bumped together with
 # custom_components/googlefindmy/const.py INTEGRATION_VERSION and
 # custom_components/googlefindmy/manifest.json "version" on every release.
-# semantic-release keeps all three in sync automatically on any release line
-# (main and every X.Y maintenance branch) via [tool.semantic_release] version_toml
-# + version_variables below; a manual three-file bump is only a fallback. Canonical
-# anchor:
+# semantic-release keeps all three in sync automatically only on SemVer release
+# lines (main), via [tool.semantic_release] version_toml + version_variables
+# below. On PEP 440 maintenance lines (X.Y, tagged four-segment `.N` or beta
+# `bN`), PSR silently skips the tag scheme (see .github/workflows/release.yml);
+# there the maintainer hand-tags and release-stamp.yml stamps the triple via
+# script/stamp_version.py, so on those lines the hand-tag/stamp path is primary,
+# not a fallback. Canonical anchor:
 # custom_components/googlefindmy/AGENTS.md ("Version bump touches three files").
 version = "1.7.14.0"
 description = "Home Assistant integration for Google's Find My Device network."


### PR DESCRIPTION
## What

Corrects the coupled-triple version comment in `pyproject.toml` so it no longer contradicts the release workflow.

The old comment claimed:

> semantic-release keeps all three in sync automatically on any release line (main and every X.Y maintenance branch) ... a manual three-file bump is only a fallback.

That is the opposite of the truth on the `1.7` maintenance line. As `.github/workflows/release.yml` (lines 88-107) already documents, **semantic-release only understands SemVer**. This project's maintenance lines are tagged PEP 440 (four-segment `.N`, beta `bN`), which PSR silently skips, so on those lines the maintainer hand-tags and `release-stamp.yml` stamps the three literals (`script/stamp_version.py`). There the hand-tag/stamp path is the **primary** path, not a fallback.

## Why

Codex flagged the comment on #205 as contradicting the workflow. It is a documentation self-contradiction (claim drift), not a runtime bug: the actual release mechanics work correctly (the `1.7.14.0` release stamped and shipped fine). But the comment promises an automation that silently no-ops on maintenance branches and could mislead a future maintainer.

## Scope

- **Comment-only.** The `version = "1.7.14.0"` literal and every `[tool.*]` setting are byte-unchanged; `pyproject.toml` still parses.
- No logic, no version, no workflow behaviour change.
- The new comment mirrors the `release.yml` wording and references it as the single source of truth; the AGENTS.md canonical anchor is preserved.
