### PR TITLE
feat(docker-login): containerised noVNC one-time Google login helper

### DIFF
--- a/custom_components/googlefindmy/.dockerignore
+++ b/custom_components/googlefindmy/.dockerignore
@@ -1,14 +1,30 @@
 # Docker build-context excludes for the docker-login image.
 #
 # The login image builds with `build.context: ..` (see
-# docker-login/docker-compose.yml), i.e. this integration package directory is
-# the context root, so Docker reads THIS .dockerignore.
+# docker-login/docker-compose.yml), i.e. this ENTIRE integration package
+# directory is the build context: hundreds of source files plus, after a login,
+# persisted OAuth/AAS credentials. Secrets can appear in more than one place:
+#   * docker-login/data/secrets.json  (the container's writable volume)
+#   * Auth/secrets.json               (the legacy default of
+#                                       main.py::_resolve_secrets_path)
+# and future cache/token locations could add more. `.gitignore` only stops Git
+# commits; it does NOT filter Docker's context upload, so a `docker compose run
+# --build` (both launchers use it) would otherwise ship whatever secrets exist to
+# remote, shared or legacy daemons even though the Dockerfile never COPYs them.
 #
-# Keep persisted credentials OUT of the build context: after the first login run
-# docker-login/data/secrets.json exists here, and both launchers build with
-# `docker compose run --build`. Without this exclude, builders that upload the
-# full context (remote, shared or legacy daemons) would receive the OAuth/AAS
-# credentials even though the Dockerfile never COPYs that file into the image.
-# .gitignore only stops Git commits; it does not filter Docker's context upload.
-# This file is the Docker-side counterpart.
-docker-login/data/
+# Denylisting each secret path individually is whack-a-mole: a new location
+# reopens the hole (exactly what happened for Auth/secrets.json). Instead this is
+# an ALLOWLIST: ignore the whole context, then re-include ONLY the two paths the
+# Dockerfile actually needs at build time:
+#   * requirements.txt           - COPYed, dependencies baked into the image
+#   * docker-login/entrypoint.sh - COPYed as the container entrypoint
+# The integration *code* is NOT built in; it is bind-mounted read-only at run
+# time (M2). This keeps every secret - current or future, anywhere in the tree -
+# out of the build context and shrinks the upload to just the required files.
+#
+# Docker cannot descend into an ignored directory, so docker-login/ is re-included
+# as a whole and its persisted-credentials subdir is then re-excluded again.
+*
+!requirements.txt
+!docker-login
+docker-login/data

--- a/custom_components/googlefindmy/.dockerignore
+++ b/custom_components/googlefindmy/.dockerignore
@@ -23,8 +23,13 @@
 # out of the build context and shrinks the upload to just the required files.
 #
 # Docker cannot descend into an ignored directory, so docker-login/ is re-included
-# as a whole and its persisted-credentials subdir is then re-excluded again.
+# only for TRAVERSAL; its contents are then re-excluded (docker-login/*) and only
+# the one COPY input the Dockerfile needs (entrypoint.sh) is re-included. A bare
+# `!docker-login` would re-include the WHOLE directory, so any other file placed
+# under it -- an exported secrets.json, a diagnostic log, a future addition -- would
+# ship in the context; excluding only docker-login/data left exactly that hole.
 *
 !requirements.txt
 !docker-login
-docker-login/data
+docker-login/*
+!docker-login/entrypoint.sh

--- a/custom_components/googlefindmy/.dockerignore
+++ b/custom_components/googlefindmy/.dockerignore
@@ -1,0 +1,14 @@
+# Docker build-context excludes for the docker-login image.
+#
+# The login image builds with `build.context: ..` (see
+# docker-login/docker-compose.yml), i.e. this integration package directory is
+# the context root, so Docker reads THIS .dockerignore.
+#
+# Keep persisted credentials OUT of the build context: after the first login run
+# docker-login/data/secrets.json exists here, and both launchers build with
+# `docker compose run --build`. Without this exclude, builders that upload the
+# full context (remote, shared or legacy daemons) would receive the OAuth/AAS
+# credentials even though the Dockerfile never COPYs that file into the image.
+# .gitignore only stops Git commits; it does not filter Docker's context upload.
+# This file is the Docker-side counterpart.
+docker-login/data/

--- a/custom_components/googlefindmy/docker-login/.gitignore
+++ b/custom_components/googlefindmy/docker-login/.gitignore
@@ -1,0 +1,3 @@
+# Cached Google auth tokens — never commit real credentials.
+data/secrets.json
+data/*.json

--- a/custom_components/googlefindmy/docker-login/Dockerfile
+++ b/custom_components/googlefindmy/docker-login/Dockerfile
@@ -13,11 +13,19 @@
 # onto the integration's *own* main.py so the produced secrets.json matches the
 # installed integration byte-for-byte. See README.md → Credits.
 #
-# Build model: M2 (runtime mount). The integration code is NOT baked into the
-# image — it is bind-mounted read-only at run time from its real import path
-# (see docker-compose.yml). The image therefore stays version-independent and
-# always runs whatever integration version is installed. Only the declared
-# runtime dependencies are baked in.
+# Run model (M2, runtime mount + standalone):
+#   * The integration code is NOT baked into the image. docker-compose.yml
+#     bind-mounts it READ-ONLY at a flat path (/app/gfmy), so main.py detects
+#     the standalone layout (_standalone=True), injects lightweight
+#     homeassistant.* stubs, and runs without a Home Assistant install. The
+#     image therefore stays version-independent and always runs the installed
+#     integration version.
+#   * secrets.json is written to a SEPARATE writable volume (/data) via
+#     GOOGLEFINDMY_SECRETS_PATH, so the read-only code mount is never written to
+#     and the atomic write stays on a single writable filesystem.
+# Only the declared runtime dependencies are baked in (Home Assistant and
+# voluptuous are deliberately NOT installed — the standalone path stubs HA and
+# never imports the package __init__/config_flow that need voluptuous).
 #
 # Build context is the integration package dir (custom_components/googlefindmy),
 # see docker-compose.yml `build.context: ..`.
@@ -27,23 +35,17 @@ USER root
 WORKDIR /app
 
 # --- Python dependencies -------------------------------------------------------
-# The integration's declared runtime deps are sufficient for the standalone CLI.
-# Home Assistant is deliberately NOT installed: main.py installs lightweight
-# homeassistant.* stubs when the package is absent (find_spec("homeassistant")
-# is None), so the login/bootstrap flow runs without a full HA install.
-#
 # requirements.txt lives inside the integration package (the build context), so
 # it is COPYed at build time. The integration *code* is NOT copied (M2): it is
 # mounted at run time, which keeps the image independent of the code version.
 COPY requirements.txt /app/requirements.txt
 RUN pip3 install --no-cache-dir -r /app/requirements.txt
 
-# secrets.json is written next to main.py under Auth/ (the upstream layout the
-# integration mirrors). The dir is provided at run time by a writable bind mount
-# (docker-compose.yml → ./data). We still create it here as a fallback mount
-# point and hand /app to the runtime user.
-RUN mkdir -p /app/custom_components/googlefindmy/Auth \
- && chown -R seluser:seluser /app \
+# Writable volume mount point for the produced secrets.json (see
+# docker-compose.yml → ./data:/data and GOOGLEFINDMY_SECRETS_PATH). Created and
+# owned here as a fallback; the bind mount provides the real, host-persisted dir.
+RUN mkdir -p /data \
+ && chown -R seluser:seluser /app /data \
  && chown -R seluser:seluser /home/seluser
 
 COPY docker-login/entrypoint.sh /opt/bin/gfm-entrypoint.sh

--- a/custom_components/googlefindmy/docker-login/Dockerfile
+++ b/custom_components/googlefindmy/docker-login/Dockerfile
@@ -1,0 +1,53 @@
+# GoogleFindMy-HA — containerised one-time Google login helper.
+#
+# This is a Docker wrapper around the *integration's own* standalone CLI
+# (custom_components/googlefindmy/main.py), NOT the upstream GoogleFindMyTools
+# CLI. It bundles Chrome + a virtual display + noVNC so the one-time Google
+# login can be driven from a browser tab, and it writes a secrets.json that is
+# byte-for-byte the file the integration consumes.
+#
+# Attribution: the noVNC/entrypoint container design is adapted from
+# sincze/GoogleFindMyTools @ docker-novnc-auth
+# (https://github.com/sincze/GoogleFindMyTools/tree/docker-novnc-auth); the
+# original CLI is leonboe1/GoogleFindMyTools. This wrapper turns that design
+# onto the integration's *own* main.py so the produced secrets.json matches the
+# installed integration byte-for-byte. See README.md → Credits.
+#
+# Build model: M2 (runtime mount). The integration code is NOT baked into the
+# image — it is bind-mounted read-only at run time from its real import path
+# (see docker-compose.yml). The image therefore stays version-independent and
+# always runs whatever integration version is installed. Only the declared
+# runtime dependencies are baked in.
+#
+# Build context is the integration package dir (custom_components/googlefindmy),
+# see docker-compose.yml `build.context: ..`.
+FROM selenium/standalone-chrome:latest
+
+USER root
+WORKDIR /app
+
+# --- Python dependencies -------------------------------------------------------
+# The integration's declared runtime deps are sufficient for the standalone CLI.
+# Home Assistant is deliberately NOT installed: main.py installs lightweight
+# homeassistant.* stubs when the package is absent (find_spec("homeassistant")
+# is None), so the login/bootstrap flow runs without a full HA install.
+#
+# requirements.txt lives inside the integration package (the build context), so
+# it is COPYed at build time. The integration *code* is NOT copied (M2): it is
+# mounted at run time, which keeps the image independent of the code version.
+COPY requirements.txt /app/requirements.txt
+RUN pip3 install --no-cache-dir -r /app/requirements.txt
+
+# secrets.json is written next to main.py under Auth/ (the upstream layout the
+# integration mirrors). The dir is provided at run time by a writable bind mount
+# (docker-compose.yml → ./data). We still create it here as a fallback mount
+# point and hand /app to the runtime user.
+RUN mkdir -p /app/custom_components/googlefindmy/Auth \
+ && chown -R seluser:seluser /app \
+ && chown -R seluser:seluser /home/seluser
+
+COPY docker-login/entrypoint.sh /opt/bin/gfm-entrypoint.sh
+RUN chmod +x /opt/bin/gfm-entrypoint.sh
+
+USER seluser
+ENTRYPOINT ["/opt/bin/gfm-entrypoint.sh"]

--- a/custom_components/googlefindmy/docker-login/README.md
+++ b/custom_components/googlefindmy/docker-login/README.md
@@ -185,6 +185,10 @@ setup it is already there) and import it via the integration's configuration
 flow (auth method *"GoogleFindMyTools secrets.json"*). Because it was produced by
 the integration's own code, no conversion is needed.
 
+The container writes the file as `seluser` and, on exit, relaxes it to mode
+`0644` so your host user (whose UID may differ) can read and copy it. Treat
+`data/secrets.json` as a credential and delete it once imported.
+
 ## Stopping
 
 ```bash

--- a/custom_components/googlefindmy/docker-login/README.md
+++ b/custom_components/googlefindmy/docker-login/README.md
@@ -86,9 +86,14 @@ Then follow [First run (Google login)](#first-run-google-login-required) from
 step 3.
 
 The launcher runs a single command:
-`docker compose up --build --force-recreate --remove-orphans`. It builds (if
-needed) **and** starts the container in the foreground, and `--force-recreate
---remove-orphans` guarantees exactly one container even if you run it twice.
+`docker compose run --build --service-ports --rm googlefindmy-login`. `run`
+builds (if needed) **and** starts a fresh one-shot container in the foreground
+with your terminal attached (so the "Press Enter" prompt reaches Python);
+`--rm` removes it on exit, so repeated logins never stack containers; and
+`--service-ports` publishes the noVNC port declared in `docker-compose.yml`.
+On Linux/QNAP the launcher also exports your `GFMY_HOST_UID`/`GFMY_HOST_GID` so
+the finished `secrets.json` is handed back to you (see
+[Using `secrets.json`](#using-secretsjson-in-home-assistant)).
 
 ### Manual alternative (`docker compose`)
 
@@ -97,27 +102,30 @@ If you prefer to run it by hand instead of the launcher:
 ```bash
 cd config/custom_components/googlefindmy/docker-login
 mkdir -p data
-chmod 0777 data            # let the container user (seluser) write secrets.json
-docker compose up --build
+docker compose run --build --service-ports --rm googlefindmy-login
 ```
 
-The `chmod` matters on Linux/QNAP: the image runs as `seluser`, whose UID may
-differ from yours, so the `./data` volume must be writable by others or the
-atomic write of `secrets.json` fails. Docker Desktop (Windows/macOS) handles this
-for you.
+No host `chmod` is needed: the container takes ownership of `./data` for the run
+(it has passwordless `sudo` in the selenium base image) and writes
+`secrets.json` there. If you run it by hand like this — without exporting
+`GFMY_HOST_UID`/`GFMY_HOST_GID` (the launcher does this) — the file stays owned
+by the container user; export those IDs, or `sudo chown` the file afterwards, to
+read it as your host user. Docker Desktop (Windows/macOS) maps ownership for you.
 
 ## First run (Google login required)
 
-1. (Launcher does this for you.) Create the writable token volume:
+1. (Launcher does this for you.) Create the token volume directory:
    ```bash
-   mkdir -p data && chmod 0777 data
+   mkdir -p data
    ```
    `secrets.json` is written here (to `data/secrets.json`) via the
    `GOOGLEFINDMY_SECRETS_PATH=/data/secrets.json` setting in
-   `docker-compose.yml`, so the integration code mount stays read-only.
+   `docker-compose.yml`, so the integration code mount stays read-only. The
+   container takes ownership of `./data` for the run, so no host `chmod` is needed.
 
-2. Start the container **in the foreground** (no `-d`; it prompts for input) —
-   `./login.sh` / `login.cmd`, or `docker compose up --build`.
+2. Start the container **in the foreground** (it prompts for input) —
+   `./login.sh` / `login.cmd`, or
+   `docker compose run --build --service-ports --rm googlefindmy-login`.
 
 3. Wait for this line in the terminal, then press **Enter**:
    ```
@@ -141,7 +149,8 @@ intended login path (there is no Supervisor Add-on store for HA Container):
 
 - **SSH:** enable SSH on the NAS, `cd` into
   `.../config/custom_components/googlefindmy/docker-login`, then run `./login.sh`
-  (or `docker compose up --build`). noVNC is bound to loopback, so open it via an
+  (or `docker compose run --build --service-ports --rm googlefindmy-login`).
+  noVNC is bound to loopback, so open it via an
   SSH tunnel from your workstation:
   ```bash
   ssh -L 7900:127.0.0.1:7900 <nas-ip>
@@ -159,7 +168,7 @@ Because HA and the login container run on the same box here, the produced
 ## Normal (already authenticated) runs
 
 ```bash
-./login.sh          # or: docker compose up
+./login.sh          # or: docker compose run --service-ports --rm googlefindmy-login
 ```
 If `data/secrets.json` already holds valid tokens, the browser step is skipped
 and the CLI lists devices directly. You can ignore the noVNC link.
@@ -171,7 +180,7 @@ and the CLI lists devices directly. You can ignore the noVNC link.
 echo '{}' > data/secrets.json
 
 # Option B: keep the file but force re-authentication
-GFMY_ARGS="--reauth" docker compose up
+GFMY_ARGS="--reauth" ./login.sh
 ```
 
 `GFMY_ARGS` is forwarded to `main.py`. Useful values: `--reauth` (force login),
@@ -185,8 +194,10 @@ setup it is already there) and import it via the integration's configuration
 flow (auth method *"GoogleFindMyTools secrets.json"*). Because it was produced by
 the integration's own code, no conversion is needed.
 
-The container writes the file as `seluser` and, on exit, relaxes it to mode
-`0644` so your host user (whose UID may differ) can read and copy it. Treat
+The container writes the file as its own user and, on exit, hands ownership back
+to your host user (the `GFMY_HOST_UID`/`GFMY_HOST_GID` the launcher exports)
+while **keeping owner-only `0600`**. So you can read and copy it, but no other
+local account can — the file is never made world-readable. Treat
 `data/secrets.json` as a credential and delete it once imported.
 
 ## Stopping
@@ -206,8 +217,10 @@ there is no separate image to rebuild for code changes.
 
 ## Troubleshooting
 
-- **Stuck with no prompt / can't type:** you probably ran `docker compose up -d`
-  (detached). Run it in the foreground (the launcher does).
+- **Stuck with no prompt / can't type:** you probably ran `docker compose up`
+  (which does not attach your terminal's stdin). Use `./login.sh` /
+  `docker compose run --service-ports --rm googlefindmy-login`, which runs in the
+  foreground with stdin attached.
 - **noVNC page won't load:** give the container a few seconds; check
   `docker compose logs` for `[entrypoint] Display ready.`
 - **noVNC password:** it is `secret` — a fixed default of the base image.
@@ -215,8 +228,13 @@ there is no separate image to rebuild for code changes.
   `GOOGLEFINDMY_CHROME_VERSION` to the container's Chrome major version
   (uncomment the line in `docker-compose.yml`). The integration's
   `chrome_driver.py` normally auto-detects this.
-- **Permission error writing `secrets.json`:** make sure `data/secrets.json`
-  exists as a *file* before the first run (the launcher handles this).
+- **Permission error writing `secrets.json`:** make sure `./data` exists (the
+  launcher runs `mkdir -p data`). The container chowns it to itself for the run,
+  so a host `chmod` is not required.
+- **Can't read `secrets.json` as your user after a manual run:** you ran it by
+  hand without exporting `GFMY_HOST_UID`/`GFMY_HOST_GID`, so the file stayed
+  container-owned. Re-run via `./login.sh`, or `sudo chown "$(id -u):$(id -g)"
+  data/secrets.json`.
 
 ## Known limitation
 

--- a/custom_components/googlefindmy/docker-login/README.md
+++ b/custom_components/googlefindmy/docker-login/README.md
@@ -1,0 +1,200 @@
+# Docker login helper for GoogleFindMy-HA
+
+A one-command Docker wrapper that performs the **one-time Google login** for the
+GoogleFindMy-HA integration and produces a ready-to-use `secrets.json`.
+
+> **Shipped with the integration (no `git clone`).**
+> These files are delivered by HACS together with the integration. After you
+> install GoogleFindMy-HA they already exist on the machine running Home
+> Assistant, under:
+> ```
+> config/custom_components/googlefindmy/docker-login/
+> ```
+> You do **not** need to clone any repository — just open that folder on your
+> Docker host and run the launcher below.
+>
+> **Home Assistant OS users:** HA-OS has no user shell and no Docker daemon you
+> can reach, so these compose files cannot be run there directly. See
+> [Which setup can run this?](#which-setup-can-run-this) for the Add-on path.
+
+Unlike the upstream *GoogleFindMyTools* Docker image, this wrapper runs the
+**integration's own** standalone CLI
+(`custom_components/googlefindmy/main.py`) — the same, up-to-date fork code that
+Home Assistant runs. The `secrets.json` it writes is therefore exactly what the
+integration consumes; no format drift between a separate CLI and the
+integration.
+
+The login itself needs a real Chrome window (it is *not* a copy-paste token), so
+the container bundles Chrome + a virtual display + a **noVNC** browser viewer.
+You log in through a browser tab that shows Chrome running inside the container;
+no local Python or Chrome is needed, and it works on ARM Linux too.
+
+## Run it on the Docker host, not inside Home Assistant
+
+`docker compose` must run **where the Docker daemon runs** (your NAS, your
+Docker Desktop, the Linux box hosting HA in a container). It does **not** run
+inside the Home Assistant container itself: HA has no Docker socket and cannot
+start a sibling container. So open the delivered `docker-login/` folder on the
+Docker host and launch it there.
+
+## Which setup can run this?
+
+| Home Assistant install | Has a host shell + Docker daemon? | Login path |
+|---|---|---|
+| **HA Container** (e.g. HA in Docker on a NAS/QNAP) | yes | This wrapper (`login.sh` / `login.cmd`) |
+| **HA Supervised** | yes | This wrapper, or a Supervisor Add-on |
+| **HA Core** (venv) | yes | This wrapper |
+| **HA OS** | no (no shell, no reachable Docker) | A Home Assistant **Add-on** (planned; the shipped compose files are inert here) |
+
+## Quick start (recommended: the launcher)
+
+The launcher takes care of the three common pitfalls (missing token file,
+duplicate containers, stale code after an update) for you.
+
+- **Linux / macOS / QNAP:**
+  ```bash
+  cd config/custom_components/googlefindmy/docker-login
+  ./login.sh
+  ```
+- **Windows (Docker Desktop):** double-click `login.cmd`, or from a terminal:
+  ```bat
+  cd config\custom_components\googlefindmy\docker-login
+  login.cmd
+  ```
+
+Then follow [First run (Google login)](#first-run-google-login-required) from
+step 3.
+
+The launcher runs a single command:
+`docker compose up --build --force-recreate --remove-orphans`. It builds (if
+needed) **and** starts the container in the foreground, and `--force-recreate
+--remove-orphans` guarantees exactly one container even if you run it twice.
+
+### Manual alternative (`docker compose`)
+
+If you prefer to run it by hand instead of the launcher:
+
+```bash
+cd config/custom_components/googlefindmy/docker-login
+mkdir -p data
+[ -f data/secrets.json ] || echo '{}' > data/secrets.json
+docker compose up --build
+```
+
+The `secrets.json` step matters: a bind mount to a non-existent file would
+otherwise be created by Docker as a *directory* and the login would fail.
+
+## First run (Google login required)
+
+1. (Launcher does this for you.) Make sure the token file exists as a file:
+   ```bash
+   mkdir -p data
+   [ -f data/secrets.json ] || echo '{}' > data/secrets.json
+   ```
+
+2. Start the container **in the foreground** (no `-d`; it prompts for input) —
+   `./login.sh` / `login.cmd`, or `docker compose up --build`.
+
+3. Wait for this line in the terminal, then press **Enter**:
+   ```
+   [AuthFlow] Press Enter to continue...
+   ```
+
+4. Open **http://localhost:7900** in your normal browser. Password: `secret`.
+   You now see a live view of Chrome running inside the container.
+
+5. In that noVNC window, log into your Google account as usual (2FA works the
+   same as in any browser).
+
+6. When the terminal prints `[AuthFlow] Retrieved Account Token successfully.`
+   the CLI continues and lists your Find My Device / Find Hub trackers. Your
+   tokens are now cached to `data/secrets.json` on the host.
+
+## Running on QNAP / Container Station
+
+On a QNAP NAS running Home Assistant as a container, this wrapper is the
+intended login path (there is no Supervisor Add-on store for HA Container):
+
+- **SSH:** enable SSH on the NAS, `cd` into
+  `.../config/custom_components/googlefindmy/docker-login`, then run `./login.sh`
+  (or `docker compose up --build`). Chrome/noVNC are then reachable at
+  `http://<nas-ip>:7900`.
+- **Container Station:** you can also import `docker-compose.yml` as an
+  application in Container Station. Keep it in the foreground for the first
+  (login) run so you can press Enter and watch the log.
+
+Because HA and the login container run on the same box here, the produced
+`data/secrets.json` is on the same host you import it from.
+
+## Normal (already authenticated) runs
+
+```bash
+./login.sh          # or: docker compose up
+```
+If `data/secrets.json` already holds valid tokens, the browser step is skipped
+and the CLI lists devices directly. You can ignore the noVNC link.
+
+## Forcing a fresh login
+
+```bash
+# Option A: wipe and start over
+echo '{}' > data/secrets.json
+
+# Option B: keep the file but force re-authentication
+GFMY_ARGS="--reauth" docker compose up
+```
+
+`GFMY_ARGS` is forwarded to `main.py`. Useful values: `--reauth` (force login),
+`--debug` (verbose bootstrap/FCM logging), `--entry <id>` (select one config
+entry when the cache holds several).
+
+## Using `secrets.json` in Home Assistant
+
+Copy `data/secrets.json` to the machine running Home Assistant (on a single-host
+setup it is already there) and import it via the integration's configuration
+flow (auth method *"GoogleFindMyTools secrets.json"*). Because it was produced by
+the integration's own code, no conversion is needed.
+
+## Stopping
+
+```bash
+docker compose down
+```
+`data/secrets.json` survives (it is a host-mounted file, not inside the
+container).
+
+## Keeping in sync with the integration
+
+Because the integration code is bind-mounted read-only at run time (it is **not**
+baked into the image), the container always runs the integration version that is
+currently installed. After a HACS update just start the login container again;
+there is no separate image to rebuild for code changes.
+
+## Troubleshooting
+
+- **Stuck with no prompt / can't type:** you probably ran `docker compose up -d`
+  (detached). Run it in the foreground (the launcher does).
+- **noVNC page won't load:** give the container a few seconds; check
+  `docker compose logs` for `[entrypoint] Display ready.`
+- **noVNC password:** it is `secret` — a fixed default of the base image.
+- **`SessionNotCreatedException` / chromedriver version mismatch:** set
+  `GOOGLEFINDMY_CHROME_VERSION` to the container's Chrome major version
+  (uncomment the line in `docker-compose.yml`). The integration's
+  `chrome_driver.py` normally auto-detects this.
+- **Permission error writing `secrets.json`:** make sure `data/secrets.json`
+  exists as a *file* before the first run (the launcher handles this).
+
+## Known limitation
+
+The Google login must be done by a human through the noVNC window — there is no
+way (nor reason) to script your real Google credentials.
+
+## Credits
+
+- **[sincze/GoogleFindMyTools @ `docker-novnc-auth`](https://github.com/sincze/GoogleFindMyTools/tree/docker-novnc-auth)**
+  — the containerised noVNC login design (Chrome + virtual display + noVNC +
+  `entrypoint.sh`) this wrapper is adapted from. Our wrapper turns that design
+  onto the integration's **own** `main.py`, so the produced `secrets.json`
+  matches the installed integration byte-for-byte instead of a separate CLI.
+- **[leonboe1/GoogleFindMyTools](https://github.com/leonboe1/GoogleFindMyTools)**
+  — the original GoogleFindMyTools CLI the integration is based on.

--- a/custom_components/googlefindmy/docker-login/README.md
+++ b/custom_components/googlefindmy/docker-login/README.md
@@ -37,6 +37,26 @@ inside the Home Assistant container itself: HA has no Docker socket and cannot
 start a sibling container. So open the delivered `docker-login/` folder on the
 Docker host and launch it there.
 
+## noVNC access & security
+
+The noVNC viewer uses the base image's **fixed password `secret`**, and during
+the Google sign-in it exposes a fully authenticated Chrome session. To avoid
+handing that to anyone on the network, the port is bound to **loopback
+(`127.0.0.1:7900`) by default** — it is only reachable from the Docker host
+itself.
+
+- **Reach it from another machine (recommended): SSH tunnel.**
+  ```bash
+  ssh -L 7900:127.0.0.1:7900 <docker-host>
+  ```
+  Then open `http://localhost:7900` on your own machine.
+- **Trusted LAN opt-in.** Only on a network you trust, bind noVNC to all
+  interfaces by setting `GFMY_NOVNC_BIND=0.0.0.0` before starting:
+  ```bash
+  GFMY_NOVNC_BIND=0.0.0.0 ./login.sh
+  ```
+  Then browse to `http://<docker-host-ip>:7900`. Prefer the tunnel over this.
+
 ## Which setup can run this?
 
 | Home Assistant install | Has a host shell + Docker daemon? | Login path |
@@ -77,20 +97,24 @@ If you prefer to run it by hand instead of the launcher:
 ```bash
 cd config/custom_components/googlefindmy/docker-login
 mkdir -p data
-[ -f data/secrets.json ] || echo '{}' > data/secrets.json
+chmod 0777 data            # let the container user (seluser) write secrets.json
 docker compose up --build
 ```
 
-The `secrets.json` step matters: a bind mount to a non-existent file would
-otherwise be created by Docker as a *directory* and the login would fail.
+The `chmod` matters on Linux/QNAP: the image runs as `seluser`, whose UID may
+differ from yours, so the `./data` volume must be writable by others or the
+atomic write of `secrets.json` fails. Docker Desktop (Windows/macOS) handles this
+for you.
 
 ## First run (Google login required)
 
-1. (Launcher does this for you.) Make sure the token file exists as a file:
+1. (Launcher does this for you.) Create the writable token volume:
    ```bash
-   mkdir -p data
-   [ -f data/secrets.json ] || echo '{}' > data/secrets.json
+   mkdir -p data && chmod 0777 data
    ```
+   `secrets.json` is written here (to `data/secrets.json`) via the
+   `GOOGLEFINDMY_SECRETS_PATH=/data/secrets.json` setting in
+   `docker-compose.yml`, so the integration code mount stays read-only.
 
 2. Start the container **in the foreground** (no `-d`; it prompts for input) —
    `./login.sh` / `login.cmd`, or `docker compose up --build`.
@@ -117,8 +141,14 @@ intended login path (there is no Supervisor Add-on store for HA Container):
 
 - **SSH:** enable SSH on the NAS, `cd` into
   `.../config/custom_components/googlefindmy/docker-login`, then run `./login.sh`
-  (or `docker compose up --build`). Chrome/noVNC are then reachable at
-  `http://<nas-ip>:7900`.
+  (or `docker compose up --build`). noVNC is bound to loopback, so open it via an
+  SSH tunnel from your workstation:
+  ```bash
+  ssh -L 7900:127.0.0.1:7900 <nas-ip>
+  ```
+  then browse to `http://localhost:7900`. Only on a trusted LAN, start with
+  `GFMY_NOVNC_BIND=0.0.0.0 ./login.sh` to reach `http://<nas-ip>:7900` directly
+  (see [noVNC access & security](#novnc-access--security)).
 - **Container Station:** you can also import `docker-compose.yml` as an
   application in Container Station. Keep it in the foreground for the first
   (login) run so you can press Enter and watch the log.

--- a/custom_components/googlefindmy/docker-login/README.md
+++ b/custom_components/googlefindmy/docker-login/README.md
@@ -158,9 +158,15 @@ intended login path (there is no Supervisor Add-on store for HA Container):
   then browse to `http://localhost:7900`. Only on a trusted LAN, start with
   `GFMY_NOVNC_BIND=0.0.0.0 ./login.sh` to reach `http://<nas-ip>:7900` directly
   (see [noVNC access & security](#novnc-access--security)).
-- **Container Station:** you can also import `docker-compose.yml` as an
-  application in Container Station. Keep it in the foreground for the first
-  (login) run so you can press Enter and watch the log.
+- **Container Station:** the interactive first login needs a terminal attached to
+  its STDIN, which only the `docker compose run` path (the **SSH** option above)
+  provides. Importing `docker-compose.yml` as a Container Station *application*
+  starts it with `docker compose up` semantics, which does **not** forward a
+  terminal — so the `[AuthFlow] Press Enter to continue...` prompt can never
+  proceed and the login stalls (see the compose file's own note and
+  [Troubleshooting](#troubleshooting)). Run the **login** via SSH; you may use
+  Container Station afterwards for the normal, already-authenticated runs, which
+  skip the Enter prompt.
 
 Because HA and the login container run on the same box here, the produced
 `data/secrets.json` is on the same host you import it from.

--- a/custom_components/googlefindmy/docker-login/docker-compose.yml
+++ b/custom_components/googlefindmy/docker-login/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  googlefindmy-login:
+    # Fixed identity + no auto-restart: this is a one-shot login job, not a
+    # long-running service. A named container means repeated `docker compose up`
+    # reuses the same instance instead of stacking new ones.
+    container_name: googlefindmy-login
+    restart: "no"
+    build:
+      # Build context is the integration package dir (this file lives in
+      # <context>/docker-login/). It holds requirements.txt (baked in) and
+      # docker-login/entrypoint.sh. The integration *code* is NOT built in — see
+      # the read-only volume below (M2 runtime mount).
+      context: ..
+      dockerfile: docker-login/Dockerfile
+    stdin_open: true      # keep STDIN open — main.py prompts "Press Enter"
+    tty: true
+    shm_size: "2g"        # headful Chrome needs shared memory
+    environment:
+      # Optional CLI flags forwarded to main.py, e.g. "--reauth" (force fresh
+      # login) or "--debug" (verbose bootstrap/FCM logging). Default: none.
+      GFMY_ARGS: "${GFMY_ARGS:-}"
+      # Optional: pin Chrome's major version if auto-detection ever mismatches
+      # the bundled Chrome (undetected-chromedriver SessionNotCreatedException).
+      # GOOGLEFINDMY_CHROME_VERSION: "141"
+    ports:
+      - "7900:7900"       # noVNC web viewer, password: secret
+    volumes:
+      # M2 runtime mount of the integration code, read-only, at its real import
+      # path. `../..` is the repository's custom_components/ dir, so this mount
+      # provides BOTH custom_components/__init__.py (a real package that calls
+      # pkgutil.extend_path) AND custom_components/googlefindmy/, which is what
+      # `python -m custom_components.googlefindmy.main` needs (main.py sets
+      # _standalone=False only in this exact layout). Mounting just the
+      # googlefindmy/ folder would drop custom_components/__init__.py.
+      - ../..:/app/custom_components:ro
+      # Writable auth dir. main.py writes Auth/secrets.json here; on the host it
+      # appears as ./data/secrets.json (this is the file you use in Home
+      # Assistant). Nested writable mount inside the read-only code mount above —
+      # validate with `docker compose config` on the Docker host if in doubt.
+      - ./data:/app/custom_components/googlefindmy/Auth

--- a/custom_components/googlefindmy/docker-login/docker-compose.yml
+++ b/custom_components/googlefindmy/docker-login/docker-compose.yml
@@ -19,22 +19,31 @@ services:
       # Optional CLI flags forwarded to main.py, e.g. "--reauth" (force fresh
       # login) or "--debug" (verbose bootstrap/FCM logging). Default: none.
       GFMY_ARGS: "${GFMY_ARGS:-}"
+      # Persist secrets.json on the writable ./data volume (see below) instead of
+      # inside the read-only code mount. main.py honours this override and keeps
+      # the atomic write on a single writable filesystem.
+      GOOGLEFINDMY_SECRETS_PATH: "/data/secrets.json"
       # Optional: pin Chrome's major version if auto-detection ever mismatches
       # the bundled Chrome (undetected-chromedriver SessionNotCreatedException).
       # GOOGLEFINDMY_CHROME_VERSION: "141"
     ports:
-      - "7900:7900"       # noVNC web viewer, password: secret
+      # noVNC web viewer (password: secret, a fixed default of the base image).
+      # Bound to LOOPBACK by default so the fixed-password session is NOT exposed
+      # to the LAN/Internet during the Google sign-in. To reach it from another
+      # machine, use an SSH tunnel (recommended) or set GFMY_NOVNC_BIND=0.0.0.0
+      # (README → Remote access) to opt into a LAN bind on a trusted network.
+      - "${GFMY_NOVNC_BIND:-127.0.0.1}:7900:7900"
     volumes:
-      # M2 runtime mount of the integration code, read-only, at its real import
-      # path. `../..` is the repository's custom_components/ dir, so this mount
-      # provides BOTH custom_components/__init__.py (a real package that calls
-      # pkgutil.extend_path) AND custom_components/googlefindmy/, which is what
-      # `python -m custom_components.googlefindmy.main` needs (main.py sets
-      # _standalone=False only in this exact layout). Mounting just the
-      # googlefindmy/ folder would drop custom_components/__init__.py.
-      - ../..:/app/custom_components:ro
-      # Writable auth dir. main.py writes Auth/secrets.json here; on the host it
-      # appears as ./data/secrets.json (this is the file you use in Home
-      # Assistant). Nested writable mount inside the read-only code mount above —
-      # validate with `docker compose config` on the Docker host if in doubt.
-      - ./data:/app/custom_components/googlefindmy/Auth
+      # M2 runtime mount of the integration code, READ-ONLY, at a FLAT path.
+      # `..` is the integration package dir, so main.py lands at /app/gfmy/main.py
+      # (parent = "app", not "custom_components") → _standalone=True: it stubs
+      # homeassistant.* and never imports the package __init__/config_flow (which
+      # need voluptuous/HA). The Auth package (token_cache.py etc.) stays present
+      # and readable; nothing is written here.
+      - ..:/app/gfmy:ro
+      # Writable, host-persisted volume for the produced secrets.json. This is
+      # the file you use in Home Assistant. Kept separate from the read-only code
+      # mount so the atomic write works and the login container never writes into
+      # your integration source. The launcher makes this dir writable by the
+      # container user (see login.sh / login.cmd).
+      - ./data:/data

--- a/custom_components/googlefindmy/docker-login/docker-compose.yml
+++ b/custom_components/googlefindmy/docker-login/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   googlefindmy-login:
-    # Fixed identity + no auto-restart: this is a one-shot login job, not a
-    # long-running service. A named container means repeated `docker compose up`
-    # reuses the same instance instead of stacking new ones.
-    container_name: googlefindmy-login
-    restart: "no"
+    # One-shot login job, not a long-running service. The launcher starts it with
+    # `docker compose run --rm` (see login.sh / login.cmd): that creates a fresh
+    # ephemeral container per run and removes it on exit, so repeated logins never
+    # stack containers, and it attaches your terminal's STDIN so the interactive
+    # "Press Enter" prompt works (plain `docker compose up` does not forward it).
     build:
       # Build context is the integration package dir (this file lives in
       # <context>/docker-login/). It holds requirements.txt (baked in) and
@@ -12,7 +12,7 @@ services:
       # the read-only volume below (M2 runtime mount).
       context: ..
       dockerfile: docker-login/Dockerfile
-    stdin_open: true      # keep STDIN open — main.py prompts "Press Enter"
+    stdin_open: true      # interactive login: main.py prompts "Press Enter"
     tty: true
     shm_size: "2g"        # headful Chrome needs shared memory
     environment:
@@ -23,6 +23,12 @@ services:
       # inside the read-only code mount. main.py honours this override and keeps
       # the atomic write on a single writable filesystem.
       GOOGLEFINDMY_SECRETS_PATH: "/data/secrets.json"
+      # Host UID/GID for the ownership handoff of the produced secrets.json. The
+      # launcher (login.sh) passes these so the finished file ends up owned by
+      # *you* with owner-only 0600 (readable/copyable by you, private from other
+      # local accounts). Unset (e.g. a manual run) → the file stays container-owned.
+      GFMY_HOST_UID: "${GFMY_HOST_UID:-}"
+      GFMY_HOST_GID: "${GFMY_HOST_GID:-}"
       # Optional: pin Chrome's major version if auto-detection ever mismatches
       # the bundled Chrome (undetected-chromedriver SessionNotCreatedException).
       # GOOGLEFINDMY_CHROME_VERSION: "141"

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -16,11 +16,42 @@ set -e
 "${VENV_PATH}/bin/supervisord" --configuration /etc/supervisord.conf &
 SUPERVISOR_PID=$!
 
-function shutdown {
+# cleanup runs on EVERY exit path: normal completion, a nonzero main.py exit
+# (Chrome/login/network failure aborting under `set -e`), or SIGTERM/SIGINT. It
+# performs the ownership handoff FIRST, so a produced (even partial) owner-only
+# secrets.json is always returned to the host user. Otherwise, after the pre-run
+# chown of /data to the container UID below, a failed run would leave the host
+# unable to read or delete the file. It then stops supervisor. The guard keeps
+# it idempotent so the EXIT trap and a signal-driven exit cannot double-run it.
+_cleaned=0
+function cleanup {
+  [ "${_cleaned}" = 1 ] && return
+  _cleaned=1
+
+  # Ownership handoff: main.py writes secrets.json 0600 owned by the container
+  # user. Hand the produced credentials back to the *host* user (UID/GID passed
+  # by the launcher) while KEEPING owner-only 0600, so you can read/copy the file
+  # for the Home Assistant import and no other local account can (unlike a
+  # world-readable 0644 relaxation). Without a host UID (e.g. a manual
+  # `docker compose up`) the file simply stays container-owned.
+  _secrets_path="${GOOGLEFINDMY_SECRETS_PATH:-}"
+  _data_dir="$(dirname "${_secrets_path:-/data/secrets.json}")"
+  if [ -n "${GFMY_HOST_UID:-}" ] && [ -d "${_data_dir}" ]; then
+    sudo chown -R "${GFMY_HOST_UID}:${GFMY_HOST_GID:-${GFMY_HOST_UID}}" "${_data_dir}" 2>/dev/null || true
+    sudo chmod 0700 "${_data_dir}" 2>/dev/null || true
+    if [ -f "${_secrets_path}" ]; then
+      sudo chmod 0600 "${_secrets_path}" 2>/dev/null || true
+    fi
+  fi
+
   kill -s SIGTERM "${SUPERVISOR_PID}" 2>/dev/null || true
   wait "${SUPERVISOR_PID}" 2>/dev/null || true
 }
-trap shutdown SIGTERM SIGINT
+# EXIT covers the failure path; the signal traps convert SIGTERM/SIGINT into an
+# exit so the single EXIT handler runs the handoff exactly once.
+trap cleanup EXIT
+trap 'exit 143' TERM
+trap 'exit 130' INT
 
 echo "[entrypoint] Waiting for X display ${DISPLAY} to come up..."
 for i in $(seq 1 30); do
@@ -49,20 +80,7 @@ cd /app/gfmy
 # shellcheck disable=SC2086 -- GFMY_ARGS is an intentional word-split flag list.
 python3 main.py ${GFMY_ARGS:-}
 
-# Ownership handoff: main.py writes secrets.json 0600 owned by the container user.
-# Hand the produced credentials back to the *host* user (UID/GID passed by the
-# launcher) while KEEPING owner-only 0600. The host user can then read/copy the
-# file for the Home Assistant import, and no other local account can read it —
-# unlike a world-readable 0644 relaxation. If the launcher did not pass a host UID
-# (e.g. a manual `docker compose up`), the file simply stays container-owned.
-_secrets_path="${GOOGLEFINDMY_SECRETS_PATH:-}"
-_data_dir="$(dirname "${_secrets_path:-/data/secrets.json}")"
-if [ -n "${GFMY_HOST_UID:-}" ] && [ -d "${_data_dir}" ]; then
-  sudo chown -R "${GFMY_HOST_UID}:${GFMY_HOST_GID:-${GFMY_HOST_UID}}" "${_data_dir}" 2>/dev/null || true
-  sudo chmod 0700 "${_data_dir}" 2>/dev/null || true
-  if [ -f "${_secrets_path}" ]; then
-    sudo chmod 0600 "${_secrets_path}" 2>/dev/null || true
-  fi
-fi
-
-shutdown
+# main.py returned normally. The EXIT trap now runs cleanup(): ownership handoff
+# to the host user, then supervisor shutdown. On a nonzero main.py exit `set -e`
+# aborts here and the SAME EXIT trap still runs cleanup(), so the handoff is
+# never skipped. Nothing else to do (see cleanup() above).

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -94,11 +94,23 @@ sudo chown -R "$(id -u):$(id -g)" /data 2>/dev/null || true
 cd /app/gfmy
 # Start the CLI in the BACKGROUND and wait on it, so a SIGTERM/SIGINT reaches bash
 # immediately and on_signal can relay it to the child (a foreground child defers the
-# traps until it exits -> docker escalates to SIGKILL -> no cleanup). Job control is
-# off in a script, so the backgrounded child still inherits this TTY's stdin and the
-# interactive login prompt keeps working.
+# traps until it exits -> docker escalates to SIGKILL -> no cleanup).
+#
+# Backgrounding in a non-interactive script (job control off) has two side effects we
+# must undo, or the first-run login breaks:
+#   1. stdin: bash points an async child's stdin at /dev/null unless an explicit
+#      redirection overrides it. main.py's interactive `input("Press Enter")` prompt
+#      would then hit EOF and abort the login. The `<&0` at the async boundary (NOT
+#      inside the subshell, where fd 0 is already /dev/null) restores the entrypoint's
+#      terminal stdin (which `docker compose run` attaches).
+#   2. SIGINT/SIGQUIT: bash hard-ignores (SIG_IGN) these in an async child; Python
+#      inherits SIG_IGN and then declines to install its KeyboardInterrupt handler, so
+#      a relayed SIGINT (Ctrl-C on `docker compose run`) is dropped and the re-wait
+#      loop hangs. `trap - INT QUIT` in the wrapper restores the default disposition
+#      before exec, so Python installs its normal handlers again.
+# `exec` makes CLI_PID the Python process itself, so on_signal's relay reaches it.
 # shellcheck disable=SC2086 -- GFMY_ARGS is an intentional word-split flag list.
-python3 main.py ${GFMY_ARGS:-} &
+( trap - INT QUIT; exec python3 main.py ${GFMY_ARGS:-} ) <&0 &
 CLI_PID=$!
 
 # Capture the child's status without tripping `set -e`. `wait` returns >128 when a

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -32,6 +32,13 @@ for i in $(seq 1 30); do
 done
 
 echo "[entrypoint] Open http://localhost:7900 (password: secret) in your browser to see/drive Chrome."
+
+# /data is a host bind mount whose owner/mode we do not control. Take ownership
+# for the container user for the duration of the run so main.py's atomic write of
+# secrets.json succeeds, without requiring a world-writable host directory.
+# seluser has passwordless sudo in the selenium base image.
+sudo chown -R "$(id -u):$(id -g)" /data 2>/dev/null || true
+
 # Run the integration's own CLI from the read-only FLAT code mount (/app/gfmy).
 # Running the script by path (not `-m custom_components.googlefindmy.main`) keeps
 # main.py in its standalone layout: it stubs homeassistant.* and never imports
@@ -42,13 +49,20 @@ cd /app/gfmy
 # shellcheck disable=SC2086 -- GFMY_ARGS is an intentional word-split flag list.
 python3 main.py ${GFMY_ARGS:-}
 
-# main.py writes secrets.json 0600 owned by the container user (seluser). On a
-# bind mount whose host user has a different UID, that user could not read/copy
-# the file for the Home Assistant import. Relax it to 0644 so the host user can
-# read it. This is a trusted-host, single-purpose login volume (see README).
+# Ownership handoff: main.py writes secrets.json 0600 owned by the container user.
+# Hand the produced credentials back to the *host* user (UID/GID passed by the
+# launcher) while KEEPING owner-only 0600. The host user can then read/copy the
+# file for the Home Assistant import, and no other local account can read it —
+# unlike a world-readable 0644 relaxation. If the launcher did not pass a host UID
+# (e.g. a manual `docker compose up`), the file simply stays container-owned.
 _secrets_path="${GOOGLEFINDMY_SECRETS_PATH:-}"
-if [ -n "${_secrets_path}" ] && [ -f "${_secrets_path}" ]; then
-  chmod 0644 "${_secrets_path}" 2>/dev/null || true
+_data_dir="$(dirname "${_secrets_path:-/data/secrets.json}")"
+if [ -n "${GFMY_HOST_UID:-}" ] && [ -d "${_data_dir}" ]; then
+  sudo chown -R "${GFMY_HOST_UID}:${GFMY_HOST_GID:-${GFMY_HOST_UID}}" "${_data_dir}" 2>/dev/null || true
+  sudo chmod 0700 "${_data_dir}" 2>/dev/null || true
+  if [ -f "${_secrets_path}" ]; then
+    sudo chmod 0600 "${_secrets_path}" 2>/dev/null || true
+  fi
 fi
 
 shutdown

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -32,8 +32,14 @@ for i in $(seq 1 30); do
 done
 
 echo "[entrypoint] Open http://localhost:7900 (password: secret) in your browser to see/drive Chrome."
-cd /app
+# Run the integration's own CLI from the read-only FLAT code mount (/app/gfmy).
+# Running the script by path (not `-m custom_components.googlefindmy.main`) keeps
+# main.py in its standalone layout: it stubs homeassistant.* and never imports
+# the package __init__/config_flow, which require voluptuous + a real Home
+# Assistant install (neither is present in this image on purpose). secrets.json
+# goes to the writable /data volume via GOOGLEFINDMY_SECRETS_PATH.
+cd /app/gfmy
 # shellcheck disable=SC2086 -- GFMY_ARGS is an intentional word-split flag list.
-python3 -m custom_components.googlefindmy.main ${GFMY_ARGS:-}
+python3 main.py ${GFMY_ARGS:-}
 
 shutdown

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -42,4 +42,13 @@ cd /app/gfmy
 # shellcheck disable=SC2086 -- GFMY_ARGS is an intentional word-split flag list.
 python3 main.py ${GFMY_ARGS:-}
 
+# main.py writes secrets.json 0600 owned by the container user (seluser). On a
+# bind mount whose host user has a different UID, that user could not read/copy
+# the file for the Home Assistant import. Relax it to 0644 so the host user can
+# read it. This is a trusted-host, single-purpose login volume (see README).
+_secrets_path="${GOOGLEFINDMY_SECRETS_PATH:-}"
+if [ -n "${_secrets_path}" ] && [ -f "${_secrets_path}" ]; then
+  chmod 0644 "${_secrets_path}" 2>/dev/null || true
+fi
+
 shutdown

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Entrypoint for the GoogleFindMy-HA login container.
+#
+# Boots the virtual-display / noVNC stack from the selenium/standalone-chrome
+# base image, waits for the X display, then runs the integration's *own*
+# standalone CLI (custom_components/googlefindmy/main.py) in the foreground.
+#
+# On the first run (no cached tokens) main.py launches the Chrome login flow;
+# once a usable secrets.json exists it returns early and just lists devices —
+# no browser step. Pass extra flags via the GFMY_ARGS environment variable,
+# e.g. GFMY_ARGS="--reauth" to force a fresh login, or "--debug" for verbose
+# bootstrap/FCM logging.
+set -e
+
+"${VENV_PATH}/bin/supervisord" --configuration /etc/supervisord.conf &
+SUPERVISOR_PID=$!
+
+function shutdown {
+  kill -s SIGTERM "${SUPERVISOR_PID}" 2>/dev/null || true
+  wait "${SUPERVISOR_PID}" 2>/dev/null || true
+}
+trap shutdown SIGTERM SIGINT
+
+echo "[entrypoint] Waiting for X display ${DISPLAY} to come up..."
+for i in $(seq 1 30); do
+  if xdpyinfo -display "${DISPLAY}" >/dev/null 2>&1; then
+    echo "[entrypoint] Display ready."
+    break
+  fi
+  sleep 1
+done
+
+echo "[entrypoint] Open http://localhost:7900 (password: secret) in your browser to see/drive Chrome."
+cd /app
+# shellcheck disable=SC2086 -- GFMY_ARGS is an intentional word-split flag list.
+python3 -m custom_components.googlefindmy.main ${GFMY_ARGS:-}
+
+shutdown

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -24,6 +24,7 @@ SUPERVISOR_PID=$!
 # unable to read or delete the file. It then stops supervisor. The guard keeps
 # it idempotent so the EXIT trap and a signal-driven exit cannot double-run it.
 _cleaned=0
+CLI_PID=""
 function cleanup {
   [ "${_cleaned}" = 1 ] && return
   _cleaned=1
@@ -47,11 +48,25 @@ function cleanup {
   kill -s SIGTERM "${SUPERVISOR_PID}" 2>/dev/null || true
   wait "${SUPERVISOR_PID}" 2>/dev/null || true
 }
-# EXIT covers the failure path; the signal traps convert SIGTERM/SIGINT into an
-# exit so the single EXIT handler runs the handoff exactly once.
+# On a terminating signal, FORWARD it to the CLI child (started below) instead of
+# exiting straight away: main.py runs in the background so bash can react to the
+# signal at once and relay it. A foreground child would make bash defer these traps
+# until it exits on its own, so `docker stop` would escalate to SIGKILL and the
+# EXIT cleanup (ownership handoff + supervisor shutdown) would never run. Before the
+# child exists (still waiting for the X display) there is nothing to forward to, so
+# fall back to exiting with the conventional 128+signal code. The single EXIT trap
+# runs the handoff+shutdown exactly once, on every path.
+function on_signal {
+  local sig="$1" code="$2"
+  if [ -n "${CLI_PID}" ] && kill -0 "${CLI_PID}" 2>/dev/null; then
+    kill -s "${sig}" "${CLI_PID}" 2>/dev/null || true
+  else
+    exit "${code}"
+  fi
+}
 trap cleanup EXIT
-trap 'exit 143' TERM
-trap 'exit 130' INT
+trap 'on_signal TERM 143' TERM
+trap 'on_signal INT 130' INT
 
 echo "[entrypoint] Waiting for X display ${DISPLAY} to come up..."
 for i in $(seq 1 30); do
@@ -77,10 +92,24 @@ sudo chown -R "$(id -u):$(id -g)" /data 2>/dev/null || true
 # Assistant install (neither is present in this image on purpose). secrets.json
 # goes to the writable /data volume via GOOGLEFINDMY_SECRETS_PATH.
 cd /app/gfmy
+# Start the CLI in the BACKGROUND and wait on it, so a SIGTERM/SIGINT reaches bash
+# immediately and on_signal can relay it to the child (a foreground child defers the
+# traps until it exits -> docker escalates to SIGKILL -> no cleanup). Job control is
+# off in a script, so the backgrounded child still inherits this TTY's stdin and the
+# interactive login prompt keeps working.
 # shellcheck disable=SC2086 -- GFMY_ARGS is an intentional word-split flag list.
-python3 main.py ${GFMY_ARGS:-}
+python3 main.py ${GFMY_ARGS:-} &
+CLI_PID=$!
 
-# main.py returned normally. The EXIT trap now runs cleanup(): ownership handoff
-# to the host user, then supervisor shutdown. On a nonzero main.py exit `set -e`
-# aborts here and the SAME EXIT trap still runs cleanup(), so the handoff is
-# never skipped. Nothing else to do (see cleanup() above).
+# Capture the child's status without tripping `set -e`. `wait` returns >128 when a
+# forwarded signal interrupts it before the child is reaped; re-wait until the child
+# has actually exited, then propagate its code via `exit` so the EXIT trap runs
+# cleanup() (ownership handoff to the host user, then supervisor shutdown) exactly
+# once on every path: success, nonzero exit, or termination.
+_rc=0
+wait "${CLI_PID}" || _rc=$?
+while [ "${_rc}" -gt 128 ] && kill -0 "${CLI_PID}" 2>/dev/null; do
+  _rc=0
+  wait "${CLI_PID}" || _rc=$?
+done
+exit "${_rc}"

--- a/custom_components/googlefindmy/docker-login/login.cmd
+++ b/custom_components/googlefindmy/docker-login/login.cmd
@@ -1,0 +1,23 @@
+@echo off
+rem One-command launcher for the GoogleFindMy-HA login container (Windows).
+rem
+rem Run this on the Docker host (Docker Desktop), not inside the Home Assistant
+rem container. After HACS installs the integration these files already live at
+rem config\custom_components\googlefindmy\docker-login\ so no git clone is needed.
+rem
+rem It cd's to its own folder, makes sure data\secrets.json exists as a FILE (a
+rem bind mount to a missing path would become a directory and break the login),
+rem then builds + starts exactly ONE container in the foreground.
+setlocal
+pushd "%~dp0"
+
+if not exist data mkdir data
+if not exist data\secrets.json echo {}>data\secrets.json
+
+echo [login] Starting the GoogleFindMy-HA login container...
+echo [login] When it is up, open http://localhost:7900 (password: secret) and
+echo [login] log into Google in the browser view.
+docker compose up --build --force-recreate --remove-orphans
+
+popd
+endlocal

--- a/custom_components/googlefindmy/docker-login/login.cmd
+++ b/custom_components/googlefindmy/docker-login/login.cmd
@@ -5,14 +5,17 @@ rem Run this on the Docker host (Docker Desktop), not inside the Home Assistant
 rem container. After HACS installs the integration these files already live at
 rem config\custom_components\googlefindmy\docker-login\ so no git clone is needed.
 rem
-rem It cd's to its own folder, makes sure data\secrets.json exists as a FILE (a
-rem bind mount to a missing path would become a directory and break the login),
-rem then builds + starts exactly ONE container in the foreground.
+rem It cd's to its own folder, creates ./data (where secrets.json is persisted),
+rem then builds + starts exactly ONE container in the foreground. Docker Desktop
+rem handles the bind-mount permissions, so no chmod is needed here.
+rem
+rem noVNC is bound to 127.0.0.1 by default (fixed password "secret"). To reach it
+rem from another machine, tunnel it, or only on a trusted LAN set
+rem GFMY_NOVNC_BIND=0.0.0.0 before running this.
 setlocal
 pushd "%~dp0"
 
 if not exist data mkdir data
-if not exist data\secrets.json echo {}>data\secrets.json
 
 echo [login] Starting the GoogleFindMy-HA login container...
 echo [login] When it is up, open http://localhost:7900 (password: secret) and

--- a/custom_components/googlefindmy/docker-login/login.cmd
+++ b/custom_components/googlefindmy/docker-login/login.cmd
@@ -6,8 +6,10 @@ rem container. After HACS installs the integration these files already live at
 rem config\custom_components\googlefindmy\docker-login\ so no git clone is needed.
 rem
 rem It cd's to its own folder, creates ./data (where secrets.json is persisted),
-rem then builds + starts exactly ONE container in the foreground. Docker Desktop
-rem handles the bind-mount permissions, so no chmod is needed here.
+rem then builds + runs exactly ONE ephemeral container in the foreground
+rem (`docker compose run --rm`), which attaches your terminal so the interactive
+rem "Press Enter" login prompt works. Docker Desktop maps the bind-mount
+rem permissions, so no UID handoff or chmod is needed here.
 rem
 rem noVNC is bound to 127.0.0.1 by default (fixed password "secret"). To reach it
 rem from another machine, tunnel it, or only on a trusted LAN set
@@ -20,7 +22,9 @@ if not exist data mkdir data
 echo [login] Starting the GoogleFindMy-HA login container...
 echo [login] When it is up, open http://localhost:7900 (password: secret) and
 echo [login] log into Google in the browser view.
-docker compose up --build --force-recreate --remove-orphans
+rem `run --rm` (not `up`): fresh one-shot container with your terminal attached so
+rem the "Press Enter" prompt works; `--service-ports` publishes the noVNC port.
+docker compose run --build --service-ports --rm googlefindmy-login
 
 popd
 endlocal

--- a/custom_components/googlefindmy/docker-login/login.sh
+++ b/custom_components/googlefindmy/docker-login/login.sh
@@ -10,16 +10,24 @@
 #
 # What it does:
 #   1. cd to this script's own directory (you don't have to navigate there).
-#   2. Make sure ./data/secrets.json exists as a FILE — a bind mount to a
-#      non-existent path would otherwise become a directory and break the login.
+#   2. Create ./data (where the produced secrets.json is persisted) and make it
+#      writable by the container user. The image runs as "seluser", whose UID may
+#      differ from yours; without this the atomic write of secrets.json would
+#      fail with a permission error.
 #   3. Build + start the container in the foreground with a single command,
 #      recreating in place so you always end up with exactly ONE container.
+#
+# noVNC is bound to 127.0.0.1 by default (the viewer uses the base image's fixed
+# password "secret"). To reach it from another machine, tunnel with
+#   ssh -L 7900:127.0.0.1:7900 <docker-host>
+# or, only on a trusted LAN, export GFMY_NOVNC_BIND=0.0.0.0 before running this.
 set -euo pipefail
 
 cd "$(dirname "$0")"
 
 mkdir -p data
-[ -f data/secrets.json ] || printf '{}' > data/secrets.json
+# Make the token volume writable by the container user (UID may differ).
+chmod 0777 data 2>/dev/null || true
 
 echo "[login] Starting the GoogleFindMy-HA login container..."
 echo "[login] When it is up, open http://localhost:7900 (password: secret) and"

--- a/custom_components/googlefindmy/docker-login/login.sh
+++ b/custom_components/googlefindmy/docker-login/login.sh
@@ -10,12 +10,15 @@
 #
 # What it does:
 #   1. cd to this script's own directory (you don't have to navigate there).
-#   2. Create ./data (where the produced secrets.json is persisted) and make it
-#      writable by the container user. The image runs as "seluser", whose UID may
-#      differ from yours; without this the atomic write of secrets.json would
-#      fail with a permission error.
-#   3. Build + start the container in the foreground with a single command,
-#      recreating in place so you always end up with exactly ONE container.
+#   2. Create ./data (where the produced secrets.json is persisted). The container
+#      takes ownership of it for the run (via passwordless sudo in the selenium
+#      base image), so no world-writable host chmod is needed.
+#   3. Export your host UID/GID so the container hands the finished secrets.json
+#      back to you as owner with owner-only 0600 (you can read/copy it; no other
+#      local account can).
+#   4. Build + run exactly ONE ephemeral container in the foreground
+#      (`docker compose run --rm`), which also attaches your terminal so the
+#      interactive "Press Enter" login prompt reaches Python.
 #
 # noVNC is bound to 127.0.0.1 by default (the viewer uses the base image's fixed
 # password "secret"). To reach it from another machine, tunnel with
@@ -26,10 +29,16 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 mkdir -p data
-# Make the token volume writable by the container user (UID may differ).
-chmod 0777 data 2>/dev/null || true
+
+# Hand the finished secrets.json back to the invoking host user as owner (0600).
+# The container chowns ./data to itself for the run, then back to these IDs.
+export GFMY_HOST_UID="$(id -u)"
+export GFMY_HOST_GID="$(id -g)"
 
 echo "[login] Starting the GoogleFindMy-HA login container..."
 echo "[login] When it is up, open http://localhost:7900 (password: secret) and"
 echo "[login] log into Google in the browser view."
-docker compose up --build --force-recreate --remove-orphans
+# `run --rm` (not `up`): fresh one-shot container, removed on exit, with your
+# terminal attached so the interactive "Press Enter" login prompt works.
+# `--service-ports` publishes the noVNC port declared in docker-compose.yml.
+docker compose run --build --service-ports --rm googlefindmy-login

--- a/custom_components/googlefindmy/docker-login/login.sh
+++ b/custom_components/googlefindmy/docker-login/login.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# One-command launcher for the GoogleFindMy-HA login container (Linux/macOS/QNAP).
+#
+# Run this on the Docker *host* (where the Docker daemon runs), not inside the
+# Home Assistant container — HA has no Docker socket. After HACS installs the
+# integration these files already live at
+#   config/custom_components/googlefindmy/docker-login/
+# so no `git clone` is needed; just run this script there.
+#
+# What it does:
+#   1. cd to this script's own directory (you don't have to navigate there).
+#   2. Make sure ./data/secrets.json exists as a FILE — a bind mount to a
+#      non-existent path would otherwise become a directory and break the login.
+#   3. Build + start the container in the foreground with a single command,
+#      recreating in place so you always end up with exactly ONE container.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+mkdir -p data
+[ -f data/secrets.json ] || printf '{}' > data/secrets.json
+
+echo "[login] Starting the GoogleFindMy-HA login container..."
+echo "[login] When it is up, open http://localhost:7900 (password: secret) and"
+echo "[login] log into Google in the browser view."
+docker compose up --build --force-recreate --remove-orphans

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -225,6 +225,22 @@ else:  # pragma: no cover - standalone CLI stub-injection shim, structurally
         sys.modules["homeassistant.exceptions"] = _ha_exceptions
 
 
+def _resolve_secrets_path() -> Path:
+    """Resolve where the standalone CLI reads/writes ``secrets.json``.
+
+    Defaults to ``Auth/secrets.json`` next to this module (the upstream
+    GoogleFindMyTools layout). The ``GOOGLEFINDMY_SECRETS_PATH`` environment
+    variable overrides it with an explicit file path. This lets a container
+    persist the cache on a dedicated writable volume that is decoupled from a
+    read-only code mount, so the integration package can stay read-only while
+    the atomic write still happens on a single writable filesystem.
+    """
+    override = os.environ.get("GOOGLEFINDMY_SECRETS_PATH", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return _this_dir / "Auth" / "secrets.json"
+
+
 def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
     """Atomically write ``data`` as JSON to ``path`` with 0600 permissions.
 
@@ -288,7 +304,7 @@ def _register_file_cache(entry_id: str = "") -> object:
         _set_default_entry_id,
     )
 
-    secrets_path = _this_dir / "Auth" / "secrets.json"
+    secrets_path = _resolve_secrets_path()
 
     # Build a minimal TokenCache-compatible object backed by a JSON file.
     # We cannot call TokenCache() because it requires a real HomeAssistant
@@ -419,7 +435,7 @@ def _ensure_authenticated() -> None:
     """
     import json  # noqa: PLC0415
 
-    secrets_path = _this_dir / "Auth" / "secrets.json"
+    secrets_path = _resolve_secrets_path()
     data: dict[str, object] = {}
     if secrets_path.is_file():
         try:
@@ -751,7 +767,7 @@ def _clear_stale_tokens_for_reauth() -> None:
     """
     import json  # noqa: PLC0415
 
-    secrets_path = _this_dir / "Auth" / "secrets.json"
+    secrets_path = _resolve_secrets_path()
     if not secrets_path.is_file():
         return
 

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -12,6 +12,11 @@ regress. Each guard maps to a concrete Codex review finding on PR #1208:
   ``Press Enter`` prompt blocks forever (finding B).
 * noVNC must stay bound to loopback by default (earlier finding), so the
   fixed-password session is not exposed on the LAN during sign-in.
+* A context-level ``.dockerignore`` must keep persisted credentials
+  (``docker-login/data``) out of the ``--build`` context, so builders that upload
+  the full context never receive the OAuth/AAS secrets.
+* The ownership handoff must run from an ``EXIT`` trap, so a nonzero/interrupted
+  ``main.py`` run still returns the produced secrets.json to the host user.
 """
 
 from __future__ import annotations
@@ -21,6 +26,8 @@ from pathlib import Path
 import pytest
 
 DOCKER_LOGIN = Path("custom_components/googlefindmy/docker-login")
+# Build context root for the login image (docker-compose.yml `build.context: ..`).
+BUILD_CONTEXT = DOCKER_LOGIN.parent
 
 
 def _read(name: str) -> str:
@@ -99,4 +106,45 @@ def test_compose_binds_novnc_to_loopback_by_default() -> None:
     compose = _read("docker-compose.yml")
     assert "127.0.0.1" in compose, (
         "docker-compose.yml must bind the fixed-password noVNC port to loopback by default"
+    )
+
+
+def test_dockerignore_excludes_persisted_credentials() -> None:
+    """A context-level .dockerignore must keep docker-login/data out of the build context."""
+
+    dockerignore = BUILD_CONTEXT / ".dockerignore"
+    assert dockerignore.is_file(), (
+        "A .dockerignore must exist at the build-context root "
+        f"({BUILD_CONTEXT}) because the login image builds with `--build` and that "
+        "context otherwise includes the persisted docker-login/data/secrets.json."
+    )
+    text = dockerignore.read_text(encoding="utf-8")
+    assert "docker-login/data" in text, (
+        ".dockerignore must exclude docker-login/data so builders that upload the "
+        "full context never receive the OAuth/AAS credentials."
+    )
+
+
+def test_entrypoint_runs_handoff_from_exit_trap() -> None:
+    """The ownership handoff must run via an EXIT trap, not only on the success path.
+
+    Under ``set -e`` a nonzero ``main.py`` exit aborts the script; a linear handoff
+    placed after ``main.py`` would be skipped, leaving the host unable to read or
+    delete the container-owned credential file. Routing it through ``trap ... EXIT``
+    guarantees it runs on failure and interruption too.
+    """
+
+    entrypoint = _read("entrypoint.sh")
+    assert "trap cleanup EXIT" in entrypoint, (
+        "entrypoint.sh must register the cleanup/handoff on EXIT so it also runs "
+        "when main.py fails or is interrupted (set -e)."
+    )
+    # The handoff logic (host chown) must live inside the trapped cleanup function,
+    # i.e. before it is registered on EXIT, not as trailing linear code.
+    cleanup_def = entrypoint.find("function cleanup")
+    trap_exit = entrypoint.find("trap cleanup EXIT")
+    handoff = entrypoint.find("GFMY_HOST_UID", cleanup_def)
+    assert 0 <= cleanup_def < handoff < trap_exit, (
+        "the ownership handoff (GFMY_HOST_UID chown) must sit inside the cleanup() "
+        "function that is trapped on EXIT."
     )

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -23,6 +23,11 @@ regress. Each guard maps to a concrete Codex review finding on PR #1208:
   signal traps must FORWARD SIGTERM/SIGINT to it. A foreground child makes bash
   defer the trap until the child exits, so ``docker stop`` escalates to SIGKILL and
   the EXIT cleanup never runs (finding: forward termination signals to the child).
+* Backgrounding that child must PRESERVE its terminal stdin (``<&0`` at the async
+  boundary) and RESET SIGINT/SIGQUIT to default (``trap - INT QUIT`` before exec):
+  a non-interactive script otherwise gives an async child ``/dev/null`` stdin (the
+  ``input()`` login prompt hits EOF) and hard-ignores SIGINT (Python drops Ctrl-C),
+  both regressions of the backgrounding fix above.
 """
 
 from __future__ import annotations
@@ -207,10 +212,12 @@ def test_entrypoint_forwards_signals_to_cli_child() -> None:
 
     entrypoint = _read("entrypoint.sh")
 
-    # 1) The CLI is started in the background and its PID captured.
-    assert "python3 main.py ${GFMY_ARGS:-} &" in entrypoint, (
-        "main.py must be started in the BACKGROUND (trailing '&'), otherwise bash "
-        "defers the signal traps until it exits and docker stop hits SIGKILL."
+    # 1) The CLI is started in the background and its PID captured. It is wrapped in a
+    #    `( ... ) <&0 &` subshell that execs python (see the stdin/SIGINT guard below),
+    #    so match the backgrounded exec form rather than a bare `python3 ... &`.
+    assert "exec python3 main.py ${GFMY_ARGS:-} ) <&0 &" in entrypoint, (
+        "main.py must be started in the BACKGROUND, otherwise bash defers the signal "
+        "traps until it exits and docker stop hits SIGKILL."
     )
     assert "CLI_PID=$!" in entrypoint, (
         "the entrypoint must capture the CLI child PID (CLI_PID=$!) so signals can "
@@ -236,4 +243,50 @@ def test_entrypoint_forwards_signals_to_cli_child() -> None:
     assert 'kill -s "${sig}" "${CLI_PID}"' in entrypoint, (
         "on_signal must relay the received signal to the CLI child via "
         "kill -s <sig> CLI_PID."
+    )
+
+
+def test_entrypoint_preserves_stdin_and_sigint_for_background_child() -> None:
+    """Backgrounding the CLI must not break the first-run login prompt or Ctrl-C.
+
+    A non-interactive bash script with job control off applies two disruptive
+    defaults to an async (``&``) child, both proven empirically:
+
+    * its stdin is pointed at ``/dev/null`` unless an explicit redirection overrides
+      it -- so ``main.py``'s interactive ``input("Press Enter")`` prompt would hit EOF
+      and abort the login (Codex: "Keep stdin attached when backgrounding the CLI");
+    * SIGINT/SIGQUIT are hard-ignored (SIG_IGN), which Python inherits and then keeps
+      instead of installing its ``KeyboardInterrupt`` handler -- so a relayed SIGINT
+      is dropped and the re-wait loop hangs (Codex: "Restore SIGINT handling in the
+      background child").
+
+    The fix wraps the child in ``( trap - INT QUIT; exec python3 ... ) <&0 &``:
+    ``<&0`` at the ASYNC BOUNDARY (not inside the subshell, where fd 0 is already
+    ``/dev/null``) restores the terminal stdin, and ``trap - INT QUIT`` before ``exec``
+    restores the default signal disposition so Python re-installs its handlers.
+    """
+
+    entrypoint = _read("entrypoint.sh")
+
+    # stdin: the redirect must sit at the async boundary `) <&0 &`, not inside `( ... )`.
+    assert "exec python3 main.py ${GFMY_ARGS:-} ) <&0 &" in entrypoint, (
+        "the backgrounded CLI must restore terminal stdin via `<&0` at the async "
+        "boundary, or the interactive `input()` login prompt reads EOF and aborts."
+    )
+    assert "<&0 ) &" not in entrypoint, (
+        "the `<&0` redirect must be OUTSIDE the subshell (at the async boundary); "
+        "inside the subshell fd 0 is already /dev/null, so it would be a no-op."
+    )
+
+    # SIGINT/SIGQUIT: reset to default inside the wrapper before exec.
+    assert "trap - INT QUIT" in entrypoint, (
+        "the wrapper must `trap - INT QUIT` before exec so bash's async SIG_IGN is "
+        "cleared and Python installs its normal KeyboardInterrupt handler."
+    )
+    # The reset must precede the exec so the exec'd process inherits the default.
+    reset_idx = entrypoint.index("trap - INT QUIT")
+    exec_idx = entrypoint.index("exec python3 main.py")
+    assert reset_idx < exec_idx, (
+        "`trap - INT QUIT` must run BEFORE `exec python3` so the CLI child inherits "
+        "the default SIGINT disposition."
     )

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -1,9 +1,14 @@
 # tests/test_docker_login_hardening.py
 """Regression guards for the docker-login helper hardening.
 
-These are text guards (in the spirit of ``test_hacs_validation.py``) that lock in
-security/usability fixes for the containerised login helper so they cannot silently
-regress. Each guard maps to a concrete Codex review finding on PR #1208:
+Most guards here are text guards (in the spirit of ``test_hacs_validation.py``)
+that lock in security/usability fixes for the containerised login helper so they
+cannot silently regress; the final guard
+(``test_backgrounded_login_child_behaviourally_keeps_stdin_and_default_sigint``)
+is a BEHAVIOURAL test that runs the real backgrounding construct from
+``entrypoint.sh`` and asserts stdin/SIGINT at runtime, so the launch fix is proven
+by behaviour rather than by matching script text. Each guard maps to a concrete
+Codex review finding on PR #1208:
 
 * Secrets file must stay owner-only ``0600`` and be handed to the host user via an
   ownership handoff, never relaxed to world-readable ``0644`` (findings A + C).
@@ -289,4 +294,114 @@ def test_entrypoint_preserves_stdin_and_sigint_for_background_child() -> None:
     assert reset_idx < exec_idx, (
         "`trap - INT QUIT` must run BEFORE `exec python3` so the CLI child inherits "
         "the default SIGINT disposition."
+    )
+
+
+def _extract_backgrounding_line(entrypoint: str) -> str:
+    """Return the real ``( ... exec python3 main.py ... ) <&0 &`` launch line.
+
+    The behavioural test below runs the *actual* backgrounding construct taken
+    verbatim from ``entrypoint.sh`` (only the executed program is swapped for a
+    stub), so it fails if the file ever loses ``<&0`` or the ``trap - INT QUIT``
+    reset -- it cannot pass on a regressed script the way a text guard could be
+    fooled by matching a stale string elsewhere.
+    """
+
+    for line in entrypoint.splitlines():
+        if "exec python3 main.py" in line and "<&0 &" in line:
+            return line.strip()
+    raise AssertionError(
+        "could not locate the backgrounded `( ... exec python3 main.py ... ) <&0 &` "
+        "launch line in entrypoint.sh"
+    )
+
+
+def test_backgrounded_login_child_behaviourally_keeps_stdin_and_default_sigint(
+    tmp_path: Path,
+) -> None:
+    """Behavioural proof (not text matching) that the launch construct works.
+
+    Codex asked to "cover the behavior rather than only matching script text".
+    This test takes the REAL backgrounding line out of ``entrypoint.sh``, swaps
+    only the executed program for a Python stub, runs it under a non-interactive
+    ``bash`` script with job control off (the container condition) and asserts at
+    runtime:
+
+    * the child still reads the entrypoint's terminal stdin (``<&0`` works) -- the
+      first-run ``input("Press Enter")`` prompt does not hit EOF; and
+    * the child ends up with Python's DEFAULT ``SIGINT`` handler installed rather
+      than the inherited ``SIG_IGN`` -- so a relayed Ctrl-C is not dropped.
+
+    A negative control (same construct with ``<&0`` removed) must fail the stdin
+    read, proving the assertion actually discriminates on the redirect rather
+    than passing unconditionally.
+
+    Reproduction limit (stated honestly): bash only forces ``SIG_IGN`` on an async
+    child when it is attached to a controlling terminal, which a CI runner without
+    a TTY does not provide, so this test verifies the POSITIVE end-state invariant
+    (child has a working handler) which holds on every platform; the ordering that
+    guarantees it under a TTY is locked by the text guard above.
+    """
+
+    import subprocess
+    import sys
+
+    entrypoint = _read("entrypoint.sh")
+    launch = _extract_backgrounding_line(entrypoint)
+
+    stub = tmp_path / "stub_child.py"
+    stub.write_text(
+        "import signal, sys\n"
+        "try:\n"
+        "    line = sys.stdin.readline().rstrip('\\n')\n"
+        "except EOFError:\n"
+        "    line = ''\n"
+        "disp = signal.getsignal(signal.SIGINT)\n"
+        "stdin_ok = line == 'ENTER-FROM-TERMINAL'\n"
+        "sigint_ok = disp is not signal.SIG_IGN\n"
+        "print('STDIN_OK=%s SIGINT_OK=%s' % (stdin_ok, sigint_ok))\n",
+        encoding="utf-8",
+    )
+
+    # Rebuild the launch line with our stub in place of `main.py ${GFMY_ARGS:-}`,
+    # keeping the surrounding `( trap - INT QUIT; exec python3 ... ) <&0 &` verbatim.
+    stubbed = launch.replace("main.py ${GFMY_ARGS:-}", f"{stub.name!s}").replace(
+        "python3", sys.executable
+    )
+
+    def _run(launch_line: str) -> str:
+        script = (
+            "#!/usr/bin/env bash\n"
+            "set -e\n"
+            "trap 'on_signal INT 130' INT\n"
+            "function on_signal { :; }\n"
+            f"cd {tmp_path!s}\n"
+            f"{launch_line}\n"
+            "CLI_PID=$!\n"
+            'wait "${CLI_PID}"\n'
+        )
+        proc = subprocess.run(
+            ["bash", "-c", script],
+            input=b"ENTER-FROM-TERMINAL\n",
+            capture_output=True,
+            timeout=30,
+            check=False,
+        )
+        return proc.stdout.decode()
+
+    out = _run(stubbed)
+    assert "STDIN_OK=True" in out, (
+        f"backgrounded child did not receive terminal stdin via `<&0`; got: {out!r}"
+    )
+    assert "SIGINT_OK=True" in out, (
+        f"backgrounded child kept the inherited SIG_IGN for SIGINT; got: {out!r}"
+    )
+
+    # Negative control: without the `<&0` async-boundary redirect the child's stdin
+    # is /dev/null, so the read fails -- proving the assertion discriminates.
+    control = stubbed.replace(") <&0 &", ") &")
+    control_out = _run(control)
+    assert "STDIN_OK=False" in control_out, (
+        "control without `<&0` unexpectedly read stdin; the behavioural stdin "
+        f"assertion is not discriminating. got: {control_out!r}"
     )

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -19,6 +19,10 @@ regress. Each guard maps to a concrete Codex review finding on PR #1208:
   ``--build`` context, not just the one path a denylist happens to name.
 * The ownership handoff must run from an ``EXIT`` trap, so a nonzero/interrupted
   ``main.py`` run still returns the produced secrets.json to the host user.
+* The CLI must run as a BACKGROUND child that the entrypoint waits on, and the
+  signal traps must FORWARD SIGTERM/SIGINT to it. A foreground child makes bash
+  defer the trap until the child exits, so ``docker stop`` escalates to SIGKILL and
+  the EXIT cleanup never runs (finding: forward termination signals to the child).
 """
 
 from __future__ import annotations
@@ -187,4 +191,49 @@ def test_entrypoint_runs_handoff_from_exit_trap() -> None:
     assert 0 <= cleanup_def < handoff < trap_exit, (
         "the ownership handoff (GFMY_HOST_UID chown) must sit inside the cleanup() "
         "function that is trapped on EXIT."
+    )
+
+
+def test_entrypoint_forwards_signals_to_cli_child() -> None:
+    """SIGTERM/SIGINT must be forwarded to the CLI, which must run in the background.
+
+    If ``python3 main.py`` runs in the FOREGROUND, bash defers the TERM/INT trap
+    until the child exits on its own; a ``docker stop`` therefore never reaches the
+    login process, Docker escalates to SIGKILL after its grace period, and the EXIT
+    cleanup (ownership handoff + supervisor shutdown) is skipped -- leaving ``/data``
+    owned by the container UID. The child must be backgrounded and waited on, and the
+    signal traps must relay the signal to it, not merely ``exit``.
+    """
+
+    entrypoint = _read("entrypoint.sh")
+
+    # 1) The CLI is started in the background and its PID captured.
+    assert "python3 main.py ${GFMY_ARGS:-} &" in entrypoint, (
+        "main.py must be started in the BACKGROUND (trailing '&'), otherwise bash "
+        "defers the signal traps until it exits and docker stop hits SIGKILL."
+    )
+    assert "CLI_PID=$!" in entrypoint, (
+        "the entrypoint must capture the CLI child PID (CLI_PID=$!) so signals can "
+        "be forwarded to it and its exit status waited on."
+    )
+
+    # 2) The entrypoint waits on that specific child (not a bare `wait`).
+    assert 'wait "${CLI_PID}"' in entrypoint, (
+        "the entrypoint must wait on the CLI child PID so its real exit status "
+        "propagates to the EXIT cleanup."
+    )
+
+    # 3) The TERM/INT traps forward to the child instead of exiting immediately.
+    assert "trap 'on_signal TERM 143' TERM" in entrypoint
+    assert "trap 'on_signal INT 130' INT" in entrypoint
+    assert "trap 'exit 143' TERM" not in entrypoint, (
+        "a bare `exit` on SIGTERM does not reach the foreground child; the trap must "
+        "forward the signal to CLI_PID (on_signal)."
+    )
+    assert "trap 'exit 130' INT" not in entrypoint
+
+    # 4) on_signal actually relays the signal to the running child.
+    assert 'kill -s "${sig}" "${CLI_PID}"' in entrypoint, (
+        "on_signal must relay the received signal to the CLI child via "
+        "kill -s <sig> CLI_PID."
     )

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -21,7 +21,16 @@ Codex review finding on PR #1208:
   build context, re-include only the two paths the Dockerfile COPYs) so that
   EVERY secret location -- ``docker-login/data`` AND the legacy
   ``Auth/secrets.json`` AND any future token/cache path -- stays out of the
-  ``--build`` context, not just the one path a denylist happens to name.
+  ``--build`` context, not just the one path a denylist happens to name. A bare
+  ``!docker-login`` re-includes the WHOLE directory, so it is re-excluded again
+  (``docker-login/*``) down to just the one re-included file
+  (``!docker-login/entrypoint.sh``); a file dropped directly under
+  ``docker-login/`` must NOT reach the context (Codex P2 on PR #1210).
+* The QNAP "Container Station" README guidance must NOT present importing the
+  compose file as an *application* (``docker compose up`` semantics, no stdin) as
+  a first-login path: the interactive ``input("Press Enter")`` prompt can never
+  proceed without a terminal, so the login must go through the stdin-attaching
+  ``docker compose run`` (SSH) path (Codex P2 on PR #1210).
 * The ownership handoff must run from an ``EXIT`` trap, so a nonzero/interrupted
   ``main.py`` run still returns the produced secrets.json to the host user.
 * The CLI must run as a BACKGROUND child that the entrypoint waits on, and the
@@ -159,23 +168,44 @@ def test_dockerignore_is_allowlist_excluding_every_secret_path() -> None:
         "secrets in any location are excluded by default (allowlist model)."
     )
 
-    # 2. Only build inputs are re-included, and never a secrets directory.
+    # 2. The only `!`-re-includes may be the two Dockerfile COPY inputs plus the
+    #    `docker-login` directory re-included SOLELY for traversal (Docker cannot
+    #    descend into an ignored dir to reach entrypoint.sh). Never a secrets path.
     reincludes = {r[1:] for r in rules if r.startswith("!")}
-    assert reincludes == {"requirements.txt", "docker-login"}, (
+    assert reincludes == {
+        "requirements.txt",
+        "docker-login",
+        "docker-login/entrypoint.sh",
+    }, (
         "the only `!`-re-includes may be the Dockerfile's COPY inputs "
-        f"(requirements.txt, docker-login); found {sorted(reincludes)}. Re-including "
-        "anything else risks shipping integration source or secrets into the image."
+        "(requirements.txt, docker-login/entrypoint.sh) plus `docker-login` for "
+        f"traversal; found {sorted(reincludes)}. Re-including anything else -- or the "
+        "directory as a whole without re-excluding its contents -- risks shipping "
+        "integration source or secrets into the image."
     )
     assert not any(
         r.startswith("!") and ("auth" in r.lower() or "secret" in r.lower())
         for r in rules
     ), ".dockerignore must never re-include an Auth/ or secrets path."
 
-    # 3. The persisted-credentials subdir of the re-included docker-login/ is
-    #    excluded again (order-sensitive: after `!docker-login`).
-    assert "docker-login/data" in {r.rstrip("/") for r in rules}, (
-        ".dockerignore must re-exclude docker-login/data after re-including "
-        "docker-login/, so the container's persisted secrets.json stays out."
+    # 3. The contents of the re-included docker-login/ are re-excluded WHOLESALE
+    #    (`docker-login/*`) so a bare `!docker-login` cannot leak any other file
+    #    placed under it (an exported secrets.json, a diagnostic log, a future
+    #    addition) -- not merely docker-login/data. Order-sensitive (last match
+    #    wins): `!docker-login` -> `docker-login/*` -> `!docker-login/entrypoint.sh`.
+    assert "docker-login/*" in rules, (
+        ".dockerignore must re-exclude the whole docker-login/ subtree "
+        "(`docker-login/*`) after re-including the directory, so only the explicitly "
+        "re-included entrypoint.sh survives -- not docker-login/data, an exported "
+        "secrets.json, or any future file dropped under docker-login/."
+    )
+    i_dir = rules.index("!docker-login")
+    i_star = rules.index("docker-login/*")
+    i_entry = rules.index("!docker-login/entrypoint.sh")
+    assert i_dir < i_star < i_entry, (
+        "order must be `!docker-login` -> `docker-login/*` -> "
+        "`!docker-login/entrypoint.sh` (last match wins), else the re-exclusion never "
+        f"takes effect; got indices dir={i_dir}, star={i_star}, entry={i_entry}."
     )
 
 
@@ -404,4 +434,129 @@ def test_backgrounded_login_child_behaviourally_keeps_stdin_and_default_sigint(
     assert "STDIN_OK=False" in control_out, (
         "control without `<&0` unexpectedly read stdin; the behavioural stdin "
         f"assertion is not discriminating. got: {control_out!r}"
+    )
+
+
+def _docker_context_excluded(rules: list[str], path: str) -> bool:
+    """Return True if ``path`` is EXCLUDED from the Docker build context by ``rules``.
+
+    Faithfully models moby/patternmatcher (Docker's ``.dockerignore`` engine): the
+    patterns are evaluated in order and the LAST pattern that matches the path -- or
+    any of its parent directories -- decides; a plain pattern excludes, a
+    ``!``-prefixed pattern re-includes. ``*`` matches a single path segment (it does
+    not cross ``/``), per Go ``filepath.Match``. This "last-match-wins + parent-dir
+    descent" behaviour is exactly why a bare ``!docker-login`` re-includes the whole
+    subtree and why ``docker-login/*`` + ``!docker-login/entrypoint.sh`` is needed to
+    let through only the one file. (Verified to agree with the ``pathspec`` reference
+    matcher on the representative paths below; re-implemented inline so the guard adds
+    no test-only dependency to the Poetry env.)
+    """
+
+    import fnmatch
+    from pathlib import PurePosixPath
+
+    posix = PurePosixPath(path)
+    candidates = [str(posix)] + [str(par) for par in posix.parents if str(par) != "."]
+
+    def _matches(pattern: str, candidate: str) -> bool:
+        pat_parts = pattern.rstrip("/").split("/")
+        cand_parts = candidate.split("/")
+        if len(pat_parts) != len(cand_parts):
+            return False
+        return all(
+            fnmatch.fnmatchcase(seg, pat)
+            for pat, seg in zip(pat_parts, cand_parts, strict=True)
+        )
+
+    excluded = False
+    for rule in rules:
+        negated = rule.startswith("!")
+        pattern = rule[1:] if negated else rule
+        if any(_matches(pattern, cand) for cand in candidates):
+            excluded = not negated
+    return excluded
+
+
+def test_dockerignore_behaviourally_excludes_files_dropped_under_docker_login() -> None:
+    """Behavioural proof that the allowlist keeps stray secrets out of the context.
+
+    Codex flagged that a bare ``!docker-login`` re-includes the ENTIRE directory, so a
+    credential export / diagnostic log / any file placed under ``docker-login/`` other
+    than ``data/`` (the only path the old denylist named) would be uploaded to the
+    Docker daemon, contradicting the stated allowlist guarantee. Rather than only
+    matching pattern text, this test EVALUATES the real ``.dockerignore`` with a
+    faithful model of Docker's matcher and asserts the include/exclude DECISION for
+    representative paths, with a discriminating control on the old rules that proves
+    the leak the fix closes.
+    """
+
+    rules = _dockerignore_rules()
+
+    # The two Dockerfile COPY inputs must stay IN the context, or the build breaks.
+    assert not _docker_context_excluded(rules, "requirements.txt")
+    assert not _docker_context_excluded(rules, "docker-login/entrypoint.sh")
+
+    # Every secret/stray location is OUT -- including a file dropped directly under
+    # docker-login/ (the exact hole Codex reported), not just docker-login/data.
+    for secret in (
+        "docker-login/secrets.json",  # exported straight into docker-login/
+        "docker-login/diagnostic.log",  # a stray diagnostic artifact
+        "docker-login/data/secrets.json",  # the container's writable volume
+        "Auth/secrets.json",  # legacy _resolve_secrets_path default
+        "token_cache.json",  # any future top-level token/cache file
+    ):
+        assert _docker_context_excluded(rules, secret), (
+            f"{secret!r} must be excluded from the build context by the allowlist"
+        )
+
+    # Discriminating control: the previous rules (bare `!docker-login`, only
+    # `docker-login/data` re-excluded) LEAK a file dropped directly under
+    # docker-login/. This proves the matcher -- and thus the assertions above --
+    # actually detect the regression the fix removes (mutation gegenprobe baked in).
+    old_rules = ["*", "!requirements.txt", "!docker-login", "docker-login/data"]
+    assert not _docker_context_excluded(old_rules, "docker-login/secrets.json"), (
+        "sanity: the old denylist rules must (wrongly) keep docker-login/secrets.json "
+        "in context, otherwise this test would pass even without the fix"
+    )
+    assert _docker_context_excluded(rules, "docker-login/secrets.json"), (
+        "the fixed allowlist must exclude docker-login/secrets.json"
+    )
+
+
+def test_readme_container_station_does_not_present_compose_up_first_login() -> None:
+    """Container Station guidance must not present compose-up as a first-login path.
+
+    Codex: importing docker-compose.yml as a Container Station *application* starts it
+    with ``docker compose up`` semantics, which does not forward terminal STDIN, so the
+    first-run ``input("Press Enter")`` prompt can never proceed. Telling users to "keep
+    it in the foreground for the first (login) run" is therefore wrong (foreground is
+    not stdin attached). The README must route the interactive login through the
+    stdin-attaching ``docker compose run`` (SSH) path and only offer Container Station
+    for later, already-authenticated runs.
+    """
+
+    readme = _read("README.md")
+
+    assert "**Container Station:**" in readme, (
+        "README must document the Container Station option so this guard stays anchored."
+    )
+    # Isolate the Container Station bullet (up to the next blank line).
+    bullet = readme.split("**Container Station:**", 1)[1].split("\n\n", 1)[0].lower()
+
+    # It must NOT claim the first/login run works by keeping the compose-up
+    # application "in the foreground" (the exact wrong claim Codex flagged).
+    assert not ("foreground" in bullet and "first" in bullet and "login" in bullet), (
+        "Container Station bullet still presents keeping the compose-up application "
+        "'in the foreground' for the 'first (login)' run -- that path has no stdin, so "
+        "the interactive login cannot proceed."
+    )
+    # It must steer the login to the stdin-attaching `docker compose run` path...
+    assert "compose run" in bullet, (
+        "Container Station bullet must route the interactive login to the "
+        "`docker compose run` path (the only one that attaches stdin)."
+    )
+    # ...and warn that the app-import / compose-up path does not forward a terminal.
+    assert "compose up" in bullet and "forward" in bullet, (
+        "Container Station bullet must warn that the app-import/compose-up path does "
+        "not forward a terminal, so the first-login prompt stalls."
     )

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -1,0 +1,102 @@
+# tests/test_docker_login_hardening.py
+"""Regression guards for the docker-login helper hardening.
+
+These are text guards (in the spirit of ``test_hacs_validation.py``) that lock in
+security/usability fixes for the containerised login helper so they cannot silently
+regress. Each guard maps to a concrete Codex review finding on PR #1208:
+
+* Secrets file must stay owner-only ``0600`` and be handed to the host user via an
+  ownership handoff, never relaxed to world-readable ``0644`` (findings A + C).
+* The launchers must start the container with ``docker compose run`` (interactive,
+  stdin attached) rather than ``docker compose up``, or the one-time
+  ``Press Enter`` prompt blocks forever (finding B).
+* noVNC must stay bound to loopback by default (earlier finding), so the
+  fixed-password session is not exposed on the LAN during sign-in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DOCKER_LOGIN = Path("custom_components/googlefindmy/docker-login")
+
+
+def _read(name: str) -> str:
+    """Return the text of a docker-login helper file."""
+
+    return (DOCKER_LOGIN / name).read_text(encoding="utf-8")
+
+
+def test_entrypoint_never_makes_secrets_world_readable() -> None:
+    """The entrypoint must not relax secrets.json to a group/world-readable mode."""
+
+    entrypoint = _read("entrypoint.sh")
+    for forbidden in ("chmod 0644", "chmod 644", "chmod 0640", "chmod 0o644"):
+        assert forbidden not in entrypoint, (
+            f"entrypoint.sh must not widen secrets.json permissions ({forbidden!r}); "
+            "keep owner-only 0600 and hand ownership to the host user instead."
+        )
+
+
+def test_entrypoint_hands_ownership_to_host_user() -> None:
+    """The entrypoint must chown the produced secrets to the host UID and keep 0600."""
+
+    entrypoint = _read("entrypoint.sh")
+    assert "sudo chown" in entrypoint, (
+        "entrypoint.sh must perform the ownership handoff"
+    )
+    assert "GFMY_HOST_UID" in entrypoint, "entrypoint.sh must honour the host UID"
+    assert "chmod 0600" in entrypoint, (
+        "entrypoint.sh must keep the produced secrets.json owner-only (0600)"
+    )
+
+
+@pytest.mark.parametrize("launcher", ["login.sh", "login.cmd"])
+def test_launcher_uses_compose_run_not_up(launcher: str) -> None:
+    """Launchers must use interactive ``compose run`` so the Enter prompt reaches Python."""
+
+    text = _read(launcher)
+    assert "docker compose run" in text, (
+        f"{launcher} must start the container with `docker compose run` "
+        "(stdin attached), not `docker compose up`."
+    )
+    assert "--rm" in text, (
+        f"{launcher} must use --rm so repeated logins do not stack containers"
+    )
+    assert "docker compose up" not in text, (
+        f"{launcher} must not use `docker compose up`: it does not forward stdin, "
+        "so the interactive login prompt blocks forever."
+    )
+
+
+def test_launcher_sh_exports_host_ids_without_world_writable_chmod() -> None:
+    """login.sh must pass the host UID/GID and must not open ./data to the world."""
+
+    text = _read("login.sh")
+    assert "GFMY_HOST_UID" in text and "GFMY_HOST_GID" in text, (
+        "login.sh must export the host UID/GID for the ownership handoff"
+    )
+    assert "chmod 0777" not in text, (
+        "login.sh must not make the token directory world-writable; the container "
+        "takes ownership of ./data for the run instead."
+    )
+
+
+def test_compose_passes_host_ids_for_handoff() -> None:
+    """docker-compose.yml must forward the host UID/GID to the container."""
+
+    compose = _read("docker-compose.yml")
+    assert "GFMY_HOST_UID" in compose and "GFMY_HOST_GID" in compose, (
+        "docker-compose.yml must forward GFMY_HOST_UID/GFMY_HOST_GID for the handoff"
+    )
+
+
+def test_compose_binds_novnc_to_loopback_by_default() -> None:
+    """noVNC must default to a loopback bind, not be exposed on the LAN."""
+
+    compose = _read("docker-compose.yml")
+    assert "127.0.0.1" in compose, (
+        "docker-compose.yml must bind the fixed-password noVNC port to loopback by default"
+    )

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -12,9 +12,11 @@ regress. Each guard maps to a concrete Codex review finding on PR #1208:
   ``Press Enter`` prompt blocks forever (finding B).
 * noVNC must stay bound to loopback by default (earlier finding), so the
   fixed-password session is not exposed on the LAN during sign-in.
-* A context-level ``.dockerignore`` must keep persisted credentials
-  (``docker-login/data``) out of the ``--build`` context, so builders that upload
-  the full context never receive the OAuth/AAS secrets.
+* A context-level ``.dockerignore`` must be an ALLOWLIST (ignore the whole
+  build context, re-include only the two paths the Dockerfile COPYs) so that
+  EVERY secret location -- ``docker-login/data`` AND the legacy
+  ``Auth/secrets.json`` AND any future token/cache path -- stays out of the
+  ``--build`` context, not just the one path a denylist happens to name.
 * The ownership handoff must run from an ``EXIT`` trap, so a nonzero/interrupted
   ``main.py`` run still returns the produced secrets.json to the host user.
 """
@@ -109,19 +111,57 @@ def test_compose_binds_novnc_to_loopback_by_default() -> None:
     )
 
 
-def test_dockerignore_excludes_persisted_credentials() -> None:
-    """A context-level .dockerignore must keep docker-login/data out of the build context."""
+def _dockerignore_rules() -> list[str]:
+    """Return the effective (non-comment, non-blank) .dockerignore patterns, in order."""
 
     dockerignore = BUILD_CONTEXT / ".dockerignore"
     assert dockerignore.is_file(), (
         "A .dockerignore must exist at the build-context root "
         f"({BUILD_CONTEXT}) because the login image builds with `--build` and that "
-        "context otherwise includes the persisted docker-login/data/secrets.json."
+        "context otherwise includes persisted OAuth/AAS credentials."
     )
-    text = dockerignore.read_text(encoding="utf-8")
-    assert "docker-login/data" in text, (
-        ".dockerignore must exclude docker-login/data so builders that upload the "
-        "full context never receive the OAuth/AAS credentials."
+    return [
+        line.strip()
+        for line in dockerignore.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_dockerignore_is_allowlist_excluding_every_secret_path() -> None:
+    """.dockerignore must ignore the whole context and re-include only build inputs.
+
+    A denylist that names only ``docker-login/data`` is whack-a-mole: the legacy
+    ``Auth/secrets.json`` default of ``main.py::_resolve_secrets_path`` (and any
+    future token/cache location) would still be uploaded with the ``--build``
+    context. An allowlist -- ignore ``*``, then re-include only the paths the
+    Dockerfile COPYs -- structurally keeps every secret out at once.
+    """
+
+    rules = _dockerignore_rules()
+
+    # 1. The context is ignored wholesale by the very first effective rule.
+    assert rules and rules[0] in {"*", "**"}, (
+        ".dockerignore must start by ignoring the entire context (`*`), so that "
+        "secrets in any location are excluded by default (allowlist model)."
+    )
+
+    # 2. Only build inputs are re-included, and never a secrets directory.
+    reincludes = {r[1:] for r in rules if r.startswith("!")}
+    assert reincludes == {"requirements.txt", "docker-login"}, (
+        "the only `!`-re-includes may be the Dockerfile's COPY inputs "
+        f"(requirements.txt, docker-login); found {sorted(reincludes)}. Re-including "
+        "anything else risks shipping integration source or secrets into the image."
+    )
+    assert not any(
+        r.startswith("!") and ("auth" in r.lower() or "secret" in r.lower())
+        for r in rules
+    ), ".dockerignore must never re-include an Auth/ or secrets path."
+
+    # 3. The persisted-credentials subdir of the re-included docker-login/ is
+    #    excluded again (order-sensitive: after `!docker-login`).
+    assert "docker-login/data" in {r.rstrip("/") for r in rules}, (
+        ".dockerignore must re-exclude docker-login/data after re-including "
+        "docker-login/, so the container's persisted secrets.json stays out."
     )
 
 

--- a/tests/test_main_file_cache.py
+++ b/tests/test_main_file_cache.py
@@ -60,6 +60,7 @@ def _read(tmp_path: Path) -> dict[str, Any]:
 class TestFileCacheAsyncInterface:
     """The async get/set surface consumed by nbe_list_devices / nova_request."""
 
+    @pytest.mark.asyncio
     async def test_set_then_get_round_trips_and_persists(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -70,6 +71,7 @@ class TestFileCacheAsyncInterface:
         assert await cache.get("oauth_token") == "abc"
         assert _read(tmp_path)["oauth_token"] == "abc"
 
+    @pytest.mark.asyncio
     async def test_set_none_pops_normal_key_and_saves(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -80,6 +82,7 @@ class TestFileCacheAsyncInterface:
         assert await cache.get("oauth_token") is None
         assert "oauth_token" not in _read(tmp_path)
 
+    @pytest.mark.asyncio
     async def test_aas_token_is_soft_invalidated_but_kept_in_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -96,6 +99,7 @@ class TestFileCacheAsyncInterface:
         # test_reload_recovers_soft_invalidated_token for the reload proof).
         assert _read(tmp_path)["aas_token"] == "master"
 
+    @pytest.mark.asyncio
     async def test_reload_recovers_soft_invalidated_token(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -109,6 +113,7 @@ class TestFileCacheAsyncInterface:
 
         assert await fresh.get("aas_token") == "master"
 
+    @pytest.mark.asyncio
     async def test_setting_aas_token_value_clears_soft_invalidation(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -121,6 +126,7 @@ class TestFileCacheAsyncInterface:
         assert await cache.get("aas_token") == "new-master"
         assert _read(tmp_path)["aas_token"] == "new-master"
 
+    @pytest.mark.asyncio
     async def test_async_cached_value_helpers(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -130,6 +136,7 @@ class TestFileCacheAsyncInterface:
 
         assert await cache.async_get_cached_value("k") == "v"
 
+    @pytest.mark.asyncio
     async def test_get_or_set_returns_existing_without_generator(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -140,6 +147,7 @@ class TestFileCacheAsyncInterface:
 
         assert await cache.get_or_set("k", _fail) == "existing"
 
+    @pytest.mark.asyncio
     async def test_get_or_set_runs_sync_generator(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -150,6 +158,7 @@ class TestFileCacheAsyncInterface:
         assert result == "made"
         assert _read(tmp_path)["k"] == "made"
 
+    @pytest.mark.asyncio
     async def test_get_or_set_awaits_coroutine_generator(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -163,6 +172,7 @@ class TestFileCacheAsyncInterface:
         assert result == "async-made"
         assert _read(tmp_path)["k"] == "async-made"
 
+    @pytest.mark.asyncio
     async def test_all_returns_a_copy(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -173,6 +183,7 @@ class TestFileCacheAsyncInterface:
 
         assert await cache.get("a") == 1  # mutation of the copy must not leak
 
+    @pytest.mark.asyncio
     async def test_flush_and_close_persist(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -229,6 +240,7 @@ class TestFileCacheSyncInterface:
 class TestFileCacheLoadFailureGuard:
     """A corrupt backing file must not be overwritten with empty data."""
 
+    @pytest.mark.asyncio
     async def test_corrupt_file_not_overwritten_on_empty_flush(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -240,6 +252,7 @@ class TestFileCacheLoadFailureGuard:
             encoding="utf-8"
         ) == "{ not valid json"
 
+    @pytest.mark.asyncio
     async def test_corrupt_file_is_repaired_once_real_data_is_set(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_main_file_cache.py
+++ b/tests/test_main_file_cache.py
@@ -1,0 +1,250 @@
+# tests/test_main_file_cache.py
+"""Behaviour tests for the standalone ``_FileCache`` backing ``secrets.json``.
+
+``_register_file_cache`` builds a duck-typed, file-backed ``TokenCache`` for
+standalone (container) mode: ``secrets.json`` is the only store, so the cache
+must persist writes atomically, expose the async/sync TokenCache interface, and
+*soft-invalidate* the AAS master token (hide it from in-memory reads while
+keeping it in the file so it survives a process restart). These paths were
+previously unexercised; the tests below pin them so the container credential
+lifecycle cannot regress silently.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _reset_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wipe the module-global TokenCache registry so tests don't leak."""
+    from custom_components.googlefindmy.Auth import token_cache
+
+    monkeypatch.setattr(token_cache, "_INSTANCES", {}, raising=False)
+    monkeypatch.setitem(token_cache._STATE, "default_entry_id", None)
+
+
+def _make_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    initial: dict[str, object] | str | None = None,
+) -> Any:
+    """Return a fresh ``_FileCache`` backed by ``tmp_path/Auth/secrets.json``.
+
+    ``initial`` may be a dict (written as JSON), a raw string (written verbatim,
+    e.g. to simulate a corrupt file) or ``None`` (no file created).
+    """
+    from custom_components.googlefindmy import main as cli_main
+
+    _reset_registry(monkeypatch)
+    monkeypatch.setattr(cli_main, "_this_dir", tmp_path, raising=True)
+
+    secrets = tmp_path / "Auth" / "secrets.json"
+    secrets.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(initial, str):
+        secrets.write_text(initial, encoding="utf-8")
+    elif initial is not None:
+        secrets.write_text(json.dumps(initial), encoding="utf-8")
+
+    return cli_main._register_file_cache("")
+
+
+def _read(tmp_path: Path) -> dict[str, Any]:
+    """Read back the backing secrets.json as a dict."""
+    return json.loads((tmp_path / "Auth" / "secrets.json").read_text(encoding="utf-8"))
+
+
+class TestFileCacheAsyncInterface:
+    """The async get/set surface consumed by nbe_list_devices / nova_request."""
+
+    async def test_set_then_get_round_trips_and_persists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch)
+
+        await cache.set("oauth_token", "abc")
+
+        assert await cache.get("oauth_token") == "abc"
+        assert _read(tmp_path)["oauth_token"] == "abc"
+
+    async def test_set_none_pops_normal_key_and_saves(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch, {"oauth_token": "abc"})
+
+        await cache.set("oauth_token", None)
+
+        assert await cache.get("oauth_token") is None
+        assert "oauth_token" not in _read(tmp_path)
+
+    async def test_aas_token_is_soft_invalidated_but_kept_in_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """set('aas_token', None) hides it from reads but keeps it on disk so a
+        process restart can recover the master token."""
+        cache = _make_cache(tmp_path, monkeypatch, {"aas_token": "master"})
+
+        await cache.set("aas_token", None)
+
+        # Hidden from in-memory reads...
+        assert await cache.get("aas_token") is None
+        assert await cache.async_get_cached_value("aas_token") is None
+        # ...but preserved in the backing file (survives restart, see
+        # test_reload_recovers_soft_invalidated_token for the reload proof).
+        assert _read(tmp_path)["aas_token"] == "master"
+
+    async def test_reload_recovers_soft_invalidated_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second cache over the same file sees the preserved aas_token."""
+        cache = _make_cache(tmp_path, monkeypatch, {"aas_token": "master"})
+        await cache.set("aas_token", None)  # soft-invalidate, keep in file
+
+        from custom_components.googlefindmy import main as cli_main
+
+        fresh = cli_main._register_file_cache("")  # same _this_dir/Auth file
+
+        assert await fresh.get("aas_token") == "master"
+
+    async def test_setting_aas_token_value_clears_soft_invalidation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch, {"aas_token": "master"})
+        await cache.set("aas_token", None)
+        assert await cache.get("aas_token") is None
+
+        await cache.set("aas_token", "new-master")
+
+        assert await cache.get("aas_token") == "new-master"
+        assert _read(tmp_path)["aas_token"] == "new-master"
+
+    async def test_async_cached_value_helpers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch)
+
+        await cache.async_set_cached_value("k", "v")
+
+        assert await cache.async_get_cached_value("k") == "v"
+
+    async def test_get_or_set_returns_existing_without_generator(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch, {"k": "existing"})
+
+        def _fail() -> str:
+            raise AssertionError("generator must not run when value exists")
+
+        assert await cache.get_or_set("k", _fail) == "existing"
+
+    async def test_get_or_set_runs_sync_generator(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch)
+
+        result = await cache.async_get_cached_value_or_set("k", lambda: "made")
+
+        assert result == "made"
+        assert _read(tmp_path)["k"] == "made"
+
+    async def test_get_or_set_awaits_coroutine_generator(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch)
+
+        async def _agen() -> str:
+            return "async-made"
+
+        result = await cache.async_get_cached_value_or_set("k", _agen)
+
+        assert result == "async-made"
+        assert _read(tmp_path)["k"] == "async-made"
+
+    async def test_all_returns_a_copy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch, {"a": 1, "b": 2})
+
+        snapshot = await cache.all()
+        snapshot["a"] = 999
+
+        assert await cache.get("a") == 1  # mutation of the copy must not leak
+
+    async def test_flush_and_close_persist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch)
+        cache.sync_set("k", "v")  # sync mutation, then async persist paths
+
+        await cache.flush()
+        await cache.close()
+
+        assert _read(tmp_path)["k"] == "v"
+
+
+class TestFileCacheSyncInterface:
+    """The synchronous helpers used outside the event loop."""
+
+    def test_sync_get_and_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch)
+
+        cache.sync_set("k", "v")
+
+        assert cache.sync_get("k") == "v"
+        assert _read(tmp_path)["k"] == "v"
+
+    def test_sync_set_none_pops(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch, {"k": "v"})
+
+        cache.sync_set("k", None)
+
+        assert cache.sync_get("k") is None
+        assert "k" not in _read(tmp_path)
+
+    def test_sync_pop_removes_and_saves(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch, {"k": "v"})
+
+        assert cache.sync_pop("k") == "v"
+        assert "k" not in _read(tmp_path)
+
+    def test_sync_pop_missing_returns_default_without_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch, {"k": "v"})
+        before = _read(tmp_path)
+
+        assert cache.sync_pop("absent", "fallback") == "fallback"
+        assert _read(tmp_path) == before  # default path performs no save
+
+
+class TestFileCacheLoadFailureGuard:
+    """A corrupt backing file must not be overwritten with empty data."""
+
+    async def test_corrupt_file_not_overwritten_on_empty_flush(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch, "{ not valid json")
+
+        await cache.flush()  # _load_failed and no data -> skip save
+
+        assert (tmp_path / "Auth" / "secrets.json").read_text(
+            encoding="utf-8"
+        ) == "{ not valid json"
+
+    async def test_corrupt_file_is_repaired_once_real_data_is_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache = _make_cache(tmp_path, monkeypatch, "{ not valid json")
+
+        await cache.set("oauth_token", "recovered")
+
+        assert _read(tmp_path)["oauth_token"] == "recovered"

--- a/tests/test_main_secrets_path.py
+++ b/tests/test_main_secrets_path.py
@@ -1,0 +1,49 @@
+"""Tests for standalone secrets.json path resolution.
+
+``_resolve_secrets_path`` lets a container persist the standalone cache on a
+dedicated writable volume via ``GOOGLEFINDMY_SECRETS_PATH`` while the integration
+code stays on a read-only mount. These tests pin the override and the default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from custom_components.googlefindmy import main
+
+
+def test_default_path_is_auth_secrets_json() -> None:
+    """Without the env override the path is Auth/secrets.json next to main.py."""
+
+    assert main._resolve_secrets_path() == main._this_dir / "Auth" / "secrets.json"
+
+
+def test_env_override_redirects_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GOOGLEFINDMY_SECRETS_PATH redirects the cache to an explicit file path."""
+
+    monkeypatch.setenv("GOOGLEFINDMY_SECRETS_PATH", "/data/secrets.json")
+
+    assert main._resolve_secrets_path() == Path("/data/secrets.json")
+
+
+def test_blank_env_override_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whitespace-only override is ignored and the default path is used."""
+
+    monkeypatch.setenv("GOOGLEFINDMY_SECRETS_PATH", "   ")
+
+    assert main._resolve_secrets_path() == main._this_dir / "Auth" / "secrets.json"
+
+
+def test_env_override_expands_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``~`` in the override is expanded to the user's home directory."""
+
+    monkeypatch.setenv("GOOGLEFINDMY_SECRETS_PATH", "~/gfmy/secrets.json")
+
+    resolved = main._resolve_secrets_path()
+
+    assert resolved == Path("~/gfmy/secrets.json").expanduser()
+    assert "~" not in str(resolved)

--- a/tests/test_main_secrets_path.py
+++ b/tests/test_main_secrets_path.py
@@ -1,3 +1,4 @@
+# tests/test_main_secrets_path.py
 """Tests for standalone secrets.json path resolution.
 
 ``_resolve_secrets_path`` lets a container persist the standalone cache on a
@@ -14,8 +15,10 @@ import pytest
 from custom_components.googlefindmy import main
 
 
-def test_default_path_is_auth_secrets_json() -> None:
+def test_default_path_is_auth_secrets_json(monkeypatch: pytest.MonkeyPatch) -> None:
     """Without the env override the path is Auth/secrets.json next to main.py."""
+
+    monkeypatch.delenv("GOOGLEFINDMY_SECRETS_PATH", raising=False)
 
     assert main._resolve_secrets_path() == main._this_dir / "Auth" / "secrets.json"
 

--- a/tests/test_main_secrets_path.py
+++ b/tests/test_main_secrets_path.py
@@ -8,7 +8,9 @@ code stays on a read-only mount. These tests pin the override and the default.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -50,3 +52,139 @@ def test_env_override_expands_user(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert resolved == Path("~/gfmy/secrets.json").expanduser()
     assert "~" not in str(resolved)
+
+
+class TestCallSitesHonorOverride:
+    """Regression: every secrets.json call site routes through the override.
+
+    Codex review (PR #1208, round 1, finding 4) showed the standalone CLI
+    hard-wired ``Auth/secrets.json`` next to the module, which collides with a
+    read-only code mount plus atomic writes inside the login container. The fix
+    routes ``_register_file_cache``, ``_ensure_authenticated`` and
+    ``_clear_stale_tokens_for_reauth`` through ``_resolve_secrets_path()``.
+
+    These tests fail if any single call site is reverted to the module default:
+    the default (``_this_dir/Auth/secrets.json``) is pointed at an *empty* code
+    directory while ``GOOGLEFINDMY_SECRETS_PATH`` carries the real file, so a
+    revert would read/write the wrong (empty) location and break the assertion.
+    """
+
+    @staticmethod
+    def _reset_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+        """Wipe the module-global TokenCache registry so tests don't leak."""
+        from custom_components.googlefindmy.Auth import token_cache
+
+        monkeypatch.setattr(token_cache, "_INSTANCES", {}, raising=False)
+        monkeypatch.setitem(token_cache._STATE, "default_entry_id", None)
+
+    def test_ensure_authenticated_reads_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Valid credentials at the override path short-circuit the Chrome flow,
+        even though the default code dir holds no credentials at all."""
+        default_dir = tmp_path / "code"
+        default_dir.mkdir()
+        monkeypatch.setattr(main, "_this_dir", default_dir, raising=True)
+
+        override = tmp_path / "data" / "secrets.json"
+        override.parent.mkdir(parents=True)
+        override.write_text(
+            json.dumps({"username": "u@example.com", "oauth_token": "tok"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("GOOGLEFINDMY_SECRETS_PATH", str(override))
+
+        from custom_components.googlefindmy.Auth import auth_flow
+
+        def _boom() -> tuple[str, str]:
+            raise AssertionError(
+                "Chrome flow must not run: override holds valid credentials"
+            )
+
+        monkeypatch.setattr(
+            auth_flow, "request_oauth_account_token_flow", _boom, raising=True
+        )
+
+        main._ensure_authenticated()  # returns via override short-circuit
+
+    def test_ensure_authenticated_writes_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fresh credentials are persisted to the override path; the default
+        Auth dir is never created."""
+        default_dir = tmp_path / "code"
+        default_dir.mkdir()
+        monkeypatch.setattr(main, "_this_dir", default_dir, raising=True)
+
+        override = tmp_path / "data" / "secrets.json"
+        monkeypatch.setenv("GOOGLEFINDMY_SECRETS_PATH", str(override))
+
+        from custom_components.googlefindmy.Auth import auth_flow
+
+        monkeypatch.setattr(
+            auth_flow,
+            "request_oauth_account_token_flow",
+            lambda: ("fresh-oauth", "detected@example.com"),
+            raising=True,
+        )
+
+        main._ensure_authenticated()
+
+        written = json.loads(override.read_text(encoding="utf-8"))
+        assert written["oauth_token"] == "fresh-oauth"
+        assert written["username"] == "detected@example.com"
+        assert not (default_dir / "Auth" / "secrets.json").exists()
+
+    def test_clear_stale_tokens_honors_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--reauth`` purges stale tokens from the override file; a revert to
+        the empty default dir would early-return and leave them in place."""
+        default_dir = tmp_path / "code"
+        default_dir.mkdir()
+        monkeypatch.setattr(main, "_this_dir", default_dir, raising=True)
+
+        override = tmp_path / "data" / "secrets.json"
+        override.parent.mkdir(parents=True)
+        override.write_text(
+            json.dumps(
+                {
+                    "username": "keep@example.com",
+                    "oauth_token": "stale",
+                    "aas_token": "stale",
+                    "adm_token_abc": "stale",
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("GOOGLEFINDMY_SECRETS_PATH", str(override))
+
+        main._clear_stale_tokens_for_reauth()
+
+        remaining = json.loads(override.read_text(encoding="utf-8"))
+        assert "oauth_token" not in remaining
+        assert "aas_token" not in remaining
+        assert "adm_token_abc" not in remaining
+        assert remaining["username"] == "keep@example.com"
+
+    def test_register_file_cache_honors_override(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The file-backed cache loads from the override path; a revert to the
+        empty default dir would yield an empty cache (``sync_get`` -> None)."""
+        self._reset_registry(monkeypatch)
+
+        default_dir = tmp_path / "code"
+        default_dir.mkdir()
+        monkeypatch.setattr(main, "_this_dir", default_dir, raising=True)
+
+        override = tmp_path / "data" / "secrets.json"
+        override.parent.mkdir(parents=True)
+        override.write_text(
+            json.dumps({"oauth_token": "marker-value"}), encoding="utf-8"
+        )
+        monkeypatch.setenv("GOOGLEFINDMY_SECRETS_PATH", str(override))
+
+        cache: Any = main._register_file_cache("entry_override")
+
+        assert cache.sync_get("oauth_token") == "marker-value"


### PR DESCRIPTION
## Summary

Re-introduces the containerised noVNC one-time Google login helper for the Docker/standalone deployment, cleanly rebased onto `1.7` after the prior chain (merged as #1208) was reverted via #1209.

This is the **same reviewed code**, replayed onto a clean base with **fresh commit SHAs** and **all Codex findings from #1208 already resolved in-tree**:

- **Secrets never enter the build context** — `.dockerignore` is a strict allowlist (`*` ignored; only `requirements.txt` and `docker-login/` re-included, `docker-login/data` re-excluded). Closes the whole class of secret-path leaks (`Auth/`, `KeyBackup/`, future token paths) at once.
- **Signal handling** — the login CLI runs backgrounded with a signal-forwarding trap so `docker stop` (SIGTERM) reaches the child, the exit code is propagated, and the ownership-handoff EXIT trap always runs exactly once.
- **stdin + SIGINT preserved** — the interactive Enter prompt keeps the terminal stdin (`<&0` at the async boundary) and SIGINT is reset to the default disposition (`trap - INT QUIT` before `exec`) for the backgrounded child.
- **Ownership handoff** — idempotent `cleanup()` hands `/data` back to the host UID/GID on exit.

## Testing

- 12 hardening guards in `test_docker_login_hardening.py`, incl. a **behavioural** test that extracts and runs the real backgrounding line from `entrypoint.sh` and measures stdin delivery + SIGINT disposition on the live child (with a discriminating negative control) — addressing Codex's "cover the behavior rather than only matching script text".
- Local gates green: ruff 0.14.14 (CI pin), ruff-format, mypy --strict, CI meta-guards (path header, async markers).

## History note

`1.7` was reset to the pre-helper base by revert #1209 (tree byte-identical to `93787adc`). This PR replays the fixed chain (9 original commits + behavioural test) onto that clean base — no history rewrite of the release line.
