### PR TITLE
fix(config_flow): apply discovered credentials to the entry and ask before overwriting

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -4752,6 +4752,81 @@ def _normalize_contributor_mode(value: Any) -> str:
     return DEFAULT_CONTRIBUTOR_MODE
 
 
+# Key of the stray mapping an older discovery import left inside ``entry.data``.
+# It is not a setting: the integration never writes a key called ``data`` into an
+# entry (the only similar constant is ``secrets_data``), and nothing reads one.
+_STRAY_NESTED_DATA_KEY = "data"
+
+
+def _strip_stray_nested_entry_data(
+    data: Mapping[str, Any],
+) -> tuple[dict[str, Any], int]:
+    """Return ``data`` without the stray nested ``data`` key, and how deep it went.
+
+    Discovery used to hand Home Assistant a nested ``{"data": {...}}`` payload,
+    which the core merged verbatim into ``entry.data``. The credentials therefore
+    never reached the level that is read, and the next import wrapped the whole
+    thing again: the nesting grows by one level per run, and a live installation
+    was found at depth 3 with roughly three quarters of its entry data spent on
+    the dead copies.
+
+    Removing the top key removes the whole chain, so the returned depth is a
+    report, not a loop counter. A depth of 0 means nothing was found, and the
+    returned mapping equals the input: callers must skip the write in that case
+    so a healthy entry is never touched.
+
+    Only a *mapping* is stripped. A future setting that happens to be called
+    ``data`` and holds a scalar is left alone rather than silently deleted.
+    """
+
+    cleaned = dict(data)
+    stray = cleaned.get(_STRAY_NESTED_DATA_KEY)
+    if not isinstance(stray, Mapping):
+        return cleaned, 0
+
+    depth = 0
+    while isinstance(stray, Mapping):
+        depth += 1
+        stray = stray.get(_STRAY_NESTED_DATA_KEY)
+
+    del cleaned[_STRAY_NESTED_DATA_KEY]
+    return cleaned, depth
+
+
+def _async_strip_stray_nested_entry_data(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Drop the discovery leftovers from ``entry.data``; idempotent, log-only.
+
+    Runs on every setup rather than from ``async_migrate_entry``: migration only
+    runs when the stored entry version differs from ``CONFIG_ENTRY_VERSION``, and
+    affected entries are already at the current version, so they would never be
+    reached. Bumping the version purely to trigger a cleanup would also block
+    downgrades, which is a steep price for removing a stray key. The sibling
+    ``_async_soft_migrate_data_to_options`` establishes the idiom: an idempotent
+    setup-time fixup that writes only when it has something to change.
+
+    The discarded copies are not promoted to the top level. They are ordered by
+    age only as long as nothing else wrote to the entry in between; a reauth
+    writes to the top level and inverts that order, so promoting the deeper copy
+    could replace fresh credentials with stale ones. Running the login again is
+    the reliable route, and after the discovery fix it lands correctly.
+    """
+
+    cleaned, depth = _strip_stray_nested_entry_data(entry.data)
+    if depth == 0:
+        return
+
+    _LOGGER.warning(
+        "[%s] Removing %d nested 'data' level(s) an earlier discovery import left "
+        "in the entry. The credentials stored there are discarded; run the login "
+        "again if the credentials in use are outdated.",
+        entry.entry_id,
+        depth,
+    )
+    hass.config_entries.async_update_entry(entry, data=cleaned)
+
+
 async def _async_soft_migrate_data_to_options(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> None:
@@ -6958,6 +7033,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MyConfigEntry) -> bool:
     parent_entry_id = getattr(entry, "parent_entry_id", None)
     if parent_entry_id:
         return await _async_setup_subentry(hass, entry)
+
+    # Before anything reads the entry: drop the leftovers of the discovery import
+    # defect. Deliberately first, not down with the other soft migrations, so the
+    # cleanup does not depend on the rest of the setup succeeding.
+    _async_strip_stray_nested_entry_data(hass, entry)
 
     legacy_cache: TokenCache | None = None
     cached_snapshot: Mapping[str, Any] | None = None

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -4524,45 +4524,7 @@ class ConfigFlow(
                         return self.async_abort(reason="already_configured")
                     return self.async_abort(reason="already_configured")
 
-                result = await self.async_step_device_selection()
-                # Delete-after-import: STAGED here, executed in
-                # async_setup_entry. A CREATE_ENTRY FlowResult is only a
-                # promise: Home Assistant adds the entry afterwards in
-                # ConfigEntriesFlowManager.async_finish_flow, so deleting the
-                # on-disk copies here would drop the credentials before they
-                # are persisted. Aborted device selection stages nothing and
-                # leaves the watched bundles in place so the flow can be
-                # retried. Only the copies the import actually consumed are
-                # removed (see the hook docstring): a co-located bundle of a
-                # different account and a same-account bundle that got fresher
-                # while the user was confirming both survive.
-                if (
-                    isinstance(result, Mapping)
-                    and result.get("type")
-                    == data_entry_flow.FlowResultType.CREATE_ENTRY
-                ):
-                    _async_stage_container_cleanup(
-                        getattr(self, "hass", None),
-                        flow_id=self._async_cleanup_ticket_id(),
-                        unique_id=self.unique_id,
-                        job=PendingContainerCleanup(
-                            imported_stable_key=_stable_key_for_discovery_payload(
-                                pending_payload
-                            ),
-                            imported_digest=_digest_for_discovery_payload(
-                                pending_payload
-                            ),
-                        ),
-                    )
-                    # This staging happens AFTER the CREATE_ENTRY result, so
-                    # the mark the create path set in async_step_device_selection
-                    # predates the ticket this call may just have created. Mark
-                    # again here, at the site that staged last: without it the
-                    # flow removal Home Assistant performs right after
-                    # async_finish_flow drops a ticket that belongs to an entry
-                    # which exists and whose setup may still be retrying.
-                    self._async_mark_own_cleanup_ticket_entry_promised()
-                return result
+                return await self._async_import_discovered_account(pending_payload)
 
         try:
             normalized = _normalize_and_validate_discovery_payload(discovery_info or {})
@@ -4612,6 +4574,100 @@ class ConfigFlow(
             description_placeholders=placeholders,
         )
 
+    async def _async_import_discovered_account(
+        self, payload: CloudDiscoveryData | None
+    ) -> FlowResult:
+        """Import ``payload`` as a new account and stage the bundle cleanup.
+
+        Split out of :meth:`async_step_discovery` because a second caller needs
+        exactly this behaviour: :meth:`async_step_discovery_overwrite` lands
+        here when the entry it was going to overwrite has disappeared while its
+        form was open, which turns the overwrite into a plain first import.
+
+        ``payload`` stays optional because the confirmation path reaches the
+        import with nothing staged as well; the cleanup helpers below resolve
+        that to "stage no key", which is what the absent payload means.
+        """
+
+        result = await self.async_step_device_selection()
+        # Delete-after-import: STAGED here, executed in
+        # async_setup_entry. A CREATE_ENTRY FlowResult is only a
+        # promise: Home Assistant adds the entry afterwards in
+        # ConfigEntriesFlowManager.async_finish_flow, so deleting the
+        # on-disk copies here would drop the credentials before they
+        # are persisted. Aborted device selection stages nothing and
+        # leaves the watched bundles in place so the flow can be
+        # retried. Only the copies the import actually consumed are
+        # removed (see the hook docstring): a co-located bundle of a
+        # different account and a same-account bundle that got fresher
+        # while the user was confirming both survive.
+        if (
+            isinstance(result, Mapping)
+            and result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
+        ):
+            _async_stage_container_cleanup(
+                getattr(self, "hass", None),
+                flow_id=self._async_cleanup_ticket_id(),
+                unique_id=self.unique_id,
+                job=PendingContainerCleanup(
+                    imported_stable_key=_stable_key_for_discovery_payload(payload),
+                    imported_digest=_digest_for_discovery_payload(payload),
+                ),
+            )
+            # This staging happens AFTER the CREATE_ENTRY result, so
+            # the mark the create path set in async_step_device_selection
+            # predates the ticket this call may just have created. Mark
+            # again here, at the site that staged last: without it the
+            # flow removal Home Assistant performs right after
+            # async_finish_flow drops a ticket that belongs to an entry
+            # which exists and whose setup may still be retrying.
+            self._async_mark_own_cleanup_ticket_entry_promised()
+        return result
+
+    def _async_write_entry_credentials(
+        self, entry: ConfigEntry, updates: Mapping[str, Any]
+    ) -> bool:
+        """Apply ``updates`` to ``entry`` and schedule its reload.
+
+        Only for the case where ``_async_prepare_account_context`` returned the
+        entry rather than aborting through Home Assistant's unique-id guard,
+        which is what normally performs this write. ``updates`` is the entry
+        data itself, flat and already merged (see
+        :func:`_ingest_discovery_credentials`), so it is written as-is: a
+        second merge would resurrect the keys the ingest deliberately dropped.
+
+        Returns whether the write happened, so the caller can report the
+        outcome it actually produced instead of assuming one.
+        """
+
+        hass_obj = getattr(self, "hass", None)
+        if hass_obj is None or not hasattr(hass_obj, "config_entries"):
+            return False
+        hass = cast(HomeAssistant, hass_obj)
+
+        try:
+            hass.config_entries.async_update_entry(entry, data=dict(updates))
+        except Exception:  # noqa: BLE001 - surface, but do not claim success
+            _LOGGER.exception(
+                "Failed to write discovered credentials to entry %s",
+                entry.entry_id,
+            )
+            return False
+
+        # ``async_update_entry`` only mutates the in-memory entry and schedules
+        # the debounced store save; the running integration keeps the old
+        # credentials until it is reloaded.
+        schedule_reload = getattr(hass.config_entries, "async_schedule_reload", None)
+        if callable(schedule_reload):
+            try:
+                schedule_reload(entry.entry_id)
+            except Exception:  # noqa: BLE001 - the write itself already landed
+                _LOGGER.exception(
+                    "Failed to schedule reload after writing credentials to entry %s",
+                    entry.entry_id,
+                )
+        return True
+
     async def async_step_discovery_overwrite(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -4627,6 +4683,11 @@ class ConfigFlow(
         Declining writes nothing at all: the entry keeps the credentials it has,
         and nothing is staged for cleanup, so the discovered bundle stays on
         disk.
+
+        Accepting reports ``credentials_updated`` only where credentials were
+        actually written. The entry can disappear while this form is open, and
+        then the guard returns instead of aborting and writes nothing; that
+        case continues as a first import of the same credentials.
         """
 
         payload = self._pending_overwrite_payload
@@ -4645,8 +4706,10 @@ class ConfigFlow(
                 )
                 return self.async_abort(reason="credentials_kept")
 
+            existing_entry: ConfigEntry | None = None
+            written = False
             try:
-                await self._async_prepare_account_context(
+                existing_entry = await self._async_prepare_account_context(
                     email=payload.email,
                     preferred_unique_id=payload.unique_id,
                     updates=updates,
@@ -4655,7 +4718,37 @@ class ConfigFlow(
                 # The expected exit: the core applied ``updates`` to the entry
                 # and then aborted the flow, which is how it signals "this
                 # account is already configured".
-                pass
+                written = True
+
+            if not written:
+                # Returning instead of aborting means the unique-id guard never
+                # ran and therefore never wrote ``updates``. Reporting success
+                # here would name an event that did not happen, so both
+                # remaining cases are resolved on their own terms.
+                if existing_entry is None:
+                    # The entry was removed, or its account identity changed,
+                    # while this form was open. There is nothing left to
+                    # overwrite, and the credentials are still in hand: import
+                    # them as a new account rather than dropping them.
+                    _LOGGER.info(
+                        "Discovery for %s confirmed, but the configured entry "
+                        "is gone; importing the credentials as a new account",
+                        _mask_email_for_logs(payload.email),
+                    )
+                    return await self._async_import_discovered_account(payload)
+
+                # The flow is bound to that very entry (``context["entry_id"]``
+                # or an attached ``config_entry``), which makes the guard return
+                # the entry instead of aborting through it. Write the update
+                # here so the reported outcome is the one that happened.
+                if not self._async_write_entry_credentials(existing_entry, updates):
+                    _LOGGER.warning(
+                        "Discovery for %s confirmed, but the credentials could "
+                        "not be written to the configured entry",
+                        _mask_email_for_logs(payload.email),
+                    )
+                    return self.async_abort(reason="already_configured")
+
             _LOGGER.info(
                 "Discovery for %s confirmed: stored credentials replaced",
                 _mask_email_for_logs(payload.email),

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -101,6 +101,7 @@ except ImportError:  # Pre-2025.5 HA builds do not expose the helper.
     OperationNotAllowed = type("OperationNotAllowed", (HomeAssistantError,), {})
 
 from .const import (
+    CLOUD_SCANNER_DISCOVERY_SOURCE,
     CONF_GOOGLE_EMAIL,
     CONF_OAUTH_TOKEN,
     CONFIG_ENTRY_VERSION,
@@ -3367,6 +3368,36 @@ class CloudDiscoveryData:
     candidates: tuple[tuple[str, str], ...]
     secrets_bundle: Mapping[str, Any] | None
     title: str | None = None
+    # Which producer assembled the payload (``discovery_source``). Kept because
+    # the flow context does not survive as a discriminator: discovery.py
+    # downgrades every non-Home-Assistant source to plain ``discovery``, so the
+    # tracker rescan and a genuine credential import arrive indistinguishable
+    # unless the payload itself says who sent it. ``None`` means the payload
+    # carried no marker, which is treated as a credential import: asking one
+    # question too many beats replacing working credentials unasked.
+    source: str | None = None
+
+
+def _is_credential_import_discovery(discovery: CloudDiscoveryData) -> bool:
+    """Return True when the payload represents credentials someone supplied.
+
+    Only such a payload may raise the overwrite question, because only there is
+    a human waiting who meant to replace something. The tracker rescan in
+    ``device_tracker.py`` re-submits the credentials the entry already stores;
+    asking whether to replace them with themselves would be a dialog about
+    nothing.
+
+    The flow context cannot answer this: ``discovery.py`` downgrades every source
+    that is not a Home Assistant ``SOURCE_*`` constant to plain ``discovery``,
+    and the file watcher's own ``discovery_update_info`` is downgraded the same
+    way, so both producers arrive under an identical context source. Hence the
+    check reads the payload marker.
+
+    An unmarked payload counts as an import: replacing working credentials
+    unasked is the worse failure, so an unknown producer gets the question.
+    """
+
+    return discovery.source != CLOUD_SCANNER_DISCOVERY_SOURCE
 
 
 def _discovery_payload_equivalent(
@@ -3482,12 +3513,14 @@ def _normalize_and_validate_discovery_payload(
     if unique_id is None:
         raise DiscoveryFlowError("invalid_discovery_info")
 
+    source = payload_dict.get("discovery_source")
     return CloudDiscoveryData(
         email=email_candidate,
         unique_id=unique_id,
         candidates=tuple(candidates),
         secrets_bundle=secrets_bundle,
         title=str(title) if isinstance(title, str) else None,
+        source=source if isinstance(source, str) and source else None,
     )
 
 
@@ -4461,14 +4494,35 @@ class ConfigFlow(
                 self._clear_discovery_confirmation_state()
 
                 if updates is not None and pending_payload is not None:
-                    # The account is already configured. Do not write yet: ask
-                    # first, because this replaces working credentials. The old
-                    # behaviour wrote unconditionally and reported
-                    # "already_configured", which said nothing about what had
-                    # happened to the credentials.
-                    self._pending_overwrite_payload = pending_payload
-                    self._pending_overwrite_updates = updates
-                    return await self.async_step_discovery_overwrite()
+                    if _is_credential_import_discovery(pending_payload):
+                        # The account is already configured and a human just
+                        # supplied credentials. Do not write yet: ask first,
+                        # because this replaces working credentials. The old
+                        # behaviour wrote unconditionally and reported
+                        # "already_configured", which said nothing about what
+                        # had happened to the credentials.
+                        self._pending_overwrite_payload = pending_payload
+                        self._pending_overwrite_updates = updates
+                        return await self.async_step_discovery_overwrite()
+
+                    # A tracker rescan re-submits the credentials the entry
+                    # already stores. There is nothing to replace and nobody to
+                    # ask, so this keeps the pre-existing behaviour: apply the
+                    # payload and abort as already configured.
+                    _LOGGER.debug(
+                        "Discovery from %s for a configured account: "
+                        "applying updates without asking",
+                        pending_payload.source,
+                    )
+                    try:
+                        await self._async_prepare_account_context(
+                            email=pending_payload.email,
+                            preferred_unique_id=pending_payload.unique_id,
+                            updates=updates,
+                        )
+                    except data_entry_flow.AbortFlow:
+                        return self.async_abort(reason="already_configured")
+                    return self.async_abort(reason="already_configured")
 
                 result = await self.async_step_device_selection()
                 # Delete-after-import: STAGED here, executed in

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -3283,6 +3283,28 @@ def _find_entry_by_email(hass: HomeAssistant, email: str) -> ConfigEntry | None:
     return None
 
 
+def _entry_carries_credentials(entry: ConfigEntry, updates: Mapping[str, Any]) -> bool:
+    """Whether ``entry`` already holds every value in ``updates``.
+
+    The evidence that Home Assistant's unique-id guard performed the write, read
+    off the entry instead of inferred from the exception that followed. The
+    guard writes ``{**entry.data, **updates}``, so a landed write means every
+    pair in ``updates`` is present verbatim; a guard that returned early leaves
+    the entry untouched and fails this test.
+
+    Callers must not treat ``AbortFlow`` alone as proof: the guard returns
+    silently when the flow has no unique id or when no entry claims it (a legacy
+    entry without ``unique_id``, or one whose account identity has moved), and
+    :meth:`_async_prepare_account_context` then raises its own ``AbortFlow``
+    without anything having been written.
+    """
+
+    data = getattr(entry, "data", None)
+    if not isinstance(data, Mapping):
+        return False
+    return all(key in data and data[key] == value for key, value in updates.items())
+
+
 async def _async_coalesce_account_entries(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -4629,9 +4651,11 @@ class ConfigFlow(
     ) -> bool:
         """Apply ``updates`` to ``entry`` and schedule its reload.
 
-        Only for the case where ``_async_prepare_account_context`` returned the
-        entry rather than aborting through Home Assistant's unique-id guard,
-        which is what normally performs this write. ``updates`` is the entry
+        For the cases where Home Assistant's unique-id guard, which normally
+        performs this write, did not: ``_async_prepare_account_context``
+        returned the entry instead of aborting through the guard, or the guard
+        returned before its write because no entry claimed the flow's unique id
+        and the helper then aborted on its own. ``updates`` is the entry
         data itself, flat and already merged (see
         :func:`_ingest_discovery_credentials`), so it is written as-is: a
         second merge would resurrect the keys the ingest deliberately dropped.
@@ -4685,8 +4709,11 @@ class ConfigFlow(
         disk.
 
         Accepting reports ``credentials_updated`` only where credentials were
-        actually written. The entry can disappear while this form is open, and
-        then the guard returns instead of aborting and writes nothing; that
+        actually written, and that is read off the entry rather than inferred
+        from the abort that ended the guard: the guard also aborts without
+        writing when no entry claims the flow's unique id. Whatever the reason,
+        an entry that does not hold the credentials afterwards is written here
+        explicitly. The entry can also disappear while this form is open; that
         case continues as a first import of the same credentials.
 
         Accepting also stages the delete-after-import cleanup of the bundle,
@@ -4719,25 +4746,32 @@ class ConfigFlow(
                     updates=updates,
                 )
             except data_entry_flow.AbortFlow:
-                # The expected exit: the core applied ``updates`` to the entry
-                # and then aborted the flow, which is how it signals "this
-                # account is already configured".
-                written = True
-                # The exception skipped the assignment above, so the entry has
-                # to be resolved again -- and deliberately *after* the write,
-                # because the cleanup ticket below needs the entry's fresh
-                # ``modified_at`` as its durability watermark.
+                # Two different aborts arrive here and only one of them wrote:
+                # the core's unique-id guard applies ``updates`` and then aborts
+                # to signal "this account is already configured", but it also
+                # returns silently when no entry claims this unique id (a legacy
+                # entry without one, or an account identity that moved), and
+                # ``_async_prepare_account_context`` then raises its own abort
+                # having written nothing. So the entry is resolved again -- the
+                # exception skipped the assignment above -- and asked what it
+                # actually holds. Resolving happens deliberately *after* the
+                # write, because the cleanup ticket below needs the entry's
+                # fresh ``modified_at`` as its durability watermark.
                 hass_obj = getattr(self, "hass", None)
                 if hass_obj is not None and hasattr(hass_obj, "config_entries"):
                     existing_entry = _find_entry_by_email(
                         cast(HomeAssistant, hass_obj), payload.email
                     )
+                written = existing_entry is not None and _entry_carries_credentials(
+                    existing_entry, updates
+                )
 
             if not written:
-                # Returning instead of aborting means the unique-id guard never
-                # ran and therefore never wrote ``updates``. Reporting success
-                # here would name an event that did not happen, so both
-                # remaining cases are resolved on their own terms.
+                # Nothing was written: either the guard returned the entry
+                # instead of aborting through it, or it aborted without ever
+                # reaching its write. Reporting success here would name an event
+                # that did not happen, so both remaining cases are resolved on
+                # their own terms.
                 if existing_entry is None:
                     # The entry was removed, or its account identity changed,
                     # while this form was open. There is nothing left to
@@ -4750,10 +4784,13 @@ class ConfigFlow(
                     )
                     return await self._async_import_discovered_account(payload)
 
-                # The flow is bound to that very entry (``context["entry_id"]``
-                # or an attached ``config_entry``), which makes the guard return
-                # the entry instead of aborting through it. Write the update
-                # here so the reported outcome is the one that happened.
+                # The entry exists but does not hold the credentials, either
+                # because the flow is bound to that very entry
+                # (``context["entry_id"]`` or an attached ``config_entry``),
+                # which makes the guard return it instead of aborting through
+                # it, or because no entry claimed the flow's unique id and the
+                # guard returned before its write. Write the update here so the
+                # reported outcome is the one that happened.
                 if not self._async_write_entry_credentials(existing_entry, updates):
                     _LOGGER.warning(
                         "Discovery for %s confirmed, but the credentials could "

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -4688,6 +4688,10 @@ class ConfigFlow(
         actually written. The entry can disappear while this form is open, and
         then the guard returns instead of aborting and writes nothing; that
         case continues as a first import of the same credentials.
+
+        Accepting also stages the delete-after-import cleanup of the bundle,
+        exactly as the non-interactive update path does, so an accepted file is
+        eventually consumed instead of being rediscovered on every restart.
         """
 
         payload = self._pending_overwrite_payload
@@ -4719,6 +4723,15 @@ class ConfigFlow(
                 # and then aborted the flow, which is how it signals "this
                 # account is already configured".
                 written = True
+                # The exception skipped the assignment above, so the entry has
+                # to be resolved again -- and deliberately *after* the write,
+                # because the cleanup ticket below needs the entry's fresh
+                # ``modified_at`` as its durability watermark.
+                hass_obj = getattr(self, "hass", None)
+                if hass_obj is not None and hasattr(hass_obj, "config_entries"):
+                    existing_entry = _find_entry_by_email(
+                        cast(HomeAssistant, hass_obj), payload.email
+                    )
 
             if not written:
                 # Returning instead of aborting means the unique-id guard never
@@ -4748,6 +4761,33 @@ class ConfigFlow(
                         _mask_email_for_logs(payload.email),
                     )
                     return self.async_abort(reason="already_configured")
+
+            # Delete-after-import (update case), the same staging the
+            # non-interactive update path performs: STAGED here, executed from
+            # the durability gate in async_setup_entry, which the reload
+            # scheduled above arms. Without it an accepted bundle is never
+            # consumed -- the watcher only remembers it in the process-local
+            # ``_settled_signatures``, so the next Home Assistant restart
+            # rediscovers the unchanged file and asks this very question again,
+            # for good. A declined bundle is deliberately left alone (see the
+            # decline branch above), which is what keeps it available.
+            #
+            # No entry means no watermark, and ``entry=None`` would stage a
+            # *create-path* ticket, i.e. authorise the irreversible delete on
+            # "the file exists" alone. Staging nothing is the fail-safe answer:
+            # the bundle stays on disk and the login container's TTL delete
+            # takes over.
+            if existing_entry is not None:
+                _async_stage_container_cleanup_for(
+                    getattr(self, "hass", None),
+                    flow_id=self._async_cleanup_ticket_id(),
+                    unique_id=getattr(existing_entry, "unique_id", None),
+                    job=PendingContainerCleanup(
+                        imported_stable_key=_stable_key_for_discovery_payload(payload),
+                        imported_digest=_digest_for_discovery_payload(payload),
+                    ),
+                    entry=existing_entry,
+                )
 
             _LOGGER.info(
                 "Discovery for %s confirmed: stored credentials replaced",

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -3840,7 +3840,6 @@ class ConfigFlow(
         self._subentry_key_service = SERVICE_SUBENTRY_KEY
         self._pending_discovery_payload: CloudDiscoveryData | None = None
         self._pending_discovery_updates: dict[str, Any] | None = None
-        self._pending_discovery_existing_entry: ConfigEntry | None = None
         self._discovery_confirm_pending = False
         # Survives _clear_discovery_confirmation_state on purpose: the overwrite
         # question is asked *after* the discovery card has been confirmed and
@@ -4373,7 +4372,6 @@ class ConfigFlow(
         self._discovery_confirm_pending = False
         self._pending_discovery_payload = None
         self._pending_discovery_updates = None
-        self._pending_discovery_existing_entry = None
         context = getattr(self, "context", None)
         if isinstance(context, dict):
             context.pop("confirm_only", None)
@@ -4553,7 +4551,6 @@ class ConfigFlow(
         self.context["title_placeholders"] = placeholders
         self._pending_discovery_payload = normalized
         self._pending_discovery_updates = updates
-        self._pending_discovery_existing_entry = existing_entry
         self._discovery_confirm_pending = True
         self._set_confirm_only()
         return self.async_show_form(
@@ -4574,7 +4571,8 @@ class ConfigFlow(
         nothing about their credentials.
 
         Declining writes nothing at all: the entry keeps the credentials it has,
-        and the bundle stays on disk, so the offer returns on the next scan.
+        and nothing is staged for cleanup, so the discovered bundle stays on
+        disk.
         """
 
         payload = self._pending_overwrite_payload

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -3491,7 +3491,15 @@ async def _ingest_discovery_credentials(
     *,
     existing_entry: ConfigEntry | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any] | None]:
-    """Validate discovery credentials and prepare flow + entry payloads."""
+    """Validate discovery credentials and prepare flow + entry payloads.
+
+    The second element is the ``updates`` payload for
+    ``_abort_if_unique_id_configured``. Home Assistant merges it *flat* into the
+    entry (``data={**entry.data, **updates}``, ``config_entries.py``), so it must
+    be the entry data itself, not ``{"data": ...}``: a nested payload would leave
+    every credential on its old value and add a stray ``data`` key inside
+    ``entry.data`` instead.
+    """
 
     candidates = list(discovery.candidates)
     secrets_bundle = (
@@ -3560,7 +3568,7 @@ async def _ingest_discovery_credentials(
             updated.pop(DATA_AAS_TOKEN, None)
         if fcm_credentials is not None:
             updated["fcm_credentials"] = fcm_credentials
-        updates: dict[str, Any] | None = {"data": updated}
+        updates: dict[str, Any] | None = updated
     else:
         updates = None
 
@@ -4641,7 +4649,7 @@ class ConfigFlow(
         self._auth_data = auth_data
 
         if updates is None:
-            updates = {"data": dict(existing_entry.data)}
+            updates = dict(existing_entry.data)
 
         _LOGGER.info(
             "Handling discovery-update-info flow for %s",  # noqa: G004 - logging mask helper
@@ -4667,19 +4675,14 @@ class ConfigFlow(
             hass = None
 
         if hass is not None:
-            update_payload: dict[str, Any] = {}
-            if "data" in updates_to_apply:
-                update_payload["data"] = updates_to_apply["data"]
-            if "options" in updates_to_apply:
-                update_payload["options"] = updates_to_apply["options"]
-
-            try:
-                hass.config_entries.async_update_entry(existing_entry, **update_payload)
-            except TypeError:  # Legacy cores without options support
-                hass.config_entries.async_update_entry(
-                    existing_entry,
-                    data=update_payload.get("data", existing_entry.data),
-                )
+            # ``updates_to_apply`` *is* the entry data, flat, the same payload
+            # ``_abort_if_unique_id_configured`` merged above. It is applied
+            # again here because that call only reaches the entry when the core
+            # aborts; unpacking a nested ``data`` key would be wrong now and was
+            # what hid the nesting defect before.
+            hass.config_entries.async_update_entry(
+                existing_entry, data=updates_to_apply
+            )
 
             # Delete-after-import (update case): STAGED here, executed from the
             # durability gate in async_setup_entry. `async_update_entry` only

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -1237,6 +1237,12 @@ _FIELD_REPAIR_DEVICES = "device_ids"
 # form.
 _FIELD_USE_FOUND_BUNDLE = "use_found_bundle"
 
+# Discovery for an account that is already configured: "replace the stored
+# credentials with the ones just discovered?". Unset means "no", which leaves the
+# entry untouched. Defaults to yes, because a discovery for a configured account
+# follows a login the user just performed on purpose.
+_FIELD_OVERWRITE_CREDENTIALS = "overwrite_credentials"
+
 _SUBENTRIES_DOCS_URL = (
     "https://github.com/BSkando/GoogleFindMy-HA/blob/main/README.md"
     "#subentries-and-feature-groups"
@@ -3836,6 +3842,11 @@ class ConfigFlow(
         self._pending_discovery_updates: dict[str, Any] | None = None
         self._pending_discovery_existing_entry: ConfigEntry | None = None
         self._discovery_confirm_pending = False
+        # Survives _clear_discovery_confirmation_state on purpose: the overwrite
+        # question is asked *after* the discovery card has been confirmed and
+        # that state torn down.
+        self._pending_overwrite_payload: CloudDiscoveryData | None = None
+        self._pending_overwrite_updates: dict[str, Any] | None = None
         # Two-phase-delete (F4): a container-login fetch stages its result here so
         # the ack (which tells the container to delete its on-disk secret) is only
         # sent AFTER the config entry is actually created in device_selection. If
@@ -4449,19 +4460,17 @@ class ConfigFlow(
                 self._clear_discovery_confirmation_state()
             else:
                 updates = self._pending_discovery_updates
-                existing_entry = self._pending_discovery_existing_entry
                 self._clear_discovery_confirmation_state()
 
                 if updates is not None and pending_payload is not None:
-                    try:
-                        await self._async_prepare_account_context(
-                            email=pending_payload.email,
-                            preferred_unique_id=pending_payload.unique_id,
-                            updates=updates,
-                        )
-                    except data_entry_flow.AbortFlow:
-                        return self.async_abort(reason="already_configured")
-                    return self.async_abort(reason="already_configured")
+                    # The account is already configured. Do not write yet: ask
+                    # first, because this replaces working credentials. The old
+                    # behaviour wrote unconditionally and reported
+                    # "already_configured", which said nothing about what had
+                    # happened to the credentials.
+                    self._pending_overwrite_payload = pending_payload
+                    self._pending_overwrite_updates = updates
+                    return await self.async_step_discovery_overwrite()
 
                 result = await self.async_step_device_selection()
                 # Delete-after-import: STAGED here, executed in
@@ -4550,6 +4559,67 @@ class ConfigFlow(
         return self.async_show_form(
             step_id="discovery",
             description_placeholders=placeholders,
+        )
+
+    async def async_step_discovery_overwrite(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask before replacing the credentials of an already configured account.
+
+        Reached from :meth:`async_step_discovery` once the discovery card has
+        been confirmed and the account turns out to have an entry already. The
+        answer decides between two aborts, both of which say what happened:
+        ``credentials_updated`` or ``credentials_kept``. Neither is
+        ``already_configured``, which used to end both outcomes and told the user
+        nothing about their credentials.
+
+        Declining writes nothing at all: the entry keeps the credentials it has,
+        and the bundle stays on disk, so the offer returns on the next scan.
+        """
+
+        payload = self._pending_overwrite_payload
+        updates = self._pending_overwrite_updates
+        if payload is None or updates is None:  # pragma: no cover - defensive
+            return self.async_abort(reason="already_configured")
+
+        if user_input is not None:
+            self._pending_overwrite_payload = None
+            self._pending_overwrite_updates = None
+
+            if not user_input.get(_FIELD_OVERWRITE_CREDENTIALS, False):
+                _LOGGER.info(
+                    "Discovery for %s declined: stored credentials kept",
+                    _mask_email_for_logs(payload.email),
+                )
+                return self.async_abort(reason="credentials_kept")
+
+            try:
+                await self._async_prepare_account_context(
+                    email=payload.email,
+                    preferred_unique_id=payload.unique_id,
+                    updates=updates,
+                )
+            except data_entry_flow.AbortFlow:
+                # The expected exit: the core applied ``updates`` to the entry
+                # and then aborted the flow, which is how it signals "this
+                # account is already configured".
+                pass
+            _LOGGER.info(
+                "Discovery for %s confirmed: stored credentials replaced",
+                _mask_email_for_logs(payload.email),
+            )
+            return self.async_abort(reason="credentials_updated")
+
+        return self.async_show_form(
+            step_id="discovery_overwrite",
+            data_schema=vol.Schema(
+                {vol.Required(_FIELD_OVERWRITE_CREDENTIALS, default=True): bool}
+            ),
+            description_placeholders={
+                # The account is the user's own and is shown to them in their own
+                # UI, so it is spelled out here; only the *log* is redacted.
+                "email": payload.email,
+            },
         )
 
     async def async_step_discovery_update_info(

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -75,6 +75,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Final,
     Protocol,
     TypeAlias,
     TypeVar,
@@ -3546,6 +3547,40 @@ def _normalize_and_validate_discovery_payload(
     )
 
 
+#: Credential keys an account may or may not carry. They are removed from the
+#: entry when the freshly discovered credentials do not carry them, which a flat
+#: merge cannot do on its own -- hence the full-data payload below.
+_OPTIONAL_CREDENTIAL_KEYS: Final = (DATA_SECRET_BUNDLE, DATA_AAS_TOKEN)
+
+
+def _merge_credential_updates(
+    entry_data: Mapping[str, Any], auth_data: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Merge the discovered credential delta onto ``entry_data``.
+
+    The result is the *entry data itself*, flat: that is what
+    ``_abort_if_unique_id_configured(updates=...)`` merges into the entry
+    (``data={**entry.data, **updates}``) and what
+    :meth:`_async_write_entry_credentials` writes verbatim. A full payload is
+    required rather than the bare delta because a flat merge can only add or
+    replace keys, never drop them, and credentials that no longer include a
+    secrets bundle or an ``aas_et/`` token must not leave the old ones behind.
+
+    Callers must apply this as late as possible -- against the entry data as it
+    is when the write happens, not as it was when a form was shown. A payload
+    built before a confirmation dialog is a snapshot, and writing a snapshot
+    rolls back whatever else touched the entry meanwhile (the options flow
+    refreshes credentials through ``_async_options_container_persist``, for
+    one).
+    """
+
+    merged = {**entry_data, **auth_data}
+    for key in _OPTIONAL_CREDENTIAL_KEYS:
+        if key not in auth_data:
+            merged.pop(key, None)
+    return merged
+
+
 async def _ingest_discovery_credentials(
     flow: ConfigFlow,
     discovery: CloudDiscoveryData,
@@ -3560,6 +3595,12 @@ async def _ingest_discovery_credentials(
     be the entry data itself, not ``{"data": ...}``: a nested payload would leave
     every credential on its old value and add a stray ``data`` key inside
     ``entry.data`` instead.
+
+    That second element is only good for an immediate write. It is merged from
+    ``existing_entry`` as it is *now*; a caller that shows a form before writing
+    must carry the first element (the delta) across it and merge again through
+    :func:`_merge_credential_updates`, or it will roll back whatever touched the
+    entry meanwhile.
     """
 
     candidates = list(discovery.candidates)
@@ -3622,14 +3663,9 @@ async def _ingest_discovery_credentials(
         auth_data.pop(DATA_AAS_TOKEN, None)
 
     if existing_entry is not None:
-        updated = {**existing_entry.data, **auth_data}
-        if not secrets_bundle:
-            updated.pop(DATA_SECRET_BUNDLE, None)
-        if not (isinstance(to_persist, str) and to_persist.startswith("aas_et/")):
-            updated.pop(DATA_AAS_TOKEN, None)
-        if fcm_credentials is not None:
-            updated["fcm_credentials"] = fcm_credentials
-        updates: dict[str, Any] | None = updated
+        updates: dict[str, Any] | None = _merge_credential_updates(
+            existing_entry.data, auth_data
+        )
     else:
         updates = None
 
@@ -3894,13 +3930,17 @@ class ConfigFlow(
         self._subentry_key_core_tracking = TRACKER_SUBENTRY_KEY
         self._subentry_key_service = SERVICE_SUBENTRY_KEY
         self._pending_discovery_payload: CloudDiscoveryData | None = None
-        self._pending_discovery_updates: dict[str, Any] | None = None
+        # The credential *delta*, not a merged entry payload: what a form
+        # carries across a user's think time must not be a snapshot of another
+        # object's state (see _merge_credential_updates).
+        self._pending_discovery_auth: dict[str, Any] | None = None
+        self._pending_discovery_entry_exists = False
         self._discovery_confirm_pending = False
         # Survives _clear_discovery_confirmation_state on purpose: the overwrite
         # question is asked *after* the discovery card has been confirmed and
         # that state torn down.
         self._pending_overwrite_payload: CloudDiscoveryData | None = None
-        self._pending_overwrite_updates: dict[str, Any] | None = None
+        self._pending_overwrite_auth: dict[str, Any] | None = None
         # Two-phase-delete (F4): a container-login fetch stages its result here so
         # the ack (which tells the container to delete its on-disk secret) is only
         # sent AFTER the config entry is actually created in device_selection. If
@@ -4426,7 +4466,8 @@ class ConfigFlow(
 
         self._discovery_confirm_pending = False
         self._pending_discovery_payload = None
-        self._pending_discovery_updates = None
+        self._pending_discovery_auth = None
+        self._pending_discovery_entry_exists = False
         context = getattr(self, "context", None)
         if isinstance(context, dict):
             context.pop("confirm_only", None)
@@ -4512,10 +4553,15 @@ class ConfigFlow(
             if not is_submission:
                 self._clear_discovery_confirmation_state()
             else:
-                updates = self._pending_discovery_updates
+                pending_auth = self._pending_discovery_auth
+                entry_exists = self._pending_discovery_entry_exists
                 self._clear_discovery_confirmation_state()
 
-                if updates is not None and pending_payload is not None:
+                if (
+                    entry_exists
+                    and pending_auth is not None
+                    and pending_payload is not None
+                ):
                     if _is_credential_import_discovery(pending_payload):
                         # The account is already configured and a human just
                         # supplied credentials. Do not write yet: ask first,
@@ -4524,7 +4570,7 @@ class ConfigFlow(
                         # "already_configured", which said nothing about what
                         # had happened to the credentials.
                         self._pending_overwrite_payload = pending_payload
-                        self._pending_overwrite_updates = updates
+                        self._pending_overwrite_auth = pending_auth
                         return await self.async_step_discovery_overwrite()
 
                     # A tracker rescan re-submits the credentials the entry
@@ -4536,11 +4582,20 @@ class ConfigFlow(
                         "applying updates without asking",
                         pending_payload.source,
                     )
+                    rebased = self._async_rebase_credential_updates(
+                        pending_payload.email, pending_auth
+                    )
+                    if rebased is None:
+                        # The entry went away while the card was open. There is
+                        # nothing to update, and this path deliberately does not
+                        # create anything: the payload is a rescan of an account
+                        # the user configured, not an import they asked for.
+                        return self.async_abort(reason="already_configured")
                     try:
                         await self._async_prepare_account_context(
                             email=pending_payload.email,
                             preferred_unique_id=pending_payload.unique_id,
-                            updates=updates,
+                            updates=rebased[1],
                         )
                     except data_entry_flow.AbortFlow:
                         return self.async_abort(reason="already_configured")
@@ -4588,7 +4643,8 @@ class ConfigFlow(
         placeholders.setdefault("email", normalized.email)
         self.context["title_placeholders"] = placeholders
         self._pending_discovery_payload = normalized
-        self._pending_discovery_updates = updates
+        self._pending_discovery_auth = dict(auth_data)
+        self._pending_discovery_entry_exists = updates is not None
         self._discovery_confirm_pending = True
         self._set_confirm_only()
         return self.async_show_form(
@@ -4645,6 +4701,41 @@ class ConfigFlow(
             # which exists and whose setup may still be retrying.
             self._async_mark_own_cleanup_ticket_entry_promised()
         return result
+
+    def _async_rebase_credential_updates(
+        self, email: str, auth_data: Mapping[str, Any]
+    ) -> tuple[ConfigEntry, dict[str, Any]] | None:
+        """Resolve the configured entry *now* and merge the delta onto it.
+
+        Both discovery forms (the card, then the overwrite question) sit between
+        the moment the credentials are validated and the moment they are
+        written. Anything merged before them is a snapshot: writing it back
+        would undo whatever else changed the entry meanwhile, and the options
+        flow does exactly that when it refreshes credentials through the login
+        container. So the merge happens here, against the entry as it is, and
+        only the delta travels across the forms.
+
+        Returns ``None`` when no entry can be resolved -- no ``hass``, or the
+        account is no longer configured -- which leaves the decision about that
+        case to the caller, where it differs (import versus abort).
+
+        This closes the window a form holds open, not the one between this call
+        and the write a few statements later; that one is bounded by the event
+        loop rather than by user think time.
+        """
+
+        hass_obj = getattr(self, "hass", None)
+        if hass_obj is None or not hasattr(hass_obj, "config_entries"):
+            return None
+
+        entry = _find_entry_by_email(cast(HomeAssistant, hass_obj), email)
+        if entry is None:
+            return None
+
+        entry_data = getattr(entry, "data", None)
+        if not isinstance(entry_data, Mapping):
+            entry_data = {}
+        return entry, _merge_credential_updates(entry_data, auth_data)
 
     def _async_write_entry_credentials(
         self, entry: ConfigEntry, updates: Mapping[str, Any]
@@ -4719,16 +4810,23 @@ class ConfigFlow(
         Accepting also stages the delete-after-import cleanup of the bundle,
         exactly as the non-interactive update path does, so an accepted file is
         eventually consumed instead of being rediscovered on every restart.
+
+        What crosses this form is the credential delta alone. The payload that
+        is written is merged from the entry's *current* data once the answer is
+        in (:meth:`_async_rebase_credential_updates`), because a payload merged
+        before the question would carry an entry state that may be minutes old
+        and would roll back, say, a credential refresh the options flow ran in
+        the meantime.
         """
 
         payload = self._pending_overwrite_payload
-        updates = self._pending_overwrite_updates
-        if payload is None or updates is None:  # pragma: no cover - defensive
+        auth_data = self._pending_overwrite_auth
+        if payload is None or auth_data is None:  # pragma: no cover - defensive
             return self.async_abort(reason="already_configured")
 
         if user_input is not None:
             self._pending_overwrite_payload = None
-            self._pending_overwrite_updates = None
+            self._pending_overwrite_auth = None
 
             if not user_input.get(_FIELD_OVERWRITE_CREDENTIALS, False):
                 _LOGGER.info(
@@ -4737,6 +4835,20 @@ class ConfigFlow(
                 )
                 return self.async_abort(reason="credentials_kept")
 
+            rebased = self._async_rebase_credential_updates(payload.email, auth_data)
+            if rebased is None:
+                # No entry to overwrite any more: it was removed, or its account
+                # identity changed, while this form was open. The credentials
+                # are still in hand, so import them as a new account rather than
+                # dropping them.
+                _LOGGER.info(
+                    "Discovery for %s confirmed, but the configured entry "
+                    "is gone; importing the credentials as a new account",
+                    _mask_email_for_logs(payload.email),
+                )
+                return await self._async_import_discovered_account(payload)
+
+            updates = rebased[1]
             existing_entry: ConfigEntry | None = None
             written = False
             try:
@@ -4773,10 +4885,11 @@ class ConfigFlow(
                 # that did not happen, so both remaining cases are resolved on
                 # their own terms.
                 if existing_entry is None:
-                    # The entry was removed, or its account identity changed,
-                    # while this form was open. There is nothing left to
-                    # overwrite, and the credentials are still in hand: import
-                    # them as a new account rather than dropping them.
+                    # The entry the rebase above resolved is gone again, removed
+                    # between that resolution and this write. Same answer as for
+                    # the wider window before the rebase: the credentials are
+                    # still in hand, so import them as a new account rather than
+                    # dropping them.
                     _LOGGER.info(
                         "Discovery for %s confirmed, but the configured entry "
                         "is gone; importing the credentials as a new account",

--- a/custom_components/googlefindmy/config_flow.py
+++ b/custom_components/googlefindmy/config_flow.py
@@ -3284,14 +3284,31 @@ def _find_entry_by_email(hass: HomeAssistant, email: str) -> ConfigEntry | None:
     return None
 
 
+#: Credential keys an account may or may not carry. They are removed from the
+#: entry when the freshly discovered credentials do not carry them, which a flat
+#: merge cannot do on its own -- hence the full-data payload built by
+#: :func:`_merge_credential_updates`, and hence the absence check in
+#: :func:`_entry_carries_credentials`.
+_OPTIONAL_CREDENTIAL_KEYS: Final = (DATA_SECRET_BUNDLE, DATA_AAS_TOKEN)
+
+
 def _entry_carries_credentials(entry: ConfigEntry, updates: Mapping[str, Any]) -> bool:
-    """Whether ``entry`` already holds every value in ``updates``.
+    """Whether ``entry`` holds exactly the credentials ``updates`` describes.
 
     The evidence that Home Assistant's unique-id guard performed the write, read
     off the entry instead of inferred from the exception that followed. The
     guard writes ``{**entry.data, **updates}``, so a landed write means every
     pair in ``updates`` is present verbatim; a guard that returned early leaves
     the entry untouched and fails this test.
+
+    Presence alone is not enough, though. ``updates`` is the intended entry data
+    in full, and :func:`_merge_credential_updates` expresses a *removal* by
+    leaving an optional credential key out of it. A flat merge cannot act on
+    that: the guard leaves the superseded ``secrets_data`` or ``aas_token``
+    behind, where the reload would seed it into the entry-scoped token cache
+    next to the new credentials. So every optional key missing from ``updates``
+    must also be missing from the entry; where it is not, the caller's wholesale
+    write is still owed.
 
     Callers must not treat ``AbortFlow`` alone as proof: the guard returns
     silently when the flow has no unique id or when no entry claims it (a legacy
@@ -3303,7 +3320,11 @@ def _entry_carries_credentials(entry: ConfigEntry, updates: Mapping[str, Any]) -
     data = getattr(entry, "data", None)
     if not isinstance(data, Mapping):
         return False
-    return all(key in data and data[key] == value for key, value in updates.items())
+    if not all(key in data and data[key] == value for key, value in updates.items()):
+        return False
+    return all(
+        key not in data for key in _OPTIONAL_CREDENTIAL_KEYS if key not in updates
+    )
 
 
 async def _async_coalesce_account_entries(
@@ -3545,12 +3566,6 @@ def _normalize_and_validate_discovery_payload(
         title=str(title) if isinstance(title, str) else None,
         source=source if isinstance(source, str) and source else None,
     )
-
-
-#: Credential keys an account may or may not carry. They are removed from the
-#: entry when the freshly discovered credentials do not carry them, which a flat
-#: merge cannot do on its own -- hence the full-data payload below.
-_OPTIONAL_CREDENTIAL_KEYS: Final = (DATA_SECRET_BUNDLE, DATA_AAS_TOKEN)
 
 
 def _merge_credential_updates(
@@ -4742,14 +4757,16 @@ class ConfigFlow(
     ) -> bool:
         """Apply ``updates`` to ``entry`` and schedule its reload.
 
-        For the cases where Home Assistant's unique-id guard, which normally
-        performs this write, did not: ``_async_prepare_account_context``
-        returned the entry instead of aborting through the guard, or the guard
-        returned before its write because no entry claimed the flow's unique id
-        and the helper then aborted on its own. ``updates`` is the entry
-        data itself, flat and already merged (see
+        For the cases Home Assistant's unique-id guard, which normally performs
+        this write, does not cover: ``_async_prepare_account_context`` returned
+        the entry instead of aborting through the guard; the guard returned
+        before its write because no entry claimed the flow's unique id and the
+        helper then aborted on its own; or the guard did write, but flat, which
+        leaves behind the credential keys the payload means to drop.
+        ``updates`` is the entry data itself, flat and already merged (see
         :func:`_ingest_discovery_credentials`), so it is written as-is: a
-        second merge would resurrect the keys the ingest deliberately dropped.
+        second merge would resurrect the keys the ingest deliberately dropped,
+        which is precisely the third case above.
 
         Returns whether the write happened, so the caller can report the
         outcome it actually produced instead of assuming one.
@@ -4802,9 +4819,10 @@ class ConfigFlow(
         Accepting reports ``credentials_updated`` only where credentials were
         actually written, and that is read off the entry rather than inferred
         from the abort that ended the guard: the guard also aborts without
-        writing when no entry claims the flow's unique id. Whatever the reason,
-        an entry that does not hold the credentials afterwards is written here
-        explicitly. The entry can also disappear while this form is open; that
+        writing when no entry claims the flow's unique id, and where it does
+        write it merges flat, which cannot drop a superseded bundle or token.
+        Whatever the reason, an entry that does not hold exactly these
+        credentials afterwards is written here explicitly. The entry can also disappear while this form is open; that
         case continues as a first import of the same credentials.
 
         Accepting also stages the delete-after-import cleanup of the bundle,
@@ -4879,11 +4897,12 @@ class ConfigFlow(
                 )
 
             if not written:
-                # Nothing was written: either the guard returned the entry
-                # instead of aborting through it, or it aborted without ever
-                # reaching its write. Reporting success here would name an event
-                # that did not happen, so both remaining cases are resolved on
-                # their own terms.
+                # The entry does not hold these credentials: the guard returned
+                # the entry instead of aborting through it, or it aborted
+                # without ever reaching its write, or it wrote flat and left a
+                # superseded ``secrets_data``/``aas_token`` behind. Reporting
+                # success here would name an event that did not happen, so the
+                # remaining cases are resolved on their own terms.
                 if existing_entry is None:
                     # The entry the rebase above resolved is gone again, removed
                     # between that resolution and this write. Same answer as for
@@ -4897,13 +4916,14 @@ class ConfigFlow(
                     )
                     return await self._async_import_discovered_account(payload)
 
-                # The entry exists but does not hold the credentials, either
-                # because the flow is bound to that very entry
-                # (``context["entry_id"]`` or an attached ``config_entry``),
-                # which makes the guard return it instead of aborting through
-                # it, or because no entry claimed the flow's unique id and the
-                # guard returned before its write. Write the update here so the
-                # reported outcome is the one that happened.
+                # The entry exists but does not hold the credentials: the flow
+                # is bound to that very entry (``context["entry_id"]`` or an
+                # attached ``config_entry``), which makes the guard return it
+                # instead of aborting through it; or no entry claimed the
+                # flow's unique id and the guard returned before its write; or
+                # the guard's flat merge could not drop what the payload drops.
+                # Write the payload wholesale here, which covers all three, so
+                # the reported outcome is the one that happened.
                 if not self._async_write_entry_credentials(existing_entry, updates):
                     _LOGGER.warning(
                         "Discovery for %s confirmed, but the credentials could "

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -93,6 +93,22 @@ def service_device_identifier(entry_id: str) -> tuple[str, str]:
 
 
 # --------------------------------------------------------------------------------------
+# Cloud discovery producers
+# --------------------------------------------------------------------------------------
+# Marker carried in the discovery payload (``discovery_source``) by the tracker
+# rescan in device_tracker.py. That producer re-submits the credentials the entry
+# already stores; it is not a credential import, so the config flow must not ask
+# whether to replace the stored credentials with themselves.
+#
+# The flow context cannot tell the producers apart: discovery.py downgrades every
+# source that is not a Home Assistant ``SOURCE_*`` constant to plain ``discovery``,
+# which is exactly what the file watcher's payloads arrive as too. The payload
+# marker is the only reliable discriminator, so it lives here as the single source
+# shared by producer (device_tracker.py) and consumer (config_flow.py); const.py
+# is the shared home because discovery.py already imports config_flow.
+CLOUD_SCANNER_DISCOVERY_SOURCE: Final[Literal["cloud_scanner"]] = "cloud_scanner"
+
+# --------------------------------------------------------------------------------------
 # Configuration keys (data vs. options separation)
 # NOTE: Keep keys stable to avoid migration churn across releases.
 # --------------------------------------------------------------------------------------

--- a/custom_components/googlefindmy/device_tracker.py
+++ b/custom_components/googlefindmy/device_tracker.py
@@ -40,6 +40,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import EntityRecoveryManager, _extract_email_from_entry, _opt
 from .const import (
+    CLOUD_SCANNER_DISCOVERY_SOURCE,
     CONF_OAUTH_TOKEN,
     DATA_SECRET_BUNDLE,
     DEFAULT_SHOW_LOCATION_AGE,
@@ -567,7 +568,7 @@ async def async_setup_entry(
                         secrets_bundle=secrets_bundle,
                         discovery_ns=discovery_ns,
                         discovery_stable_key=stable_key,
-                        source="cloud_scanner",
+                        source=CLOUD_SCANNER_DISCOVERY_SOURCE,
                         entry=config_entry,
                     )
                     _log_cloud_scan_outcome(

--- a/custom_components/googlefindmy/discovery.py
+++ b/custom_components/googlefindmy/discovery.py
@@ -1678,11 +1678,13 @@ class DiscoveryManager:
         for why the exclusion is explicit.
 
         Only *added* paths justify re-arming and rescanning. A force scan
-        re-imports whatever bundle it finds, and the discovery update flow
-        applies such an import to the matching entry without any user
-        interaction, so an unconditional rescan on an unchanged or shrunken
-        path set would overwrite credentials and delete bundles that nobody
-        touched. Therefore, per watcher:
+        re-imports whatever bundle it finds, and for an account that already
+        has an entry the discovery flow now raises a confirmation prompt for
+        that import (``config_flow.ConfigFlow.async_step_discovery_overwrite``,
+        pre-answered with "replace"), so an unconditional rescan on an
+        unchanged or shrunken path set would put an unasked-for question in
+        front of the user, and answering it would overwrite credentials and
+        delete bundles that nobody touched. Therefore, per watcher:
 
         * identical path set: skip entirely (no update, no scan),
         * paths only removed: update without forgetting the signature and

--- a/custom_components/googlefindmy/strings.json
+++ b/custom_components/googlefindmy/strings.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Keep this enabled to import the file shown above. Turn it off to pick an authentication method yourself instead."
         }
       },
+      "discovery_overwrite": {
+        "title": "Replace the stored credentials?",
+        "description": "{email} is already set up in Home Assistant, and a new credentials file has just been found.\n\nReplacing writes the new credentials into the existing entry and reloads it. Declining leaves the entry exactly as it is.",
+        "data": {
+          "overwrite_credentials": "Replace the stored credentials"
+        },
+        "data_description": {
+          "overwrite_credentials": "Keep this enabled if you have just signed in again. Turn it off to keep the credentials Home Assistant is using right now."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Run GoogleFindMyTools (Chrome) to generate authentication tokens, then paste the full contents of the Auth/secrets.json file below.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "Google Find My Device is already configured.",
+      "credentials_updated": "The stored credentials for this account were replaced with the ones that were found.",
+      "credentials_kept": "The stored credentials were kept. Nothing was changed.",
       "cannot_connect": "Failed to connect to Google Find My Device.",
       "dependency_not_ready": "Google Find My Device dependencies are not installed. Install the requirements and try again.",
       "invalid_discovery_info": "The discovery payload was invalid. Check the credentials and try again.",

--- a/custom_components/googlefindmy/translations/de.json
+++ b/custom_components/googlefindmy/translations/de.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Lass die Option aktiviert, um die oben angezeigte Datei zu importieren. Schalte sie aus, um stattdessen selbst eine Anmeldemethode zu wählen."
         }
       },
+      "discovery_overwrite": {
+        "title": "Gespeicherte Zugangsdaten ersetzen?",
+        "description": "{email} ist in Home Assistant bereits eingerichtet, und soeben wurde eine neue Zugangsdaten-Datei gefunden.\n\nBeim Ersetzen werden die neuen Zugangsdaten in den vorhandenen Eintrag geschrieben und der Eintrag wird neu geladen. Lehnst du ab, bleibt der Eintrag unverändert.",
+        "data": {
+          "overwrite_credentials": "Gespeicherte Zugangsdaten ersetzen"
+        },
+        "data_description": {
+          "overwrite_credentials": "Lass die Option aktiviert, wenn du dich gerade neu angemeldet hast. Schalte sie aus, um die Zugangsdaten zu behalten, die Home Assistant derzeit verwendet."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Führe GoogleFindMyTools (Chrome) aus, um Authentifizierungs-Tokens zu erzeugen, und füge unten den vollständigen Inhalt der Datei Auth/secrets.json ein.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "Google Find My Device ist bereits konfiguriert.",
+      "credentials_updated": "Die gespeicherten Zugangsdaten für dieses Konto wurden durch die gefundenen ersetzt.",
+      "credentials_kept": "Die gespeicherten Zugangsdaten wurden behalten. Es wurde nichts geändert.",
       "cannot_connect": "Verbindung zu Google Find My Device fehlgeschlagen.",
       "dependency_not_ready": "Google Find My Device-Abhängigkeiten sind nicht installiert. Installiere die Anforderungen und versuche es erneut.",
       "invalid_discovery_info": "Die Discovery-Nutzlast war ungültig. Überprüfe die Anmeldedaten und versuche es erneut.",

--- a/custom_components/googlefindmy/translations/en.json
+++ b/custom_components/googlefindmy/translations/en.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Keep this enabled to import the file shown above. Turn it off to pick an authentication method yourself instead."
         }
       },
+      "discovery_overwrite": {
+        "title": "Replace the stored credentials?",
+        "description": "{email} is already set up in Home Assistant, and a new credentials file has just been found.\n\nReplacing writes the new credentials into the existing entry and reloads it. Declining leaves the entry exactly as it is.",
+        "data": {
+          "overwrite_credentials": "Replace the stored credentials"
+        },
+        "data_description": {
+          "overwrite_credentials": "Keep this enabled if you have just signed in again. Turn it off to keep the credentials Home Assistant is using right now."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Run GoogleFindMyTools (Chrome) to generate authentication tokens, then paste the full contents of the Auth/secrets.json file below.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "Google Find My Device is already configured.",
+      "credentials_updated": "The stored credentials for this account were replaced with the ones that were found.",
+      "credentials_kept": "The stored credentials were kept. Nothing was changed.",
       "cannot_connect": "Failed to connect to Google Find My Device.",
       "dependency_not_ready": "Google Find My Device dependencies are not installed. Install the requirements and try again.",
       "invalid_discovery_info": "The discovery payload was invalid. Check the credentials and try again.",

--- a/custom_components/googlefindmy/translations/es.json
+++ b/custom_components/googlefindmy/translations/es.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Déjalo activado para importar el archivo mostrado arriba. Desactívalo para elegir tú mismo un método de autenticación."
         }
       },
+      "discovery_overwrite": {
+        "title": "¿Reemplazar las credenciales guardadas?",
+        "description": "{email} ya está configurado en Home Assistant y se acaba de encontrar un archivo de credenciales nuevo.\n\nAl reemplazarlas, las nuevas credenciales se escriben en la entrada existente y esta se recarga. Si lo rechazas, la entrada queda tal como está.",
+        "data": {
+          "overwrite_credentials": "Reemplazar las credenciales guardadas"
+        },
+        "data_description": {
+          "overwrite_credentials": "Déjalo activado si acabas de iniciar sesión de nuevo. Desactívalo para conservar las credenciales que Home Assistant usa ahora mismo."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Ejecuta GoogleFindMyTools (Chrome) para generar los tokens de autenticación y pega a continuación el contenido completo del archivo Auth/secrets.json.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "Google Find My Device ya está configurado.",
+      "credentials_updated": "Las credenciales guardadas de esta cuenta se reemplazaron por las encontradas.",
+      "credentials_kept": "Se conservaron las credenciales guardadas. No se cambió nada.",
       "cannot_connect": "No se pudo conectar con Google Find My Device.",
       "dependency_not_ready": "Las dependencias de Google Find My Device no están instaladas. Instala los requisitos e inténtalo de nuevo.",
       "invalid_discovery_info": "La carga de descubrimiento no es válida. Verifica las credenciales y vuelve a intentarlo.",

--- a/custom_components/googlefindmy/translations/fr.json
+++ b/custom_components/googlefindmy/translations/fr.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Laissez cette option activée pour importer le fichier affiché ci-dessus. Désactivez-la pour choisir vous-même une méthode d'authentification."
         }
       },
+      "discovery_overwrite": {
+        "title": "Remplacer les identifiants enregistrés ?",
+        "description": "{email} est déjà configuré dans Home Assistant, et un nouveau fichier d'identifiants vient d'être trouvé.\n\nLe remplacement écrit les nouveaux identifiants dans l'entrée existante et la recharge. Si vous refusez, l'entrée reste telle quelle.",
+        "data": {
+          "overwrite_credentials": "Remplacer les identifiants enregistrés"
+        },
+        "data_description": {
+          "overwrite_credentials": "Laissez cette option activée si vous venez de vous reconnecter. Désactivez-la pour conserver les identifiants que Home Assistant utilise actuellement."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Exécutez GoogleFindMyTools (Chrome) pour générer des jetons d’authentification, puis collez ci-dessous le contenu complet du fichier Auth/secrets.json.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "Google Find My Device est déjà configuré.",
+      "credentials_updated": "Les identifiants enregistrés pour ce compte ont été remplacés par ceux qui ont été trouvés.",
+      "credentials_kept": "Les identifiants enregistrés ont été conservés. Rien n'a été modifié.",
       "cannot_connect": "Échec de la connexion à Google Find My Device.",
       "dependency_not_ready": "Les dépendances de Google Find My Device ne sont pas installées. Installez les dépendances requises puis réessayez.",
       "invalid_discovery_info": "La charge de découverte est invalide. Vérifiez les identifiants et réessayez.",

--- a/custom_components/googlefindmy/translations/he.json
+++ b/custom_components/googlefindmy/translations/he.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "השאר אפשרות זו פעילה כדי לייבא את הקובץ המוצג למעלה. כבה אותה כדי לבחור בעצמך שיטת אימות."
         }
       },
+      "discovery_overwrite": {
+        "title": "להחליף את פרטי ההתחברות השמורים?",
+        "description": "{email} כבר מוגדר ב-Home Assistant, וכעת נמצא קובץ פרטי התחברות חדש.\n\nהחלפה כותבת את פרטי ההתחברות החדשים לרשומה הקיימת וטוענת אותה מחדש. אם תסרב, הרשומה תישאר כפי שהיא.",
+        "data": {
+          "overwrite_credentials": "החלפת פרטי ההתחברות השמורים"
+        },
+        "data_description": {
+          "overwrite_credentials": "השאר אפשרות זו פעילה אם התחברת זה עתה מחדש. כבה אותה כדי לשמור על פרטי ההתחברות שבהם Home Assistant משתמש כרגע."
+        }
+      },
       "secrets_json": {
         "title": "קובץ secrets.json של GoogleFindMyTools",
         "description": "יש להריץ את GoogleFindMyTools (ב-Chrome) כדי לייצר טוקנים לאימות, ולאחר מכן להדביק כאן את התוכן המלא של הקובץ Auth/secrets.json.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "Google Find My Device כבר מוגדר.",
+      "credentials_updated": "פרטי ההתחברות השמורים של חשבון זה הוחלפו בפרטים שנמצאו.",
+      "credentials_kept": "פרטי ההתחברות השמורים נשמרו. דבר לא שונה.",
       "cannot_connect": "נכשל החיבור ל-Google Find My Device.",
       "dependency_not_ready": "תלויות של Google Find My Device לא מותקנות. יש להתקין את הדרישות ולנסות שוב.",
       "invalid_discovery_info": "מטען הגילוי לא היה תקין. יש לבדוק את האישורים ולנסות שוב.",

--- a/custom_components/googlefindmy/translations/it.json
+++ b/custom_components/googlefindmy/translations/it.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Lascia l'opzione attiva per importare il file mostrato sopra. Disattivala per scegliere tu stesso un metodo di autenticazione."
         }
       },
+      "discovery_overwrite": {
+        "title": "Sostituire le credenziali salvate?",
+        "description": "{email} è già configurato in Home Assistant ed è appena stato trovato un nuovo file di credenziali.\n\nCon la sostituzione le nuove credenziali vengono scritte nella voce esistente, che viene ricaricata. Se rifiuti, la voce resta com'è.",
+        "data": {
+          "overwrite_credentials": "Sostituisci le credenziali salvate"
+        },
+        "data_description": {
+          "overwrite_credentials": "Lascia l'opzione attiva se hai appena effettuato di nuovo l'accesso. Disattivala per mantenere le credenziali che Home Assistant sta usando adesso."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Esegui GoogleFindMyTools (Chrome) per generare i token di autenticazione, quindi incolla qui sotto il contenuto completo del file Auth/secrets.json.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "Google Find My Device è già configurato.",
+      "credentials_updated": "Le credenziali salvate per questo account sono state sostituite con quelle trovate.",
+      "credentials_kept": "Le credenziali salvate sono state mantenute. Non è stato modificato nulla.",
       "cannot_connect": "Impossibile connettersi a Google Find My Device.",
       "dependency_not_ready": "Le dipendenze di Google Find My Device non sono installate. Installa i requisiti e riprova.",
       "invalid_discovery_info": "Il payload di rilevamento non è valido. Controlla le credenziali e riprova.",

--- a/custom_components/googlefindmy/translations/nl.json
+++ b/custom_components/googlefindmy/translations/nl.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Laat dit aan staan om het bestand hierboven te importeren. Zet het uit om zelf een aanmeldmethode te kiezen."
         }
       },
+      "discovery_overwrite": {
+        "title": "Opgeslagen inloggegevens vervangen?",
+        "description": "{email} is al ingesteld in Home Assistant en er is zojuist een nieuw bestand met inloggegevens gevonden.\n\nBij vervangen worden de nieuwe inloggegevens naar het bestaande item geschreven en wordt het opnieuw geladen. Als je weigert, blijft het item precies zoals het is.",
+        "data": {
+          "overwrite_credentials": "Opgeslagen inloggegevens vervangen"
+        },
+        "data_description": {
+          "overwrite_credentials": "Laat dit aan staan als je je zojuist opnieuw hebt aangemeld. Zet het uit om de inloggegevens te behouden die Home Assistant nu gebruikt."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Voer GoogleFindMyTools (Chrome) uit om authenticatietokens te genereren en plak vervolgens de volledige inhoud van het Auth/secrets.json-bestand hieronder.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "Google Find My Device is al geconfigureerd.",
+      "credentials_updated": "De opgeslagen inloggegevens voor dit account zijn vervangen door de gevonden gegevens.",
+      "credentials_kept": "De opgeslagen inloggegevens zijn behouden. Er is niets gewijzigd.",
       "cannot_connect": "Kan geen verbinding maken met Google Find My Device.",
       "dependency_not_ready": "Google Find My Device-afhankelijkheden zijn niet geïnstalleerd. Installeer de vereisten en probeer het opnieuw.",
       "invalid_discovery_info": "De discovery-payload was ongeldig. Controleer de inloggegevens en probeer het opnieuw.",

--- a/custom_components/googlefindmy/translations/pl.json
+++ b/custom_components/googlefindmy/translations/pl.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Zostaw tę opcję włączoną, aby zaimportować pokazany wyżej plik. Wyłącz ją, aby samodzielnie wybrać metodę uwierzytelniania."
         }
       },
+      "discovery_overwrite": {
+        "title": "Zastąpić zapisane poświadczenia?",
+        "description": "{email} jest już skonfigurowane w Home Assistant, a właśnie znaleziono nowy plik poświadczeń.\n\nZastąpienie zapisuje nowe poświadczenia we wpisie i przeładowuje go. Jeśli odmówisz, wpis pozostanie bez zmian.",
+        "data": {
+          "overwrite_credentials": "Zastąp zapisane poświadczenia"
+        },
+        "data_description": {
+          "overwrite_credentials": "Zostaw tę opcję włączoną, jeśli właśnie zalogowano się ponownie. Wyłącz ją, aby zachować poświadczenia, których Home Assistant używa obecnie."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Uruchom GoogleFindMyTools (Chrome), aby wygenerować tokeny uwierzytelniające, a następnie wklej poniżej pełną zawartość pliku Auth/secrets.json.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "Google Find My Device jest już skonfigurowane.",
+      "credentials_updated": "Zapisane poświadczenia tego konta zostały zastąpione znalezionymi.",
+      "credentials_kept": "Zapisane poświadczenia zostały zachowane. Nic nie zmieniono.",
       "cannot_connect": "Nie udało się połączyć z Google Find My Device.",
       "dependency_not_ready": "Zależności Google Find My Device nie są zainstalowane. Zainstaluj wymagane pakiety i spróbuj ponownie.",
       "invalid_discovery_info": "Ładunek wykrywania jest nieprawidłowy. Sprawdź dane logowania i spróbuj ponownie.",

--- a/custom_components/googlefindmy/translations/pt-BR.json
+++ b/custom_components/googlefindmy/translations/pt-BR.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Mantenha esta opção ativada para importar o arquivo mostrado acima. Desative-a para escolher você mesmo um método de autenticação."
         }
       },
+      "discovery_overwrite": {
+        "title": "Substituir as credenciais salvas?",
+        "description": "{email} já está configurado no Home Assistant e um novo arquivo de credenciais acabou de ser encontrado.\n\nA substituição grava as novas credenciais na entrada existente e a recarrega. Se você recusar, a entrada fica exatamente como está.",
+        "data": {
+          "overwrite_credentials": "Substituir as credenciais salvas"
+        },
+        "data_description": {
+          "overwrite_credentials": "Mantenha esta opção ativada se você acabou de fazer login novamente. Desative-a para manter as credenciais que o Home Assistant está usando agora."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Execute o GoogleFindMyTools (Chrome) para gerar os tokens de autenticação, depois cole abaixo o conteúdo completo do arquivo Auth/secrets.json.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "O Google Encontrar Meu Dispositivo já está configurado.",
+      "credentials_updated": "As credenciais salvas desta conta foram substituídas pelas que foram encontradas.",
+      "credentials_kept": "As credenciais salvas foram mantidas. Nada foi alterado.",
       "cannot_connect": "Falha ao conectar-se ao Encontre Meu Dispositivo do Google.",
       "dependency_not_ready": "As dependências do Encontre Meu Dispositivo do Google não estão instaladas. ",
       "invalid_discovery_info": "A carga de descoberta era inválida. ",

--- a/custom_components/googlefindmy/translations/pt.json
+++ b/custom_components/googlefindmy/translations/pt.json
@@ -23,6 +23,16 @@
           "use_found_bundle": "Mantenha esta opção ativada para importar o ficheiro mostrado acima. Desative-a para escolher por si mesmo um método de autenticação."
         }
       },
+      "discovery_overwrite": {
+        "title": "Substituir as credenciais guardadas?",
+        "description": "{email} já está configurado no Home Assistant e acabou de ser encontrado um novo ficheiro de credenciais.\n\nA substituição escreve as novas credenciais na entrada existente e volta a carregá-la. Se recusar, a entrada fica exatamente como está.",
+        "data": {
+          "overwrite_credentials": "Substituir as credenciais guardadas"
+        },
+        "data_description": {
+          "overwrite_credentials": "Mantenha esta opção ativada se acabou de iniciar sessão novamente. Desative-a para manter as credenciais que o Home Assistant está a utilizar neste momento."
+        }
+      },
       "secrets_json": {
         "title": "GoogleFindMyTools secrets.json",
         "description": "Execute GoogleFindMyTools (Chrome) para gerar tokens de autenticação e cole todo o conteúdo do arquivo Auth/secrets.json abaixo.",
@@ -118,6 +128,8 @@
     },
     "abort": {
       "already_configured": "O Encontre Meu Dispositivo do Google já está configurado.",
+      "credentials_updated": "As credenciais guardadas desta conta foram substituídas pelas que foram encontradas.",
+      "credentials_kept": "As credenciais guardadas foram mantidas. Nada foi alterado.",
       "cannot_connect": "Falha ao conectar-se ao Encontre Meu Dispositivo do Google.",
       "dependency_not_ready": "As dependências do Encontre Meu Dispositivo do Google não estão instaladas. ",
       "invalid_discovery_info": "A carga de descoberta era inválida. ",

--- a/tests/helpers/config_entries_stub.py
+++ b/tests/helpers/config_entries_stub.py
@@ -177,7 +177,16 @@ def install_config_entries_stubs(target: ModuleType) -> None:
                         None,
                     )
                     if callable(update_callable):
-                        update_callable(entry, **updates)
+                        # Home Assistant merges ``updates`` FLAT into the entry
+                        # data (``data={**entry.data, **updates}``, see
+                        # ``config_entries.ConfigFlow._abort_if_unique_id_configured``).
+                        # Splatting ``updates`` as keyword arguments instead
+                        # would accept a nested ``{"data": ...}`` payload that
+                        # the real core silently turns into a stray key, so this
+                        # double must not be more forgiving than the original.
+                        update_callable(
+                            entry, data={**dict(entry.data), **dict(updates)}
+                        )
 
                     if reload:
                         reload_callable = getattr(

--- a/tests/test_config_entries_stub_abort_semantics.py
+++ b/tests/test_config_entries_stub_abort_semantics.py
@@ -1,0 +1,99 @@
+# tests/test_config_entries_stub_abort_semantics.py
+"""Pin the config-entries double to Home Assistant's ``updates`` semantics.
+
+``ConfigFlow._abort_if_unique_id_configured`` in Home Assistant merges its
+``updates`` payload *flat* into the entry::
+
+    self.hass.config_entries.async_update_entry(entry, data={**entry.data, **updates})
+
+The double in ``tests/helpers/config_entries_stub.py`` used to splat the payload
+as keyword arguments instead (``async_update_entry(entry, **updates)``). That is
+strictly more forgiving: a nested ``{"data": {...}}`` payload looks correct under
+the double and silently becomes a stray ``data`` key inside ``entry.data`` under
+the real core. A discovery defect lived behind exactly that gap, so the semantics
+are pinned here rather than left to the callers that happen to exercise them.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+from typing import Any
+
+from tests.helpers.config_entries_stub import install_config_entries_stubs
+
+
+def _make_flow_class() -> type[Any]:
+    """Return a freshly stubbed ``ConfigFlow`` class, isolated per test."""
+
+    module = ModuleType("homeassistant.config_entries.__stub_for_test__")
+    install_config_entries_stubs(module)
+    return module.ConfigFlow  # type: ignore[attr-defined,no-any-return]
+
+
+class _Entry:
+    def __init__(self) -> None:
+        self.entry_id = "entry-1"
+        self.unique_id = "account-1"
+        self.data: dict[str, Any] = {"google_email": "user@example.com", "token": "old"}
+
+
+class _ConfigEntries:
+    def __init__(self, entry: _Entry) -> None:
+        self._entry = entry
+        self.updated: list[tuple[Any, dict[str, Any]]] = []
+
+    def async_entries(self, _domain: str | None = None) -> list[_Entry]:
+        return [self._entry]
+
+    def async_update_entry(self, target: Any, **kwargs: Any) -> None:
+        self.updated.append((target, kwargs))
+        if "data" in kwargs:
+            target.data = dict(kwargs["data"])
+
+
+class _Hass:
+    def __init__(self, entry: _Entry) -> None:
+        self.config_entries = _ConfigEntries(entry)
+
+
+def _run_abort(updates: dict[str, Any]) -> tuple[_Entry, _ConfigEntries]:
+    entry = _Entry()
+    hass = _Hass(entry)
+    flow_cls = _make_flow_class()
+    flow = flow_cls()
+    flow.hass = hass
+    flow.unique_id = entry.unique_id
+    flow._abort_if_unique_id_configured(updates=updates, reload=False)
+    return entry, hass.config_entries
+
+
+def test_stub_merges_updates_flat_into_entry_data() -> None:
+    """A flat payload must merge, leaving untouched keys in place."""
+
+    entry, manager = _run_abort({"token": "new"})
+
+    assert manager.updated, "the double did not update the entry at all"
+    _target, kwargs = manager.updated[0]
+    assert set(kwargs) == {"data"}, (
+        "Home Assistant passes the merged mapping as the single ``data`` keyword"
+    )
+    assert entry.data["token"] == "new"
+    assert entry.data["google_email"] == "user@example.com"
+
+
+def test_stub_does_not_absorb_a_nested_data_payload() -> None:
+    """A nested payload must land as a stray key, exactly as the real core does.
+
+    This is the failure the double used to hide. It is asserted, not fixed: the
+    double's job is to reproduce Home Assistant, and production code must hand
+    over a flat payload.
+    """
+
+    entry, _manager = _run_abort({"data": {"token": "new"}})
+
+    assert entry.data["token"] == "old", (
+        "a nested payload must NOT update the credential"
+    )
+    assert entry.data["data"] == {"token": "new"}, (
+        "a nested payload lands as a stray 'data' key inside entry.data"
+    )

--- a/tests/test_config_flow_container_login.py
+++ b/tests/test_config_flow_container_login.py
@@ -3857,7 +3857,7 @@ async def test_discovery_create_branch_marks_its_own_late_staged_ticket() -> Non
     )
     flow._discovery_confirm_pending = True  # type: ignore[attr-defined]
     flow._pending_discovery_payload = payload  # type: ignore[attr-defined]
-    flow._pending_discovery_updates = None  # type: ignore[attr-defined]
+    flow._pending_discovery_entry_exists = False  # type: ignore[attr-defined]
 
     async def _created() -> Any:
         # Mirrors what the create path does right before returning: mark, then

--- a/tests/test_config_flow_container_login.py
+++ b/tests/test_config_flow_container_login.py
@@ -3858,7 +3858,6 @@ async def test_discovery_create_branch_marks_its_own_late_staged_ticket() -> Non
     flow._discovery_confirm_pending = True  # type: ignore[attr-defined]
     flow._pending_discovery_payload = payload  # type: ignore[attr-defined]
     flow._pending_discovery_updates = None  # type: ignore[attr-defined]
-    flow._pending_discovery_existing_entry = None  # type: ignore[attr-defined]
 
     async def _created() -> Any:
         # Mirrors what the create path does right before returning: mark, then

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.helpers import frame
 
 from custom_components.googlefindmy import config_flow
@@ -327,8 +328,11 @@ def test_async_step_discovery_existing_entry_updates(
             existing_entry=entry,
         )
         assert updates is not None
-        assert updates["data"][CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE"
-        assert updates["data"].get(DATA_SECRET_BUNDLE) is None
+        # Flat, not ``{"data": ...}``: Home Assistant merges the payload into
+        # ``entry.data`` directly.
+        assert "data" not in updates
+        assert updates[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE"
+        assert updates.get(DATA_SECRET_BUNDLE) is None
 
         abort_calls: list[dict[str, Any] | None] = []
         recorded_forms = record_flow_forms(flow)
@@ -352,8 +356,9 @@ def test_async_step_discovery_existing_entry_updates(
         assert len(abort_calls) == 1
         payload = abort_calls[0]
         assert payload is not None
-        data_updates = payload.get("data", {}) if isinstance(payload, dict) else {}
-        assert data_updates.get(CONF_OAUTH_TOKEN) == "aas_et/NEW_TOKEN_VALUE"
+        assert isinstance(payload, dict)
+        assert "data" not in payload
+        assert payload.get(CONF_OAUTH_TOKEN) == "aas_et/NEW_TOKEN_VALUE"
         assert recorded_forms == ["discovery"]
         return discovery_form, abort_result, abort_calls, recorded_forms
 
@@ -363,6 +368,135 @@ def test_async_step_discovery_existing_entry_updates(
     assert len(abort_calls) == 1
     assert abort_result["type"] == "abort"
     assert abort_result["reason"] == "already_configured"
+
+
+def test_discovery_confirmation_replaces_credentials_in_entry_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Confirming a discovery for a configured account must replace the token.
+
+    Regression guard for the nested-payload defect. ``updates`` used to be
+    ``{"data": {...}}``, but Home Assistant merges the payload *flat*
+    (``data={**entry.data, **updates}``): the stored ``oauth_token`` kept its old
+    value while a stray ``data`` key appeared beside it, and the resulting
+    ``changed=True`` reloaded the entry, so it looked like it had worked.
+
+    The assertions deliberately inspect ``entry.data`` rather than the payload
+    handed to the abort helper. Checking the argument is exactly what let the
+    defect through.
+    """
+
+    async def _fake_pick(
+        hass: Any,
+        email: str,
+        candidates: list[tuple[str, str]],
+        *,
+        secrets_bundle: dict[str, Any] | None = None,
+    ) -> str | None:
+        return candidates[0][1]
+
+    monkeypatch.setattr(config_flow, "async_pick_working_token", _fake_pick)
+
+    class _Entry:
+        def __init__(self) -> None:
+            self.entry_id = "existing-entry"
+            self.unique_id = unique_account_id("existing@example.com")
+            self.data: dict[str, Any] = {
+                CONF_GOOGLE_EMAIL: "existing@example.com",
+                CONF_OAUTH_TOKEN: "aas_et/OLD_TOKEN_VALUE",
+            }
+            self.subentries: dict[str, Any] = {}
+            # Home Assistant's own ``_abort_if_unique_id_configured`` runs here,
+            # so the entry has to answer the attributes that helper reads.
+            self.state = ConfigEntryState.LOADED
+            self.source = "user"
+            self.domain = config_flow.DOMAIN
+
+    entry = _Entry()
+
+    class _ConfigEntries(ConfigEntriesDomainUniqueIdLookupMixin):
+        def __init__(self) -> None:
+            self.reloaded: list[str] = []
+            self.setup_calls: list[str] = []
+            attach_config_entries_flow_manager(self)
+
+        def async_entries(self, domain: str) -> list[Any]:
+            assert domain == config_flow.DOMAIN
+            return [entry]
+
+        def async_update_entry(self, target: Any, **updates: Any) -> bool:
+            # Mirror Home Assistant: the ``data`` keyword replaces the mapping
+            # wholesale; the merge happened in the caller.
+            if "data" in updates:
+                target.data = dict(updates["data"])
+            return True
+
+        def async_reload(self, entry_id: str) -> None:
+            self.reloaded.append(entry_id)
+
+        def async_get_entry(self, entry_id: str) -> Any | None:
+            return entry if entry_id == entry.entry_id else None
+
+        def async_get_subentries(self, entry_id: str) -> list[Any]:
+            return []
+
+        async def async_setup(self, entry_id: str) -> bool:
+            self.setup_calls.append(entry_id)
+            return True
+
+    class _FlowHass:
+        def __init__(self) -> None:
+            prepare_flow_hass_config_entries(
+                self,
+                _ConfigEntries,
+                frame_module=frame,
+            )
+
+    async def _exercise() -> tuple[dict[str, Any], dict[str, Any]]:
+        hass = _FlowHass()
+        flow = config_flow.ConfigFlow()
+        flow.hass = hass  # type: ignore[assignment]
+        flow.context = {}
+        set_config_flow_unique_id(flow, None)
+
+        async def _set_unique_id(
+            value: str, *, raise_on_progress: bool = False
+        ) -> None:
+            set_config_flow_unique_id(flow, value)
+
+        flow.async_set_unique_id = _set_unique_id  # type: ignore[assignment]
+
+        payload = {
+            CONF_GOOGLE_EMAIL: "existing@example.com",
+            "candidate_tokens": ["aas_et/NEW_TOKEN_VALUE"],
+        }
+
+        form = await flow.async_step_discovery(payload)
+        if inspect.isawaitable(form):
+            form = await form
+        assert form["type"] == "form"
+        assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE", (
+            "showing the confirmation form must not write anything yet"
+        )
+
+        confirmed = await flow.async_step_discovery({})
+        if inspect.isawaitable(confirmed):
+            confirmed = await confirmed
+        return form, confirmed
+
+    form, confirmed = asyncio.run(_exercise())
+
+    assert form.get("step_id") == "discovery"
+    assert confirmed["type"] == "abort"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE", (
+        "the confirmed discovery must replace the stored credentials"
+    )
+    assert "data" not in entry.data, (
+        "a nested 'data' key inside entry.data is the defect signature"
+    )
+    assert entry.data[CONF_GOOGLE_EMAIL] == "existing@example.com", (
+        "unrelated entry data must survive the merge"
+    )
 
 
 def test_async_step_discovery_update_info_existing_entry(
@@ -439,7 +573,7 @@ def test_async_step_discovery_update_info_existing_entry(
         assert existing_entry is entry
         return (
             {"data": {CONF_OAUTH_TOKEN: "unused"}},
-            {"data": {CONF_OAUTH_TOKEN: "aas_et/UPDATED"}},
+            {CONF_OAUTH_TOKEN: "aas_et/UPDATED"},
         )
 
     monkeypatch.setattr(

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -381,7 +381,7 @@ def test_async_step_discovery_existing_entry_updates(
     assert abort_result["reason"] == "credentials_updated"
 
 
-def _drive_discovery_overwrite(
+async def _drive_discovery_overwrite(
     monkeypatch: pytest.MonkeyPatch, *, answer: bool
 ) -> tuple[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
     """Drive a discovery for an already configured account to ``answer``.
@@ -459,54 +459,50 @@ def _drive_discovery_overwrite(
                 frame_module=frame,
             )
 
-    async def _exercise() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-        hass = _FlowHass()
-        flow = config_flow.ConfigFlow()
-        flow.hass = hass  # type: ignore[assignment]
-        flow.context = {}
-        set_config_flow_unique_id(flow, None)
+    hass = _FlowHass()
+    flow = config_flow.ConfigFlow()
+    flow.hass = hass  # type: ignore[assignment]
+    flow.context = {}
+    set_config_flow_unique_id(flow, None)
 
-        async def _set_unique_id(
-            value: str, *, raise_on_progress: bool = False
-        ) -> None:
-            set_config_flow_unique_id(flow, value)
+    async def _set_unique_id(value: str, *, raise_on_progress: bool = False) -> None:
+        set_config_flow_unique_id(flow, value)
 
-        flow.async_set_unique_id = _set_unique_id  # type: ignore[assignment]
+    flow.async_set_unique_id = _set_unique_id  # type: ignore[assignment]
 
-        payload = {
-            CONF_GOOGLE_EMAIL: "existing@example.com",
-            "candidate_tokens": ["aas_et/NEW_TOKEN_VALUE"],
-        }
+    payload = {
+        CONF_GOOGLE_EMAIL: "existing@example.com",
+        "candidate_tokens": ["aas_et/NEW_TOKEN_VALUE"],
+    }
 
-        form = await flow.async_step_discovery(payload)
-        if inspect.isawaitable(form):
-            form = await form
-        assert form["type"] == "form"
-        assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE", (
-            "showing the confirmation form must not write anything yet"
-        )
+    form = await flow.async_step_discovery(payload)
+    if inspect.isawaitable(form):
+        form = await form
+    assert form["type"] == "form"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE", (
+        "showing the confirmation form must not write anything yet"
+    )
 
-        question = await flow.async_step_discovery({})
-        if inspect.isawaitable(question):
-            question = await question
-        assert question["type"] == "form"
-        assert question.get("step_id") == "discovery_overwrite"
-        assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE", (
-            "asking the question must not write anything yet"
-        )
+    question = await flow.async_step_discovery({})
+    if inspect.isawaitable(question):
+        question = await question
+    assert question["type"] == "form"
+    assert question.get("step_id") == "discovery_overwrite"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE", (
+        "asking the question must not write anything yet"
+    )
 
-        result = await flow.async_step_discovery_overwrite(
-            {config_flow._FIELD_OVERWRITE_CREDENTIALS: answer}
-        )
-        if inspect.isawaitable(result):
-            result = await result
-        return form, question, result
+    result = await flow.async_step_discovery_overwrite(
+        {config_flow._FIELD_OVERWRITE_CREDENTIALS: answer}
+    )
+    if inspect.isawaitable(result):
+        result = await result
 
-    form, question, result = asyncio.run(_exercise())
     return entry, form, question, result
 
 
-def test_discovery_overwrite_confirmed_replaces_credentials_in_entry_data(
+@pytest.mark.asyncio
+async def test_discovery_overwrite_confirmed_replaces_credentials_in_entry_data(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Answering yes must replace the stored credentials, flat, in ``entry.data``.
@@ -518,7 +514,9 @@ def test_discovery_overwrite_confirmed_replaces_credentials_in_entry_data(
     ``changed=True`` reloaded the entry, so it looked like it had worked.
     """
 
-    entry, form, question, result = _drive_discovery_overwrite(monkeypatch, answer=True)
+    entry, form, question, result = await _drive_discovery_overwrite(
+        monkeypatch, answer=True
+    )
 
     assert form.get("step_id") == "discovery"
     assert question.get("step_id") == "discovery_overwrite"
@@ -535,7 +533,8 @@ def test_discovery_overwrite_confirmed_replaces_credentials_in_entry_data(
     )
 
 
-def test_discovery_overwrite_declined_keeps_stored_credentials(
+@pytest.mark.asyncio
+async def test_discovery_overwrite_declined_keeps_stored_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Answering no must write nothing and say so.
@@ -544,7 +543,7 @@ def test_discovery_overwrite_declined_keeps_stored_credentials(
     the only reason the question is worth asking.
     """
 
-    entry, _form, _question, result = _drive_discovery_overwrite(
+    entry, _form, _question, result = await _drive_discovery_overwrite(
         monkeypatch, answer=False
     )
 

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -381,16 +381,15 @@ def test_async_step_discovery_existing_entry_updates(
     assert abort_result["reason"] == "credentials_updated"
 
 
-async def _drive_discovery_overwrite(
-    monkeypatch: pytest.MonkeyPatch, *, answer: bool
-) -> tuple[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
-    """Drive a discovery for an already configured account to ``answer``.
+async def _prepare_configured_account_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Any, Any]:
+    """Return ``(entry, flow)`` for an account that is already configured.
 
-    Returns ``(entry, discovery_card, overwrite_question, result)``. The entry is
-    a live object: the manager stub applies ``async_update_entry`` to it, so the
-    callers can assert on ``entry.data`` instead of on the payload handed to the
-    abort helper. Checking the argument is exactly what let the nested-payload
-    defect through.
+    The entry is a live object: the manager stub applies ``async_update_entry``
+    to it, so callers can assert on ``entry.data`` instead of on the payload
+    handed to the abort helper. Checking the argument is exactly what let the
+    nested-payload defect through.
     """
 
     async def _fake_pick(
@@ -470,10 +469,36 @@ async def _drive_discovery_overwrite(
 
     flow.async_set_unique_id = _set_unique_id  # type: ignore[assignment]
 
-    payload = {
+    return entry, flow
+
+
+def _discovery_payload_for_configured_account(
+    discovery_source: str | None = None,
+) -> dict[str, Any]:
+    """Return a discovery payload carrying fresh credentials for that account."""
+
+    payload: dict[str, Any] = {
         CONF_GOOGLE_EMAIL: "existing@example.com",
         "candidate_tokens": ["aas_et/NEW_TOKEN_VALUE"],
     }
+    if discovery_source is not None:
+        payload["discovery_source"] = discovery_source
+    return payload
+
+
+async def _drive_discovery_overwrite(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    answer: bool,
+    discovery_source: str | None = None,
+) -> tuple[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Drive a discovery for an already configured account to ``answer``.
+
+    Returns ``(entry, discovery_card, overwrite_question, result)``.
+    """
+
+    entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    payload = _discovery_payload_for_configured_account(discovery_source)
 
     form = await flow.async_step_discovery(payload)
     if inspect.isawaitable(form):
@@ -555,6 +580,73 @@ async def test_discovery_overwrite_declined_keeps_stored_credentials(
         "declining must leave the stored credentials untouched"
     )
     assert "data" not in entry.data
+
+
+@pytest.mark.asyncio
+async def test_discovery_from_tracker_rescan_does_not_ask_to_overwrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tracker rescan must not raise the overwrite question.
+
+    ``device_tracker.py`` re-submits the credentials the entry already stores
+    whenever it spots new trackers. Asking whether to replace them with
+    themselves would be a dialog about nothing, and its text would claim a
+    credentials file had been found when none was. The context source cannot
+    tell the producers apart (``discovery.py`` downgrades every non-Home-
+    Assistant source to plain ``discovery``), so the payload marker decides.
+    """
+
+    entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    payload = _discovery_payload_for_configured_account(
+        config_flow.CLOUD_SCANNER_DISCOVERY_SOURCE
+    )
+
+    form = await flow.async_step_discovery(payload)
+    if inspect.isawaitable(form):
+        form = await form
+    assert form["type"] == "form"
+
+    result = await flow.async_step_discovery({})
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result["type"] == "abort", (
+        "a rescan of an already configured account must not open a dialog"
+    )
+    assert result.get("step_id") != "discovery_overwrite"
+    assert result["reason"] == "already_configured", (
+        "the rescan keeps the abort behaviour it had before the dialog existed"
+    )
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE", (
+        "the rescan still applies its payload, exactly as it did before"
+    )
+    assert "data" not in entry.data
+
+
+@pytest.mark.asyncio
+async def test_discovery_from_watched_file_update_still_asks_to_overwrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real credential import must keep the question.
+
+    This is the case the dialog exists for: the file watcher spots a fresh
+    ``secrets.json`` for an account that is already configured. It marks such a
+    payload ``discovery_update_info``, which Home Assistant does not know as a
+    source, so the flow arrives here under the ordinary ``discovery`` context
+    just like a rescan does. Gating on the context instead of the payload would
+    have silenced exactly this dialog.
+    """
+
+    entry, form, question, result = await _drive_discovery_overwrite(
+        monkeypatch,
+        answer=True,
+        discovery_source=config_flow.DISCOVERY_UPDATE_SOURCE,
+    )
+
+    assert form.get("step_id") == "discovery"
+    assert question.get("step_id") == "discovery_overwrite"
+    assert result["reason"] == "credentials_updated"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE"
 
 
 def test_async_step_discovery_update_info_existing_entry(

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -8,6 +8,7 @@ import inspect
 import json
 import types
 from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -417,6 +418,10 @@ async def _prepare_configured_account_flow(
             self.state = ConfigEntryState.LOADED
             self.source = "user"
             self.domain = config_flow.DOMAIN
+            # The durability watermark the delete-after-import ticket is gated
+            # on. Without it the staging drops the job by design, so a stub
+            # lacking it would make the cleanup assertions vacuously pass.
+            self.modified_at = datetime(2026, 1, 1, tzinfo=UTC)
 
     entry = _Entry()
 
@@ -458,6 +463,9 @@ async def _prepare_configured_account_flow(
 
     class _FlowHass:
         def __init__(self) -> None:
+            # The staging area of the delete-after-import tickets lives in
+            # ``hass.data``; a stub without it could not observe them.
+            self.data: dict[str, Any] = {}
             prepare_flow_hass_config_entries(
                 self,
                 _ConfigEntries,
@@ -497,10 +505,12 @@ async def _drive_discovery_overwrite(
     *,
     answer: bool,
     discovery_source: str | None = None,
-) -> tuple[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
+) -> tuple[Any, dict[str, Any], dict[str, Any], dict[str, Any], Any]:
     """Drive a discovery for an already configured account to ``answer``.
 
-    Returns ``(entry, discovery_card, overwrite_question, result)``.
+    Returns ``(entry, discovery_card, overwrite_question, result, flow)``. The
+    flow comes last so callers that only assert on the outcome can ignore it;
+    the cleanup-staging guards need it to reach ``flow.hass.data``.
     """
 
     entry, flow = await _prepare_configured_account_flow(monkeypatch)
@@ -529,7 +539,7 @@ async def _drive_discovery_overwrite(
     if inspect.isawaitable(result):
         result = await result
 
-    return entry, form, question, result
+    return entry, form, question, result, flow
 
 
 @pytest.mark.asyncio
@@ -545,7 +555,7 @@ async def test_discovery_overwrite_confirmed_replaces_credentials_in_entry_data(
     ``changed=True`` reloaded the entry, so it looked like it had worked.
     """
 
-    entry, form, question, result = await _drive_discovery_overwrite(
+    entry, form, question, result, _flow = await _drive_discovery_overwrite(
         monkeypatch, answer=True
     )
 
@@ -574,7 +584,7 @@ async def test_discovery_overwrite_declined_keeps_stored_credentials(
     the only reason the question is worth asking.
     """
 
-    entry, _form, _question, result = await _drive_discovery_overwrite(
+    entry, _form, _question, result, _flow = await _drive_discovery_overwrite(
         monkeypatch, answer=False
     )
 
@@ -748,7 +758,7 @@ async def test_discovery_from_watched_file_update_still_asks_to_overwrite(
     have silenced exactly this dialog.
     """
 
-    entry, form, question, result = await _drive_discovery_overwrite(
+    entry, form, question, result, _flow = await _drive_discovery_overwrite(
         monkeypatch,
         answer=True,
         discovery_source=config_flow.DISCOVERY_UPDATE_SOURCE,
@@ -758,6 +768,71 @@ async def test_discovery_from_watched_file_update_still_asks_to_overwrite(
     assert question.get("step_id") == "discovery_overwrite"
     assert result["reason"] == "credentials_updated"
     assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE"
+
+
+def _staged_cleanup_tickets(flow: Any) -> list[Any]:
+    """Return the delete-after-import tickets staged on ``flow.hass``."""
+
+    bucket = flow.hass.data.get(config_flow.DOMAIN) or {}
+    return list(bucket.get(config_flow.PENDING_CONTAINER_CLEANUP_KEY) or [])
+
+
+@pytest.mark.asyncio
+async def test_discovery_overwrite_confirmed_stages_the_bundle_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An accepted overwrite must consume the bundle that carried it.
+
+    The watcher remembers a processed bundle only in the process-local
+    ``DiscoveryManager._settled_signatures``. Writing the credentials without
+    staging the delete-after-import cleanup therefore ends the question for this
+    Home Assistant run only: the next restart starts with an empty signature
+    set, rediscovers the unchanged file and asks again, forever. The
+    non-interactive update path stages exactly this ticket, and the interactive
+    one has to match it.
+    """
+
+    entry, _form, _question, result, flow = await _drive_discovery_overwrite(
+        monkeypatch, answer=True
+    )
+
+    assert result["reason"] == "credentials_updated"
+
+    tickets = _staged_cleanup_tickets(flow)
+    assert len(tickets) == 1, "the accepted bundle must be staged for deletion"
+    ticket = tickets[0]
+    assert ticket.entry_id == entry.entry_id, (
+        "an update-path ticket names its entry; without that correlation Home "
+        "Assistant's flow removal would discard it right after this abort"
+    )
+    assert ticket.min_modified_at == entry.modified_at, (
+        "the durability watermark is what keeps the delete behind the store save"
+    )
+    assert len(ticket.jobs) == 1
+    assert ticket.jobs[0].imported_stable_key is not None, (
+        "a job without a stable key would not identify the bundle to remove"
+    )
+
+
+@pytest.mark.asyncio
+async def test_discovery_overwrite_declined_keeps_the_bundle_on_disk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A declined overwrite must leave the file where it is.
+
+    The counter-direction of the guard above: staging the cleanup on both
+    answers would delete the credentials the user just refused to apply, and the
+    refusal only means something as long as the file stays available.
+    """
+
+    _entry, _form, _question, result, flow = await _drive_discovery_overwrite(
+        monkeypatch, answer=False
+    )
+
+    assert result["reason"] == "credentials_kept"
+    assert _staged_cleanup_tickets(flow) == [], (
+        "declining must not schedule the deletion of the declined bundle"
+    )
 
 
 def test_async_step_discovery_update_info_existing_entry(

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -423,6 +423,7 @@ async def _prepare_configured_account_flow(
     class _ConfigEntries(ConfigEntriesDomainUniqueIdLookupMixin):
         def __init__(self) -> None:
             self.reloaded: list[str] = []
+            self.scheduled_reloads: list[str] = []
             self.setup_calls: list[str] = []
             attach_config_entries_flow_manager(self)
 
@@ -439,6 +440,11 @@ async def _prepare_configured_account_flow(
 
         def async_reload(self, entry_id: str) -> None:
             self.reloaded.append(entry_id)
+
+        def async_schedule_reload(self, entry_id: str) -> None:
+            # Home Assistant's own unique-id guard calls this after a changed
+            # entry, and so does the explicit write for a bound flow.
+            self.scheduled_reloads.append(entry_id)
 
         def async_get_entry(self, entry_id: str) -> Any | None:
             return entry if entry_id == entry.entry_id else None
@@ -621,6 +627,111 @@ async def test_discovery_from_tracker_rescan_does_not_ask_to_overwrite(
         "the rescan still applies its payload, exactly as it did before"
     )
     assert "data" not in entry.data
+
+
+@pytest.mark.asyncio
+async def test_discovery_overwrite_imports_when_the_entry_disappeared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A vanished entry must not be reported as a completed overwrite.
+
+    The question stays on screen for as long as the user needs, and the entry
+    can be deleted (or have its account identity changed) in the meantime. The
+    unique-id guard then finds nothing, returns instead of aborting, and writes
+    nothing at all: reporting ``credentials_updated`` there would name an event
+    that did not happen. The credentials are still in hand, so the confirmed
+    import continues as a first import instead of being dropped.
+    """
+
+    entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    payload = _discovery_payload_for_configured_account()
+
+    form = await flow.async_step_discovery(payload)
+    if inspect.isawaitable(form):
+        form = await form
+    assert form["type"] == "form"
+
+    question = await flow.async_step_discovery({})
+    if inspect.isawaitable(question):
+        question = await question
+    assert question.get("step_id") == "discovery_overwrite"
+
+    # The user removes the integration while the question is on screen.
+    monkeypatch.setattr(
+        flow.hass.config_entries, "async_entries", lambda domain: [], raising=False
+    )
+
+    device_selection_calls: list[str] = []
+
+    async def _fake_device_selection() -> dict[str, Any]:
+        device_selection_calls.append("called")
+        return {"type": "form", "step_id": "device_selection"}
+
+    monkeypatch.setattr(
+        flow, "async_step_device_selection", _fake_device_selection, raising=False
+    )
+
+    result = await flow.async_step_discovery_overwrite(
+        {config_flow._FIELD_OVERWRITE_CREDENTIALS: True}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert device_selection_calls == ["called"], (
+        "the confirmed credentials must be imported, not dropped"
+    )
+    assert result["type"] == "form", (
+        "an abort here would end the flow with nothing written"
+    )
+    assert result.get("step_id") == "device_selection"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE", (
+        "the removed entry must not be written to behind the user's back"
+    )
+
+
+@pytest.mark.asyncio
+async def test_discovery_overwrite_writes_when_the_flow_is_bound_to_the_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flow bound to the entry must still write what it reports.
+
+    ``_async_prepare_account_context`` returns the entry unchanged when the
+    flow already belongs to it (``context["entry_id"]``), because the
+    unique-id guard is what normally performs the write and it is skipped in
+    that case. Without an explicit write the step would report replaced
+    credentials over unchanged entry data.
+    """
+
+    entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    flow.context = {"entry_id": entry.entry_id}
+    payload = _discovery_payload_for_configured_account()
+
+    form = await flow.async_step_discovery(payload)
+    if inspect.isawaitable(form):
+        form = await form
+    assert form["type"] == "form"
+
+    question = await flow.async_step_discovery({})
+    if inspect.isawaitable(question):
+        question = await question
+    assert question.get("step_id") == "discovery_overwrite"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE"
+
+    result = await flow.async_step_discovery_overwrite(
+        {config_flow._FIELD_OVERWRITE_CREDENTIALS: True}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "credentials_updated"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE", (
+        "reporting the replacement requires having performed it"
+    )
+    assert "data" not in entry.data
+    assert flow.hass.config_entries.scheduled_reloads == [entry.entry_id], (
+        "the running integration keeps the old credentials until it reloads"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -856,6 +856,58 @@ async def test_discovery_overwrite_does_not_write_twice_after_the_guard_wrote(
 
 
 @pytest.mark.asyncio
+async def test_discovery_overwrite_drops_credentials_the_guard_cannot_remove(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A superseded secrets bundle must not survive an accepted overwrite.
+
+    ``updates`` expresses a removal by leaving an optional credential key out,
+    but Home Assistant's guard merges flat (``{**entry.data, **updates}``) and
+    can only add or replace. Judging the write complete from the keys present in
+    ``updates`` therefore skipped the wholesale write while the old
+    ``secrets_data`` was still in the entry, and the reload that follows seeds
+    exactly that value into the entry-scoped token cache
+    (``__init__.async_setup_entry``): old and new credentials side by side.
+    """
+
+    entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    # Credentials from an earlier secrets.json import. The discovered ones are
+    # an individual token, so they carry no bundle and the old one is obsolete.
+    entry.data[DATA_SECRET_BUNDLE] = {"owner_key": "STALE_OWNER_KEY"}
+    entry.data[DATA_AAS_TOKEN] = "aas_et/OLD_TOKEN_VALUE"
+
+    payload = _discovery_payload_for_configured_account()
+
+    form = await flow.async_step_discovery(payload)
+    if inspect.isawaitable(form):
+        form = await form
+    assert form["type"] == "form"
+
+    question = await flow.async_step_discovery({})
+    if inspect.isawaitable(question):
+        question = await question
+    assert question.get("step_id") == "discovery_overwrite"
+
+    result = await flow.async_step_discovery_overwrite(
+        {config_flow._FIELD_OVERWRITE_CREDENTIALS: True}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "credentials_updated"
+    assert DATA_SECRET_BUNDLE not in entry.data, (
+        "the replaced bundle stays readable for the token cache unless the "
+        "step writes the payload wholesale"
+    )
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE"
+    assert entry.data[DATA_AAS_TOKEN] == "aas_et/NEW_TOKEN_VALUE"
+    assert flow.hass.config_entries.scheduled_reloads == [entry.entry_id], (
+        "the running integration keeps the old credentials until it reloads"
+    )
+
+
+@pytest.mark.asyncio
 async def test_discovery_overwrite_rebases_onto_data_written_while_asking(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -856,6 +856,130 @@ async def test_discovery_overwrite_does_not_write_twice_after_the_guard_wrote(
 
 
 @pytest.mark.asyncio
+async def test_discovery_overwrite_rebases_onto_data_written_while_asking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A write that lands while the question is open must survive the answer.
+
+    The payload used to be merged from ``entry.data`` when the discovery card
+    was built, which is one or two user decisions before it is written. Anything
+    that changed the entry in between -- the options flow refreshes credentials
+    through the login container, for one -- was silently rolled back to the
+    value the snapshot had captured.
+    """
+
+    entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    entry.data["polling_interval"] = 60
+
+    payload = _discovery_payload_for_configured_account()
+
+    form = await flow.async_step_discovery(payload)
+    if inspect.isawaitable(form):
+        form = await form
+    assert form["type"] == "form"
+
+    question = await flow.async_step_discovery({})
+    if inspect.isawaitable(question):
+        question = await question
+    assert question.get("step_id") == "discovery_overwrite"
+
+    # Somebody else updates the very entry this flow is about to overwrite,
+    # exactly as ``_async_options_container_persist`` does.
+    entry.data = {**entry.data, "polling_interval": 300}
+
+    result = await flow.async_step_discovery_overwrite(
+        {config_flow._FIELD_OVERWRITE_CREDENTIALS: True}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "credentials_updated"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE", (
+        "the answer was yes, so the discovered credentials must land"
+    )
+    assert entry.data["polling_interval"] == 300, (
+        "the overwrite must rebase onto the current entry data; writing the "
+        "snapshot taken before the question rolls the other write back"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rebased_updates_drop_credentials_the_new_ones_replaced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The counter-direction: the rebase is a full payload, not a bare delta.
+
+    Only a full payload can *remove* a key, and credentials that no longer come
+    with a secrets bundle must not leave the old bundle behind. A rebase reduced
+    to "merge the new values in" would keep it and the entry would carry two
+    generations of credentials at once.
+    """
+
+    entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    entry.data[config_flow.DATA_SECRET_BUNDLE] = {"stale": "bundle"}
+
+    rebased = flow._async_rebase_credential_updates(
+        "existing@example.com",
+        {
+            CONF_GOOGLE_EMAIL: "existing@example.com",
+            CONF_OAUTH_TOKEN: "aas_et/NEW_TOKEN_VALUE",
+        },
+    )
+
+    assert rebased is not None
+    resolved_entry, updates = rebased
+    assert resolved_entry is entry
+    assert updates[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE"
+    assert config_flow.DATA_SECRET_BUNDLE not in updates, (
+        "credentials without a bundle must clear the stored one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_discovery_rescan_aborts_when_the_entry_vanished_while_confirming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rescan whose account disappeared must abort, not import.
+
+    The rescan path resolves the entry when the answer arrives rather than
+    trusting the one it saw earlier. With no entry left there is nothing to
+    update, and creating one is not what a rescan of a configured account
+    means -- that would turn a background scan into an unrequested import.
+    """
+
+    _entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    payload = _discovery_payload_for_configured_account(
+        discovery_source="cloud_scanner"
+    )
+
+    form = await flow.async_step_discovery(payload)
+    if inspect.isawaitable(form):
+        form = await form
+    assert form["type"] == "form"
+
+    imported = False
+
+    async def _never_imports() -> Any:
+        nonlocal imported
+        imported = True
+        return {"type": config_flow.data_entry_flow.FlowResultType.CREATE_ENTRY}
+
+    flow.async_step_device_selection = _never_imports  # type: ignore[assignment]
+    monkeypatch.setattr(
+        flow.hass.config_entries, "async_entries", lambda domain: [], raising=False
+    )
+
+    result = await flow.async_step_discovery({})
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    assert not imported, "a rescan must never create an entry on its own"
+
+
+@pytest.mark.asyncio
 async def test_discovery_from_watched_file_update_still_asks_to_overwrite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -340,6 +340,13 @@ def test_async_step_discovery_existing_entry_updates(
 
         def _abort_helper(*, updates: dict[str, Any] | None = None, **_: Any) -> None:
             abort_calls.append(updates)
+            if updates:
+                # Mirror the core: the guard writes ``updates`` flat into the
+                # entry and only then ends the flow. A double that merely
+                # records models a guard that wrote nothing at all, which is a
+                # real but different outcome -- and one the step must no longer
+                # report as a completed overwrite.
+                entry.data = {**entry.data, **updates}
 
         flow._abort_if_unique_id_configured = _abort_helper  # type: ignore[attr-defined]
 
@@ -741,6 +748,110 @@ async def test_discovery_overwrite_writes_when_the_flow_is_bound_to_the_entry(
     assert "data" not in entry.data
     assert flow.hass.config_entries.scheduled_reloads == [entry.entry_id], (
         "the running integration keeps the old credentials until it reloads"
+    )
+
+
+@pytest.mark.asyncio
+async def test_discovery_overwrite_writes_when_the_guard_never_matched_the_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An abort is not a write: an unmatched unique id must not fake success.
+
+    ``_abort_if_unique_id_configured`` writes ``updates`` and *then* aborts, but
+    it also returns silently when no entry claims the flow's unique id, which is
+    what a legacy entry without one (or an account identity that has moved)
+    produces. ``_async_prepare_account_context`` then raises its own
+    ``AbortFlow`` at its closing line, having written nothing. Treating either
+    abort as proof of a write reported ``credentials_updated`` and staged the
+    discovered bundle for deletion over an entry that still held its old
+    credentials: file gone, credentials unchanged.
+    """
+
+    entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    # A legacy entry: it matches by email, but claims no unique id, so the
+    # core's guard finds nothing to write to.
+    entry.unique_id = None
+    payload = _discovery_payload_for_configured_account()
+
+    form = await flow.async_step_discovery(payload)
+    if inspect.isawaitable(form):
+        form = await form
+    assert form["type"] == "form"
+
+    question = await flow.async_step_discovery({})
+    if inspect.isawaitable(question):
+        question = await question
+    assert question.get("step_id") == "discovery_overwrite", (
+        "the account is configured, so the question must still be asked"
+    )
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE"
+
+    result = await flow.async_step_discovery_overwrite(
+        {config_flow._FIELD_OVERWRITE_CREDENTIALS: True}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "credentials_updated"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE", (
+        "the guard wrote nothing here, so the step owes the write itself"
+    )
+    assert "data" not in entry.data
+    assert flow.hass.config_entries.scheduled_reloads == [entry.entry_id], (
+        "a write nobody reloads leaves the integration on the old credentials"
+    )
+
+
+@pytest.mark.asyncio
+async def test_discovery_overwrite_does_not_write_twice_after_the_guard_wrote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The counter-direction: a landed guard write must not be repeated.
+
+    The step decides by reading the entry, so the check has to recognize the
+    ordinary case as written. One misread and every accepted overwrite would
+    write a second time and reload an entry that already holds exactly those
+    credentials.
+    """
+
+    entry, flow = await _prepare_configured_account_flow(monkeypatch)
+    writes: list[dict[str, Any]] = []
+    original_update = flow.hass.config_entries.async_update_entry
+
+    def _counting_update(target: Any, **updates: Any) -> bool:
+        writes.append(dict(updates))
+        return bool(original_update(target, **updates))
+
+    monkeypatch.setattr(
+        flow.hass.config_entries, "async_update_entry", _counting_update, raising=False
+    )
+
+    payload = _discovery_payload_for_configured_account()
+
+    form = await flow.async_step_discovery(payload)
+    if inspect.isawaitable(form):
+        form = await form
+    assert form["type"] == "form"
+
+    question = await flow.async_step_discovery({})
+    if inspect.isawaitable(question):
+        question = await question
+    assert question.get("step_id") == "discovery_overwrite"
+    assert not writes, "asking the question must not write anything yet"
+
+    result = await flow.async_step_discovery_overwrite(
+        {config_flow._FIELD_OVERWRITE_CREDENTIALS: True}
+    )
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "credentials_updated"
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE"
+    assert len(writes) == 1, (
+        "the guard already wrote these credentials; writing them again is "
+        "a redundant entry update and a redundant reload"
     )
 
 

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -349,7 +349,18 @@ def test_async_step_discovery_existing_entry_updates(
         assert discovery_form.get("step_id") == "discovery"
         assert not abort_calls, "abort helper should not run before confirmation"
 
-        abort_result = await flow.async_step_discovery({})
+        overwrite_form = await flow.async_step_discovery({})
+        if inspect.isawaitable(overwrite_form):
+            overwrite_form = await overwrite_form
+        # Confirming the discovery card no longer writes: the account is already
+        # configured, so the flow asks before replacing anything.
+        assert overwrite_form["type"] == "form"
+        assert overwrite_form.get("step_id") == "discovery_overwrite"
+        assert not abort_calls, "the question must be asked before the write"
+
+        abort_result = await flow.async_step_discovery_overwrite(
+            {config_flow._FIELD_OVERWRITE_CREDENTIALS: True}
+        )
         if inspect.isawaitable(abort_result):
             abort_result = await abort_result
         assert flow._auth_data.get(CONF_OAUTH_TOKEN) == "aas_et/NEW_TOKEN_VALUE"  # type: ignore[attr-defined]
@@ -359,7 +370,7 @@ def test_async_step_discovery_existing_entry_updates(
         assert isinstance(payload, dict)
         assert "data" not in payload
         assert payload.get(CONF_OAUTH_TOKEN) == "aas_et/NEW_TOKEN_VALUE"
-        assert recorded_forms == ["discovery"]
+        assert recorded_forms == ["discovery", "discovery_overwrite"]
         return discovery_form, abort_result, abort_calls, recorded_forms
 
     discovery_form, abort_result, abort_calls, recorded_forms = asyncio.run(_exercise())
@@ -367,22 +378,18 @@ def test_async_step_discovery_existing_entry_updates(
     assert discovery_form.get("step_id") == "discovery"
     assert len(abort_calls) == 1
     assert abort_result["type"] == "abort"
-    assert abort_result["reason"] == "already_configured"
+    assert abort_result["reason"] == "credentials_updated"
 
 
-def test_discovery_confirmation_replaces_credentials_in_entry_data(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Confirming a discovery for a configured account must replace the token.
+def _drive_discovery_overwrite(
+    monkeypatch: pytest.MonkeyPatch, *, answer: bool
+) -> tuple[Any, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Drive a discovery for an already configured account to ``answer``.
 
-    Regression guard for the nested-payload defect. ``updates`` used to be
-    ``{"data": {...}}``, but Home Assistant merges the payload *flat*
-    (``data={**entry.data, **updates}``): the stored ``oauth_token`` kept its old
-    value while a stray ``data`` key appeared beside it, and the resulting
-    ``changed=True`` reloaded the entry, so it looked like it had worked.
-
-    The assertions deliberately inspect ``entry.data`` rather than the payload
-    handed to the abort helper. Checking the argument is exactly what let the
+    Returns ``(entry, discovery_card, overwrite_question, result)``. The entry is
+    a live object: the manager stub applies ``async_update_entry`` to it, so the
+    callers can assert on ``entry.data`` instead of on the payload handed to the
+    abort helper. Checking the argument is exactly what let the nested-payload
     defect through.
     """
 
@@ -452,7 +459,7 @@ def test_discovery_confirmation_replaces_credentials_in_entry_data(
                 frame_module=frame,
             )
 
-    async def _exercise() -> tuple[dict[str, Any], dict[str, Any]]:
+    async def _exercise() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
         hass = _FlowHass()
         flow = config_flow.ConfigFlow()
         flow.hass = hass  # type: ignore[assignment]
@@ -479,15 +486,44 @@ def test_discovery_confirmation_replaces_credentials_in_entry_data(
             "showing the confirmation form must not write anything yet"
         )
 
-        confirmed = await flow.async_step_discovery({})
-        if inspect.isawaitable(confirmed):
-            confirmed = await confirmed
-        return form, confirmed
+        question = await flow.async_step_discovery({})
+        if inspect.isawaitable(question):
+            question = await question
+        assert question["type"] == "form"
+        assert question.get("step_id") == "discovery_overwrite"
+        assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE", (
+            "asking the question must not write anything yet"
+        )
 
-    form, confirmed = asyncio.run(_exercise())
+        result = await flow.async_step_discovery_overwrite(
+            {config_flow._FIELD_OVERWRITE_CREDENTIALS: answer}
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        return form, question, result
+
+    form, question, result = asyncio.run(_exercise())
+    return entry, form, question, result
+
+
+def test_discovery_overwrite_confirmed_replaces_credentials_in_entry_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Answering yes must replace the stored credentials, flat, in ``entry.data``.
+
+    Regression guard for the nested-payload defect. ``updates`` used to be
+    ``{"data": {...}}``, but Home Assistant merges the payload *flat*
+    (``data={**entry.data, **updates}``): the stored ``oauth_token`` kept its old
+    value while a stray ``data`` key appeared beside it, and the resulting
+    ``changed=True`` reloaded the entry, so it looked like it had worked.
+    """
+
+    entry, form, question, result = _drive_discovery_overwrite(monkeypatch, answer=True)
 
     assert form.get("step_id") == "discovery"
-    assert confirmed["type"] == "abort"
+    assert question.get("step_id") == "discovery_overwrite"
+    assert result["type"] == "abort"
+    assert result["reason"] == "credentials_updated"
     assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/NEW_TOKEN_VALUE", (
         "the confirmed discovery must replace the stored credentials"
     )
@@ -497,6 +533,29 @@ def test_discovery_confirmation_replaces_credentials_in_entry_data(
     assert entry.data[CONF_GOOGLE_EMAIL] == "existing@example.com", (
         "unrelated entry data must survive the merge"
     )
+
+
+def test_discovery_overwrite_declined_keeps_stored_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Answering no must write nothing and say so.
+
+    A dialog whose rejection is never exercised is an ornament: the no-path is
+    the only reason the question is worth asking.
+    """
+
+    entry, _form, _question, result = _drive_discovery_overwrite(
+        monkeypatch, answer=False
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "credentials_kept", (
+        "declining must not report 'already_configured' either"
+    )
+    assert entry.data[CONF_OAUTH_TOKEN] == "aas_et/OLD_TOKEN_VALUE", (
+        "declining must leave the stored credentials untouched"
+    )
+    assert "data" not in entry.data
 
 
 def test_async_step_discovery_update_info_existing_entry(

--- a/tests/test_discovery_abort_reason_translations.py
+++ b/tests/test_discovery_abort_reason_translations.py
@@ -204,3 +204,78 @@ async def test_discovery_without_shared_key_aborts_with_keys_missing() -> None:
 
     assert result["type"] == "abort"
     assert result["reason"] == "keys_missing"
+
+
+# The overwrite question introduced with the discovery credential fix ends in one
+# of two aborts, and neither is a Home Assistant Core common reason. They are
+# emitted by ``async_abort`` directly rather than through the
+# ``DiscoveryFlowError`` chokepoint above, so the structural guard there does not
+# see them: without this test a rename in the code would silently leave the user
+# with an untranslated abort.
+_OVERWRITE_ABORT_REASONS = ("credentials_updated", "credentials_kept")
+_OVERWRITE_STEP = "discovery_overwrite"
+
+_TRANSLATION_FILES = (
+    STRINGS_PATH,
+    *sorted(Path("custom_components/googlefindmy/translations").glob("*.json")),
+)
+
+
+@pytest.mark.parametrize("translation_path", _TRANSLATION_FILES)
+def test_overwrite_step_is_translated_everywhere(translation_path: Path) -> None:
+    """Every locale must carry the overwrite question and both of its outcomes."""
+
+    payload = json.loads(translation_path.read_text(encoding="utf-8"))
+    config = payload["config"]
+
+    step = config["step"].get(_OVERWRITE_STEP)
+    assert step, f"{translation_path} has no config.step.{_OVERWRITE_STEP}"
+    for field in ("title", "description"):
+        assert step.get(field), (
+            f"{translation_path}: {_OVERWRITE_STEP}.{field} is empty"
+        )
+    for section in ("data", "data_description"):
+        assert step.get(section, {}).get(config_flow._FIELD_OVERWRITE_CREDENTIALS), (
+            f"{translation_path}: {_OVERWRITE_STEP}.{section} lacks the toggle text"
+        )
+
+    for reason in _OVERWRITE_ABORT_REASONS:
+        assert config["abort"].get(reason), (
+            f"{translation_path} has no config.abort.{reason}"
+        )
+
+
+def test_overwrite_abort_reasons_are_the_ones_the_flow_emits() -> None:
+    """Bind the translated reasons to the literals in the step implementation.
+
+    Reading the source keeps the guard honest without driving the whole flow a
+    second time: the behavioural coverage lives in
+    ``tests/test_config_flow_discovery.py``.
+    """
+
+    tree = ast.parse(CONFIG_FLOW_PATH.read_text(encoding="utf-8"))
+    step = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef)
+            and node.name == f"async_step_{_OVERWRITE_STEP}"
+        ),
+        None,
+    )
+    assert step is not None, f"async_step_{_OVERWRITE_STEP} vanished"
+
+    emitted = {
+        keyword.value.value
+        for node in ast.walk(step)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "async_abort"
+        for keyword in node.keywords
+        if keyword.arg == "reason" and isinstance(keyword.value, ast.Constant)
+    }
+
+    assert set(_OVERWRITE_ABORT_REASONS) <= emitted, (
+        "the translated reasons are no longer the ones the step aborts with; "
+        f"the step emits {sorted(emitted)}"
+    )

--- a/tests/test_entry_data_nesting_cleanup.py
+++ b/tests/test_entry_data_nesting_cleanup.py
@@ -1,0 +1,153 @@
+# tests/test_entry_data_nesting_cleanup.py
+"""Cleanup of the nested ``data`` key an earlier discovery import left behind.
+
+Discovery handed Home Assistant a nested ``{"data": {...}}`` payload, which the
+core merged verbatim into ``entry.data`` (see
+``tests/test_config_flow_discovery.py`` for the fix on the writing side). The
+credentials therefore never reached the level that is read, and every further
+import wrapped the whole mapping again, so the nesting grows by one level per
+run. A live installation was found at depth 3.
+
+The tests below cover the reading side: existing entries have to heal on their
+own at the next start, without anyone editing ``.storage/core.config_entries``
+by hand.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any
+
+import custom_components.googlefindmy as integration
+from tests.helpers.config_entries_stub import make_config_entry
+
+INIT_PATH = Path(integration.__file__)
+
+
+class _ConfigEntriesRecorder:
+    """Minimal manager stub recording the writes the cleanup performs."""
+
+    def __init__(self) -> None:
+        self.updates: list[dict[str, Any]] = []
+
+    def async_update_entry(self, target: Any, **kwargs: Any) -> bool:
+        self.updates.append(kwargs)
+        if "data" in kwargs:
+            target.data = dict(kwargs["data"])
+        return True
+
+
+class _Hass:
+    def __init__(self) -> None:
+        self.config_entries = _ConfigEntriesRecorder()
+
+
+def _nested(depth: int, *, token: str = "buried") -> dict[str, Any]:
+    """Build the payload shape the defect produced at ``depth`` levels."""
+
+    payload: dict[str, Any] = {"oauth_token": token, "secrets_data": {"k": "v"}}
+    for _ in range(depth):
+        payload = {"data": payload}
+    return payload
+
+
+def test_strip_reports_zero_and_returns_an_equal_mapping_when_clean() -> None:
+    """A healthy entry must come back unchanged, so callers can skip the write."""
+
+    data = {"google_email": "user@example.com", "oauth_token": "aas_et/CURRENT"}
+
+    cleaned, depth = integration._strip_stray_nested_entry_data(data)
+
+    assert depth == 0
+    assert cleaned == data
+
+
+def test_strip_removes_every_level_at_once() -> None:
+    """Depth 3 is the shape found in the wild; one level is not enough.
+
+    A fix that peels a single level would leave ``{"data": {...}}`` behind and
+    pass a depth-1 test, which is why this case is the one that is asserted.
+    """
+
+    data = {"oauth_token": "aas_et/TOP", **_nested(3)}
+
+    cleaned, depth = integration._strip_stray_nested_entry_data(data)
+
+    assert depth == 3
+    assert "data" not in cleaned
+    assert cleaned == {"oauth_token": "aas_et/TOP"}
+
+
+def test_strip_leaves_a_non_mapping_data_value_alone() -> None:
+    """Only the nesting is removed, not any future setting that shares the name."""
+
+    data = {"oauth_token": "aas_et/TOP", "data": "not a mapping"}
+
+    cleaned, depth = integration._strip_stray_nested_entry_data(data)
+
+    assert depth == 0
+    assert cleaned == data
+
+
+def test_cleanup_writes_once_and_is_idempotent() -> None:
+    """The affected entry heals, and a second run has nothing left to do."""
+
+    hass = _Hass()
+    entry = make_config_entry(
+        entry_id="affected-entry",
+        data={"google_email": "user@example.com", **_nested(2)},
+    )
+
+    integration._async_strip_stray_nested_entry_data(hass, entry)  # type: ignore[arg-type]
+
+    assert len(hass.config_entries.updates) == 1
+    assert set(hass.config_entries.updates[0]) == {"data"}
+    assert entry.data == {"google_email": "user@example.com"}
+
+    integration._async_strip_stray_nested_entry_data(hass, entry)  # type: ignore[arg-type]
+
+    assert len(hass.config_entries.updates) == 1, "a second run must not write again"
+
+
+def test_cleanup_does_not_touch_a_healthy_entry() -> None:
+    """No write at all, so an untouched entry keeps its modification watermark."""
+
+    hass = _Hass()
+    before = {"google_email": "user@example.com", "oauth_token": "aas_et/CURRENT"}
+    entry = make_config_entry(entry_id="healthy-entry", data=dict(before))
+
+    integration._async_strip_stray_nested_entry_data(hass, entry)  # type: ignore[arg-type]
+
+    assert hass.config_entries.updates == []
+    assert entry.data == before
+
+
+def test_cleanup_is_wired_into_entry_setup() -> None:
+    """A helper nobody calls would heal nothing.
+
+    Asserted against the source rather than by driving a full entry setup: the
+    point here is the wiring, and reading it is cheap and unambiguous.
+    """
+
+    tree = ast.parse(INIT_PATH.read_text(encoding="utf-8"))
+    setup = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "async_setup_entry"
+        ),
+        None,
+    )
+    assert setup is not None
+
+    called = {
+        node.func.id
+        for node in ast.walk(setup)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+
+    assert "_async_strip_stray_nested_entry_data" in called, (
+        "async_setup_entry no longer runs the cleanup"
+    )

--- a/tests/test_secrets_watcher_multipath.py
+++ b/tests/test_secrets_watcher_multipath.py
@@ -507,8 +507,8 @@ async def test_refresh_watch_paths_is_a_noop_when_the_path_set_is_unchanged(
 
     The removal hook refreshes on every entry removal, and in the normal case
     the removed entry owned no extra path. Re-arming and rescanning there would
-    re-import a bundle that is already known, and the discovery update flow
-    applies such an import without asking the user.
+    re-import a bundle that is already known, which for a configured account
+    now puts an unasked-for overwrite prompt in front of the user.
     """
 
     default_path = tmp_path / "auth" / "secrets.json"

--- a/tests/test_secrets_watcher_multipath.py
+++ b/tests/test_secrets_watcher_multipath.py
@@ -1087,7 +1087,7 @@ async def test_discovery_confirm_stages_delete_instead_of_running_it(
     flow.context = {}
     flow._discovery_confirm_pending = True  # type: ignore[attr-defined]
     flow._pending_discovery_payload = payload  # type: ignore[attr-defined]
-    flow._pending_discovery_updates = None  # type: ignore[attr-defined]
+    flow._pending_discovery_entry_exists = False  # type: ignore[attr-defined]
 
     async def _fake_device_selection() -> dict[str, Any]:
         return {"type": config_flow.data_entry_flow.FlowResultType.CREATE_ENTRY}
@@ -1134,7 +1134,7 @@ async def test_aborted_discovery_confirm_stages_nothing(tmp_path: Path) -> None:
     flow.context = {}
     flow._discovery_confirm_pending = True  # type: ignore[attr-defined]
     flow._pending_discovery_payload = payload  # type: ignore[attr-defined]
-    flow._pending_discovery_updates = None  # type: ignore[attr-defined]
+    flow._pending_discovery_entry_exists = False  # type: ignore[attr-defined]
 
     async def _fake_device_selection() -> dict[str, Any]:
         return {"type": "form", "step_id": "device_selection"}


### PR DESCRIPTION
## Why

Confirming a cloud discovery for an **already configured** account did not replace the stored credentials. The flow ended on `Google Find My Device is already configured.` and the new `secrets.json` was effectively ignored.

The cause is a payload shape. `ConfigFlow._abort_if_unique_id_configured(updates=...)` merges its payload **flat** into the entry:

```python
self.hass.config_entries.async_update_entry(entry, data={**entry.data, **updates})
```

The integration passed `{"data": {...}}`. The result:

| Payload | Effect on `entry.data` |
|---|---|
| `{"data": {…new…}}` (before) | `oauth_token` keeps its old value; a stray `data` key appears next to it |
| flat `{…new…}` (after) | credentials are replaced as intended |

Because the stray key still makes `async_update_entry` report a change, Home Assistant reloads the entry, so the update *looks* like it worked.

It also compounds: the bad payload of run N is part of `existing_entry.data` in run N+1 and gets wrapped again. A live installation was found at depth 3, with ~73% of its entry data spent on dead copies.

## Why the suite did not catch it

`tests/helpers/config_entries_stub.py` modelled the helper as `async_update_entry(entry, **updates)`. Under that semantics the nested payload is correct, so the double was strictly more forgiving than the core it stands in for. It now merges the way Home Assistant does, and two dedicated tests pin that.

## Scope

- **This commit:** the payload fix, the double, and the regression tests.
- **Next in this PR:** a Ja/Nein confirmation step before overwriting (all ten locales; the `discovery` step currently has no text in any of them), and an automatic, idempotent cleanup of the stray `data` key in existing entries.

Not in scope: the discovery source switch in `discovery.py` and the bundle cleanup mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)