### PR TITLE
test(hacs): reproduce ignored HACS validators locally (Codex #206 P2)

### DIFF
--- a/tests/test_hacs_validation.py
+++ b/tests/test_hacs_validation.py
@@ -87,6 +87,55 @@ def test_hacs_metadata_field_types(hacs_metadata: dict[str, object]) -> None:
             )
 
 
+def test_hacs_metadata_requires_name(hacs_metadata: dict[str, object]) -> None:
+    """hacs.json must declare a non-empty ``name`` (HACS's ``hacsjson`` validator).
+
+    The ci.yml transient guard (see test_ci_tolerates_transient_hacs_regression)
+    tolerates a HACS run when only ``hacsjson`` + ``integration_manifest`` fail, on the
+    premise that a *genuine* metadata regression is caught locally instead.
+    ``test_hacs_metadata_field_types`` covers a wrong field *type*; this covers a
+    *missing* required key -- which HACS also rejects, but the fallback would otherwise
+    wave through green. Source: hacs.xyz/docs/publish/integration.
+    """
+
+    name = hacs_metadata.get("name")
+    assert isinstance(name, str) and name.strip(), (
+        "hacs.json must declare a non-empty 'name' string; HACS's hacsjson validator "
+        "requires it"
+    )
+
+
+def test_manifest_satisfies_hacs_integration_contract(
+    manifest: dict[str, object],
+) -> None:
+    """manifest.json must carry the keys HACS's ``integration_manifest`` validator needs.
+
+    HACS requires an integration manifest to declare ``domain``, ``documentation``,
+    ``issue_tracker``, ``codeowners``, ``name`` and ``version``
+    (hacs.xyz/docs/publish/integration). The ci.yml transient guard ignores
+    ``integration_manifest`` in its fallback and marks the job ``transient`` when the
+    remaining checks pass; that is only safe if a *genuine* manifest regression is
+    caught locally. hassfest overlaps but does not mirror HACS's exact set, so
+    reproduce the HACS contract here: a missing or wrongly-typed required key fails
+    this job deterministically, independent of the HACS tolerance.
+    """
+
+    for field in ("domain", "documentation", "issue_tracker", "name", "version"):
+        value = manifest.get(field)
+        assert isinstance(value, str) and value.strip(), (
+            f"manifest.json must declare a non-empty '{field}' string "
+            "(HACS integration_manifest requirement)"
+        )
+    codeowners = manifest.get("codeowners")
+    assert isinstance(codeowners, list) and codeowners, (
+        "manifest.json 'codeowners' must be a non-empty list "
+        "(HACS integration_manifest requirement)"
+    )
+    assert all(isinstance(owner, str) and owner.strip() for owner in codeowners), (
+        "manifest.json 'codeowners' entries must all be non-empty strings"
+    )
+
+
 def test_no_micro_sign_in_integration_files(
     integration_python_files: list[Path], integration_root: Path
 ) -> None:


### PR DESCRIPTION
## What

Harden the local reproduction of the two HACS validators the transient guard ignores, so it can never mask a **genuine** metadata regression.

## Why (Codex #206 P2)

The transient guard added in #1206 runs HACS, and on failure re-runs it with `hacsjson` + `integration_manifest` ignored, classifying the job `transient` when the remaining checks pass. The premise is that a *real* regression in those two validators is caught locally instead. That premise was only **partly** true:

- `test_hacs_metadata_field_types` reproduced hacs.json field **types**.
- Nothing reproduced **required-key presence** for either ignored validator.

So a *missing* required key (which HACS also rejects) would fail the HACS primary run, be ignored by the fallback, and slip through green. Codex flagged exactly this on #206 (`ci.yml:173`, P2) and asked to "reproduce all ignored validators locally before setting `status=transient`".

## Change (test-only, additive)

- `test_hacs_metadata_requires_name`: hacs.json must declare a non-empty `name` (the `hacsjson` validator's hard requirement).
- `test_manifest_satisfies_hacs_integration_contract`: manifest.json must carry the six keys HACS's `integration_manifest` validator requires (`domain`, `documentation`, `issue_tracker`, `name`, `version` as non-empty strings; `codeowners` as a non-empty list of strings). Source: [hacs.xyz/docs/publish/integration](https://www.hacs.xyz/docs/publish/integration/).

No `ci.yml` change. The log-free guard stays; only its local backstop is completed, so a missing or wrongly-typed required key now fails the `test` job deterministically, independent of the HACS tolerance. Codex option (a) log-grep of the failure signature was deliberately not taken (fragile), consistent with #1206.

## Verification

- Assertion logic verified standalone against the real `hacs.json`/`manifest.json` (pytest is not locally collectable: `conftest.py` requires the HA package; CI is authoritative).
- 6 mutation counter-checks (name missing/empty, manifest key missing, `codeowners` as string/empty, version missing) each rejected; real files pass.
- `ruff check` + `ruff format --check` clean.

Closes the N2 residual of the #1206 plan.
