### PR TITLE
fix(ci): accept v-prefixed release tags in release stamping

### DIFF
--- a/.github/workflows/release-stamp.yml
+++ b/.github/workflows/release-stamp.yml
@@ -66,25 +66,35 @@ jobs:
           python-version: "3.13"
 
       - name: Validate published tag
-        # Early, human-readable abort. The canonical regex (SSOT) lives in
-        # script/stamp_version.py (VERSION_RE); this guard mirrors it byte-for-byte
-        # (locked by tests/test_stamp_version.py). The shape is deliberately PEP
+        # Early, human-readable abort. The published git tag may carry a leading
+        # `v` (BSkando tags `vX.Y.Z`) or not (jleinenbach tags `X.Y.Z[.N]`) -- the
+        # shared release tooling must honour both fork conventions. The code
+        # literals, however, are ALWAYS PEP 440 versions with no `v`, so we strip
+        # an optional single leading `v` here and validate/stamp that VERSION.
+        # The canonical regex (SSOT) lives in script/stamp_version.py (VERSION_RE);
+        # this guard mirrors it byte-for-byte (locked by tests/test_stamp_version.py)
+        # and is applied to the stripped VERSION. The shape is deliberately PEP
         # 440-broad (bN/aN betas, four-segment .N) so hand-picked maintenance tags
         # stamp cleanly. semantic-release cannot *propose* for those lines (see
         # release.yml Workflow A, which opens a hand-tag draft there instead); this
         # step stamps the exact published tag regardless. Keep both regexes in sync.
         run: |
           set -euo pipefail
-          if ! printf '%s' "$TAG_NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?([ab][0-9]+)?$'; then
-            echo "::error::tag_name '$TAG_NAME' violates tag_format='{version}'; expected X.Y.Z[.N][bN], no 'v' prefix"
+          # Strip at most one leading `v` (POSIX ${VAR#v}); a no-op for v-less
+          # tags. VERSION is the v-less value written into the code literals; the
+          # full TAG_NAME (with any `v`) still addresses the git tag / release asset.
+          VERSION="${TAG_NAME#v}"
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?([ab][0-9]+)?$'; then
+            echo "::error::tag_name '$TAG_NAME' (version '$VERSION') violates tag_format; expected X.Y.Z[.N][bN] with an optional leading 'v'"
             exit 1
           fi
-          echo "validated tag=$TAG_NAME"
+          echo "validated tag=$TAG_NAME version=$VERSION"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
       - name: Stamp version into the three literals
         run: |
           set -euo pipefail
-          python script/stamp_version.py --version "$TAG_NAME"
+          python script/stamp_version.py --version "$VERSION"
 
       - name: Commit the stamp
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,13 +98,18 @@ jobs:
           # (safe). Real PSR errors still surface loudly in the dry-run preview
           # step above (`--noop version`), which is the diagnostic path.
           REAL_TIP="$(git describe --tags --abbrev=0 HEAD 2>/dev/null || true)"
+          # Strip an optional single leading `v` (BSkando tags `vX.Y.Z`,
+          # jleinenbach `X.Y.Z[.N]`) so a genuine `v`-prefixed line tip is
+          # recognised as a version below rather than blanked as foreign.
+          REAL_TIP="${REAL_TIP#v}"
           # Gate REAL_TIP against the canonical PEP 440 version shape (SSOT:
           # script/stamp_version.py VERSION_RE, byte-mirrored in release-stamp.yml).
-          # A foreign, non-version tag (e.g. `set-release-tag`, `nightly`, `v2`)
-          # is not a valid line tip: it must NOT poison the PSR_LAST != REAL_TIP
-          # comparison below and spuriously route to the hand-tag draft. PEP 440
-          # beta/four-segment tags DO match VERSION_RE, so they are kept and still
-          # trigger MODE=hand on a real stale-base mismatch -- the intended guard.
+          # A foreign, non-version tag (e.g. `set-release-tag`, `nightly`, `v2`
+          # -> `2` after the v-strip) is not a valid line tip: it must NOT poison
+          # the PSR_LAST != REAL_TIP comparison below and spuriously route to the
+          # hand-tag draft. PEP 440 beta/four-segment tags DO match VERSION_RE, so
+          # they are kept and still trigger MODE=hand on a real stale-base
+          # mismatch -- the intended guard.
           if [ -n "$REAL_TIP" ] && ! printf '%s' "$REAL_TIP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?([ab][0-9]+)?$'; then
             echo "::notice::ignoring non-PEP-440 line tip '${REAL_TIP}' for PSR routing (not a version tag)."
             REAL_TIP=""

--- a/script/stamp_version.py
+++ b/script/stamp_version.py
@@ -23,11 +23,14 @@ Usage (preview the effect on a clean worktree, then inspect ``git diff``)::
     python script/stamp_version.py --version 1.7.14
     python script/stamp_version.py --version 1.7.14b1 --repo-root /path/to/repo
 
-The tag is validated against the ``tag_format = "{version}"`` convention
-(no ``v`` prefix): ``X.Y.Z`` with an optional ``.N`` fourth segment followed by
-an optional ``bN``/``aN`` prerelease (covers 1.7.14, 1.7.14b1, 1.7.13.1,
-1.7.13.1b1). The segment order is PEP 440: the numeric release tuple precedes
-the prerelease, so ``1.7.14.1b1`` is valid but ``1.7.14b1.1`` is not.
+The ``--version`` argument is a *version* and never carries a ``v`` prefix:
+``X.Y.Z`` with an optional ``.N`` fourth segment followed by an optional
+``bN``/``aN`` prerelease (covers 1.7.14, 1.7.14b1, 1.7.13.1, 1.7.13.1b1). The
+segment order is PEP 440: the numeric release tuple precedes the prerelease, so
+``1.7.14.1b1`` is valid but ``1.7.14b1.1`` is not. The *published git tag* may
+carry a leading ``v`` (BSkando tags ``vX.Y.Z``, jleinenbach ``X.Y.Z[.N]``);
+release-stamp.yml strips that optional ``v`` before calling this script, so both
+fork tag conventions produce the same v-less version literals.
 """
 
 from __future__ import annotations
@@ -37,10 +40,13 @@ import json
 import re
 from pathlib import Path
 
-# Canonical tag/version shape (SSOT). tag_format = "{version}" means the git tag
-# IS the version, so a leading `v` is rejected. Mirrors the real tag set on 1.7,
-# which is PEP 440 (`bN`/`aN` betas, four-segment `.N`) -- deliberately broader
-# than SemVer so hand-picked maintenance tags stamp cleanly. Consequence:
+# Canonical VERSION shape (SSOT). This matches a *version* (what goes into the
+# code literals), which never carries a `v`. A `v`-prefixed git tag (BSkando
+# `vX.Y.Z`) is normalised by release-stamp.yml -- it strips the optional leading
+# `v` before validating/stamping -- so this regex stays strictly v-less. Mirrors
+# the real tag set on 1.7, which is PEP 440 (`bN`/`aN` betas, four-segment `.N`)
+# -- deliberately broader than SemVer so hand-picked maintenance tags stamp
+# cleanly. Consequence:
 # semantic-release (SemVer-only) cannot compute a trustworthy *proposal* for such
 # lines, so release.yml (Workflow A) opens an empty hand-tag draft there instead
 # of proposing a stale number; the stamp path here still honours the exact chosen

--- a/tests/test_stamp_version.py
+++ b/tests/test_stamp_version.py
@@ -55,7 +55,8 @@ VALID_TAGS = [
 ]
 
 INVALID_TAGS = [
-    "v1.7.14",  # leading v prefix violates tag_format = "{version}"
+    "v1.7.14",  # a v-prefix is not a VERSION; release-stamp.yml strips it off
+    #             the TAG first (see test_tag_to_version_v_strip_semantics)
     "1.7",  # too few segments
     "1.7.14-rc1",  # SemVer-style prerelease, not this scheme
     "1.7.14rc1",  # rc is not in the [ab] prerelease set
@@ -185,30 +186,102 @@ def test_workflow_guard_regex_matches_version_re() -> None:
 def test_real_tip_gate_blanks_foreign_tag_keeps_pep440() -> None:
     """release.yml REAL_TIP gate: foreign tips blanked, PEP 440 tips kept.
 
-    The gate re-uses VERSION_RE (the SSOT) to decide whether the topological
-    line tip is a valid version. A foreign, non-version tag (Workflow-A hand-tag
-    placeholder, ``nightly``, ``v2``) must be blanked so it cannot spuriously
-    route PSR to the hand-tag draft; a genuine PEP 440 beta/four-segment tag must
-    be kept so a real stale-base mismatch still fires ``MODE=hand``. This mirrors
-    the shell condition
+    The gate first strips an optional leading ``v`` (BSkando tags ``vX.Y.Z``),
+    then re-uses VERSION_RE (the SSOT) to decide whether the topological line tip
+    is a valid version. A foreign, non-version tag (Workflow-A hand-tag
+    placeholder, ``nightly``, ``v2`` -> ``2`` after the strip) must be blanked so
+    it cannot spuriously route PSR to the hand-tag draft; a genuine PEP 440
+    beta/four-segment tag -- and a genuine ``v``-prefixed release tag -- must be
+    kept so a real stale-base mismatch still fires ``MODE=hand``. This mirrors the
+    shell steps
+    ``REAL_TIP="${REAL_TIP#v}"`` then
     ``[ -n "$REAL_TIP" ] && ! printf '%s' "$REAL_TIP" | grep -qE '<VERSION_RE>'``.
 
-    Mutation cross-check (re-runnable): replace ``gate``'s body with a bare
-    ``return real_tip`` (no gating) and the three foreign-tag assertions turn red.
+    Mutation cross-check (re-runnable): (1) replace ``gate``'s tail with a bare
+    ``return stripped`` (no gating) and the three foreign-tag assertions turn red;
+    (2) drop the ``#v`` strip line and ``gate("v1.7.14")`` turns red.
     """
 
     def gate(real_tip: str) -> str:
-        # Faithful Python mirror of the release.yml shell gate.
-        return real_tip if VERSION_RE.match(real_tip) else ""
+        # Faithful Python mirror of the release.yml shell gate, incl. the
+        # ``REAL_TIP="${REAL_TIP#v}"`` strip that precedes the VERSION_RE check.
+        stripped = real_tip[1:] if real_tip.startswith("v") else real_tip
+        return stripped if VERSION_RE.match(stripped) else ""
 
     # foreign / non-version tips are blanked -> no spurious MODE=hand
     assert gate("set-release-tag") == ""
     assert gate("nightly") == ""
-    assert gate("v2") == ""
+    assert gate("v2") == ""  # v-strip -> "2", still not a full version
     # genuine PEP 440 line tips are kept -> MODE=hand still fires on a mismatch
     assert gate("1.7.14b1") == "1.7.14b1"
     assert gate("1.7.14.0") == "1.7.14.0"
     assert gate("1.7.13") == "1.7.13"
+    # a genuine v-prefixed release tag (BSkando) is kept as its v-less version
+    assert gate("v1.7.14") == "1.7.14"
+
+    # Lock the strip into release.yml itself: the mirror above only models the
+    # intended behaviour, so without this the strip could be dropped from the
+    # workflow with no red test.
+    wf = (_REPO_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    assert 'REAL_TIP="${REAL_TIP#v}"' in wf, (
+        "release.yml must strip an optional leading v from REAL_TIP"
+    )
+
+
+# --- v-prefix tag -> v-less version mapping (both fork conventions) ---------
+
+
+def test_release_stamp_strips_v_for_version_keeps_tag_for_release() -> None:
+    """release-stamp.yml maps a (possibly v-prefixed) TAG to a v-less VERSION.
+
+    The version stamped into the code literals is the v-less value
+    (``VERSION="${TAG_NAME#v}"``), while git/release object addressing keeps the
+    full published tag (checkout ref, ``rev-list refs/tags``, ``gh release
+    upload``). Guards against a mutation that strips the wrong variable, which the
+    byte-parity test above cannot catch (it only checks the regex pattern).
+    """
+    wf = (_REPO_ROOT / ".github/workflows/release-stamp.yml").read_text(
+        encoding="utf-8"
+    )
+    # The version passed to the stamp script is the v-stripped value.
+    assert 'VERSION="${TAG_NAME#v}"' in wf, "must derive a v-less VERSION"
+    assert '--version "$VERSION"' in wf, "stamp must use the v-less VERSION"
+    # The guard validates the stripped VERSION, not the raw TAG_NAME.
+    assert 'printf \'%s\' "$VERSION" | grep -qE' in wf, (
+        "guard must validate the stripped VERSION"
+    )
+    # Git/release object addressing keeps the full published tag (with any `v`).
+    assert "ref: ${{ github.event.release.tag_name }}" in wf
+    assert 'git rev-list -n1 "refs/tags/${TAG_NAME}"' in wf
+    assert 'gh release upload "$TAG_NAME"' in wf, (
+        "release upload must address the real tag, not the stripped version "
+        "(locked by test_hacs_validation.py)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("tag", "version"),
+    [
+        ("v1.7.14", "1.7.14"),  # BSkando v-prefix -> v-less version
+        ("1.7.14", "1.7.14"),  # jleinenbach no-prefix -> unchanged (no-op)
+        ("v1.7.14b1", "1.7.14b1"),  # v-prefix beta
+        ("1.7.13.1", "1.7.13.1"),  # four-segment, no prefix
+        ("vv1", "v1"),  # POSIX ${VAR#v} strips exactly ONE leading v
+    ],
+)
+def test_tag_to_version_v_strip_semantics(tag: str, version: str) -> None:
+    """POSIX ``${TAG_NAME#v}`` strips at most one leading ``v``.
+
+    ``vv1 -> v1`` (not ``1``) proves a single-strip, so the guard would still
+    reject a malformed double-v tag. A real ``v``-prefixed tag maps to a version
+    that VERSION_RE accepts; the raw ``v``-tag itself does not.
+    """
+    stripped = tag[1:] if tag.startswith("v") else tag
+    assert stripped == version
+    if version in {"1.7.14", "1.7.14b1", "1.7.13.1"}:
+        assert VERSION_RE.match(stripped), f"{stripped!r} must be a valid version"
+        if tag.startswith("v"):
+            assert not VERSION_RE.match(tag), f"raw tag {tag!r} must not match"
 
 
 # --- Tag-vs-branch: checkout must pin the published tag ---------------------

--- a/tests/test_stamp_version.py
+++ b/tests/test_stamp_version.py
@@ -247,7 +247,7 @@ def test_release_stamp_strips_v_for_version_keeps_tag_for_release() -> None:
     assert 'VERSION="${TAG_NAME#v}"' in wf, "must derive a v-less VERSION"
     assert '--version "$VERSION"' in wf, "stamp must use the v-less VERSION"
     # The guard validates the stripped VERSION, not the raw TAG_NAME.
-    assert 'printf \'%s\' "$VERSION" | grep -qE' in wf, (
+    assert "printf '%s' \"$VERSION\" | grep -qE" in wf, (
         "guard must validate the stripped VERSION"
     )
     # Git/release object addressing keeps the full published tag (with any `v`).


### PR DESCRIPTION
## Problem

Publishing release **`v1.7.14`** on the BSkando fork made the **Release Stamp** workflow fail at *Validate published tag* (run [29640204798](https://github.com/BSkando/GoogleFindMy-HA/actions/runs/29640204798)):

```
tag_name 'v1.7.14' violates tag_format='{version}'; expected X.Y.Z[.N][bN], no 'v' prefix
```

The guard rejected the leading `v`, so the stamp, commit, push **and the HACS ZIP upload never ran** and the published release shipped with **no `googlefindmy.zip` asset** (broken HACS installs). Root cause: the release tooling was built for the jleinenbach `X.Y.Z[.N]` (no-`v`) tag convention and shared byte-identically into BSkando, whose convention is `vX.Y.Z`.

## Fix (tag boundary strips the `v`; VERSION_RE stays version-only)

A *version* literal (manifest.json / const.py / pyproject.toml) never carries a `v`; only the *git tag* may. So the fix draws the tag<->version line at the workflow boundary:

- `release-stamp.yml`: derive `VERSION="${TAG_NAME#v}"` (strips at most one leading `v`, a no-op for v-less tags), validate and stamp that v-less `VERSION`. The full `TAG_NAME` (with any `v`) still addresses the git tag / release asset: `checkout ref`, `git rev-list refs/tags`, `gh release upload` are unchanged.
- `release.yml`: the dormant Workflow-A `REAL_TIP` gate strips `v` too, so a genuine `v`-prefixed line tip is recognised as a version instead of blanked as foreign.
- `script/stamp_version.py`: `VERSION_RE` and the `--version` contract are **unchanged** (version-only); only the docstrings/comments are corrected to describe the strip.

Both fork conventions (`vX.Y.Z` and `X.Y.Z[.N][bN]`) now stamp cleanly; v-less tags behave byte-identically to before.

## Tests

- New `test_release_stamp_strips_v_for_version_keeps_tag_for_release`: the stamp input is the v-less `$VERSION`, while `checkout`/`rev-list`/`gh release upload` keep `$TAG_NAME` (guards a mutation the byte-parity test cannot catch).
- New `test_tag_to_version_v_strip_semantics`: POSIX `${VAR#v}` strips exactly one `v` (`vv1 -> v1`), and a real `v`-tag maps to a valid version.
- `test_real_tip_gate_...` mirror extended with the strip + `gate("v1.7.14") == "1.7.14"`, and now also locks the strip line into `release.yml`.
- `test_workflow_guard_regex_matches_version_re` and `test_version_re_*` unchanged and green (the regex pattern is untouched).

Mutation cross-checks (re-runnable) confirmed each new assertion turns red when the corresponding strip is removed/misplaced. `41 passed` locally (stamp + hacs suites); YAML valid; `ruff` clean.

> Note: this prevents recurrence. The already-published `v1.7.14` release stays asset-less until its ZIP is uploaded separately (a plain re-run would re-execute the old workflow at the old tagged commit).
