### PR TITLE
feat(docker-login): interactive IP menu + in-container LAN hardening

### DIFF
--- a/custom_components/googlefindmy/.dockerignore
+++ b/custom_components/googlefindmy/.dockerignore
@@ -14,22 +14,25 @@
 #
 # Denylisting each secret path individually is whack-a-mole: a new location
 # reopens the hole (exactly what happened for Auth/secrets.json). Instead this is
-# an ALLOWLIST: ignore the whole context, then re-include ONLY the two paths the
+# an ALLOWLIST: ignore the whole context, then re-include ONLY the paths the
 # Dockerfile actually needs at build time:
-#   * requirements.txt           - COPYed, dependencies baked into the image
-#   * docker-login/entrypoint.sh - COPYed as the container entrypoint
+#   * requirements.txt            - COPYed, dependencies baked into the image
+#   * docker-login/entrypoint.sh  - COPYed as the container entrypoint
+#   * docker-login/start-novnc.sh - COPYed as the noVNC TLS override (AP-8)
 # The integration *code* is NOT built in; it is bind-mounted read-only at run
 # time (M2). This keeps every secret - current or future, anywhere in the tree -
 # out of the build context and shrinks the upload to just the required files.
 #
 # Docker cannot descend into an ignored directory, so docker-login/ is re-included
 # only for TRAVERSAL; its contents are then re-excluded (docker-login/*) and only
-# the one COPY input the Dockerfile needs (entrypoint.sh) is re-included. A bare
-# `!docker-login` would re-include the WHOLE directory, so any other file placed
-# under it -- an exported secrets.json, a diagnostic log, a future addition -- would
-# ship in the context; excluding only docker-login/data left exactly that hole.
+# the COPY inputs the Dockerfile needs (entrypoint.sh, start-novnc.sh) are
+# re-included. A bare `!docker-login` would re-include the WHOLE directory, so any
+# other file placed under it -- an exported secrets.json, a diagnostic log, a
+# future addition -- would ship in the context; excluding only docker-login/data
+# left exactly that hole.
 *
 !requirements.txt
 !docker-login
 docker-login/*
 !docker-login/entrypoint.sh
+!docker-login/start-novnc.sh

--- a/custom_components/googlefindmy/Auth/auth_flow.py
+++ b/custom_components/googlefindmy/Auth/auth_flow.py
@@ -69,11 +69,15 @@ def request_oauth_account_token_flow(
             novnc_url = (
                 os.environ.get("GOOGLEFINDMY_NOVNC_URL") or "http://localhost:7900"
             )
+            # The entrypoint mints a per-run password and exports it here for a
+            # LAN-hardened bind; on the loopback default it stays unset and the
+            # base image's fixed "secret" is what the viewer actually accepts.
+            novnc_password = os.environ.get("GOOGLEFINDMY_NOVNC_PASSWORD", "secret")
             print(
                 "[AuthFlow] ==================================================\n"
                 "[AuthFlow] Action required to sign in to Google:\n"
                 f"[AuthFlow]   1. Open {novnc_url} in your browser "
-                "(password: secret).\n"
+                f"(password: {novnc_password}).\n"
                 "[AuthFlow]   2. Return to this terminal and press Enter (below).\n"
                 "[AuthFlow]   3. Sign in to Google in the browser view that opens.\n"
                 "[AuthFlow] =================================================="

--- a/custom_components/googlefindmy/docker-login/Dockerfile
+++ b/custom_components/googlefindmy/docker-login/Dockerfile
@@ -58,5 +58,22 @@ RUN mkdir -p /data \
 COPY docker-login/entrypoint.sh /opt/bin/gfm-entrypoint.sh
 RUN chmod +x /opt/bin/gfm-entrypoint.sh
 
+# openssl is needed at RUNTIME to mint the self-signed noVNC certificate for a
+# LAN bind (docker-login/entrypoint.sh, AP-8). It is normally already present in
+# the selenium base image; install it defensively so a LAN-bind login can always
+# encrypt the viewer. A loopback login never calls openssl, so this only matters
+# for the opt-in LAN path.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openssl \
+ && rm -rf /var/lib/apt/lists/*
+
+# Self-signed TLS override for noVNC (AP-8). Preserve the base image's original
+# launcher as start-novnc.base.sh FIRST, so the override can hand off to it
+# verbatim on the loopback/tunnel default (no cert -> unchanged path), then
+# replace /opt/bin/start-novnc.sh (the path [program:novnc] already runs).
+RUN cp -a /opt/bin/start-novnc.sh /opt/bin/start-novnc.base.sh
+COPY docker-login/start-novnc.sh /opt/bin/start-novnc.sh
+RUN chmod +x /opt/bin/start-novnc.sh
+
 USER seluser
 ENTRYPOINT ["/opt/bin/gfm-entrypoint.sh"]

--- a/custom_components/googlefindmy/docker-login/README.md
+++ b/custom_components/googlefindmy/docker-login/README.md
@@ -39,34 +39,59 @@ Docker host and launch it there.
 
 ## noVNC access & security
 
-The noVNC viewer uses the base image's **fixed password `secret`**, and during
-the Google sign-in it exposes a fully authenticated Chrome session. To avoid
-handing that to anyone on the network, the port is bound to **loopback
-(`127.0.0.1:7900`) by default** — it is only reachable from the Docker host
-itself.
+The noVNC viewer exposes a fully authenticated Chrome session during the Google
+sign-in, so both its reachability and its password matter. What the viewer uses
+depends on **where you bind it**:
 
-- **Reach it from another machine (recommended): SSH tunnel.**
-  ```bash
-  ssh -L 7900:127.0.0.1:7900 <docker-host>
-  ```
-  Then open `http://localhost:7900` on your own machine.
-- **Trusted LAN opt-in.** Only on a network you trust, bind noVNC to a
-  **concrete** address of the Docker host:
+- **Loopback (default): fixed password `secret`, plain HTTP.** With no `--ip` and
+  no `GFMY_NOVNC_BIND`/`GFMY_NOVNC_URL_HOST`, the port is bound to
+  **`127.0.0.1:7900`** — reachable only from the Docker host. This is the
+  historical behaviour: the viewer keeps the base image's public password
+  `secret` over plain HTTP, which is safe **only** because nothing on the network
+  can reach it.
+- **LAN bind: per-run password + self-signed HTTPS, automatically.** The moment
+  you bind to a non-loopback address, the container hardens the viewer for you:
+  it mints a **fresh random password for that run** (so the public `secret` no
+  longer works) and, unless you pass `--no-tls`, serves the viewer over a
+  **self-signed TLS certificate** (`https://…`, SAN = the chosen address). The
+  password is minted *inside the container*, so the launcher cannot print it: it
+  appears in the container output below, shown as `(password: …)` in both the
+  `[entrypoint] noVNC available at …` line and the `[AuthFlow]` sign-in banner.
+  Because the certificate is self-signed, your browser shows a one-time warning
+  you accept once. (If `openssl` is somehow unavailable in the container it logs a
+  warning and falls back to plain HTTP for that run; the per-run password still
+  applies.)
+
+You reach a LAN-bound viewer in one of two ways:
+
+- **Interactive chooser (just run `bash login.sh`).** On an interactive terminal
+  with nothing pinned, the launcher lists the LAN addresses it detected on this
+  host and asks you to pick one; pressing **Enter** takes the highlighted default
+  (a detected `192.168.*`, else `10.*`, else the first address; loopback only
+  when none was found). Picking a LAN address turns on the hardening above;
+  picking loopback keeps `secret`/plain. Container and VPN interfaces (`docker0`,
+  `br-*`, `veth*`, `tun*`, `wg*`) are left out of the list. A **non-interactive**
+  run (no TTY) keeps the loopback default unchanged.
+- **Explicit `--ip` (scriptable, also Windows).** Skip the chooser by naming the
+  address directly:
   ```bash
   bash login.sh --ip 192.168.1.21
   ```
-  The launcher then prints exactly that address as the URL to open. Prefer this
-  over the `GFMY_NOVNC_BIND=0.0.0.0` wildcard, which publishes on every
-  interface; prefer the SSH tunnel over both.
+  `--no-tls` keeps the per-run password but serves plain HTTP instead of the
+  self-signed viewer — for people who prefer to tunnel the transport themselves.
+  `login.cmd` on Windows takes the same `--ip` flag (in both the `--ip X` and
+  `--ip=X` spellings) and gets the **same** per-run password and TLS; it has no
+  `--no-tls` (a LAN bind on Windows always encrypts) and does not auto-detect
+  addresses, because parsing `ipconfig` output in batch is locale-dependent.
 
-  Run `bash login.sh` without arguments first: when noVNC stays on loopback the
-  launcher lists the addresses it detected on this host, each with the
-  ready-to-paste `--ip` command. Container and VPN interfaces (`docker0`,
-  `br-*`, `veth*`, `tun*`, `wg*`) are left out, but the list is still a
-  suggestion: pick the one your browser can actually reach. (`login.cmd` on
-  Windows takes the same `--ip` flag, in both the `--ip X` and `--ip=X`
-  spellings, but does not auto-detect, because parsing `ipconfig` output in
-  batch is locale-dependent.)
+**Prefer an SSH tunnel over a LAN bind when you can** — it needs no LAN exposure
+at all:
+```bash
+ssh -L 7900:127.0.0.1:7900 <docker-host>
+```
+Then open `http://localhost:7900` on your own machine (loopback, so password
+`secret`). Prefer a concrete `--ip`/chooser address over the
+`GFMY_NOVNC_BIND=0.0.0.0` wildcard, which publishes on every interface.
 
 ### The three address roles
 
@@ -187,8 +212,12 @@ read it as your host user. Docker Desktop (Windows/macOS) maps ownership for you
    [AuthFlow] Press Enter to continue...
    ```
 
-4. Open **http://localhost:7900** in your normal browser. Password: `secret`.
-   You now see a live view of Chrome running inside the container.
+4. Open the noVNC URL the launcher printed and enter the password it names. On
+   the **loopback default** that is **http://localhost:7900** with password
+   `secret`. On a **LAN bind** it is the `https://<address>:7900` URL shown, with
+   the **per-run password** the container printed (`(password: …)`); accept the
+   one-time self-signed-certificate warning. You now see a live view of Chrome
+   running inside the container.
 
 5. In that noVNC window, log into your Google account as usual (2FA works the
    same as in any browser).
@@ -210,9 +239,11 @@ intended login path (there is no Supervisor Add-on store for HA Container):
   ```bash
   ssh -L 7900:127.0.0.1:7900 <nas-ip>
   ```
-  then browse to `http://localhost:7900`. Only on a trusted LAN, start with
-  `GFMY_NOVNC_BIND=0.0.0.0 bash login.sh` to reach `http://<nas-ip>:7900` directly
-  (see [noVNC access & security](#novnc-access--security)).
+  then browse to `http://localhost:7900`. Only on a trusted LAN, bind to a
+  concrete NAS address — `bash login.sh --ip <nas-ip>` (or the interactive
+  chooser) — and open the `https://<nas-ip>:7900` URL it prints with the per-run
+  password (see [noVNC access & security](#novnc-access--security)). Prefer this
+  concrete bind over the `GFMY_NOVNC_BIND=0.0.0.0` wildcard.
 - **Container Station:** the interactive first login needs a terminal attached to
   its STDIN, which only the `docker compose run` path (the **SSH** option above)
   provides. Importing `docker-compose.yml` as a Container Station *application*
@@ -473,7 +504,12 @@ there is no separate image to rebuild for code changes.
   are unaffected by a busy 7901; just start without `GFMY_ONECLICK=1`. For a
   busy 7900, stop the conflicting process (a leftover login container:
   `docker compose ps` / `docker compose down`).
-- **noVNC password:** it is `secret` — a fixed default of the base image.
+- **noVNC password:** on the **loopback default** it is `secret` (a fixed
+  default of the base image, safe only because loopback is not network-reachable).
+  On a **LAN bind** the container mints a **per-run random password** instead and
+  serves the viewer over self-signed **HTTPS**; read that password from the
+  container output (`(password: …)` in the noVNC-available line and the
+  `[AuthFlow]` banner), not from this guide.
 - **`SessionNotCreatedException` / chromedriver version mismatch:** set
   `GOOGLEFINDMY_CHROME_VERSION` to the container's Chrome major version
   (uncomment the line in `docker-compose.yml`). The integration's

--- a/custom_components/googlefindmy/docker-login/README.md
+++ b/custom_components/googlefindmy/docker-login/README.md
@@ -83,6 +83,16 @@ You reach a LAN-bound viewer in one of two ways:
   `--ip=X` spellings) and gets the **same** per-run password and TLS; it has no
   `--no-tls` (a LAN bind on Windows always encrypts) and does not auto-detect
   addresses, because parsing `ipconfig` output in batch is locale-dependent.
+- **Direct `docker compose run` (no launcher).** If you skip the launchers and run
+  `docker compose run --build --service-ports --rm googlefindmy-login` with
+  `GFMY_NOVNC_BIND` set to a LAN address (in your shell or a `.env`), the
+  **container itself** derives the hardening from that bind, so this path gets the
+  same per-run password and self-signed TLS — it cannot expose port 7900 with the
+  fixed `secret`. One nuance: with the `GFMY_NOVNC_BIND=0.0.0.0` **wildcard** and no
+  `GFMY_NOVNC_URL_HOST`, the container has no single address to certify, so it keeps
+  the per-run password but serves plain HTTP (set `GFMY_NOVNC_URL_HOST=<ip>` for
+  TLS, or `GFMY_NOVNC_TLS=0` to opt out of TLS deliberately). Prefer a concrete
+  `GFMY_NOVNC_BIND=<ip>` over the wildcard for that reason.
 
 **Prefer an SSH tunnel over a LAN bind when you can** — it needs no LAN exposure
 at all:

--- a/custom_components/googlefindmy/docker-login/docker-compose.yml
+++ b/custom_components/googlefindmy/docker-login/docker-compose.yml
@@ -89,11 +89,14 @@ services:
       # the bundled Chrome (undetected-chromedriver SessionNotCreatedException).
       # GOOGLEFINDMY_CHROME_VERSION: "141"
     ports:
-      # noVNC web viewer (password: secret, a fixed default of the base image).
-      # Bound to LOOPBACK by default so the fixed-password session is NOT exposed
-      # to the LAN/Internet during the Google sign-in. To reach it from another
-      # machine, use an SSH tunnel (recommended) or set GFMY_NOVNC_BIND=0.0.0.0
-      # (README → Remote access) to opt into a LAN bind on a trusted network.
+      # noVNC web viewer. On the LOOPBACK default (below) it keeps the base
+      # image's fixed password "secret" over plain HTTP, safe only because
+      # loopback is not network-reachable during the Google sign-in. A LAN bind
+      # (GFMY_NOVNC_BIND, or the launcher's --ip/interactive chooser) makes the
+      # container mint a per-run password and serve self-signed HTTPS instead. To
+      # reach it from another machine prefer an SSH tunnel; on a trusted LAN
+      # prefer a concrete --ip over the GFMY_NOVNC_BIND=0.0.0.0 wildcard (see
+      # README → "noVNC access & security").
       - "${GFMY_NOVNC_BIND:-127.0.0.1}:7900:7900"
       # The one-click token endpoint (port 7901) is deliberately NOT published
       # here. Its publish lives in the opt-in overlay file

--- a/custom_components/googlefindmy/docker-login/docker-compose.yml
+++ b/custom_components/googlefindmy/docker-login/docker-compose.yml
@@ -34,6 +34,34 @@ services:
       # normalised host (LAN address with --ip, else loopback); a manual
       # `docker compose run` without the launcher falls back to localhost.
       GOOGLEFINDMY_NOVNC_URL: "http://${GFMY_NOVNC_URL_HOST:-localhost}:7900"
+      # LAN-bind hardening. The launcher (login.sh / login.cmd) raises a single
+      # verdict, GFMY_NOVNC_HARDEN, ONLY when you bind noVNC to a concrete LAN
+      # (non-loopback) address; on the loopback default it stays empty and the
+      # container keeps the base image's plain-http + "secret" behaviour. These
+      # MUST be listed here to cross the host->container boundary: a bare
+      # `docker compose run` does NOT forward the launcher's shell environment,
+      # so exporting them in login.sh/login.cmd alone would leave the container
+      # blind and the LAN login would print an https/password promise it never keeps.
+      #   GFMY_NOVNC_HARDEN   -> entrypoint.sh mints a per-run dense random password
+      #                          IN THE CONTAINER, exports SE_VNC_PASSWORD (read by
+      #                          the base image's start-vnc.sh / x11vnc, replacing
+      #                          "secret") and GOOGLEFINDMY_NOVNC_PASSWORD (the same
+      #                          value, so the printed banners show the real per-run
+      #                          password). The password never crosses this boundary,
+      #                          so both launchers get identical hardening without any
+      #                          host-side crypto.
+      #   GFMY_NOVNC_TLS      -> entrypoint.sh mints a self-signed cert and
+      #                          start-novnc.sh serves https (--ssl-only).
+      #   GFMY_NOVNC_URL_HOST -> the concrete LAN IP, used as the cert SAN.
+      # There is deliberately NO SE_VNC_PASSWORD / GOOGLEFINDMY_NOVNC_PASSWORD
+      # passthrough here: the container generates the password, so an absent verdict
+      # (loopback) leaves the base image's own SE_VNC_PASSWORD=secret default intact.
+      # An empty passthrough used to OVERRIDE that default, leaving the loopback
+      # viewer with no VNC password while the prompt still printed "(password: secret)";
+      # dropping it removes that trap structurally.
+      GFMY_NOVNC_HARDEN: "${GFMY_NOVNC_HARDEN:-}"
+      GFMY_NOVNC_TLS: "${GFMY_NOVNC_TLS:-}"
+      GFMY_NOVNC_URL_HOST: "${GFMY_NOVNC_URL_HOST:-}"
       # Host UID/GID for the ownership handoff of the produced secrets.json. The
       # launcher (login.sh) passes these so the finished file ends up owned by
       # *you* with owner-only 0600 (readable/copyable by you, private from other

--- a/custom_components/googlefindmy/docker-login/docker-compose.yml
+++ b/custom_components/googlefindmy/docker-login/docker-compose.yml
@@ -53,6 +53,15 @@ services:
       #   GFMY_NOVNC_TLS      -> entrypoint.sh mints a self-signed cert and
       #                          start-novnc.sh serves https (--ssl-only).
       #   GFMY_NOVNC_URL_HOST -> the concrete LAN IP, used as the cert SAN.
+      #   GFMY_NOVNC_BIND     -> the host bind address (same value used in `ports:`
+      #                          below). Forwarded so a DIRECT `docker compose run`
+      #                          (which never runs a launcher) can still derive the
+      #                          verdict IN the container: entrypoint.sh treats any
+      #                          non-loopback bind as a LAN exposure and hardens it,
+      #                          so this supported path cannot publish port 7900 with
+      #                          the fixed "secret" over plain http. A launcher run
+      #                          already sets HARDEN explicitly and the derivation
+      #                          then stays a no-op (it never overrides a launcher).
       # There is deliberately NO SE_VNC_PASSWORD / GOOGLEFINDMY_NOVNC_PASSWORD
       # passthrough here: the container generates the password, so an absent verdict
       # (loopback) leaves the base image's own SE_VNC_PASSWORD=secret default intact.
@@ -62,6 +71,7 @@ services:
       GFMY_NOVNC_HARDEN: "${GFMY_NOVNC_HARDEN:-}"
       GFMY_NOVNC_TLS: "${GFMY_NOVNC_TLS:-}"
       GFMY_NOVNC_URL_HOST: "${GFMY_NOVNC_URL_HOST:-}"
+      GFMY_NOVNC_BIND: "${GFMY_NOVNC_BIND:-}"
       # Host UID/GID for the ownership handoff of the produced secrets.json. The
       # launcher (login.sh) passes these so the finished file ends up owned by
       # *you* with owner-only 0600 (readable/copyable by you, private from other

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -41,7 +41,9 @@ set -e
 # `x11vnc -storepasswd ${VNC_PASSWORD}`, and "$" is a shell metachar. Over 8
 # effective bytes they add negligible entropy, so dropping them costs nothing.
 # python3 (the venv CPython) is guaranteed in this image; the /dev/urandom
-# rejection-sampling fallback keeps the mint working even if it ever fails.
+# rejection-sampling fallback covers the (practically impossible) case it fails.
+# If BOTH CSPRNG sources are unavailable the mint FAILS CLOSED (aborts the launch)
+# rather than emit a weak, guessable credential onto a network-reachable viewer.
 if [ "${GFMY_NOVNC_HARDEN:-}" = "1" ]; then
   _gfmy_pw="$(python3 -c 'import secrets, string
 alphabet = string.ascii_letters + ".,=-_+@"
@@ -56,7 +58,18 @@ print("".join(secrets.choice(alphabet) for _ in range(8)))' 2>/dev/null || true)
     _gfmy_limit=$(( 256 - (256 % _gfmy_n) ))
     while [ "${#_gfmy_pw}" -lt 8 ]; do
       _gfmy_byte="$(od -An -N1 -tu1 /dev/urandom 2>/dev/null | tr -dc '0-9')"
-      [ -n "${_gfmy_byte}" ] || _gfmy_byte=$(( RANDOM % 256 ))
+      # Fail closed. If /dev/urandom yields no byte here, python3's secrets AND
+      # the kernel CSPRNG are both unavailable. Deriving the LAN-exposed VNC
+      # password from Bash's non-cryptographic $RANDOM would defeat the hardening
+      # precisely on the error path (owasp Fail-Closed): a predictable credential
+      # on a network-reachable viewer is worse than not starting. Abort BEFORE
+      # supervisord (traps are registered further down), so no viewer is served.
+      if [ -z "${_gfmy_byte}" ]; then
+        echo "[entrypoint] FATAL: no CSPRNG available (python3 'secrets' and" >&2
+        echo "[entrypoint] /dev/urandom both failed); refusing to serve a LAN-bound" >&2
+        echo "[entrypoint] noVNC viewer with a predictable password. Aborting." >&2
+        exit 1
+      fi
       [ "${_gfmy_byte}" -lt "${_gfmy_limit}" ] || continue
       _gfmy_pw="${_gfmy_pw}${_gfmy_chars:$(( _gfmy_byte % _gfmy_n )):1}"
     done

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -13,6 +13,70 @@
 # bootstrap/FCM logging.
 set -e
 
+# --- Direct-Compose LAN-hardening fallback (AP-7/AP-8 verdict derivation) -----
+# The launchers (login.sh / login.cmd) raise GFMY_NOVNC_HARDEN/_TLS for a LAN bind
+# and pass them across the host->container boundary. The SUPPORTED direct path
+#   docker compose run --build --service-ports --rm googlefindmy-login
+# runs NO launcher: it binds ${GFMY_NOVNC_BIND}:7900 on the host (see `ports:` in
+# docker-compose.yml) but sets no verdict. Without this block a LAN bind on that
+# path would publish port 7900 with the base image's fixed "secret" over plain
+# http -- the exact fixed-credential hole the launchers close. So the CONTAINER
+# derives the same verdict the launchers do, keying on the bind (the single source
+# of truth for "is this reachable off-host"): a non-loopback bind is a LAN exposure
+# and MUST be hardened. This runs only when no explicit launcher verdict is present
+# (GFMY_NOVNC_HARDEN != 1), so it never overrides a launcher decision -- including
+# an intentional launcher --no-tls run, which already sets HARDEN=1 and thus skips
+# this block entirely. Fail-closed: any doubt about a non-loopback bind hardens.
+if [ "${GFMY_NOVNC_HARDEN:-}" != "1" ]; then
+  _gfmy_bind="${GFMY_NOVNC_BIND:-127.0.0.1}"
+  # Strip one enclosing IPv6 bracket pair ("[::1]" -> "::1") so the classifier,
+  # which mirrors login.sh's is_loopback_addr/is_wildcard_addr, sees the bare host.
+  _gfmy_bind_bare="${_gfmy_bind#[}"
+  _gfmy_bind_bare="${_gfmy_bind_bare%]}"
+  case "${_gfmy_bind_bare}" in
+    127.* | ::1 | localhost | "")
+      # Loopback (or unset): nothing off-host can reach it, keep the historical
+      # plain-http "secret" default. Also clear an inherited TLS verdict: login.sh
+      # clears both up front for the same reason, so a stray GFMY_NOVNC_TLS from the
+      # caller's environment cannot switch a loopback run to https-with-fixed-secret.
+      # HARDEN is already != 1 here by the outer guard.
+      export GFMY_NOVNC_TLS=""
+      ;;
+    *)
+      # Non-loopback (concrete LAN IP or 0.0.0.0/:: wildcard): network-reachable.
+      # ALWAYS mint the per-run password -- that is what closes the fixed-secret hole.
+      export GFMY_NOVNC_HARDEN=1
+      # Determine a certificate SAN. A concrete bind IP is a usable SAN; a wildcard
+      # (0.0.0.0/::/*) is not a single browsable host. When we adopt the bind as the
+      # SAN we must also rebuild the browse URL to name the SAME host: compose builds
+      # GOOGLEFINDMY_NOVNC_URL from URL_HOST ("localhost" when the host did not set
+      # it), so without this the banner would print https://localhost while the cert
+      # certifies the bind IP -- a broken, mismatched promise.
+      case "${_gfmy_bind_bare}" in
+        0.0.0.0 | :: | "*")
+          : ;;
+        *)
+          if [ -z "${GFMY_NOVNC_URL_HOST:-}" ]; then
+            export GFMY_NOVNC_URL_HOST="${_gfmy_bind}"
+            export GOOGLEFINDMY_NOVNC_URL="http://${_gfmy_bind}:7900"
+          fi
+          ;;
+      esac
+      # Enable TLS only when a SAN is available (so we never raise an https promise
+      # the TLS block cannot keep) AND the run did not opt out (GFMY_NOVNC_TLS=0, the
+      # direct-Compose analogue of the launcher --no-tls). A wildcard bind without an
+      # explicit URL_HOST therefore stays plain http + per-run password: the hole is
+      # closed, the transport is honestly plain (documented posture), no false https.
+      if [ -n "${GFMY_NOVNC_URL_HOST:-}" ] && [ "${GFMY_NOVNC_TLS:-}" != "0" ]; then
+        export GFMY_NOVNC_TLS=1
+      else
+        export GFMY_NOVNC_TLS=""
+      fi
+      ;;
+  esac
+  unset _gfmy_bind _gfmy_bind_bare
+fi
+
 # --- Per-run noVNC password for a LAN-bound viewer (AP-7) ---------------------
 # Only when the launcher raised the LAN-hardening verdict (GFMY_NOVNC_HARDEN=1,
 # set for a non-loopback/wildcard bind); the loopback/tunnel default never sets

--- a/custom_components/googlefindmy/docker-login/entrypoint.sh
+++ b/custom_components/googlefindmy/docker-login/entrypoint.sh
@@ -13,6 +13,126 @@
 # bootstrap/FCM logging.
 set -e
 
+# --- Per-run noVNC password for a LAN-bound viewer (AP-7) ---------------------
+# Only when the launcher raised the LAN-hardening verdict (GFMY_NOVNC_HARDEN=1,
+# set for a non-loopback/wildcard bind); the loopback/tunnel default never sets
+# it, so nothing here runs and the base image keeps its public "secret" password.
+# The password MUST be minted and exported HERE, before supervisord starts the VNC
+# program, so start-vnc.sh (a supervisor child that reads
+# VNC_PASSWORD=${VNC_PASSWORD:-$SE_VNC_PASSWORD}) inherits it in time. This is the
+# same timing class as the TLS-cert block below, and both run before the
+# `supervisord &` line further down.
+#
+# This entrypoint is now the crypto OWNER: neither launcher (login.sh on
+# Linux/macOS, login.cmd on Windows) does any host-side crypto, so BOTH get
+# identical hardening. The launcher only decides LAN-vs-loopback and passes the
+# verdict across the host->container boundary via docker-compose.yml.
+#
+# Classic VNC auth (x11vnc -storepasswd, which the base image feeds SE_VNC_PASSWORD
+# into) only uses the FIRST 8 BYTES of the password, so a long passphrase would be
+# silently truncated and its nominal length would misrepresent the real strength.
+# We therefore mint a DENSE 8-character password so the full entropy lives inside
+# those 8 effective bytes.
+#
+# Charset: letters + the keyboard-easy symbols ". , = - _ + @". The equally obvious
+# "! ? % $" are deliberately EXCLUDED, each has a SILENT-failure path in the code
+# this value flows through: "%" is the cmd.exe escape char (login.cmd), "!" is
+# cmd.exe delayed expansion, "?" glob-expands in the base image's UNQUOTED
+# `x11vnc -storepasswd ${VNC_PASSWORD}`, and "$" is a shell metachar. Over 8
+# effective bytes they add negligible entropy, so dropping them costs nothing.
+# python3 (the venv CPython) is guaranteed in this image; the /dev/urandom
+# rejection-sampling fallback keeps the mint working even if it ever fails.
+if [ "${GFMY_NOVNC_HARDEN:-}" = "1" ]; then
+  _gfmy_pw="$(python3 -c 'import secrets, string
+alphabet = string.ascii_letters + ".,=-_+@"
+print("".join(secrets.choice(alphabet) for _ in range(8)))' 2>/dev/null || true)"
+  if [ -z "${_gfmy_pw}" ]; then
+    # Fallback CSPRNG: a /dev/urandom byte stream with rejection sampling, so the
+    # naive modulo bias of `byte % n` never skews the character distribution. The
+    # 256-(256%n) limit rejects the top partial bucket that would otherwise bias it.
+    _gfmy_chars='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.,=-_+@'
+    _gfmy_n=${#_gfmy_chars}
+    _gfmy_pw=""
+    _gfmy_limit=$(( 256 - (256 % _gfmy_n) ))
+    while [ "${#_gfmy_pw}" -lt 8 ]; do
+      _gfmy_byte="$(od -An -N1 -tu1 /dev/urandom 2>/dev/null | tr -dc '0-9')"
+      [ -n "${_gfmy_byte}" ] || _gfmy_byte=$(( RANDOM % 256 ))
+      [ "${_gfmy_byte}" -lt "${_gfmy_limit}" ] || continue
+      _gfmy_pw="${_gfmy_pw}${_gfmy_chars:$(( _gfmy_byte % _gfmy_n )):1}"
+    done
+  fi
+  # SE_VNC_PASSWORD is inherited by the base image's start-vnc.sh (x11vnc), so the
+  # viewer stops accepting the public "secret". GOOGLEFINDMY_NOVNC_PASSWORD carries
+  # the SAME value, so the banner below (noVNC-available line) and auth_flow.py's
+  # sign-in prompt both show the real per-run password instead of the "secret"
+  # default. On a loopback login neither is set, so both keep showing "secret".
+  export SE_VNC_PASSWORD="${_gfmy_pw}"
+  export GOOGLEFINDMY_NOVNC_PASSWORD="${_gfmy_pw}"
+  unset _gfmy_pw _gfmy_chars _gfmy_n _gfmy_limit _gfmy_byte
+fi
+
+# --- Self-signed TLS for a LAN-bound noVNC viewer (AP-8) ----------------------
+# Only when the launcher opted into TLS for a concrete LAN bind (GFMY_NOVNC_TLS=1);
+# the loopback/tunnel default never sets it, so no certificate is created and the
+# base image's plain start-novnc.sh runs completely unchanged. The cert MUST be
+# minted HERE, before supervisord starts the noVNC program, so start-novnc.sh
+# already sees it (a later write would race the proxy start). The IP is only known
+# at runtime (chosen interactively), so a cert carrying the chosen IP as a SAN --
+# which modern Chrome requires for an IP certificate -- cannot be baked into the
+# image. openssl failing (or absent) is non-fatal: we fall back to the plain
+# viewer so the login always proceeds.
+if [ "${GFMY_NOVNC_TLS:-}" = "1" ]; then
+  _tls_dir="${HOME:-/home/seluser}/gfmy-novnc"
+  _tls_pem="${_tls_dir}/combined.pem"
+  # The bind/URL host may be a bracketed IPv6 literal ("[::1]"); openssl wants the
+  # bare address in the SAN, so strip one enclosing bracket pair.
+  _san_host="${GFMY_NOVNC_URL_HOST:-}"
+  _san_host="${_san_host#[}"
+  _san_host="${_san_host%]}"
+  # A SAN entry must be TYPED: modern Chrome validates an IP cert against an IP:
+  # SAN and a hostname cert against a DNS: SAN, and openssl rejects a literal
+  # "IP:<hostname>" outright (nonzero exit). Hardcoding IP: would therefore drop a
+  # hostname URL_HOST to the plain fallback while the launcher already promised
+  # https -- a broken promise. Classify instead: a colon is an IPv6 literal, any
+  # character outside [0-9.] means a hostname, only digits and dots mean IPv4.
+  case "${_san_host}" in
+    *:*)        _san_alt="IP:${_san_host}" ;;
+    *[!0-9.]*)  _san_alt="DNS:${_san_host}" ;;
+    *)          _san_alt="IP:${_san_host}" ;;
+  esac
+  if command -v openssl >/dev/null 2>&1 && [ -n "${_san_host}" ]; then
+    mkdir -p "${_tls_dir}"
+    # -keyout and -out to SEPARATE files (same path would overwrite one with the
+    # other), then concatenate cert+key into combined.pem for websockify.
+    if openssl req -x509 -newkey rsa:2048 -nodes \
+        -keyout "${_tls_dir}/key.pem" -out "${_tls_dir}/cert.pem" \
+        -days 1 -subj "/CN=${_san_host}" \
+        -addext "subjectAltName=${_san_alt}" >/dev/null 2>&1; then
+      cat "${_tls_dir}/cert.pem" "${_tls_dir}/key.pem" > "${_tls_pem}"
+      chmod 0600 "${_tls_pem}"
+      # websockify reads only combined.pem (start-novnc.sh points both --cert and
+      # --key at it), so drop the standalone key.pem/cert.pem: leaving the bare
+      # private key on disk (created under the default umask, world-readable)
+      # serves no purpose and is one more copy of the key than necessary.
+      rm -f "${_tls_dir}/cert.pem" "${_tls_dir}/key.pem"
+      export GFMY_NOVNC_CERT="${_tls_pem}"
+      # --ssl-only serves https only, so the printed URL must be https too, or the
+      # user opens http:// and gets a blank page.
+      case "${GOOGLEFINDMY_NOVNC_URL:-}" in
+        http://*) GOOGLEFINDMY_NOVNC_URL="https://${GOOGLEFINDMY_NOVNC_URL#http://}" ;;
+      esac
+      export GOOGLEFINDMY_NOVNC_URL
+      echo "[entrypoint] Self-signed TLS enabled for noVNC (SAN ${_san_alt})."
+    else
+      echo "[entrypoint] WARNING: openssl could not create the noVNC certificate;" >&2
+      echo "[entrypoint] continuing WITHOUT TLS (plain http viewer)." >&2
+    fi
+  else
+    echo "[entrypoint] WARNING: TLS was requested but openssl or the target IP is" >&2
+    echo "[entrypoint] unavailable; continuing WITHOUT TLS (plain http viewer)." >&2
+  fi
+fi
+
 "${VENV_PATH}/bin/supervisord" --configuration /etc/supervisord.conf &
 SUPERVISOR_PID=$!
 
@@ -142,7 +262,7 @@ done
 # -- a second run with an existing secrets.json returns early and shows no such
 # prompt. Uses the real URL passed via compose (LAN address with --ip, else
 # loopback); a manual `docker run` falls back to localhost.
-echo "[entrypoint] noVNC available at ${GOOGLEFINDMY_NOVNC_URL:-http://localhost:7900} (password: secret)."
+echo "[entrypoint] noVNC available at ${GOOGLEFINDMY_NOVNC_URL:-http://localhost:7900} (password: ${GOOGLEFINDMY_NOVNC_PASSWORD:-secret})."
 
 # /data is a host bind mount whose owner/mode we do not control. Take ownership
 # for the container user for the duration of the run so main.py's atomic write of
@@ -163,6 +283,26 @@ sudo chown -R "$(id -u):$(id -g)" /data 2>/dev/null || true
 # explicit value; `export` makes the backgrounded python child inherit it.
 : "${GOOGLEFINDMY_CONTAINER_LOGIN:=1}"
 export GOOGLEFINDMY_CONTAINER_LOGIN
+
+# Grid-readiness wait (AP-2). The Selenium Standalone grid (port 4444) boots in
+# the background under supervisord and floods this console with a "Started
+# Selenium Standalone ... 4444" banner. That banner is irrelevant to the login
+# (the flow drives undetected-chromedriver directly, not the grid), but if it
+# prints AFTER the auth prompt the user mistakes the trailing 4444 line for a
+# hang. Wait for the grid to report ready first so the single actionable
+# "Press Enter" prompt from auth_flow.py is the LAST line on screen. Bounded and
+# best-effort: on timeout (or without curl) we simply continue, and this touches
+# none of the trap/wait/signal machinery above.
+if command -v curl >/dev/null 2>&1; then
+  echo "[entrypoint] Waiting for the Selenium grid to finish booting..."
+  for i in $(seq 1 30); do
+    if curl -sf http://127.0.0.1:4444/status >/dev/null 2>&1; then
+      echo "[entrypoint] Selenium grid ready."
+      break
+    fi
+    sleep 1
+  done
+fi
 
 cd /app/gfmy
 # Start the CLI in the BACKGROUND and wait on it, so a SIGTERM/SIGINT reaches bash

--- a/custom_components/googlefindmy/docker-login/login.cmd
+++ b/custom_components/googlefindmy/docker-login/login.cmd
@@ -26,7 +26,9 @@ rem The split exists because the two ports serve different consumers: 7901 is
 rem machine-to-machine (Home Assistant on this host), 7900 is opened by a browser
 rem that usually runs on a DIFFERENT machine than the Docker host.
 rem
-rem noVNC uses the fixed password "secret". To reach it from another machine,
+rem On loopback (the default) noVNC uses the fixed password "secret". A LAN bind
+rem hardens it: the container mints a per-run password and serves self-signed
+rem HTTPS (Windows has no --no-tls opt-out). To reach it from another machine,
 rem tunnel it, or on a trusted LAN bind a CONCRETE address (preferred over the
 rem 0.0.0.0 wildcard):
 rem   login.cmd --ip 192.168.1.21

--- a/custom_components/googlefindmy/docker-login/login.cmd
+++ b/custom_components/googlefindmy/docker-login/login.cmd
@@ -54,7 +54,7 @@ rem list below is not "what this script reads", it is "what a user can set and
 rem what survives into Compose or the container": the ${GFMY_*} names of
 rem docker-compose.yml plus GFMY_NOVNC_URL_HOST, which only this script uses.
 rem Without the trim the wrong mode starts silently, with exit code 0.
-for %%V in (GFMY_ONECLICK GFMY_CLEARTEXT GFMY_ARGS GFMY_HOST_UID GFMY_HOST_GID GFMY_NOVNC_BIND GFMY_NOVNC_URL_HOST) do call :trim_trailing_blanks %%V
+for %%V in (GFMY_ONECLICK GFMY_CLEARTEXT GFMY_ARGS GFMY_HOST_UID GFMY_HOST_GID GFMY_NOVNC_BIND GFMY_NOVNC_URL_HOST GFMY_NOVNC_HARDEN GFMY_NOVNC_TLS) do call :trim_trailing_blanks %%V
 
 set "NOVNC_BIND=%GFMY_NOVNC_BIND%"
 if "%NOVNC_BIND%"=="" set "NOVNC_BIND=127.0.0.1"
@@ -120,17 +120,46 @@ rem value and the URL printed inside the container would fall back to localhost.
 rem login.sh exports both at the same point, for that reason.
 set "GFMY_NOVNC_URL_HOST=%NOVNC_URL_HOST%"
 
+rem LAN-bind hardening (AP-7 + AP-8), mirroring login.sh. On a non-loopback bind
+rem raise a single verdict, GFMY_NOVNC_HARDEN=1, that the CONTAINER acts on:
+rem entrypoint.sh mints a per-run dense random password (SE_VNC_PASSWORD, fed to
+rem x11vnc) and, with GFMY_NOVNC_TLS=1, a self-signed TLS cert. Windows therefore
+rem gets the SAME hardening as login.sh WITHOUT any batch-side crypto: the password
+rem is generated in the container. Both vars reach it because docker-compose.yml
+rem interpolates ${GFMY_*} from this process environment. Classify on the BIND, not
+rem the printed address, exactly like the reachability hint below. Unlike login.sh
+rem there is no --no-tls opt-out here, so a LAN bind always encrypts the viewer.
+set "NOVNC_SCHEME=http"
+rem Clear both verdicts first, so a value inherited from the caller's environment
+rem cannot harden a loopback run (which must stay the base default). Re-raised
+rem below only for a real LAN bind.
+set "GFMY_NOVNC_HARDEN="
+set "GFMY_NOVNC_TLS="
+if not defined IS_LOOPBACK set "GFMY_NOVNC_HARDEN=1"
+if not defined IS_LOOPBACK set "GFMY_NOVNC_TLS=1"
+if not defined IS_LOOPBACK set "NOVNC_SCHEME=https"
+
 if not exist data mkdir data
 
 echo [login] Starting the GoogleFindMy-HA login container...
-echo [login] When it is up, open http://%NOVNC_URL_HOST%:7900 (password: secret)
+rem Loopback keeps the base image's known fixed password, so print it. On a LAN
+rem bind the per-run password is minted INSIDE the container, so the host cannot
+rem print it: point the user at the container output (both the noVNC-available
+rem line and the [AuthFlow] banner show it as "(password: ...)").
+if defined IS_LOOPBACK echo [login] When it is up, open %NOVNC_SCHEME%://%NOVNC_URL_HOST%:7900 (password: secret)
+if not defined IS_LOOPBACK echo [login] When it is up, open %NOVNC_SCHEME%://%NOVNC_URL_HOST%:7900
+if not defined IS_LOOPBACK echo [login] The per-run noVNC password is printed by the container below,
+if not defined IS_LOOPBACK echo [login] shown as "(password: ...)" in the noVNC-available line and the [AuthFlow] banner.
 echo [login] and log into Google in the browser view.
 
 rem Tell the truth about who can actually reach that address.
 if defined IS_LOOPBACK goto :loopback_hint
 echo [login] WARNING: noVNC is bound to %NOVNC_BIND% and is therefore reachable
-echo [login] beyond this host, protected only by the fixed password "secret".
-echo [login] Use it on a trusted LAN only, and only while logging in.
+echo [login] beyond this host. For this LAN bind the container replaces the base
+echo [login] image's public password with a per-run password, printed in the
+echo [login] container output below, and encrypts the viewer with a self-signed
+echo [login] certificate: open the https URL above and accept the one-time browser
+echo [login] warning. Use it on a trusted LAN only, and only while logging in.
 if "%NOVNC_BIND%"=="0.0.0.0" echo [login] That bind is a wildcard, so the URL above names just one interface it listens on. Prefer login.cmd --ip ^<ADDRESS^>.
 goto :hint_done
 :loopback_hint

--- a/custom_components/googlefindmy/docker-login/login.sh
+++ b/custom_components/googlefindmy/docker-login/login.sh
@@ -44,8 +44,10 @@
 #                          the first detected address: "0.0.0.0" is a bind
 #                          pattern, not a browsable address.
 #
-# noVNC uses the base image's fixed password "secret". To reach it from another
-# machine, either tunnel
+# On loopback (the default) noVNC uses the base image's fixed password "secret".
+# A LAN bind hardens it: the container mints a per-run password and (unless
+# --no-tls) serves self-signed HTTPS. To reach it from another machine, either
+# tunnel
 #   ssh -L 7900:127.0.0.1:7900 <docker-host>
 # or, only on a trusted LAN, bind it to a CONCRETE address (preferred over the
 # 0.0.0.0 wildcard, which publishes on every interface):

--- a/custom_components/googlefindmy/docker-login/login.sh
+++ b/custom_components/googlefindmy/docker-login/login.sh
@@ -68,7 +68,15 @@ Usage: bash login.sh [--ip <ADDRESS>] [--help]
   --ip <ADDRESS>  Bind the noVNC viewer (port 7900) to <ADDRESS> and print that
                   address as the URL to open. Use a concrete LAN address of this
                   Docker host, for example: bash login.sh --ip 192.168.1.21
+  --no-tls        On a LAN bind, do NOT enable the self-signed TLS viewer; serve
+                  a plain http viewer instead (e.g. when you tunnel it yourself).
+                  Ignored for a loopback bind, which is plain either way.
   --help          Show this help and exit.
+
+Without --ip and without GFMY_NOVNC_BIND/GFMY_NOVNC_URL_HOST, and only on an
+interactive terminal, the launcher asks which address to open the noVNC viewer
+on (a numbered menu of detected LAN addresses, a loopback entry, or a free-text
+IP). A non-interactive run keeps the historical loopback default unchanged.
 
 Environment (see the comment block at the top of this file):
   GFMY_NOVNC_BIND       host bind for noVNC 7900         (default 127.0.0.1)
@@ -80,8 +88,23 @@ in docker-compose.oneclick.yml, on purpose.
 EOF
 }
 
+# Capture whether the operator pinned the bind / printed host through the
+# environment BEFORE the loopback default is applied, so the interactive menu
+# (AP-1) can tell "nothing was set" from "set to the default value". The `+set`
+# form is true only when the name is defined (empty or not) and is safe under
+# `set -u`.
+novnc_bind_env_set=0
+[ -n "${GFMY_NOVNC_BIND+set}" ] && novnc_bind_env_set=1
+novnc_url_host_env_set=0
+[ -n "${GFMY_NOVNC_URL_HOST+set}" ] && novnc_url_host_env_set=1
+
 novnc_bind="${GFMY_NOVNC_BIND:-127.0.0.1}"
 novnc_url_host="${GFMY_NOVNC_URL_HOST:-}"
+# Set to 1 by set_ip_option when --ip is passed: the interactive menu is then
+# skipped because the operator already chose. tls_enabled defaults on and is
+# turned off by --no-tls (LAN transport opt-out for people who tunnel/plain).
+ip_from_cli=0
+tls_enabled=1
 
 is_ip_literal() {
   # Accept a dotted quad with in-range octets, or an (optionally bracketed)
@@ -231,6 +254,7 @@ set_ip_option() {
   fi
   novnc_bind="$1"
   novnc_url_host="$1"
+  ip_from_cli=1
 }
 
 while [ "$#" -gt 0 ]; do
@@ -245,6 +269,13 @@ while [ "$#" -gt 0 ]; do
       ;;
     --ip=*)
       set_ip_option "${1#--ip=}"
+      shift
+      ;;
+    --no-tls)
+      # LAN transport opt-out: keep the plain-http viewer even on a LAN bind
+      # (for operators who tunnel themselves or accept plain on a trusted LAN).
+      # Has no effect on a loopback bind, which is plain in either case.
+      tls_enabled=0
       shift
       ;;
     -h|--help)
@@ -291,6 +322,94 @@ detect_lan_ips() {
     || true
 }
 
+# Interactive noVNC address chooser (AP-1). Reached only from a real TTY and only
+# when nothing was pinned (no --ip, no GFMY_NOVNC_* env). It offers the detected
+# LAN addresses as a numbered menu, plus a loopback entry and a free-text option,
+# and validates the result with the SAME is_ip_literal that --ip uses, re-asking
+# on a bad entry. Bare Enter takes the most likely LAN address (192.168.x is
+# preferred over 10.x over anything else, since a home browser almost always sits
+# on the 192.168 side). Sets novnc_bind / novnc_url_host on success.
+prompt_for_ip() {
+  local ips selected choice default cand _ip idx
+  local -a options=()
+  ips="$(detect_lan_ips)"
+  while IFS= read -r _ip; do
+    [ -n "$_ip" ] && options+=("$_ip")
+  done <<EOF
+$ips
+EOF
+
+  default=""
+  for cand in ${options[@]+"${options[@]}"}; do
+    case "$cand" in 192.168.*) default="$cand"; break ;; esac
+  done
+  if [ -z "$default" ]; then
+    for cand in ${options[@]+"${options[@]}"}; do
+      case "$cand" in 10.*) default="$cand"; break ;; esac
+    done
+  fi
+  if [ -z "$default" ] && [ "${#options[@]}" -gt 0 ]; then
+    default="${options[0]}"
+  fi
+  # When nothing was detected, loopback is the only safe default: the operator
+  # can still type a concrete address, or accept loopback and tunnel to it.
+  [ -n "$default" ] || default="127.0.0.1"
+
+  while true; do
+    # The whole menu goes to stderr so it never contaminates the stdout that the
+    # behavioural launcher test parses; the read still uses the terminal stdin.
+    {
+      echo ""
+      echo "[login] Where will you open the noVNC viewer? Pick the address your"
+      echo "[login] browser can reach on this Docker host:"
+      idx=1
+      for cand in ${options[@]+"${options[@]}"}; do
+        echo "[login]   ${idx}) ${cand}"
+        idx=$((idx + 1))
+      done
+      echo "[login]   L) 127.0.0.1  (loopback only; reach it via an SSH tunnel)"
+      echo "[login]   or type any other IP address of this host"
+      printf '[login] Choice [Enter = %s]: ' "$default"
+    } >&2
+    read -r choice || choice=""
+
+    if [ -z "$choice" ]; then
+      selected="$default"
+    elif [ "$choice" = "L" ] || [ "$choice" = "l" ]; then
+      selected="127.0.0.1"
+    elif printf '%s' "$choice" | grep -qE '^[0-9]+$'; then
+      if [ "$choice" -ge 1 ] && [ "$choice" -le "${#options[@]}" ]; then
+        selected="${options[$((choice - 1))]}"
+      else
+        echo "[login] No menu entry ${choice}. Try again." >&2
+        continue
+      fi
+    else
+      selected="$choice"
+    fi
+
+    if [ -z "$selected" ]; then
+      echo "[login] No address available; type one, e.g. 192.168.1.21." >&2
+      continue
+    fi
+    if is_ip_literal "$selected"; then
+      novnc_bind="$selected"
+      novnc_url_host="$selected"
+      return 0
+    fi
+    echo "[login] '${selected}' is not an IP address of this host. Try again." >&2
+  done
+}
+
+# Interactive address selection (AP-1): only on a real terminal AND only when the
+# operator pinned nothing explicitly (no --ip, no GFMY_NOVNC_BIND/URL_HOST). In
+# CI or any non-interactive pipe `[ -t 0 ]` is false, so this is skipped and the
+# historical loopback default below is reached completely UNCHANGED.
+if [ -t 0 ] && [ "${ip_from_cli}" -eq 0 ] \
+   && [ "${novnc_bind_env_set}" -eq 0 ] && [ "${novnc_url_host_env_set}" -eq 0 ]; then
+  prompt_for_ip
+fi
+
 # The printed address is derived AFTER all parsing, so --ip and both environment
 # variables run through the same normalisation. Deriving it inside the "nothing
 # was set" branch would leave the explicit paths unnormalised.
@@ -329,8 +448,47 @@ mkdir -p data
 export GFMY_HOST_UID="$(id -u)"
 export GFMY_HOST_GID="$(id -g)"
 
+# LAN-bind hardening (AP-7 + AP-8). A non-loopback bind exposes the noVNC viewer
+# on the network, where the base image's public default password "secret" and the
+# plain-HTTP transport are both inadequate. For that case ONLY, raise a single
+# verdict, GFMY_NOVNC_HARDEN=1, that the CONTAINER acts on: entrypoint.sh mints a
+# per-run dense random password (SE_VNC_PASSWORD, fed to x11vnc by the base image's
+# start-vnc.sh) IN THE CONTAINER, so this launcher does no crypto and login.cmd on
+# Windows gets the exact same hardening. Unless --no-tls was given, also raise
+# GFMY_NOVNC_TLS=1 so entrypoint.sh switches the viewer to a self-signed TLS
+# transport (realised in entrypoint.sh + start-novnc.sh, SAN = the chosen IP). A
+# loopback bind keeps the historical "secret"/plain behaviour: nothing on the
+# network can reach it, so the extra typing would be pure friction. The keying is
+# on the BIND, mirroring the reachability hint below, so a wildcard bind is treated
+# as LAN too.
+novnc_scheme="http"
+# Clear both verdicts first, so a value inherited from the caller's environment
+# cannot harden a loopback run (which must stay byte-for-byte the base default).
+# They are re-raised below only for a real LAN bind.
+export GFMY_NOVNC_HARDEN=""
+export GFMY_NOVNC_TLS=""
+if ! is_loopback_addr "$novnc_bind"; then
+  export GFMY_NOVNC_HARDEN=1
+  if [ "$tls_enabled" -eq 1 ]; then
+    export GFMY_NOVNC_TLS=1
+    novnc_scheme="https"
+  fi
+fi
+
 echo "[login] Starting the GoogleFindMy-HA login container..."
-echo "[login] When it is up, open http://${novnc_url_host}:7900 (password: secret)"
+if is_loopback_addr "$novnc_bind"; then
+  # Loopback keeps the base image's known fixed password, so it is safe -- and
+  # helpful -- to print it here.
+  echo "[login] When it is up, open ${novnc_scheme}://${novnc_url_host}:7900 (password: secret)"
+else
+  # LAN bind: the per-run password is minted INSIDE the container, so the host does
+  # not know it and cannot print it. It appears in the container output further
+  # down, both in the '[entrypoint] noVNC available at ...' line and in the
+  # '[AuthFlow]' sign-in banner, each as '(password: ...)'.
+  echo "[login] When it is up, open ${novnc_scheme}://${novnc_url_host}:7900"
+  echo "[login] (the per-run noVNC password is printed by the container below, as"
+  echo "[login] '(password: ...)' in the noVNC-available line and the [AuthFlow] banner)."
+fi
 echo "[login] and log into Google in the browser view."
 
 # Tell the truth about who can actually reach that address. This MUST key on the
@@ -350,8 +508,17 @@ if is_loopback_addr "$novnc_bind"; then
   fi
 else
   echo "[login] WARNING: noVNC is bound to ${novnc_bind} and is therefore reachable"
-  echo "[login] beyond this host, protected only by the base image's fixed password"
-  echo "[login] \"secret\". Use it on a trusted LAN only, and only while logging in."
+  echo "[login] beyond this host. For this LAN bind the container replaces the base"
+  echo "[login] image's public password with a per-run password (printed in the"
+  echo "[login] container output below, not here: the host never sees it),"
+  if [ "$tls_enabled" -eq 1 ]; then
+    echo "[login] and encrypts the viewer with a self-signed certificate: open the"
+    echo "[login] https URL above and accept the one-time browser warning. Use it on"
+    echo "[login] a trusted LAN only, and only while logging in."
+  else
+    echo "[login] but TLS is OFF (--no-tls), so the transport is plain http. Use it"
+    echo "[login] on a trusted LAN only, and only while logging in."
+  fi
   if is_wildcard_addr "$novnc_bind"; then
     echo "[login] That bind is a wildcard, so the URL above names just one of the"
     echo "[login] interfaces it listens on. Prefer bash login.sh --ip <ADDRESS>."

--- a/custom_components/googlefindmy/docker-login/start-novnc.sh
+++ b/custom_components/googlefindmy/docker-login/start-novnc.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Override of the selenium base image's /opt/bin/start-novnc.sh, installed by
+# docker-login/Dockerfile with the same COPY mechanism as gfm-entrypoint.sh
+# ([program:novnc] in the base image's supervisor config already points at this
+# path, so no supervisor change is needed).
+#
+# Its ONLY job is to add self-signed TLS to the noVNC viewer WHEN, and only when,
+# entrypoint.sh minted a certificate for a concrete LAN bind (AP-8). In every
+# other case -- the loopback/tunnel default -- it hands off to the base image's
+# ORIGINAL script verbatim, so that path is byte-for-byte unchanged. The
+# Dockerfile copies the base script to start-novnc.base.sh before this file
+# overwrites the original, so the fallback below is the real base launch, not a
+# reproduction that could silently drift from it.
+set -e
+
+# The combined cert+key entrypoint.sh writes for a LAN bind. Its mere existence
+# is the switch: no file -> plain viewer (delegate to the untouched base script).
+GFMY_NOVNC_CERT="${GFMY_NOVNC_CERT:-/home/seluser/gfmy-novnc/combined.pem}"
+GFMY_NOVNC_BASE="${GFMY_NOVNC_BASE:-/opt/bin/start-novnc.base.sh}"
+
+if [ ! -f "${GFMY_NOVNC_CERT}" ]; then
+  # Loopback/tunnel default: nothing changed, run the untouched base launcher.
+  exec "${GFMY_NOVNC_BASE}"
+fi
+
+# LAN bind: encrypt the viewer transport. novnc_proxy passes --cert/--key/--ssl-only
+# straight through to websockify (upstream-supported). --ssl-only disables plain
+# HTTP, so the launcher prints an https:// URL for the chosen IP. The selenium
+# image serves noVNC on 7900 and VNC on 5900; honour an override if the base image
+# ever sets one. The selenium base uses NO_VNC_PORT (with underscore) for the noVNC
+# port, so accept both spellings rather than silently ignoring a base override on
+# the TLS path. combined.pem holds both cert and key, so both flags point at it.
+NOVNC_PORT="${NOVNC_PORT:-${NO_VNC_PORT:-7900}}"
+VNC_PORT="${VNC_PORT:-5900}"
+exec /opt/bin/noVNC/utils/novnc_proxy \
+  --listen "${NOVNC_PORT}" \
+  --vnc "localhost:${VNC_PORT}" \
+  --cert "${GFMY_NOVNC_CERT}" \
+  --key "${GFMY_NOVNC_CERT}" \
+  --ssl-only

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -471,12 +471,13 @@ def test_dockerignore_is_allowlist_excluding_every_secret_path() -> None:
         "requirements.txt",
         "docker-login",
         "docker-login/entrypoint.sh",
+        "docker-login/start-novnc.sh",
     }, (
         "the only `!`-re-includes may be the Dockerfile's COPY inputs "
-        "(requirements.txt, docker-login/entrypoint.sh) plus `docker-login` for "
-        f"traversal; found {sorted(reincludes)}. Re-including anything else -- or the "
-        "directory as a whole without re-excluding its contents -- risks shipping "
-        "integration source or secrets into the image."
+        "(requirements.txt, docker-login/entrypoint.sh, docker-login/start-novnc.sh) "
+        f"plus `docker-login` for traversal; found {sorted(reincludes)}. Re-including "
+        "anything else -- or the directory as a whole without re-excluding its "
+        "contents -- risks shipping integration source or secrets into the image."
     )
     assert not any(
         r.startswith("!") and ("auth" in r.lower() or "secret" in r.lower())
@@ -2388,3 +2389,102 @@ def test_pip_install_parser_ignores_inline_comments() -> None:
     assert not any(
         re.search(r"(?<![\w./-])setuptools(?![\w-])", cmd) for cmd in commands
     ), "inline-comment setuptools must not count as an installed dependency"
+
+
+def test_entrypoint_mints_password_before_supervisord_starts() -> None:
+    """The per-run noVNC password is minted IN THE CONTAINER and exported before
+    supervisord starts, so the base image's start-vnc.sh inherits it in time.
+
+    The launchers only raise the GFMY_NOVNC_HARDEN verdict; moving the crypto here
+    is what gives Windows (login.cmd) the same hardening without batch-side crypto.
+    If the SE_VNC_PASSWORD export ever slipped below the ``supervisord`` launch,
+    start-vnc.sh would have stored the public ``secret`` before the per-run
+    password landed, silently defeating the hardening.
+    """
+
+    entrypoint = _read("entrypoint.sh")
+    assert '"${GFMY_NOVNC_HARDEN:-}" = "1"' in entrypoint, (
+        "entrypoint.sh must gate the password mint on the GFMY_NOVNC_HARDEN verdict"
+    )
+    export_idx = entrypoint.find("export SE_VNC_PASSWORD")
+    launch_idx = entrypoint.find('bin/supervisord" --configuration')
+    assert export_idx != -1, "entrypoint.sh must export SE_VNC_PASSWORD for the hardened path"
+    assert launch_idx != -1, "entrypoint.sh must launch supervisord"
+    assert export_idx < launch_idx, (
+        "SE_VNC_PASSWORD must be exported BEFORE supervisord starts, or start-vnc.sh "
+        "stores the public 'secret' before the per-run password lands."
+    )
+
+
+def test_entrypoint_password_charset_excludes_shell_hostile_symbols() -> None:
+    """The in-container password alphabet stays letters + '. , = - _ + @' and never
+    admits ``! ? % $``.
+
+    Each excluded symbol has a SILENT-failure path in the code the value flows
+    through (``%`` cmd.exe escape, ``!`` cmd.exe delayed expansion, ``?`` glob in
+    the base image's unquoted ``x11vnc -storepasswd``, ``$`` shell metachar), so a
+    well-meant charset widening would break logins without an error. Locking both
+    the python3 alphabet and the /dev/urandom fallback here forces a conscious
+    change if anyone edits them.
+    """
+
+    entrypoint = _read("entrypoint.sh")
+    assert 'string.ascii_letters + ".,=-_+@"' in entrypoint, (
+        "the python3 CSPRNG alphabet must stay the keyboard-safe set"
+    )
+    assert (
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.,=-_+@" in entrypoint
+    ), "the /dev/urandom fallback alphabet must match the keyboard-safe set"
+
+
+def test_compose_generates_password_in_container_not_from_host() -> None:
+    """docker-compose.yml must NOT pass a VNC password from the host: the container
+    mints it. Passing SE_VNC_PASSWORD from the host is exactly what re-introduces
+    the empty-string override that overwrites the base image's ``secret`` default.
+    Only the GFMY_NOVNC_HARDEN verdict (+ TLS + SAN host) crosses the boundary.
+    """
+
+    compose = yaml.safe_load(_read("docker-compose.yml"))
+    env = compose["services"][LOGIN_SERVICE].get("environment", {})
+    keys = set(env) if isinstance(env, dict) else {e.split("=", 1)[0] for e in env}
+    assert "SE_VNC_PASSWORD" not in keys, (
+        "SE_VNC_PASSWORD must not be a compose environment key; the container mints it"
+    )
+    assert "GOOGLEFINDMY_NOVNC_PASSWORD" not in keys, (
+        "GOOGLEFINDMY_NOVNC_PASSWORD must not be passed from the host either"
+    )
+    assert "GFMY_NOVNC_HARDEN" in keys, (
+        "the LAN-hardening verdict must cross into the container"
+    )
+
+
+def test_auth_flow_prompt_reads_password_from_env() -> None:
+    """The [AuthFlow] sign-in banner must show the real per-run password, read from
+    GOOGLEFINDMY_NOVNC_PASSWORD, not a hardcoded ``secret`` (which was always wrong
+    for a hardened LAN login).
+    """
+
+    text = Path("custom_components/googlefindmy/Auth/auth_flow.py").read_text(
+        encoding="utf-8"
+    )
+    assert "GOOGLEFINDMY_NOVNC_PASSWORD" in text, (
+        "auth_flow.py must read the noVNC password from the environment so the "
+        "sign-in banner shows the real per-run value"
+    )
+
+
+def test_login_sh_does_no_host_side_password_crypto() -> None:
+    """login.sh must not generate or export the VNC password any more (that moved
+    into entrypoint.sh); it only raises the GFMY_NOVNC_HARDEN verdict for a LAN bind.
+    """
+
+    text = _read("login.sh")
+    assert "gen_password" not in text, (
+        "password generation moved into the container; login.sh must not mint it"
+    )
+    assert "export SE_VNC_PASSWORD" not in text, (
+        "login.sh must not export SE_VNC_PASSWORD; the container mints it"
+    )
+    assert "export GFMY_NOVNC_HARDEN=1" in text, (
+        "login.sh must raise the hardening verdict for a non-loopback bind"
+    )

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -2519,3 +2519,194 @@ def test_login_sh_does_no_host_side_password_crypto() -> None:
     assert "export GFMY_NOVNC_HARDEN=1" in text, (
         "login.sh must raise the hardening verdict for a non-loopback bind"
     )
+
+
+def test_compose_forwards_the_bind_for_container_side_verdict() -> None:
+    """The container must SEE the bind so it can derive the LAN-hardening verdict on
+    the direct ``docker compose run`` path (which runs no launcher). Without
+    GFMY_NOVNC_BIND in the container environment, a direct LAN bind would publish
+    port 7900 with the fixed ``secret`` over plain HTTP -- the fixed-credential hole
+    the launchers close. Codex flagged exactly this gap.
+    """
+
+    compose = yaml.safe_load(_read("docker-compose.yml"))
+    env = compose["services"][LOGIN_SERVICE].get("environment", {})
+    keys = set(env) if isinstance(env, dict) else {e.split("=", 1)[0] for e in env}
+    assert "GFMY_NOVNC_BIND" in keys, (
+        "GFMY_NOVNC_BIND must cross into the container so entrypoint.sh can derive "
+        "the hardening verdict for a direct `docker compose run` LAN bind"
+    )
+
+
+def _run_derivation_block(env_overrides: dict[str, str]) -> dict[str, str]:
+    """Extract the ACTUAL direct-Compose derivation block from entrypoint.sh and run
+    it in isolation, then report the resulting verdict env.
+
+    This exercises the production code slice, not a reimplementation of the
+    classifier: a behavioural test that rebuilt the loopback/wildcard logic would
+    only prove the rebuild, never the shipped block (the construct-vs-wiring trap).
+    The block is self-contained (it runs before supervisord), so slicing it between
+    its banner comment and the password-mint banner and feeding it a minimal env is
+    faithful.
+    """
+
+    entrypoint = _read("entrypoint.sh")
+    start = entrypoint.find('if [ "${GFMY_NOVNC_HARDEN:-}" != "1" ]; then')
+    end = entrypoint.find("# --- Per-run noVNC password", start)
+    assert start != -1 and end != -1, "could not extract the derivation block"
+    block = entrypoint[start:end].rstrip()
+    harness = (
+        "set -e\n"
+        + block
+        + "\nprintf 'HARDEN=%s\\nTLS=%s\\nURL_HOST=%s\\nURL=%s\\n' "
+        + '"${GFMY_NOVNC_HARDEN:-}" "${GFMY_NOVNC_TLS:-}" '
+        + '"${GFMY_NOVNC_URL_HOST:-}" "${GOOGLEFINDMY_NOVNC_URL:-}"\n'
+    )
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+    # Mirror docker-compose.yml: it builds GOOGLEFINDMY_NOVNC_URL from URL_HOST,
+    # defaulting the host to "localhost" when nothing set it on the host side.
+    url_host_in = env_overrides.get("GFMY_NOVNC_URL_HOST", "") or "localhost"
+    env["GOOGLEFINDMY_NOVNC_URL"] = f"http://{url_host_in}:7900"
+    env.update(env_overrides)
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"derivation block failed: {proc.stderr}"
+    out: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        key, _, value = line.partition("=")
+        out[key] = value
+    return out
+
+
+# (bind-env, extra-env), expected HARDEN, expected TLS, expected URL_HOST
+_DERIVATION_CASES = [
+    # Loopback (or the compose empty-string default): never harden, clear stray TLS.
+    ("compose-empty-bind", {"GFMY_NOVNC_BIND": ""}, "", "", ""),
+    ("loopback-127-1", {"GFMY_NOVNC_BIND": "127.0.0.1"}, "", "", ""),
+    ("loopback-127-x", {"GFMY_NOVNC_BIND": "127.0.0.5"}, "", "", ""),
+    ("loopback-localhost", {"GFMY_NOVNC_BIND": "localhost"}, "", "", ""),
+    ("loopback-v6", {"GFMY_NOVNC_BIND": "::1"}, "", "", ""),
+    ("loopback-v6-bracketed", {"GFMY_NOVNC_BIND": "[::1]"}, "", "", ""),
+    # A stray inherited TLS on a loopback run must be cleared, not honoured.
+    (
+        "loopback-clears-stray-tls",
+        {"GFMY_NOVNC_BIND": "127.0.0.1", "GFMY_NOVNC_TLS": "1"},
+        "",
+        "",
+        "",
+    ),
+    # Concrete LAN IP: harden + TLS, adopt the bind as SAN and browse host.
+    ("lan-ip-192", {"GFMY_NOVNC_BIND": "192.168.1.21"}, "1", "1", "192.168.1.21"),
+    ("lan-ip-10", {"GFMY_NOVNC_BIND": "10.0.0.5"}, "1", "1", "10.0.0.5"),
+    # Wildcard: harden (password) but no SAN, so TLS stays off and URL_HOST empty.
+    ("wildcard-v4", {"GFMY_NOVNC_BIND": "0.0.0.0"}, "1", "", ""),
+    ("wildcard-v6", {"GFMY_NOVNC_BIND": "::"}, "1", "", ""),
+    # Explicit TLS opt-out on a LAN bind: password stays, transport goes plain.
+    (
+        "lan-ip-opt-out",
+        {"GFMY_NOVNC_BIND": "192.168.1.21", "GFMY_NOVNC_TLS": "0"},
+        "1",
+        "",
+        "192.168.1.21",
+    ),
+    # Wildcard WITH an explicit URL_HOST: a SAN exists, so TLS is honoured.
+    (
+        "wildcard-explicit-host",
+        {"GFMY_NOVNC_BIND": "0.0.0.0", "GFMY_NOVNC_URL_HOST": "192.168.1.21"},
+        "1",
+        "1",
+        "192.168.1.21",
+    ),
+    # Concrete bracketed IPv6: the classifier strips the brackets, but URL_HOST and
+    # the browse URL must KEEP them (the URL-correct form). Regression guard for the
+    # bracket-strip-vs-keep split, the trickiest path.
+    (
+        "lan-ip-v6-bracketed",
+        {"GFMY_NOVNC_BIND": "[fd00::5]"},
+        "1",
+        "1",
+        "[fd00::5]",
+    ),
+    # Concrete bind IP WITH a preset URL_HOST: the -z guard must not overwrite the
+    # explicit host nor rebuild the URL (Browse-Host = the operator's chosen host).
+    (
+        "lan-ip-preset-host",
+        {"GFMY_NOVNC_BIND": "192.168.1.21", "GFMY_NOVNC_URL_HOST": "myhost.lan"},
+        "1",
+        "1",
+        "myhost.lan",
+    ),
+    # Bracketed wildcard: login.sh lists "[::]" explicitly; entrypoint strips to "::".
+    ("wildcard-v6-bracketed", {"GFMY_NOVNC_BIND": "[::]"}, "1", "", ""),
+    # Hostname bind (GFMY_NOVNC_BIND allows names, unlike --ip): non-loopback, adopt.
+    ("lan-hostname", {"GFMY_NOVNC_BIND": "myhost.lan"}, "1", "1", "myhost.lan"),
+    # Literal "*" wildcard: pins the quoted-literal case semantics (never a catch-all).
+    ("wildcard-star", {"GFMY_NOVNC_BIND": "*"}, "1", "", ""),
+]
+
+
+@pytest.mark.parametrize(
+    "label,env_overrides,exp_harden,exp_tls,exp_url_host",
+    _DERIVATION_CASES,
+    ids=[c[0] for c in _DERIVATION_CASES],
+)
+def test_entrypoint_derivation_hardens_every_network_reachable_bind(
+    label: str,
+    env_overrides: dict[str, str],
+    exp_harden: str,
+    exp_tls: str,
+    exp_url_host: str,
+) -> None:
+    """Behaviourally run the shipped derivation block over the bind type-space. The
+    security invariant: EVERY network-reachable bind (concrete LAN IP or wildcard)
+    ends with GFMY_NOVNC_HARDEN=1 (so the password is minted), and NO loopback bind
+    does (so the plain ``secret`` default is preserved byte-for-byte). Codex flagged
+    the direct-Compose path publishing 7900 with the fixed ``secret``; this pins the
+    fix across the whole input space, not just one grep-able line.
+    """
+
+    out = _run_derivation_block(env_overrides)
+    assert out["HARDEN"] == exp_harden, (
+        f"{label}: HARDEN {out['HARDEN']!r} != {exp_harden!r}"
+    )
+    assert out["TLS"] == exp_tls, f"{label}: TLS {out['TLS']!r} != {exp_tls!r}"
+    assert out["URL_HOST"] == exp_url_host, (
+        f"{label}: URL_HOST {out['URL_HOST']!r} != {exp_url_host!r}"
+    )
+    # WICHTIG-2 regression pin: when a concrete bind IP is adopted as the SAN, the
+    # printed browse URL must name that SAME host, never the compose "localhost"
+    # default -- otherwise the banner promises https://localhost while the cert
+    # certifies the LAN IP (a mismatched, broken promise).
+    if exp_url_host and exp_url_host not in ("0.0.0.0", "::"):
+        assert exp_url_host in out["URL"], (
+            f"{label}: browse URL {out['URL']!r} must name the SAN host {exp_url_host!r}"
+        )
+        if exp_tls == "1":
+            assert "localhost" not in out["URL"], (
+                f"{label}: browse URL {out['URL']!r} must not keep the localhost default"
+            )
+
+
+def test_entrypoint_derivation_never_overrides_a_launcher_verdict() -> None:
+    """When a launcher already raised GFMY_NOVNC_HARDEN=1, the container-side
+    derivation must NOT run at all -- so an intentional launcher --no-tls (HARDEN=1,
+    TLS="") survives, and a launcher LAN run is never downgraded. This pins the outer
+    guard behaviourally, not by grep.
+    """
+
+    # Launcher --no-tls on a LAN bind: HARDEN=1, TLS empty. Must stay untouched even
+    # though the bind itself is non-loopback (the derivation would otherwise raise TLS).
+    out = _run_derivation_block(
+        {
+            "GFMY_NOVNC_HARDEN": "1",
+            "GFMY_NOVNC_TLS": "",
+            "GFMY_NOVNC_BIND": "192.168.1.21",
+        }
+    )
+    assert out["HARDEN"] == "1", "launcher HARDEN verdict must be preserved"
+    assert out["TLS"] == "", "launcher --no-tls (TLS empty) must not be overridden to 1"

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -2439,6 +2439,35 @@ def test_entrypoint_password_charset_excludes_shell_hostile_symbols() -> None:
     ), "the /dev/urandom fallback alphabet must match the keyboard-safe set"
 
 
+def test_entrypoint_password_generator_fails_closed_without_csprng() -> None:
+    """The password mint must FAIL CLOSED, never emit a weak credential.
+
+    If both python3's ``secrets`` and ``/dev/urandom`` are unavailable, the
+    hardened launch must abort rather than derive the LAN-exposed VNC password
+    from Bash's non-cryptographic ``$RANDOM`` -- a predictable credential on a
+    network-reachable viewer is worse than not starting. Codex flagged exactly
+    this fail-open path; this guard keeps ``$RANDOM`` out of the mint and pins the
+    abort branch so a later edit cannot silently reintroduce the weak fallback.
+    """
+
+    entrypoint = _read("entrypoint.sh")
+    start = entrypoint.find('if [ "${GFMY_NOVNC_HARDEN:-}" = "1" ]; then')
+    end = entrypoint.find("export SE_VNC_PASSWORD=", start)
+    assert start != -1 and end != -1, "could not locate the password-mint block"
+    mint = entrypoint[start:end]
+    # Strip comment lines: the code must not USE $RANDOM, but a comment may name it
+    # to document WHY it is excluded. Checking the raw text would flag that comment.
+    mint_code = "\n".join(
+        line for line in mint.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "RANDOM" not in mint_code, (
+        "the password mint must not fall back to Bash's non-crypto $RANDOM"
+    )
+    assert "exit 1" in mint_code, (
+        "the mint must fail closed (abort) when no CSPRNG byte is available"
+    )
+
+
 def test_compose_generates_password_in_container_not_from_host() -> None:
     """docker-compose.yml must NOT pass a VNC password from the host: the container
     mints it. Passing SE_VNC_PASSWORD from the host is exactly what re-introduces

--- a/tests/test_docker_login_hardening.py
+++ b/tests/test_docker_login_hardening.py
@@ -2408,7 +2408,9 @@ def test_entrypoint_mints_password_before_supervisord_starts() -> None:
     )
     export_idx = entrypoint.find("export SE_VNC_PASSWORD")
     launch_idx = entrypoint.find('bin/supervisord" --configuration')
-    assert export_idx != -1, "entrypoint.sh must export SE_VNC_PASSWORD for the hardened path"
+    assert export_idx != -1, (
+        "entrypoint.sh must export SE_VNC_PASSWORD for the hardened path"
+    )
     assert launch_idx != -1, "entrypoint.sh must launch supervisord"
     assert export_idx < launch_idx, (
         "SE_VNC_PASSWORD must be exported BEFORE supervisord starts, or start-vnc.sh "


### PR DESCRIPTION
## What & why
Two problems with the first-time login helper, in one change:

1. **UX** — running `login.sh`/`login.cmd` printed `127.0.0.1` and a Selenium boot log, leaving the user unsure what to open or why the script does not exit. The container must be reachable from *outside* the container to be useful.
2. **Security** — the noVNC viewer used the base image's fixed password `secret` over plain HTTP. On a LAN bind that exposes an authenticated Google session in clear text.

## UX
- `login.sh` now offers an **interactive IP picker** (detected host addresses, LAN default) instead of only a `--ip` flag, and times the in-container sign-in prompt so it is the last line on screen.
- `login.cmd` mirrors the LAN-bind flow on Windows.

## Security (LAN bind only)
A loopback bind keeps the base image's `secret`/plain default byte-for-byte (nothing on the wire). A **non-loopback** bind hardens the viewer:

- **Per-run dense password + self-signed TLS are minted *inside the container*** (`entrypoint.sh`), before `supervisord` starts, so the base image's `start-vnc.sh` inherits the password in time (same timing class as the TLS cert). The launchers only raise the `GFMY_NOVNC_HARDEN` verdict, so **Windows gets identical hardening with no batch-side crypto**.
- Password charset is keyboard-safe (`letters + ".,=-_+@"`), the effective VNC 8-byte window is filled densely. `! ? % $` are excluded — each has a silent-failure path (cmd.exe escape/delayed-expansion, glob in the base image's unquoted `x11vnc -storepasswd`, shell metachar).
- TLS SAN is typed `IP:`/`DNS:` by host form, so a hostname `URL_HOST` does not make `openssl` fail and silently fall back to plain HTTP while an `https://` URL was promised.
- Compose passes **only** the verdict (`GFMY_NOVNC_HARDEN`), TLS flag and SAN host across the boundary; no VNC password crosses it, so it never appears in `docker inspect`.
- `auth_flow.py` reads the real per-run password from the environment instead of a hardcoded `secret`.

## Tests
Adds static regression guards for the container-side mint: verdict gate, export-before-`supervisord` ordering, charset lock, compose passthrough, and the `auth_flow` env read. `test_docker_login_hardening.py` + `test_auth_flow.py` green; `ruff`/`mypy --strict` clean on the changed Python file.

## Runtime confirmation (not automatable in CI)
The end-to-end chain (entrypoint exports `SE_VNC_PASSWORD` → `start-vnc.sh` inherits it → x11vnc; browser accepts the IP cert with one click) needs a real container run on the Docker host. The base-image assumptions (`openssl` present, `SE_VNC_PASSWORD` read by `start-vnc.sh`, `novnc_proxy --cert/--key/--ssl-only`) were confirmed against `selenium/standalone-chrome:latest`.

Draft: opened for review before requesting an automated pass.