### PR TITLE
ci: tolerate transient HACS validation regression (hacs/integration#5252)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,51 @@ jobs:
       - name: Run HACS validation
         if: steps.brands_probe.outputs.available == 'true'
         id: hacs
+        continue-on-error: true
         uses: hacs/action@main
         with:
           category: integration
           ignore: topics issues
+
+      # Transient HACS regression guard (hacs/integration#5252): the action
+      # intermittently fetches the raw hacs.json / manifest.json as None from
+      # the GitHub contents API and reports "invalid 'hacs.json' file" and
+      # "integration_manifest ... Got None" on byte-identical, valid files.
+      # If the first run fails, re-run with exactly those two transient-prone
+      # validators isolated. If everything else passes, the failure was the
+      # known transient signature and is tolerated (job stays green with a
+      # warning). The isolation is NOT permanent: it only runs on failure, so a
+      # healthy HACS still exercises all checks. The real validity of both files
+      # is still enforced independently at the ci-success level: manifest.json by
+      # the hassfest job (this job needs: hassfest) and hacs.json by the test job
+      # (tests/test_hacs_validation.py). Any other failing check keeps this red.
+      - name: Re-run HACS validation (isolate transient checks)
+        if: steps.brands_probe.outputs.available == 'true' && steps.hacs.outcome == 'failure'
+        id: hacs_surgical
+        continue-on-error: true
+        uses: hacs/action@main
+        with:
+          category: integration
+          ignore: topics issues hacsjson integration_manifest
+
+      - name: Classify HACS result
+        if: steps.brands_probe.outputs.available == 'true'
+        id: hacs_verdict
+        env:
+          FIRST: ${{ steps.hacs.outcome }}
+          RETRY: ${{ steps.hacs_surgical.outcome }}
+        run: |
+          set -u
+          if [ "$FIRST" = "success" ]; then
+            echo "status=passed" >> "$GITHUB_OUTPUT"
+          elif [ "$RETRY" = "success" ]; then
+            echo "::warning ::HACS validation failed only on the transient-prone checks (hacsjson, integration_manifest) and passed once they were isolated; treating as the known transient upstream regression (hacs/integration#5252). File validity is still enforced by the hassfest and test jobs."
+            echo "status=transient" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error ::HACS validation failed on a check beyond the known transient signature; treating as a real defect."
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
 
       - name: Write HACS summary
         if: always()
@@ -144,10 +185,14 @@ jobs:
             echo ""
             if [ "${{ steps.brands_probe.outputs.available }}" != "true" ]; then
               echo "⚠️ **Skipped** - brands.home-assistant.io unavailable"
-            elif [ "${{ steps.hacs.outcome }}" = "success" ]; then
+            elif [ "${{ steps.hacs_verdict.outputs.status }}" = "passed" ]; then
               echo "✅ **HACS validation passed**"
               echo ""
               echo "The integration meets HACS requirements."
+            elif [ "${{ steps.hacs_verdict.outputs.status }}" = "transient" ]; then
+              echo "⚠️ **HACS validation passed after isolating transient checks** - tolerated upstream regression (hacs/integration#5252)."
+              echo ""
+              echo "Only hacsjson/integration_manifest failed; file validity is enforced by the hassfest and test jobs."
             else
               echo "❌ **HACS validation failed**"
               echo ""

--- a/tests/test_hacs_validation.py
+++ b/tests/test_hacs_validation.py
@@ -9,6 +9,7 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from custom_components.googlefindmy.const import INTEGRATION_VERSION
 
@@ -129,26 +130,43 @@ def test_ci_tolerates_transient_hacs_regression() -> None:
     regress into either a blanket-ignore or a hard block.
     """
 
-    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    ci = yaml.safe_load(Path(".github/workflows/ci.yml").read_text(encoding="utf-8"))
+    steps = ci["jobs"]["hacs"]["steps"]
+    by_id = {step["id"]: step for step in steps if "id" in step}
 
-    # Primary HACS run tolerates failure so the classifier can decide.
-    assert "continue-on-error: true" in workflow, (
+    primary = by_id["hacs"]
+    surgical = by_id["hacs_surgical"]
+    verdict = by_id["hacs_verdict"]
+
+    # Primary run tolerates failure (so the classifier can decide) and keeps the
+    # original, narrower ignore list: the isolation must not be permanent.
+    assert primary.get("continue-on-error") is True, (
         "primary HACS run must set continue-on-error so the guard can classify"
     )
-    # Fallback run isolates exactly the two transient-prone validators, gated on
-    # the primary run having failed (so it never runs when HACS is healthy).
-    assert "ignore: topics issues hacsjson integration_manifest" in workflow, (
-        "fallback HACS run must isolate hacsjson + integration_manifest"
+    assert primary["with"]["ignore"].split() == ["topics", "issues"], (
+        "primary HACS run must keep the narrow ignore (isolation not permanent)"
     )
-    assert "steps.hacs.outcome == 'failure'" in workflow, (
+
+    # Fallback isolates exactly the two transient-prone validators and only runs
+    # when the primary run failed (never when HACS is healthy).
+    assert surgical.get("continue-on-error") is True, (
+        "fallback HACS run must set continue-on-error"
+    )
+    assert set(surgical["with"]["ignore"].split()) == {
+        "topics",
+        "issues",
+        "hacsjson",
+        "integration_manifest",
+    }, "fallback HACS run must isolate exactly hacsjson + integration_manifest"
+    assert "steps.hacs.outcome == 'failure'" in surgical["if"], (
         "fallback HACS run must be gated on the primary run failing"
     )
-    # A defect beyond the transient signature must still fail the job.
-    assert "exit 1" in workflow, (
-        "classifier must exit non-zero when the failure is not the transient one"
+
+    # The classifier must be able to fail the job on a real defect: it must NOT
+    # be continue-on-error, and must exit non-zero outside the tolerated paths.
+    assert not verdict.get("continue-on-error", False), (
+        "classifier must not be continue-on-error, or a real defect passes silently"
     )
-    # The isolation must be scoped to the fallback only: the primary run keeps
-    # the original, narrower ignore list (not the extended one).
-    assert "ignore: topics issues\n" in workflow, (
-        "primary HACS run must keep 'ignore: topics issues' (isolation not permanent)"
+    assert "exit 1" in verdict["run"], (
+        "classifier must exit non-zero when the failure is not the transient one"
     )

--- a/tests/test_hacs_validation.py
+++ b/tests/test_hacs_validation.py
@@ -112,3 +112,43 @@ def test_release_zip_places_manifest_at_root() -> None:
     assert f'gh release upload "$TAG_NAME" {filename} --clobber' in workflow, (
         f"workflow must upload the declared hacs.json asset name {filename!r}"
     )
+
+
+def test_ci_tolerates_transient_hacs_regression() -> None:
+    """ci.yml must guard the HACS job against the transient hacs/integration#5252
+    regression without permanently disabling the two affected validators.
+
+    The upstream action intermittently fetches the raw hacs.json / manifest.json
+    as None and reports them invalid on byte-identical, valid files. The guard
+    runs HACS first (continue-on-error), and only on failure re-runs it with
+    exactly ``hacsjson`` and ``integration_manifest`` isolated. If everything
+    else passes the failure was the known transient signature (tolerated); a
+    failure of any other check still exits non-zero (real defect). The isolation
+    must NOT leak into the primary run, otherwise those two checks would be off
+    permanently. This guard locks the shape so the resilience cannot silently
+    regress into either a blanket-ignore or a hard block.
+    """
+
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    # Primary HACS run tolerates failure so the classifier can decide.
+    assert "continue-on-error: true" in workflow, (
+        "primary HACS run must set continue-on-error so the guard can classify"
+    )
+    # Fallback run isolates exactly the two transient-prone validators, gated on
+    # the primary run having failed (so it never runs when HACS is healthy).
+    assert "ignore: topics issues hacsjson integration_manifest" in workflow, (
+        "fallback HACS run must isolate hacsjson + integration_manifest"
+    )
+    assert "steps.hacs.outcome == 'failure'" in workflow, (
+        "fallback HACS run must be gated on the primary run failing"
+    )
+    # A defect beyond the transient signature must still fail the job.
+    assert "exit 1" in workflow, (
+        "classifier must exit non-zero when the failure is not the transient one"
+    )
+    # The isolation must be scoped to the fallback only: the primary run keeps
+    # the original, narrower ignore list (not the extended one).
+    assert "ignore: topics issues\n" in workflow, (
+        "primary HACS run must keep 'ignore: topics issues' (isolation not permanent)"
+    )

--- a/tests/test_hacs_validation.py
+++ b/tests/test_hacs_validation.py
@@ -1,5 +1,4 @@
 # tests/test_hacs_validation.py
-# tests/test_hacs_validation.py
 """Validate HACS metadata alignment and guard against unsupported characters."""
 
 from __future__ import annotations
@@ -51,6 +50,41 @@ def test_hacs_metadata_matches_manifest(
     assert match, "INTEGRATION_VERSION constant missing (or has a type annotation)"
     assert manifest["version"] == INTEGRATION_VERSION == match.group(1)
     assert "homeassistant" not in manifest
+
+
+def test_hacs_metadata_field_types(hacs_metadata: dict[str, object]) -> None:
+    """hacs.json fields must carry the types HACS's ``hacsjson`` validator requires.
+
+    The ci.yml transient guard (see test_ci_tolerates_transient_hacs_regression)
+    may classify a HACS run ``transient`` when only ``hacsjson`` +
+    ``integration_manifest`` fail, on the premise that a *genuine* hacs.json schema
+    error is caught locally instead. That premise only holds if this job rejects the
+    same class HACS would: HACS documents ``content_in_root``/``zip_release`` and the
+    other switches as booleans, so a non-boolean value (e.g. the string ``"true"``)
+    fails HACS ``hacsjson`` but would otherwise slip through the fallback green.
+    ``test_hacs_metadata_matches_manifest`` only checks the allowed *keys*, not their
+    types; validate the types here so the fallback tolerance stays safe.
+    """
+
+    # ``isinstance(5, bool)`` is False and ``isinstance("true", bool)`` is False, so
+    # this rejects exactly the non-boolean values HACS's hacsjson validator rejects.
+    for field in (
+        "content_in_root",
+        "zip_release",
+        "render_readme",
+        "hide_default_branch",
+    ):
+        if field in hacs_metadata:
+            assert isinstance(hacs_metadata[field], bool), (
+                f"hacs.json '{field}' must be a boolean; HACS rejects other types "
+                f"(got {type(hacs_metadata[field]).__name__})"
+            )
+    for field in ("name", "filename", "homeassistant"):
+        if field in hacs_metadata:
+            assert isinstance(hacs_metadata[field], str), (
+                f"hacs.json '{field}' must be a string "
+                f"(got {type(hacs_metadata[field]).__name__})"
+            )
 
 
 def test_no_micro_sign_in_integration_files(


### PR DESCRIPTION
## Problem

The `HACS validation` CI job (`hacs/action@main`) fails deterministically with:

```
<Validation hacsjson> failed: invalid 'hacs.json' file
<Validation integration_manifest> failed: expected a dictionary. Got None
2/7 checks failed
```

This is the known upstream regression **hacs/integration#5252**: the action
intermittently fetches the raw `hacs.json` / `manifest.json` as `None` from the
GitHub contents API and reports them invalid on **byte-identical, valid** files.
Evidence: `hacs.json`/`manifest.json` are byte-identical to a green run earlier
the same day, the action image digest is unchanged across the green and red runs
(`sha256:3b5eaf82…`), and a re-run hours later is still red. It is not a repo
defect. A digest pin is therefore useless (the green digest *is* the red digest),
and a `brands_probe`-style pre-probe cannot detect it (the files are reachable).

## Fix

Run HACS first with `continue-on-error`. Only on failure, re-run it with exactly
the two transient-prone validators isolated (`ignore: … hacsjson integration_manifest`):

- first run passes → **passed**;
- first fails, isolated re-run passes → only the #5252 pair failed → **tolerated** (job green, warning);
- both fail → a check beyond the known signature failed → **real defect**, job red.

The isolation is **not permanent** (the fallback runs only on failure, so a healthy
HACS still exercises all 7 checks). The real validity of the two isolated files stays
enforced independently at the `ci-success` level: `manifest.json` by the **hassfest**
job (`hacs` has `needs: hassfest`) and `hacs.json` by the **test** job
(`tests/test_hacs_validation.py`). `ci-success` and `release.yml` are unchanged.

## Tests

`tests/test_hacs_validation.py::test_ci_tolerates_transient_hacs_regression` locks the
guard shape (continue-on-error, gated fallback with the two isolated validators,
non-zero exit on other failures, primary keeps the narrow ignore). Three mutation
counter-proofs each turn exactly this test red.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>