### PR TITLE
docs(uwt): document the specified semantics of the unwanted tracking protection mode (#210)

### DIFF
--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -941,8 +941,35 @@ class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
     a separation duration. An earlier docstring here claimed that the sensor
     turns on after a fixed separation window; no such window exists in the
     specification, and the claim caused misdirected automations and bug reports
-    (issue #210). A separation-based anti-stalking chime is a DULT platform
+    (BSkando#210). A separation-based anti-stalking chime is a DULT platform
     behaviour and is not what this bit reports.
+
+    Why the mode is nonetheless relevant to reports of spurious ringing:
+    activation (Data ID 0x07) takes an optional control flag, ``0x01``
+    "Skip ringing authentication", specified as "When set, ringing requests
+    aren't authenticated while in unwanted tracking protection mode" (section
+    "Beacon Actions", retrieved 2026-08-05). A beacon activated with that flag
+    set still expects authentication data on a ring request but no longer
+    verifies it, so while the mode is active the OWNER ring path is reachable
+    without the ring key by any party in Bluetooth range. Two caveats, both
+    load-bearing:
+
+        - The likelier explanation for the existing reports is the DULT
+          non-owner sound path, which is unauthenticated by design and needs no
+          such flag (see ``docs/PLAY_SOUND_ARCHITECTURE.md``). The flag is
+          documented here because it is the only mechanism that also removes
+          authentication from the OWNER path, which the DULT explanation does
+          not. Neither is asserted as the cause of any particular report.
+        - The bit itself is not yet trustworthy as a trigger. Episodes of 38
+          and 57 seconds and same-second flips across two devices at home are
+          on record (BSkando#210). Treat this sensor as context for a report,
+          never as an alerting signal.
+
+    What this does establish: a chime with no cloud request behind it is
+    specification-conformant and does not imply that this integration sent
+    anything (BSkando#195, BSkando#108). This integration has no GATT write
+    path at all. The advertisement carries the mode, never the flag, so the
+    sensor can narrow such a report down but cannot confirm a cause.
 
     Data source: spec bit 7 (standard bit 0) of the FMDN hashed-flags byte,
     decoded by the EID resolver as :pyattr:`BLEBatteryState.uwt_mode`.
@@ -1012,7 +1039,7 @@ class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
         no measurement in this project that would justify any particular TTL
         value. Ageing is therefore left to the consumer, which is why
         ``last_ble_observation`` is exposed as an attribute. Revisit when field
-        data from FMDN_FLAGS_PROBE exists (issue #210).
+        data from FMDN_FLAGS_PROBE exists (BSkando#210).
         """
         resolver = self._get_resolver()
         if resolver is None or self._device_id is None:

--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -919,15 +919,33 @@ class GoogleFindMyConnectivitySensor(GoogleFindMyEntity, BinarySensorEntity):
 # Per-device UWT-Mode sensor
 # --------------------------------------------------------------------------------------
 class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
-    """Per-device binary sensor indicating FMDN Unwanted Tracking (UWT) mode.
+    """Per-device binary sensor for the FMDN unwanted tracking protection mode.
 
-    Semantics:
-        - ``on``  → The tracker has entered UWT / separated state (away from
-          owner for 8-24 hours).  DULT anti-stalking sound becomes available.
-        - ``off`` → Normal operation, tracker is near owner.
+    Semantics (per the Find Hub Network Accessory Specification, section
+    "Hashed flags", retrieved 2026-08-04:
+    https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn):
+        - ``on``  → The beacon reports that unwanted tracking protection mode
+          is active: spec bit 7 of the hashed-flags byte is set. Note that the
+          specification numbers hashed-flags bits MSB-first, so spec bit 7 is
+          standard bit 0; the resolver mask is therefore ``0x01`` and not
+          ``0x80`` (see ``eid_resolver.py``, which marks ``0x80`` as an
+          anti-pattern). The mode is entered and left by COMMAND (Data ID 0x07
+          activates it, 0x08 deactivates it), not by elapsed time.
+        - ``off`` → The beacon reports normal operation.
+        - ``None`` → No hashed-flags byte has been decoded for this device.
+          The byte is optional: a beacon without battery indication that is not
+          in unwanted tracking protection mode may omit it entirely.
 
-    Data source: bit 7 of the FMDN hashed-flags byte, decoded by the EID
-    resolver as :pyattr:`BLEBatteryState.uwt_mode`.
+    Not what this sensor means: the specification's "24 hours" figure refers to
+    the reduced MAC address rotation frequency WHILE the mode is active, not to
+    a separation duration. An earlier docstring here claimed that the sensor
+    turns on after a fixed separation window; no such window exists in the
+    specification, and the claim caused misdirected automations and bug reports
+    (issue #210). A separation-based anti-stalking chime is a DULT platform
+    behaviour and is not what this bit reports.
+
+    Data source: spec bit 7 (standard bit 0) of the FMDN hashed-flags byte,
+    decoded by the EID resolver as :pyattr:`BLEBatteryState.uwt_mode`.
 
     Created dynamically alongside the BLE battery sensor when the resolver
     first decodes hashed-flags data for a device.
@@ -982,7 +1000,20 @@ class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool | None:
-        """Return True when UWT / separated state is active."""
+        """Return True when the beacon reports unwanted tracking protection mode.
+
+        ``None`` means "no hashed-flags byte decoded yet", not "off": the byte
+        is optional per specification.
+
+        No BLE staleness TTL: the last decoded value is reported for as long as
+        the coordinator's TTL-smoothed presence holds. Rationale, and why this
+        is a decision rather than an oversight: the hashed-flags byte is
+        optional and may be sent rarely, so a short TTL would flap; and there is
+        no measurement in this project that would justify any particular TTL
+        value. Ageing is therefore left to the consumer, which is why
+        ``last_ble_observation`` is exposed as an attribute. Revisit when field
+        data from FMDN_FLAGS_PROBE exists (issue #210).
+        """
         resolver = self._get_resolver()
         if resolver is None or self._device_id is None:
             return None
@@ -993,12 +1024,23 @@ class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
 
     @property
     def icon(self) -> str:
-        """Return a dynamic icon reflecting UWT state."""
+        """Return the icon for the reported unwanted tracking protection mode.
+
+        ``mdi:shield-alert`` when the mode is reported active, ``mdi:shield-check``
+        otherwise. The undecoded ``None`` case is deliberately rendered as "no
+        alert" rather than as an alarm.
+        """
         return "mdi:shield-alert" if self.is_on else "mdi:shield-check"
 
     @property
     def available(self) -> bool:
-        """Return True when the coordinator considers the device present."""
+        """Return True when the coordinator considers the device present.
+
+        Availability follows the coordinator's TTL-smoothed presence only; it
+        carries no separate staleness rule for the decoded flags byte. See
+        :pyattr:`is_on` for why that absence is a decision rather than an
+        oversight.
+        """
         if not super().available:
             return False
         if not self.coordinator_has_device():

--- a/docs/PLAY_SOUND_ARCHITECTURE.md
+++ b/docs/PLAY_SOUND_ARCHITECTURE.md
@@ -413,7 +413,7 @@ device logged into the owner's Google account. This is the opposite of our use c
 > Find Hub Network Accessory Specification, section "Beacon Actions"
 > (<https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>,
 > retrieved 2026-08-04). Do not use the `uwt_mode` binary sensor as a separation timer
-> (issue #210).
+> ([BSkando#210](https://github.com/BSkando/GoogleFindMy-HA/issues/210)).
 
 **We must use FMDN Beacon Actions (authenticated ring)** because:
 1. We have the EIK → can derive the ring key
@@ -431,6 +431,40 @@ three independent ring trigger sources:
 | Non-owner BLE sound | `DULT_BT_GATT` | DULT ANOS (`15190001-12F4`) | None |
 | Motion auto-ring | `DULT_MOTION_DETECTOR` | Internal (separated state) | N/A |
 
+> **The `HMAC-SHA256` in row 1 is conditional on how UTP mode was activated.**
+> Activating unwanted tracking protection mode (Data ID `0x07`) takes an optional
+> control flag, `0x01` "Skip ringing authentication", specified as "When set, ringing
+> requests aren't authenticated while in unwanted tracking protection mode" (Find Hub
+> Network Accessory Specification, section "Beacon Actions",
+> <https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>,
+> retrieved 2026-08-05). A beacon activated with that flag set still expects
+> authentication data on a ring request but no longer verifies it, so while the mode
+> is active the owner ring path is reachable by any party in Bluetooth range without
+> the ring key.
+>
+> Three consequences, in decreasing order of confidence:
+>
+> 1. An implementation of the owner ring must not infer from a successful ring that
+>    the ring was authenticated, and must not treat the ring key as a capability that
+>    only the owner holds while the mode is active.
+> 2. A chime with no cloud request behind it is specification-conformant and does not
+>    imply a defect in this integration
+>    ([BSkando#195](https://github.com/BSkando/GoogleFindMy-HA/issues/195),
+>    [BSkando#108](https://github.com/BSkando/GoogleFindMy-HA/issues/108)).
+> 3. This flag is **not** the likeliest explanation for those reports. Row 2 of the
+>    table above, the DULT non-owner sound, is unauthenticated by design and needs no
+>    flag at all; the reporter in
+>    [BSkando#210](https://github.com/BSkando/GoogleFindMy-HA/issues/210) attributes
+>    the observed chirps to that path, having instrumented the event bus to rule this
+>    integration out as the source. The `0x07` flag is documented here because it is
+>    the only mechanism that also removes authentication from the **owner** path,
+>    which the DULT explanation does not.
+>
+> The advertisement reports the mode (`uwt_mode` binary sensor), never the flag, and
+> the mode itself is observed to flap on timescales of under a minute
+> ([BSkando#210](https://github.com/BSkando/GoogleFindMy-HA/issues/210)). It is
+> context for a report, not evidence of a cause.
+
 ---
 
 ## Comparison: All Three Ring Paths
@@ -439,7 +473,7 @@ three independent ring trigger sources:
 |--------|------------------|-----------------------|---------------------------|
 | **Latency** | 2-15 seconds (FCM) | < 1 second | < 1 second |
 | **Range** | Global | ~30m BLE | ~30m BLE |
-| **Auth** | Google OAuth + FCM | HMAC-SHA256 (ring key) | None |
+| **Auth** | Google OAuth + FCM | HMAC-SHA256 (ring key), but see the UTP control-flag note above: not verified while the tracker is in unwanted tracking protection mode that was activated with flag `0x01` | None |
 | **Availability** | Always | Always (owner has key) | Separated state only |
 | **Confirmation** | None (fire-and-forget) | Ring state notification | Command_Response indication |
 | **Reliability** | FCM delivery dependent | Direct, deterministic | Direct, deterministic |
@@ -574,7 +608,7 @@ The ring key is currently only used during device registration
 | **FMDN** | Find My Device Network — Google's crowdsource tracker protocol |
 | **EIK** | Ephemeral Identity Key — 32-byte root key for tracker crypto |
 | **EID** | Ephemeral Identifier — rotating BLE address derived from EIK |
-| **Beacon Actions** | FMDN GATT characteristic (`FE2C1238`) for owner-authenticated commands (ring, UTP) |
+| **Beacon Actions** | FMDN GATT characteristic (`FE2C1238`) for owner-authenticated commands (ring, UTP); ring authentication can be waived for the duration of UTP mode by control flag `0x01` at activation |
 | **DULT** | Detecting Unwanted Location Trackers — IETF specification for anti-stalking |
 | **ANOS** | Accessory Non-Owner Service — DULT GATT service (`15190001-12F4`) for unauthenticated commands |
 | **Separated State** | DULT platform state, entered after roughly 30 minutes without an owner device; the unauthenticated DULT sound is enabled only after a further 8-24 hours (both figures from DULT drafts and field reports, not from the FMDN specification; see `docs/TRIGGER_MECHANISMS.md` sections 4.1 and 8). **Not** the same as the FMDN unwanted tracking protection mode, which is command-driven (Data ID `0x07` / `0x08`) and is what the `uwt_mode` binary sensor reports |

--- a/docs/PLAY_SOUND_ARCHITECTURE.md
+++ b/docs/PLAY_SOUND_ARCHITECTURE.md
@@ -334,7 +334,7 @@ use case where the caller does NOT own the tracker.
 | CCCD Descriptor | `00002902-0000-1000-8000-00805F9B34FB` |
 | Byte Order | **Little endian** (opposite of FMDN Beacon Actions!) |
 | Authentication | **None** |
-| Availability | **Separated state only** (tracker away from owner 8-24 hours) |
+| Availability | **Separated state only**; the unauthenticated sound is enabled 8-24 hours after separation (figure from DULT/AirTag field reports, not from the FMDN specification; see `docs/TRIGGER_MECHANISMS.md` sections 4.1 and 8) |
 
 ### DULT Opcodes (Little-Endian Wire Format)
 
@@ -404,6 +404,16 @@ account). In near-owner state, the tracker responds to DULT Sound_Start with
 
 DULT only works when the tracker enters "separated state" — 8-24 hours away from any
 device logged into the owner's Google account. This is the opposite of our use case.
+
+> **Provenance of the 8-24 hour figure:** it comes from DULT/AirTag field reports and
+> describes a *platform* behaviour (see `docs/TRIGGER_MECHANISMS.md` sections 4.1 and 8
+> for the per-device figures and their sources). It is **not** in the FMDN
+> specification, and it is **not** what the FMDN unwanted tracking protection mode
+> reports: that mode is entered and left by command (Data ID `0x07` / `0x08`), per the
+> Find Hub Network Accessory Specification, section "Beacon Actions"
+> (<https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>,
+> retrieved 2026-08-04). Do not use the `uwt_mode` binary sensor as a separation timer
+> (issue #210).
 
 **We must use FMDN Beacon Actions (authenticated ring)** because:
 1. We have the EIK → can derive the ring key
@@ -567,7 +577,7 @@ The ring key is currently only used during device registration
 | **Beacon Actions** | FMDN GATT characteristic (`FE2C1238`) for owner-authenticated commands (ring, UTP) |
 | **DULT** | Detecting Unwanted Location Trackers — IETF specification for anti-stalking |
 | **ANOS** | Accessory Non-Owner Service — DULT GATT service (`15190001-12F4`) for unauthenticated commands |
-| **Separated State** | Tracker state when away from owner device for 8-24 hours; enables DULT/UTP features |
+| **Separated State** | DULT platform state, entered after roughly 30 minutes without an owner device; the unauthenticated DULT sound is enabled only after a further 8-24 hours (both figures from DULT drafts and field reports, not from the FMDN specification; see `docs/TRIGGER_MECHANISMS.md` sections 4.1 and 8). **Not** the same as the FMDN unwanted tracking protection mode, which is command-driven (Data ID `0x07` / `0x08`) and is what the `uwt_mode` binary sensor reports |
 | **GATT** | Generic Attribute Profile — BLE protocol for read/write operations |
 | **CCCD** | Client Characteristic Configuration Descriptor — enables BLE notifications/indications |
 | **ADM** | Android Device Management — Google auth token type |

--- a/docs/TRIGGER_MECHANISMS.md
+++ b/docs/TRIGGER_MECHANISMS.md
@@ -75,6 +75,16 @@ Unlike the proprietary obscurity of Apple's initial launch, the DULT specificati
 
 ### **4.2 Unwanted Tracking (UT) Mode**
 
+> **Not the same thing as the `uwt_mode` binary sensor.** This section describes the
+> DULT *platform* behaviour, which is reached by elapsed time. The FMDN *unwanted
+> tracking protection mode*, which bit 7 of the hashed-flags byte reports and which the
+> `uwt_mode` entity exposes, is entered and left by command (Data ID `0x07` / `0x08`)
+> per the Find Hub Network Accessory Specification
+> (<https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>,
+> retrieved 2026-08-04). Do not read this section as documentation of that sensor, and
+> do not build separation timers on it (issue #210). See
+> `custom_components/googlefindmy/binary_sensor.py::GoogleFindMyUWTModeSensor`.
+
 The UT Mode is the critical operational phase for anti-stalking alerts. When a device has been in the Separated state for an extended period, it alters its behavior to become more visible to detection networks.
 
 * **Static MAC Address:** Crucially, upon entering UT Mode, the tracker ceases the rapid rotation of its MAC address. The MAC address rotation slows significantly, often persisting for **24 hours**. This allows the "Unknown Tracker Alert" algorithms on Android and iOS devices to recognize the device as a persistent companion rather than a series of transient devices passing by.¹⁷  

--- a/docs/TRIGGER_MECHANISMS.md
+++ b/docs/TRIGGER_MECHANISMS.md
@@ -82,7 +82,7 @@ Unlike the proprietary obscurity of Apple's initial launch, the DULT specificati
 > per the Find Hub Network Accessory Specification
 > (<https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>,
 > retrieved 2026-08-04). Do not read this section as documentation of that sensor, and
-> do not build separation timers on it (issue #210). See
+> do not build separation timers on it ([BSkando#210](https://github.com/BSkando/GoogleFindMy-HA/issues/210)). See
 > `custom_components/googlefindmy/binary_sensor.py::GoogleFindMyUWTModeSensor`.
 
 The UT Mode is the critical operational phase for anti-stalking alerts. When a device has been in the Separated state for an extended period, it alters its behavior to become more visible to detection networks.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -977,10 +977,19 @@ reads docstrings via `inspect.getdoc` and asserts that a specific, previously
 wrong claim cannot return and that the specification reference stays present.
 It exists because the UWT-mode sensor documented a separation duration the Find
 Hub Network Accessory Specification never defines, which produced misdirected
-automations and bug reports (issue #210) without a single failing test.
+automations and bug reports (BSkando#210) without a single failing test.
 
-Use this pattern only where a wrong docstring has already caused a real defect,
-and keep three properties:
+Use this pattern in one of exactly two situations, and keep four properties:
+
+- **(a) Corrective.** A wrong docstring has already caused a real defect. This is
+  the original case above.
+- **(b) Load-bearing cross-reference.** The docstring carries the only in-repo
+  statement that links an entity to an open upstream report, so deleting the prose
+  silently deletes the link. `test_docstring_keeps_the_skip_ringing_authentication_caveat`
+  is the first member of this kind: it pins the "Skip ringing authentication"
+  control flag, which is what connects the UWT-mode sensor to the spurious-ring
+  reports. Case (b) is narrower than it looks and is not a licence to freeze prose
+  in general: without property 4 below it degenerates into exactly that.
 
 1. **Match patterns, not one spelling.** The negative guard uses a regular
    expression covering hyphen, en-dash and spelled-out variants. A plain
@@ -992,3 +1001,8 @@ and keep three properties:
 3. **State the blind spot in the test class docstring.** These are pattern and
    presence checks; they cannot distinguish good prose from a bag of the right
    keywords. Like the CLI kill guard, this is a ratchet, not a proof.
+4. **Name the retirement condition.** Every guard states in its own docstring
+   what would make it obsolete: for case (a) that the corrected claim has been
+   stable across a release, for case (b) that the named upstream report has
+   closed. A guard with no stated exit turns documentation into a permanent
+   fixture and outlives the reason it was written.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -968,3 +968,27 @@ following to preserve migration coverage:
 `custom_components.googlefindmy.const.SERVICE_DEVICE_TRANSLATION_KEY`. Update this
 test whenever new locales or service-device translation keys are introduced so it
 continues to guard localized device names.
+
+## Docstring semantics guards
+
+`tests/test_uwt_mode_binary_sensor.py::TestUWTModeSensorDocumentationMatchesSpec`
+introduces a guard family that pins *documentation* rather than behaviour: it
+reads docstrings via `inspect.getdoc` and asserts that a specific, previously
+wrong claim cannot return and that the specification reference stays present.
+It exists because the UWT-mode sensor documented a separation duration the Find
+Hub Network Accessory Specification never defines, which produced misdirected
+automations and bug reports (issue #210) without a single failing test.
+
+Use this pattern only where a wrong docstring has already caused a real defect,
+and keep three properties:
+
+1. **Match patterns, not one spelling.** The negative guard uses a regular
+   expression covering hyphen, en-dash and spelled-out variants. A plain
+   substring check is trivially evaded by rewording, which makes the guard read
+   as protection while providing none.
+2. **Do not paraphrase the banned claim in the guarded docstring.** If the
+   prose needs to mention what was wrong, it must do so without restating the
+   figure, otherwise the guard fires on its own debunking.
+3. **State the blind spot in the test class docstring.** These are pattern and
+   presence checks; they cannot distinguish good prose from a bag of the right
+   keywords. Like the CLI kill guard, this is a ratchet, not a proof.

--- a/tests/test_uwt_mode_binary_sensor.py
+++ b/tests/test_uwt_mode_binary_sensor.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import inspect
+import re
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -330,3 +332,88 @@ class TestUWTModeSensorCoordinatorUpdate:
         sensor._handle_coordinator_update()
 
         sensor.async_write_ha_state.assert_called_once()
+
+
+# ===========================================================================
+# 7. GoogleFindMyUWTModeSensor — documentation guards (issue #210)
+# ===========================================================================
+
+
+class TestUWTModeSensorDocumentationMatchesSpec:
+    """Guard the docstrings against the semantics drift fixed for issue #210.
+
+    The class docstring once claimed a fixed separation window that the Find Hub
+    Network Accessory Specification does not define, which produced misdirected
+    automations and bug reports.
+
+    Scope and blind spot, stated plainly: these are pattern and presence checks,
+    not prose review. They pin that the debunked figure stays out (in any of its
+    common spellings) and that the specification reference stays discoverable.
+    They cannot tell a well-written docstring from a bag of the right keywords.
+    Widen them when a regression slips past, not before.
+    """
+
+    #: Matches the debunked separation figure in its common spellings, including
+    #: hyphen/en-dash/em-dash variants, "8 to 24" and the spelled-out form.
+    SEPARATION_FIGURE_RE = re.compile(
+        r"8\s*[-\u2010-\u2015]\s*24\s*h|8\s+to\s+24\s+h|eight\s+to\s+twenty[- ]four",
+        re.IGNORECASE,
+    )
+
+    def test_docstring_does_not_claim_a_separation_duration(self) -> None:
+        """The debunked separation figure must not reappear in the docstrings."""
+        class_doc = inspect.getdoc(GoogleFindMyUWTModeSensor) or ""
+        is_on_doc = inspect.getdoc(GoogleFindMyUWTModeSensor.is_on.fget) or ""
+        icon_doc = inspect.getdoc(GoogleFindMyUWTModeSensor.icon.fget) or ""
+
+        for name, doc in (
+            ("class", class_doc),
+            ("is_on", is_on_doc),
+            ("icon", icon_doc),
+        ):
+            match = self.SEPARATION_FIGURE_RE.search(doc)
+            assert match is None, (
+                f"{name} docstring reintroduces the debunked separation figure: "
+                f"{match.group(0)!r}"
+            )
+
+    def test_docstring_names_spec_term_and_source(self) -> None:
+        """The docstrings must name the specification term, source and mechanism."""
+        class_doc = inspect.getdoc(GoogleFindMyUWTModeSensor) or ""
+        is_on_doc = inspect.getdoc(GoogleFindMyUWTModeSensor.is_on.fget) or ""
+
+        assert "unwanted tracking protection mode" in class_doc
+        assert (
+            "developers.google.com/nearby/fast-pair/specifications/extensions/fmdn"
+            in class_doc
+        )
+        assert "unwanted tracking protection mode" in is_on_doc
+        # The mode is command-driven; both Data IDs must stay named, otherwise the
+        # "not by elapsed time" statement loses its evidence.
+        assert "0x07" in class_doc
+        assert "0x08" in class_doc
+
+    def test_docstring_keeps_the_msb_first_bit_numbering_caveat(self) -> None:
+        """Spec bit 7 is standard bit 0; the mask is 0x01, never 0x80.
+
+        The resolver marks ``0x80`` as an anti-pattern. A docstring that says
+        "bit 7" without the caveat invites exactly that "fix".
+        """
+        class_doc = inspect.getdoc(GoogleFindMyUWTModeSensor) or ""
+
+        assert "spec bit 7" in class_doc
+        assert "0x01" in class_doc
+        assert "0x80" in class_doc
+
+    def test_is_on_docstring_documents_absence_of_ttl(self) -> None:
+        """The missing staleness TTL must be documented as a decision.
+
+        Mirrors the rationale comment on the BLE battery sensor: the absence of
+        ageing is deliberate, has a stated reason, and names what would make it
+        revisitable.
+        """
+        is_on_doc = inspect.getdoc(GoogleFindMyUWTModeSensor.is_on.fget) or ""
+
+        assert "No BLE staleness TTL" in is_on_doc
+        assert "decision rather than an oversight" in is_on_doc
+        assert "FMDN_FLAGS_PROBE" in is_on_doc

--- a/tests/test_uwt_mode_binary_sensor.py
+++ b/tests/test_uwt_mode_binary_sensor.py
@@ -335,12 +335,12 @@ class TestUWTModeSensorCoordinatorUpdate:
 
 
 # ===========================================================================
-# 7. GoogleFindMyUWTModeSensor — documentation guards (issue #210)
+# 7. GoogleFindMyUWTModeSensor — documentation guards (BSkando#210)
 # ===========================================================================
 
 
 class TestUWTModeSensorDocumentationMatchesSpec:
-    """Guard the docstrings against the semantics drift fixed for issue #210.
+    """Guard the docstrings against the semantics drift fixed for BSkando#210.
 
     The class docstring once claimed a fixed separation window that the Find Hub
     Network Accessory Specification does not define, which produced misdirected
@@ -392,6 +392,35 @@ class TestUWTModeSensorDocumentationMatchesSpec:
         # "not by elapsed time" statement loses its evidence.
         assert "0x07" in class_doc
         assert "0x08" in class_doc
+
+    def test_docstring_keeps_the_skip_ringing_authentication_caveat(self) -> None:
+        """The unauthenticated-ring consequence of the mode must stay documented.
+
+        Case (b) of the guard family in ``tests/AGENTS.md``, "load-bearing
+        cross-reference": the class docstring carries the only in-repo statement
+        that links this sensor to the spurious-ring reports, namely that while
+        the mode is active and was activated with control flag ``0x01``, ring
+        requests are not authenticated, so a chime with no cloud request behind
+        it is specification-conformant. Deleting the prose deletes the link
+        silently, and no behavioural test would notice.
+
+        This guard pins that the mechanism stays documented. It deliberately
+        does NOT pin any claim about what caused a given report: the docstring
+        names the DULT non-owner path as the likelier explanation, and that
+        attribution is the reporter's, not this repository's.
+
+        The guard does not assert on ``0x01``: that literal is already required
+        by the bit-mask caveat above and would pass even if the control flag
+        went unmentioned.
+
+        Retirement condition: BSkando#195 and BSkando#210 both closed, or the
+        mechanism documented somewhere that a docstring edit cannot silently
+        remove.
+        """
+        class_doc = inspect.getdoc(GoogleFindMyUWTModeSensor) or ""
+
+        assert "Skip ringing authentication" in class_doc
+        assert "BSkando#195" in class_doc
 
     def test_docstring_keeps_the_msb_first_bit_numbering_caveat(self) -> None:
         """Spec bit 7 is standard bit 0; the mask is 0x01, never 0x80.


### PR DESCRIPTION
## What this is

Documentation-only fix for the `uwt_mode` binary sensor. No behaviour change.

The class docstring claimed the sensor turns on when the tracker "has entered UWT /
separated state (away from owner for 8-24 hours)". The Find Hub Network Accessory
Specification does not define any such window. Bit 7 of the hashed-flags byte reports
the **unwanted tracking protection mode**, which the beacon enters and leaves **by
command** (Data ID `0x07` activates, `0x08` deactivates). The specification's "24 hours"
figure refers to the reduced MAC address rotation frequency *while* the mode is active.

Source: <https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>
(section "Hashed flags", retrieved 2026-08-04).

Relates to BSkando/GoogleFindMy-HA#210, where a user reported the sensor flipping on and
off within minutes. Short episodes do not contradict the specification; they only
contradicted our docstring.

## Changes

| Area | Change |
|---|---|
| `binary_sensor.py` | Class, `is_on` and `icon` docstrings restated against the specification, with the MSB-first caveat (spec bit 7 == standard bit 0, mask `0x01`, never `0x80`) |
| `binary_sensor.py` | `is_on` now documents the absent staleness TTL as a decision, with its reason and what would make it revisitable; `available` cross-references it |
| `docs/PLAY_SOUND_ARCHITECTURE.md` | The three 8-24 hour mentions are attributed to DULT/AirTag field reports and separated from the FMDN mode; glossary corrected |
| `docs/TRIGGER_MECHANISMS.md` | Section 4.2 gets a note that it documents the DULT platform behaviour, not the `uwt_mode` entity |
| `tests/` | Four regression guards; `tests/AGENTS.md` documents the new guard family and its blind spot |

Nothing was deleted; all figures are kept and attributed (root `AGENTS.md`, Rule 9.DOC).

## Why no TTL / debounce was added

The sensor reports the last decoded value without ageing. That stays. The hashed-flags
byte is optional and may be sent rarely, and this project has no measurement of its
advertisement frequency, so any TTL value would be invented and would trade "value
stays too long" for "value disappears too early". The decision is now documented rather
than left looking like an oversight, together with the condition for revisiting it
(field data from `FMDN_FLAGS_PROBE`).

## Glossary correction worth flagging

The glossary previously implied the Separated State is entered after 8-24 hours. Per
`docs/TRIGGER_MECHANISMS.md` (sections 4.1 and 8) the state is reached after roughly 30
minutes; the 8-24 hours are the delay until the unauthenticated DULT sound is enabled.
Both the glossary and the DULT availability row now say so.

## Deliberate omissions

- **`strings.json` and `translations/` are not touched here.** They carry the entity
  name only, and that name is `Unwanted Tracking Mode` in every locale, i.e. without
  "protection". That reads as "the tracker is tracking unwantedly" rather than "the
  protection is active", so it is arguably the same class of confusion on the user-facing
  side. Renaming touches eleven files plus hassfest translation validation, so it is left
  for a follow-up rather than smuggled into a docs PR. Flagging it explicitly so the
  omission is not read as an oversight.
- **`docs/FMDN.md` is not touched here.** It still lists the hashed-flags bit meanings as
  "not publicly fixed". Correcting that belongs to the decode-hardening branch; this PR
  therefore cites the specification URL directly rather than pointing at a repo document
  that currently says the opposite.

## Test plan

All four CI gates were run locally against a Python 3.13 venv with the pinned toolchain
(`ruff` 0.15.22, matching `poetry.lock`):

| Gate | Result |
|---|---|
| `ruff check .` | All checks passed |
| `ruff format --check .` | 487 files already formatted |
| `mypy --strict -p custom_components.googlefindmy` | no issues in 129 source files |
| full `pytest` | exit 0, coverage 78.09% (threshold 77%) |

`hassfest` was not run locally and is left to CI, but this PR touches no translation,
manifest or icon file.

Mutation testing on the guards, since a guard that cannot fail is decoration:

- Restoring the old docstring turns all guards red.
- Removing the specification URL turns the source guard red.
- Removing the TTL rationale turns the TTL guard red.
- Seven evasion spellings of the banned figure (`8-24 hours`, `8 - 24 hours`,
  `8–24 hours`, `8 to 24 hours`, `8-24 HOURS`, `eight to twenty-four hours`,
  `eight to twenty four hours`) each turn the negative guard red. The first draft used a
  plain substring check and let six of those through; that is why the guard is a regex.

Behaviour neutrality was verified structurally: the AST of `binary_sensor.py` with
docstring constants stripped is identical before and after this change.
