### PR TITLE
perf(coordinator): look up device labels without copying the subentry snapshot

### DIFF
--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -321,6 +321,11 @@ class _MixinBase:
     ) -> list[dict[str, Any]]:
         raise NotImplementedError
 
+    def get_device_label_in_subentry(
+        self, subentry_key: str | None, device_id: str
+    ) -> str | None:
+        raise NotImplementedError
+
     # ------------------------------------------------------------------
     # Cross-mixin methods: PollingOperations
     # ------------------------------------------------------------------

--- a/custom_components/googlefindmy/coordinator/subentry.py
+++ b/custom_components/googlefindmy/coordinator/subentry.py
@@ -1405,3 +1405,36 @@ class SubentryOperations(_MixinBase):
         if not self.is_device_visible_in_subentry(subentry_key, device_id):
             return None
         return self.get_device_last_seen(device_id)
+
+    def get_device_label_in_subentry(
+        self, subentry_key: str | None, device_id: str
+    ) -> str | None:
+        """Return the snapshot label for a device without copying the snapshot.
+
+        Allocation-free counterpart to scanning ``get_subentry_snapshot()``:
+        the stored tuple is iterated in place, so no row is copied.
+        Deliberately keyed on ``id`` only (never ``device_id``), deliberately
+        without the ``ENTRY_ID:DEVICE_ID`` suffix handling of
+        ``is_device_visible_in_subentry`` and deliberately without a visibility
+        gate, so the result matches what a scan of the stored snapshot yields.
+        Returns ``None`` when the subentry key is unknown, the device has no
+        row, the stored name is not a ``str``, or the instance carries no
+        snapshot store at all; callers must treat ``None`` as ``leave the
+        current label untouched``.  That last case is the one deliberate
+        divergence from ``get_subentry_snapshot``, which raises there.
+        """
+
+        lookup_key = (
+            subentry_key if subentry_key is not None else self._default_subentry_key()
+        )
+        # ``getattr`` guard: coordinator doubles built via ``__new__`` skip
+        # ``__init__`` and therefore carry no ``_subentry_snapshots`` at all.
+        snapshots: dict[str, tuple[dict[str, Any], ...]] = getattr(
+            self, "_subentry_snapshots", {}
+        )
+        for row in snapshots.get(lookup_key) or ():
+            if row.get("id") != device_id:
+                continue
+            name = row.get("name")
+            return name if isinstance(name, str) else None
+        return None

--- a/custom_components/googlefindmy/entity.py
+++ b/custom_components/googlefindmy/entity.py
@@ -679,38 +679,72 @@ class GoogleFindMyDeviceEntity(GoogleFindMyEntity):
             name=name,
         )
 
+    def _coordinator_device_label(self, device_id: str) -> str | None:
+        """Return the coordinator's label for ``device_id``, or ``None``.
+
+        Prefers the coordinator's allocation-free accessor and falls back to a
+        scan of ``get_subentry_snapshot()`` for coordinator doubles that do not
+        implement it.  Both branches share one contract: a ``str`` when the
+        snapshot carries a string name for this device, ``None`` otherwise.
+
+        ``device_id`` is passed in rather than read from ``self`` so the caller
+        can resolve it outside its ``except`` block: a device dictionary without
+        a string ``id`` must keep raising instead of turning into a silent
+        no-op.
+        """
+
+        getter = getattr(self.coordinator, "get_device_label_in_subentry", None)
+        if callable(getter):
+            label = getter(self._subentry_key, device_id)
+            if isinstance(label, str):
+                return label
+            if label is None:
+                return None
+            # A non-str, non-None answer means the coordinator is a double whose
+            # attribute was auto-created rather than implemented.  Fall through
+            # to its real snapshot instead of treating the proxy as an answer.
+        for candidate in self.coordinator.get_subentry_snapshot(self._subentry_key):
+            if candidate.get("id") != device_id:
+                continue
+            name = candidate.get("name")
+            return name if isinstance(name, str) else None
+        return None
+
     def refresh_device_label_from_coordinator(
         self, *, log_prefix: str | None = None
     ) -> None:
         """Update the cached device label from the coordinator snapshot."""
 
+        device_id = self.device_id
         try:
-            snapshot = self.coordinator.get_subentry_snapshot(self._subentry_key)
-        except Exception as err:  # pragma: no cover - defensive best effort
-            _LOGGER.debug("Failed to fetch snapshot for %s: %s", self.device_id, err)
+            new_name = self._coordinator_device_label(device_id)
+        except Exception as err:
+            # Wider than the snapshot call it replaces: this also covers the
+            # accessor and the fallback scan.  Deliberate, because a broken
+            # coordinator must not take the entity down mid-update.
+            _LOGGER.debug(
+                "Failed to read the device label for %s from the coordinator: %s",
+                device_id,
+                err,
+            )
             return
 
-        for candidate in snapshot:
-            if candidate.get("id") != self.device_id:
-                continue
-            new_name = candidate.get("name")
-            if not isinstance(new_name, str) or not new_name.strip():
-                break
-            current = self._device.get("name")
-            if current == new_name:
-                break
-            self._device["name"] = new_name
-            self._fallback_label = new_name
-            self.maybe_update_device_registry_name(new_name)
-            if log_prefix:
-                _LOGGER.debug(
-                    "%s device label refreshed for %s: '%s' -> '%s'",
-                    log_prefix,
-                    self.device_id,
-                    current,
-                    new_name,
-                )
-            break
+        if new_name is None or not new_name.strip():
+            return
+        current = self._device.get("name")
+        if current == new_name:
+            return
+        self._device["name"] = new_name
+        self._fallback_label = new_name
+        self.maybe_update_device_registry_name(new_name)
+        if log_prefix:
+            _LOGGER.debug(
+                "%s device label refreshed for %s: '%s' -> '%s'",
+                log_prefix,
+                device_id,
+                current,
+                new_name,
+            )
 
     def coordinator_has_device(self) -> bool:
         """Return ``True`` if the device is currently visible in the coordinator."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2243,6 +2243,34 @@ def fixture_stub_coordinator_factory() -> Callable[..., type[Any]]:
                     return list(self._snapshot_callback(key, feature))
                 return list(self.data)
 
+            def get_device_label_in_subentry(
+                self, subentry_key: str | None, device_id: str
+            ) -> str | None:
+                """Mirror the coordinator's allocation-free label accessor.
+
+                Reads the same source as ``get_subentry_snapshot`` but does not
+                call it: tests asserting that the fast path never requests a
+                snapshot copy would otherwise count this stub's own call.
+                Rebuilt on every call, without a cache, because the coordinator
+                contract does not promise one.  The production accessor takes no
+                ``feature`` argument, so the callback is invoked with ``None``;
+                a test whose ``_snapshot_callback`` branches on ``feature`` will
+                see this method and ``get_subentry_snapshot`` answer from
+                different rows.
+                """
+
+                rows = (
+                    self._snapshot_callback(subentry_key, None)
+                    if self._snapshot_callback is not None
+                    else self.data
+                )
+                for row in rows:
+                    if row.get("id") != device_id:
+                        continue
+                    name = row.get("name")
+                    return name if isinstance(name, str) else None
+                return None
+
             async def async_wait_subentry_visibility_updates(self) -> None:
                 """Mirror the coordinator visibility wait helper."""
 

--- a/tests/test_coordinator_subentry_device_label.py
+++ b/tests/test_coordinator_subentry_device_label.py
@@ -1,0 +1,190 @@
+# tests/test_coordinator_subentry_device_label.py
+"""Contract tests for ``get_device_label_in_subentry``.
+
+The accessor is the allocation-free counterpart to scanning
+``get_subentry_snapshot()``: it iterates the stored tuple in place and returns
+one name.  Its whole reason to exist is that it answers *exactly* what such a
+scan would answer, so the tests below pin the four points where a plausible
+implementation could quietly diverge: the key it matches on (``id``, never
+``device_id``), the absence of a visibility gate, which row wins on duplicates,
+and what happens when the stored name is not a string.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.googlefindmy.const import TRACKER_SUBENTRY_KEY
+from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+
+DEVICE_ID = "device-1"
+
+
+def _coordinator(
+    snapshots: dict[str, tuple[dict[str, Any], ...]] | None,
+    *,
+    default_key: str = TRACKER_SUBENTRY_KEY,
+) -> GoogleFindMyCoordinator:
+    """Return a bare coordinator carrying only what the accessor reads."""
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    if snapshots is not None:
+        coordinator._subentry_snapshots = snapshots
+    coordinator._default_subentry_key_value = default_key
+    coordinator._subentry_metadata = {}
+    return coordinator
+
+
+def test_returns_the_stored_name_for_a_known_device() -> None:
+    coordinator = _coordinator(
+        {TRACKER_SUBENTRY_KEY: ({"id": DEVICE_ID, "name": "Pixel Tag"},)}
+    )
+
+    assert (
+        coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+        == "Pixel Tag"
+    )
+
+
+def test_none_key_falls_back_to_the_default_subentry_key() -> None:
+    """``None`` resolves like the ``feature``-free branch of the snapshot getter."""
+
+    coordinator = _coordinator(
+        {TRACKER_SUBENTRY_KEY: ({"id": DEVICE_ID, "name": "Pixel Tag"},)},
+        default_key=TRACKER_SUBENTRY_KEY,
+    )
+
+    assert coordinator.get_device_label_in_subentry(None, DEVICE_ID) == "Pixel Tag"
+
+
+def test_unknown_device_returns_none() -> None:
+    coordinator = _coordinator(
+        {TRACKER_SUBENTRY_KEY: ({"id": "someone-else", "name": "Other"},)}
+    )
+
+    assert (
+        coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+        is None
+    )
+
+
+def test_unknown_subentry_key_returns_none() -> None:
+    coordinator = _coordinator(
+        {TRACKER_SUBENTRY_KEY: ({"id": DEVICE_ID, "name": "Pixel Tag"},)}
+    )
+
+    assert coordinator.get_device_label_in_subentry("no-such-key", DEVICE_ID) is None
+
+
+def test_row_keyed_only_by_device_id_is_not_matched() -> None:
+    """``id`` only: a ``device_id``-keyed row is unreachable, as in the scan."""
+
+    coordinator = _coordinator(
+        {TRACKER_SUBENTRY_KEY: ({"device_id": DEVICE_ID, "name": "Pixel Tag"},)}
+    )
+
+    assert (
+        coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+        is None
+    )
+
+
+def test_duplicate_rows_resolve_to_the_first_one() -> None:
+    coordinator = _coordinator(
+        {
+            TRACKER_SUBENTRY_KEY: (
+                {"id": DEVICE_ID, "name": "First"},
+                {"id": DEVICE_ID, "name": "Second"},
+            )
+        }
+    )
+
+    assert (
+        coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+        == "First"
+    )
+
+
+def test_invisible_device_still_yields_its_label() -> None:
+    """No visibility gate: the accessor mirrors the snapshot, not the ACL.
+
+    ``_subentry_metadata`` is empty, so ``is_device_visible_in_subentry``
+    answers ``False`` for the very same device.  The scan this accessor replaces
+    has no visibility gate either, and adding one here would be a behaviour
+    change dressed up as a performance change.
+    """
+
+    coordinator = _coordinator(
+        {TRACKER_SUBENTRY_KEY: ({"id": DEVICE_ID, "name": "Pixel Tag"},)}
+    )
+
+    assert not coordinator.is_device_visible_in_subentry(
+        TRACKER_SUBENTRY_KEY, DEVICE_ID
+    )
+    assert (
+        coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+        == "Pixel Tag"
+    )
+
+
+def test_coordinator_without_snapshot_attribute_returns_none() -> None:
+    """A ``__new__``-built double carries no ``_subentry_snapshots`` at all.
+
+    ``get_subentry_snapshot`` raises ``AttributeError`` in that situation.  The
+    accessor deliberately diverges and answers ``None``: observably the same
+    "nothing happens", but without an exception that the caller's defensive
+    ``except`` would swallow.
+    """
+
+    coordinator = _coordinator(None)
+
+    assert not hasattr(coordinator, "_subentry_snapshots")
+    assert (
+        coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+        is None
+    )
+
+
+def test_non_string_name_returns_none() -> None:
+    coordinator = _coordinator({TRACKER_SUBENTRY_KEY: ({"id": DEVICE_ID, "name": 42},)})
+
+    assert (
+        coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+        is None
+    )
+
+
+def test_missing_name_key_returns_none() -> None:
+    coordinator = _coordinator({TRACKER_SUBENTRY_KEY: ({"id": DEVICE_ID},)})
+
+    assert (
+        coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+        is None
+    )
+
+
+def test_empty_snapshot_tuple_returns_none() -> None:
+    coordinator = _coordinator({TRACKER_SUBENTRY_KEY: ()})
+
+    assert (
+        coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+        is None
+    )
+
+
+def test_stored_row_is_not_mutated_by_the_lookup() -> None:
+    """Aliasing guard: the stored row must survive a lookup unchanged.
+
+    Note what this test is *not*: with a ``str`` return type it cannot fail, so
+    it proves nothing about the current implementation and must not be counted
+    as coverage of the no-aliasing requirement.  It is a standing guard for a
+    later refactor that returns the row itself, where the mistake it describes
+    becomes possible for the first time.
+    """
+
+    row: dict[str, Any] = {"id": DEVICE_ID, "name": "Pixel Tag", "latitude": 1.0}
+    coordinator = _coordinator({TRACKER_SUBENTRY_KEY: (row,)})
+
+    coordinator.get_device_label_in_subentry(TRACKER_SUBENTRY_KEY, DEVICE_ID)
+
+    assert row == {"id": DEVICE_ID, "name": "Pixel Tag", "latitude": 1.0}

--- a/tests/test_entity_label_refresh_hotpath.py
+++ b/tests/test_entity_label_refresh_hotpath.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 from typing import Any
 
 from custom_components.googlefindmy.const import TRACKER_SUBENTRY_KEY
+from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from custom_components.googlefindmy.entity import GoogleFindMyDeviceEntity
 
 DEVICE_ID = "device-1"
@@ -197,6 +198,155 @@ def test_row_keyed_only_by_device_id_is_not_matched() -> None:
     assert recorded == []
 
 
+class _FastPathCoordinator(_SnapshotCoordinator):
+    """Coordinator double implementing the allocation-free accessor as well."""
+
+    def get_device_label_in_subentry(
+        self, subentry_key: str | None, device_id: str
+    ) -> str | None:
+        for row in self._snapshots.get(subentry_key or "", []):
+            if row.get("id") != device_id:
+                continue
+            name = row.get("name")
+            return name if isinstance(name, str) else None
+        return None
+
+
+def test_fast_path_never_copies_the_snapshot() -> None:
+    """Wiring proof: a coordinator with the accessor is never asked to copy.
+
+    Asserting on the *absence* of the snapshot call is the point of this test.
+    A green refresh alone would also pass if the fast path were dead code.
+    """
+
+    coordinator = _FastPathCoordinator(
+        {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": "New name"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    for _ in range(5):
+        entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "New name"
+    assert recorded == ["New name"]  # only the first pass changes anything
+    assert coordinator.calls == []
+
+
+def test_fast_path_is_used_even_when_the_snapshot_getter_would_raise() -> None:
+    """Second wiring proof, positive this time: the label still arrives."""
+
+    class _ExplodingSnapshot(_FastPathCoordinator):
+        def get_subentry_snapshot(self, key: str | None = None) -> list[dict[str, Any]]:
+            raise AssertionError("the snapshot copy must not be requested")
+
+    coordinator = _ExplodingSnapshot(
+        {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": "New name"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "New name"
+    assert entity._fallback_label == "New name"
+    assert recorded == ["New name"]
+
+
+def test_accessor_answering_none_is_final() -> None:
+    """``None`` is an answer, not a failure: it must not trigger the scan.
+
+    A coordinator that implements the accessor and reports "no label" is
+    authoritative. Falling back to the snapshot copy here would reintroduce
+    exactly the allocation this change removes, on the most common path of all
+    (a device whose name has not changed).
+    """
+
+    coordinator = _FastPathCoordinator(
+        {TRACKER_SUBENTRY_KEY: [{"id": "someone-else", "name": "Other"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "Old name"
+    assert entity._fallback_label == "Old name"
+    assert recorded == []
+    assert coordinator.calls == []
+
+
+def test_coordinator_without_the_accessor_still_refreshes() -> None:
+    """Fallback proof: the 11 decentral test doubles keep working unchanged."""
+
+    coordinator = _SnapshotCoordinator(
+        {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": "New name"}]}
+    )
+    assert not hasattr(coordinator, "get_device_label_in_subentry")
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "New name"
+    assert recorded == ["New name"]
+    assert coordinator.calls == [TRACKER_SUBENTRY_KEY]
+
+
+def test_raising_accessor_does_not_fall_back_to_the_scan() -> None:
+    """The asymmetry is deliberate, so it is pinned rather than described.
+
+    A *missing* accessor falls back to the scan; a *raising* one does not. It
+    signals a broken coordinator, and silently scanning past that would hide
+    the defect behind a working label.
+    """
+
+    class _ExplodingAccessor(_SnapshotCoordinator):
+        def get_device_label_in_subentry(
+            self, subentry_key: str | None, device_id: str
+        ) -> str | None:
+            raise RuntimeError("accessor is broken")
+
+    coordinator = _ExplodingAccessor(
+        {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": "New name"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "Old name"
+    assert entity._fallback_label == "Old name"
+    assert recorded == []
+    assert coordinator.calls == []
+
+
+def test_auto_attribute_double_falls_through_to_the_scan() -> None:
+    """A double whose accessor is auto-created answers with a proxy object.
+
+    The branch exists for doubles that implement ``get_subentry_snapshot`` for
+    real but grow ``get_device_label_in_subentry`` automatically: without it,
+    the proxy would be mistaken for an answer and the refresh would stop.
+
+    Measured limit, so the branch is not oversold: a plain
+    ``unittest.mock.MagicMock`` is *not* rescued by it. Its
+    ``get_subentry_snapshot`` yields an empty iterator, so the scan finds
+    nothing and the refresh stays a no-op either way.
+    """
+
+    class _MockLike(_SnapshotCoordinator):
+        def get_device_label_in_subentry(
+            self, subentry_key: str | None, device_id: str
+        ) -> Any:
+            return object()
+
+    coordinator = _MockLike(
+        {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": "New name"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "New name"
+    assert recorded == ["New name"]
+    assert coordinator.calls == [TRACKER_SUBENTRY_KEY]
+
+
 def test_duplicate_rows_resolve_to_the_first_one() -> None:
     """Case 8: with two rows for one ``id``, the first row wins."""
 
@@ -215,3 +365,38 @@ def test_duplicate_rows_resolve_to_the_first_one() -> None:
     assert entity._device["name"] == "First"
     assert entity._fallback_label == "First"
     assert recorded == ["First"]
+
+
+def test_real_coordinator_and_real_entity_use_the_accessor() -> None:
+    """The seam itself, with no hand-written accessor on either side.
+
+    Every other wiring proof in this file pairs the production entity with a
+    *double* that reimplements the accessor, so all of them would stay green if
+    the production accessor were renamed, removed or changed its return type:
+    ``getattr`` resolves to ``None``, the entity falls back to the scan and
+    nothing turns red. ``mypy`` does not close that gap either, because the
+    ``getattr`` result is ``Any``.
+
+    This test pairs the real ``GoogleFindMyCoordinator`` with the real entity
+    and makes the snapshot copy explode, so the label can only arrive through
+    ``SubentryOperations.get_device_label_in_subentry``.
+    """
+
+    def _explode(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        raise AssertionError("the snapshot copy must not be requested")
+
+    coordinator = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coordinator._subentry_snapshots = {
+        TRACKER_SUBENTRY_KEY: ({"id": DEVICE_ID, "name": "New name"},)
+    }
+    coordinator._default_subentry_key_value = TRACKER_SUBENTRY_KEY
+    coordinator._subentry_metadata = {}
+    coordinator.get_subentry_snapshot = _explode  # type: ignore[method-assign]
+
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "New name"
+    assert entity._fallback_label == "New name"
+    assert recorded == ["New name"]

--- a/tests/test_entity_label_refresh_hotpath.py
+++ b/tests/test_entity_label_refresh_hotpath.py
@@ -1,0 +1,217 @@
+# tests/test_entity_label_refresh_hotpath.py
+"""Characterisation tests for ``refresh_device_label_from_coordinator``.
+
+The method runs from five ``_handle_coordinator_update`` implementations
+(``sensor.py``, ``button.py``, ``device_tracker.py``) on every coordinator
+update, immediately before ``async_write_ha_state()``.  Until now it had no
+test at all, so a refactor of its snapshot access had no safety net.  These
+tests pin the *current* behaviour before any production change, so a later
+change that alters it becomes visible as a red test rather than as a silent
+semantic drift.
+
+Scope and limits of this file (deliberate, do not read it as "the entity is
+tested"):
+
+* The instances are built with ``__new__`` and the four attributes the method
+  actually reads (``coordinator``, ``_device``, ``_subentry_key``,
+  ``_fallback_label``) plus the ``device_id`` property, which derives from
+  ``_device["id"]``.  A full Home Assistant bootstrap is not needed and would
+  contradict the "Fast" rule of ``AGENTS.md`` 3.4.
+* Consequently these tests are **blind** to regressions in ``__init__``
+  (``entity.py`` around the ``_subentry_key``/``_fallback_label`` assignments)
+  and in ``maybe_update_device_registry_name``, which is replaced by a recorder
+  on the instance.  Registry behaviour is out of scope here.
+* Every case gives ``_device`` a non-empty string ``id``.  The ``device_id``
+  property raises ``ValueError`` otherwise, and a minimal ``_device`` would make
+  the "device missing from the snapshot" cases vacuously green: the current code
+  would never enter its loop, a rewritten fast path would raise inside the
+  defensive ``except`` block, and both variants would look identical.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.googlefindmy.const import TRACKER_SUBENTRY_KEY
+from custom_components.googlefindmy.entity import GoogleFindMyDeviceEntity
+
+DEVICE_ID = "device-1"
+OTHER_DEVICE_ID = "device-2"
+
+
+class _SnapshotCoordinator:
+    """Minimal coordinator double exposing only ``get_subentry_snapshot``."""
+
+    def __init__(self, snapshots: dict[str, list[dict[str, Any]]]) -> None:
+        self._snapshots = snapshots
+        self.calls: list[str | None] = []
+
+    def get_subentry_snapshot(self, key: str | None = None) -> list[dict[str, Any]]:
+        self.calls.append(key)
+        return [dict(row) for row in self._snapshots.get(key or "", [])]
+
+
+def _make_entity(
+    coordinator: Any,
+    *,
+    name: str | None = "Old name",
+    fallback: str | None = "Old name",
+) -> tuple[GoogleFindMyDeviceEntity, list[str | None]]:
+    """Build a bare entity plus a recorder for the registry-sync call."""
+
+    entity = GoogleFindMyDeviceEntity.__new__(GoogleFindMyDeviceEntity)
+    entity.coordinator = coordinator
+    entity._device = {"id": DEVICE_ID, "name": name}
+    entity._subentry_key = TRACKER_SUBENTRY_KEY
+    entity._fallback_label = fallback
+
+    recorded: list[str | None] = []
+    entity.maybe_update_device_registry_name = recorded.append  # type: ignore[method-assign]
+    return entity, recorded
+
+
+def test_changed_name_updates_device_fallback_and_registry() -> None:
+    """Case 1: a new string name propagates to all three sinks."""
+
+    coordinator = _SnapshotCoordinator(
+        {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": "New name"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "New name"
+    assert entity._fallback_label == "New name"
+    assert recorded == ["New name"]
+
+
+def test_changed_name_with_log_prefix_behaves_identically() -> None:
+    """Case 1b: the optional ``log_prefix`` only adds a debug line."""
+
+    coordinator = _SnapshotCoordinator(
+        {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": "New name"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator(log_prefix="[test]")
+
+    assert entity._device["name"] == "New name"
+    assert entity._fallback_label == "New name"
+    assert recorded == ["New name"]
+
+
+def test_unchanged_name_touches_nothing() -> None:
+    """Case 2: an identical name leaves state and registry untouched."""
+
+    coordinator = _SnapshotCoordinator(
+        {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": "Old name"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "Old name"
+    assert entity._fallback_label == "Old name"
+    assert recorded == []
+
+
+def test_blank_name_is_ignored() -> None:
+    """Case 3: empty and whitespace-only names never overwrite the label."""
+
+    for blank in ("", "   "):
+        coordinator = _SnapshotCoordinator(
+            {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": blank}]}
+        )
+        entity, recorded = _make_entity(coordinator)
+
+        entity.refresh_device_label_from_coordinator()
+
+        assert entity._device["name"] == "Old name"
+        assert entity._fallback_label == "Old name"
+        assert recorded == []
+
+
+def test_non_string_name_is_ignored() -> None:
+    """Case 4: a non-``str`` name is discarded rather than coerced."""
+
+    coordinator = _SnapshotCoordinator(
+        {TRACKER_SUBENTRY_KEY: [{"id": DEVICE_ID, "name": 42}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "Old name"
+    assert entity._fallback_label == "Old name"
+    assert recorded == []
+
+
+def test_device_absent_from_snapshot_keeps_current_label() -> None:
+    """Case 5: a foreign row must not trigger any fallback label."""
+
+    coordinator = _SnapshotCoordinator(
+        {TRACKER_SUBENTRY_KEY: [{"id": OTHER_DEVICE_ID, "name": "Someone else"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "Old name"
+    assert entity._fallback_label == "Old name"
+    assert entity._fallback_label != GoogleFindMyDeviceEntity._DEFAULT_DEVICE_LABEL
+    assert recorded == []
+
+
+def test_empty_snapshot_and_unknown_key_keep_current_label() -> None:
+    """Case 6: an empty snapshot and an unknown key both no-op."""
+
+    for snapshots in ({TRACKER_SUBENTRY_KEY: []}, {"some-other-key": []}):
+        coordinator = _SnapshotCoordinator(snapshots)
+        entity, recorded = _make_entity(coordinator)
+
+        entity.refresh_device_label_from_coordinator()
+
+        assert entity._device["name"] == "Old name"
+        assert entity._fallback_label == "Old name"
+        assert recorded == []
+
+
+def test_row_keyed_only_by_device_id_is_not_matched() -> None:
+    """Case 7: the lookup keys on ``id`` alone, never on ``device_id``.
+
+    ``coordinator/helpers/subentry.py`` groups rows by ``device_id or id``, so a
+    row carrying only ``device_id`` is reachable elsewhere but invisible here.
+    That asymmetry is the current behaviour and is pinned deliberately: widening
+    the key would resurrect rows that are unreachable today.
+    """
+
+    coordinator = _SnapshotCoordinator(
+        {TRACKER_SUBENTRY_KEY: [{"device_id": DEVICE_ID, "name": "New name"}]}
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "Old name"
+    assert entity._fallback_label == "Old name"
+    assert recorded == []
+
+
+def test_duplicate_rows_resolve_to_the_first_one() -> None:
+    """Case 8: with two rows for one ``id``, the first row wins."""
+
+    coordinator = _SnapshotCoordinator(
+        {
+            TRACKER_SUBENTRY_KEY: [
+                {"id": DEVICE_ID, "name": "First"},
+                {"id": DEVICE_ID, "name": "Second"},
+            ]
+        }
+    )
+    entity, recorded = _make_entity(coordinator)
+
+    entity.refresh_device_label_from_coordinator()
+
+    assert entity._device["name"] == "First"
+    assert entity._fallback_label == "First"
+    assert recorded == ["First"]


### PR DESCRIPTION
## Summary

`GoogleFindMyDeviceEntity.refresh_device_label_from_coordinator()` asked the
coordinator for a **copy of the whole subentry snapshot**, scanned it linearly
for its own row and read one key from it. `get_subentry_snapshot()` returns
`[dict(row) for row in entries]`, so every call allocates one dict per device in
the subentry. The method runs from five `_handle_coordinator_update`
implementations (`sensor.py`, `button.py`, `device_tracker.py`) on every
coordinator update, immediately before `async_write_ha_state()` — i.e. on the
event loop.

This PR adds `SubentryOperations.get_device_label_in_subentry`, which iterates
the stored tuple in place, and routes the entity through it. Purely additive in
the coordinator: one block at the end of `subentry.py`, no existing method
touched, `get_subentry_snapshot` byte-identical for its twelve other callers.

Two commits, deliberately in this order: the characterisation test lands first,
so the "before" behaviour is recorded rather than reconstructed afterwards.

## Motivation

Per coordinator update and subentry, with *n* devices and *m* entities, the old
path allocated *n × m* dicts to read *m* names. On a 15-device account with 76
entities that is ~1140 dict copies of full location rows per update.

**Honest bounds, measured rather than asserted:**

* The gain on a typical installation is small in absolute terms — on the order
  of tens of milliseconds per day at a 300 s poll interval. The case for this
  change is allocation hygiene on the event loop, not a user-visible speed-up.
* This PR does **not** fix the `Updating state for … took N seconds` warnings
  from `homeassistant.helpers.entity`. Those measure
  `__async_calculate_state()` — the entity's property getters — and this method
  is not part of that measurement. Anyone arriving here from such a warning is
  in the wrong place.
* This removes the **copying**, not the **scan**. The linear search over the
  subentry's rows remains; no index and no cached state are introduced.

## Behaviour

The accessor mirrors the scan it replaces rather than improving on it:

* keys on `id` alone, never on `device_id`, so it does not resurrect rows that
  are unreachable today (`coordinator/helpers/subentry.py` groups by
  `device_id or id`, the entity never did);
* no visibility gate and none of the `ENTRY_ID:DEVICE_ID` suffix handling of
  `is_device_visible_in_subentry`, because the scan had neither;
* first matching row wins, as the previous `break` did;
* one deliberate divergence: a coordinator built via `__new__` carries no
  `_subentry_snapshots`, where `get_subentry_snapshot` raises `AttributeError`
  and the accessor answers `None` — observably the same "nothing happens",
  without an exception for the caller's defensive `except` to swallow.

`entity.py` gains `_coordinator_device_label`, which prefers the accessor and
falls back to the scan for coordinator doubles that do not implement it, so none
of the eleven decentral test stubs needs to change. `None` from the accessor is
final; a non-`str`, non-`None` answer falls through (an auto-attribute proxy is
not an answer); a *raising* accessor does **not** fall back, because that
signals a broken coordinator and scanning past it would hide the defect behind
a working label.

Two consequences of routing both branches through one helper, called out rather
than left to be discovered:

* The `except` in the caller now covers the accessor and the fallback scan, not
  just the snapshot call. Its message was reworded, and its `# pragma: no cover`
  was dropped: the branch is no longer an untestable defensive path, it carries
  the no-fallback decision above and a test exercises it.
* `device_id` is resolved *before* the `try`, so a device dictionary without a
  string `id` keeps raising instead of being converted into a silent no-op.

## Non-goals

* No change to `get_subentry_snapshot()`: signature, copying semantics and its
  twelve other callers stay as they are. The copy is the right default for
  callers that may mutate what they receive.
* No rework of the setup paths in `sensor.py`, `button.py` and
  `device_tracker.py` that pass `device` mappings into entity constructors.
* No new coordinator state: no per-subentry index, no cache, no cleanup hooks on
  the snapshot writers. `_store_subentry_snapshots` and `_refresh_subentry_index`
  have zero changed lines.
* No version bump, no `manifest.json` / `const.py` / `pyproject.toml` change.
* No timing-based test — wall-clock assertions are not reproducible in CI.

## Testing

Interpreter: the repo venv. `cwd` is the worktree.

* **Full suite before/after** (`pytest -q`, coverage gate active): 6124 passed /
  18 skipped / 78.08 % → **6154 passed / 18 skipped / 78.09 %**, `rc=0` both
  times. The delta is 28 new tests plus 2 additional parametrisations of
  `test_callback_stub_lint.py`, which enumerates repo files. No existing test
  disappeared or turned into `skipped` (verified by diffing the full
  `--collect-only` node-id lists against `1.7`).
* **Lint and types**: `ruff check --fix`, `ruff check`, `ruff format --check`
  clean; `mypy --strict --explicit-package-bases custom_components/googlefindmy
  tests` reports no issues.
* **New tests**: `tests/test_entity_label_refresh_hotpath.py` (16) and
  `tests/test_coordinator_subentry_device_label.py` (12).
* **Mutation checks**, because a green suite alone proves nothing here:
  * disabling the accessor lookup in `entity.py` turns the two wiring proofs and
    the asymmetry test red;
  * renaming `get_device_label_in_subentry` in `subentry.py` turns exactly one
    test in the entity file red — the real-coordinator/real-entity seam test.
    The other fifteen stay green, which is precisely the gap that test exists to
    close: every other proof runs against a hand-written double, and `getattr`
    plus `Any` means neither the suite nor `mypy` would notice the drift.
* **Deliberate limits**, stated rather than papered over:
  * the characterisation tests build entities via `__new__` and replace
    `maybe_update_device_registry_name`, so they are blind to regressions in
    `__init__` and in the registry sync — this is a test of one method, not of
    the entity;
  * `test_stored_row_is_not_mutated_by_the_lookup` cannot fail while the return
    type is `str | None`; it is a guard for a later refactor, not coverage of
    the no-aliasing requirement;
  * after this PR the fast path is exercised wherever the central `conftest`
    stub is used; the eleven decentral coordinator doubles keep exercising the
    fallback branch;
  * `pre-commit run --all-files` was **not** run: neither the binary nor the
    module is available in this environment. The `ruff`, `ruff-format` and
    `mypy` hooks were run individually; `codespell` is unverified.
