### PR TITLE
fix(coordinator): require finite sub-physical accuracy in is_reliable_fix (Codex #205)

### DIFF
--- a/custom_components/googlefindmy/coordinator/helpers/geo.py
+++ b/custom_components/googlefindmy/coordinator/helpers/geo.py
@@ -312,11 +312,28 @@ def is_reliable_fix(row: Mapping[str, Any] | None) -> bool:
     *display* gate (:func:`select_display_row`) so a fresh estimated fix is
     still shown; ``is_reliable_fix`` is the retention gate so only a real
     measurement overwrites the last reliable position.
+
+    Also rejects a numerically *present* but non-physical accuracy even when
+    ``accuracy_estimated`` is absent: Android's no-accuracy sentinel (``0.0``),
+    a negative value, a sub-``MIN_PHYSICAL_ACCURACY_M`` value, or a non-finite
+    one (``NaN``/``inf``). Such a row is accuracy-less in substance, so it must
+    not be retained as last-good, seed a round-trip anchor, or serve as a
+    speed-gate reference. This mirrors the incoming-side ``new_acc_measured``
+    check in ``cache.py`` (``math.isfinite`` + ``>= MIN_PHYSICAL_ACCURACY_M``),
+    closing the asymmetry where the cached/reference endpoint was gated only on
+    presence. ``has_usable_accuracy`` deliberately stays lenient here (a ``0.0``
+    is still "present" for display), so only ``is_reliable_fix`` tightens.
     """
+    if not has_usable_accuracy(row) or row is None:
+        return False
+    if bool(row.get("accuracy_estimated")):
+        return False
+    acc = row.get("accuracy")
     return (
-        has_usable_accuracy(row)
-        and row is not None
-        and not bool(row.get("accuracy_estimated"))
+        isinstance(acc, (int, float))
+        and not isinstance(acc, bool)
+        and math.isfinite(acc)
+        and acc >= MIN_PHYSICAL_ACCURACY_M
     )
 
 

--- a/tests/test_cache_round_trip.py
+++ b/tests/test_cache_round_trip.py
@@ -118,6 +118,29 @@ def test_far_jump_accept_sets_anchor() -> None:
     assert "dev" not in coord._round_trip_anchors  # store untouched by unbound fusion
 
 
+def test_zero_sentinel_source_a_sets_no_anchor() -> None:
+    """Codex #205: an anchor source A carrying the 0.0 no-accuracy sentinel
+    (NOT flagged estimated) must NOT seed a return anchor.
+
+    The anchor is seeded only from a reliable A (cache.py is_reliable_fix(existing)).
+    After the fix, a restored/legacy A with ``accuracy=0.0`` is no longer reliable,
+    so the speed gate falls through (unreliable reference, F-2) and the anchor-seed
+    site is never reached: no ``_round_trip_anchor_seed`` intent marker is set, so a
+    later stale crowd report near A cannot ride a phantom anchor back.
+
+    Mutation guard: reverting is_reliable_fix makes ``{"accuracy": 0.0}`` reliable
+    again, so the wide jump is gate-evaluated as a clear jump and seeds the anchor
+    (``_round_trip_anchor_seed`` present), failing this assertion.
+    """
+    coord = _coord(_fix(HOME, last_seen=BASE_TS, acc=0.0))  # A = 0.0 sentinel
+    b_ts = BASE_TS + 3 * 3600
+    nd = _fix(FAR, last_seen=b_ts, acc=50.0)
+    result = _fuse(coord, nd)
+    assert result is True
+    assert "_round_trip_anchor_seed" not in nd
+    assert "dev" not in coord._round_trip_anchors
+
+
 def test_stale_offline_jump_then_return_recovers() -> None:
     """F-CODEX-5 end-to-end: a device offline for 3 h jumps to B, then returns
     near A 300 s later. The anchor TTL must run from B (accept time), not from

--- a/tests/test_cache_speed_gate.py
+++ b/tests/test_cache_speed_gate.py
@@ -445,3 +445,24 @@ def test_fast_report_against_reliable_existing_still_gated() -> None:
     result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, is_own=False))
     assert result is False
     coord.increment_stat.assert_called_once_with("speed_gate_rejects")
+
+
+def test_fast_report_against_zero_sentinel_existing_not_gated() -> None:
+    """Codex #205: a fast crowd fix against a cached endpoint carrying the 0.0
+    no-accuracy sentinel (NOT flagged estimated) must NOT be gated.
+
+    is_reliable_fix now rejects a sub-physical/non-finite accuracy even without
+    the accuracy_estimated flag, so a restored/legacy ``existing`` with
+    ``accuracy=0.0`` is treated as an unreliable reference (like the estimated
+    fallback): the symmetric guard makes the gate fall through and the incoming
+    measured report is accepted (result True), rather than being rejected
+    against a 0 m phantom reference.
+
+    Mutation guard: reverting is_reliable_fix (dropping the finite/floor check)
+    makes ``{"accuracy": 0.0}`` reliable again, so this jump is gated and
+    ``result is False`` with the reject counter firing.
+    """
+    coord = _coord(_existing(last_seen=BASE_TS, acc=0.0, estimated=False))
+    result = _fuse(coord, _incoming(last_seen=BASE_TS + 300, is_own=False))
+    assert result is True
+    coord.increment_stat.assert_not_called()

--- a/tests/test_coordinator_geo.py
+++ b/tests/test_coordinator_geo.py
@@ -29,6 +29,7 @@ from custom_components.googlefindmy.coordinator.helpers.geo import (
     coerce_float,
     has_usable_accuracy,
     haversine_distance,
+    is_reliable_fix,
     location_age_seconds,
     resolve_seeded_accuracy,
     resolve_stale_threshold,
@@ -506,6 +507,45 @@ class TestHasUsableAccuracy:
         # ``has_usable_accuracy`` only checks presence; ``safe_accuracy`` owns
         # the "0.0 means no accuracy" policy downstream.
         assert has_usable_accuracy({"accuracy": 0.0}) is True
+
+
+class TestIsReliableFix:
+    """is_reliable_fix - retention gate: only a real, finite, physical accuracy.
+
+    Stricter than has_usable_accuracy (the display gate, which stays lenient so
+    a 0.0/estimated fix is still shown). is_reliable_fix additionally rejects a
+    numerically present but non-physical accuracy (Android's 0.0 sentinel,
+    negative, sub-MIN_PHYSICAL_ACCURACY_M or non-finite) even without the
+    accuracy_estimated flag, mirroring the incoming-side new_acc_measured check
+    (Codex #205). Retaining/anchoring/gating against such a phantom reference
+    would strand a genuine measured fix (#1179 poisoning class).
+    """
+
+    def test_real_accuracy_is_reliable(self) -> None:
+        assert is_reliable_fix({"accuracy": 12.0}) is True
+        assert is_reliable_fix({"accuracy": 12.0, "accuracy_estimated": False}) is True
+
+    def test_zero_sentinel_is_not_reliable(self) -> None:
+        # Android's no-accuracy sentinel: finite but < MIN_PHYSICAL_ACCURACY_M.
+        assert is_reliable_fix({"accuracy": 0.0}) is False
+
+    def test_negative_accuracy_is_not_reliable(self) -> None:
+        assert is_reliable_fix({"accuracy": -1.0}) is False
+
+    def test_non_finite_accuracy_is_not_reliable(self) -> None:
+        assert is_reliable_fix({"accuracy": float("inf")}) is False
+        assert is_reliable_fix({"accuracy": float("nan")}) is False
+
+    def test_bool_accuracy_is_not_reliable(self) -> None:
+        # bool is an int subclass; True must not slip through as 1.0 m.
+        assert is_reliable_fix({"accuracy": True}) is False
+
+    def test_estimated_is_not_reliable(self) -> None:
+        assert is_reliable_fix({"accuracy": 200.0, "accuracy_estimated": True}) is False
+
+    def test_none_and_missing_are_not_reliable(self) -> None:
+        assert is_reliable_fix({"accuracy": None}) is False
+        assert is_reliable_fix(None) is False
 
 
 class TestSelectDisplayRow:

--- a/tests/test_coordinator_geo.py
+++ b/tests/test_coordinator_geo.py
@@ -25,6 +25,7 @@ from custom_components.googlefindmy.const import (
 )
 from custom_components.googlefindmy.coordinator.helpers.geo import (
     DEFAULT_ACCURACY_FALLBACK_M,
+    MIN_PHYSICAL_ACCURACY_M,
     clamp,
     coerce_float,
     has_usable_accuracy,
@@ -528,6 +529,12 @@ class TestIsReliableFix:
     def test_zero_sentinel_is_not_reliable(self) -> None:
         # Android's no-accuracy sentinel: finite but < MIN_PHYSICAL_ACCURACY_M.
         assert is_reliable_fix({"accuracy": 0.0}) is False
+
+    def test_boundary_at_min_physical_accuracy(self) -> None:
+        # Pins the >= operator: exactly MIN_PHYSICAL_ACCURACY_M is reliable, a
+        # hair below is not. Guards against a >=/> mutation on the floor check.
+        assert is_reliable_fix({"accuracy": MIN_PHYSICAL_ACCURACY_M}) is True
+        assert is_reliable_fix({"accuracy": MIN_PHYSICAL_ACCURACY_M / 2}) is False
 
     def test_negative_accuracy_is_not_reliable(self) -> None:
         assert is_reliable_fix({"accuracy": -1.0}) is False

--- a/tests/test_plus_code_last_known.py
+++ b/tests/test_plus_code_last_known.py
@@ -432,6 +432,29 @@ async def test_estimated_fix_does_not_poison_last_good_direct() -> None:
     assert coord.get_display_location_data("dev-1") == good
 
 
+async def test_zero_sentinel_fix_does_not_poison_last_good_direct() -> None:
+    """Codex #205: a fix carrying the 0.0 no-accuracy sentinel (NOT flagged
+    estimated) must not overwrite a reliable last-good either.
+
+    is_reliable_fix now rejects a sub-physical accuracy even without the
+    accuracy_estimated flag, so a restored/legacy row with ``accuracy=0.0`` is
+    treated as accuracy-less in substance (same #1179 poisoning class as the
+    estimated fallback) and does not advance the retention cache.
+
+    Mutation guard: reverting is_reliable_fix makes ``{"accuracy": 0.0}``
+    reliable again, so it overwrites the reliable last-good and this assertion
+    fails.
+    """
+    coord = _bare_coordinator()
+    good = {"latitude": 52.52, "longitude": 13.405, "accuracy": 12.0}
+    coord._record_last_good_location("dev-1", good)
+
+    zero_sentinel = {"latitude": 48.0, "longitude": 11.0, "accuracy": 0.0}
+    coord._record_last_good_location("dev-1", zero_sentinel)
+    # The retention cache is untouched: it still holds the reliable fix.
+    assert coord._device_last_good_location["dev-1"] == good
+
+
 async def test_estimated_fix_does_not_poison_last_good_via_update_cache() -> None:
     """Production path: an accuracy-less update sanitized to estimated 200 m must
     not poison the coordinator last-good (Codex PR #1181, previously uncovered)."""


### PR DESCRIPTION
## Problem (Codex #205)

`is_reliable_fix()` only checked `accuracy is not None` and `not accuracy_estimated`, so a cached/reference endpoint carrying Android's `0.0` no-accuracy sentinel (or a negative, sub-`MIN_PHYSICAL_ACCURACY_M`, or non-finite value) **without** the `accuracy_estimated` flag was treated as a real, reliable fix. The incoming side already filters this exact error-code set (`math.isfinite` + `>= MIN_PHYSICAL_ACCURACY_M`), but the reference side did not, so a genuine measured crowd fix could be speed-gated against a 0 m phantom reference and dropped (the #1179 poisoning class). A restored/legacy/primed row bypasses `_is_significant_update` sanitization, which is where such a raw `0.0` row can survive.

## Fix (predicate level, DRY)

`is_reliable_fix()` now additionally requires a finite, `>= MIN_PHYSICAL_ACCURACY_M`, non-bool numeric accuracy, mirroring the incoming-side `new_acc_measured` check. This closes the gap at every call site in one place, so no call site duplicates the check:

- `coordinator/cache.py:1161` speed gate reference
- `coordinator/cache.py:1286` round-trip anchor seed source A
- `coordinator/cache.py:193` last-good retention
- `device_tracker.py:1003` restore-prime last-good
- `device_tracker.py:1336` record last-good (tracker-private)

`has_usable_accuracy()` (the **display** gate, `select_display_row`) is deliberately left lenient so a sanitized estimated/`0.0` fix is still shown. No new imports (`math`, `MIN_PHYSICAL_ACCURACY_M` already in scope). No call-site edit: predicate-only change.

## SA-8 sweep / consistency

- 5 behaviour-changing call sites, all intended (retention/anchor/speed-gate all follow the same #1179/#1181 poisoning logic). Orthogonal and untouched: `coordinator/main.py:735` (comment only), `coordinator/__init__.py` re-exports, all `has_usable_accuracy` sites.
- SA-11: no spec conflict. The existing F-2 trade-off (an estimated `existing` makes the gate block fall through rather than gating against a phantom reference) is consistently extended to a `0.0`/non-finite `existing` (it belongs to the same "unreliable reference" class as estimated).

## Tests (mutation-sharp)

- `TestIsReliableFix` (unit): the predicate rejects `0.0`/`-1.0`/`inf`/`nan`/`True`, accepts a real measured accuracy.
- Speed gate: a fast crowd fix against a `0.0` cached endpoint is **not** gated (accepted).
- Retention: a `0.0` fix does **not** advance a reliable last-good.
- Anchor seed: a `0.0` source A seeds **no** anchor.

Each has a mutation counter-proof (reverting the finite/floor check turns it red; verified locally). Changed geo.py lines are covered (0 missing). ruff/mypy green.

Fixes the finding on the cross-fork PR BSkando#205.
