### PR TITLE
ci(deps): modernize five actions off the deprecated node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Wait for hassfest auto-fix workflow to finish
         if: steps.hassfest_autofix.outputs.found == 'true'
-        uses: lewagon/wait-on-check-action@v1.3.3
+        uses: lewagon/wait-on-check-action@v1.9.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           check-regexp: '^[Hh]assfest( \(auto-fix\)( / hassfest.*)?)?$'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
           poetry run pytest -q --cov --cov-report=xml --cov-report=term --cov-fail-under=78 2>&1 | tee pytest_output.log
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/hassfest-auto-fix.yml
+++ b/.github/workflows/hassfest-auto-fix.yml
@@ -24,7 +24,7 @@ jobs:
         continue-on-error: true
 
       - name: Commit hassfest auto-sorts (if any)
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7.2.0
         with:
           commit_message: "chore(hassfest): auto-sort manifest keys"
           file_pattern: "custom_components/**/manifest.json"

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Create pull request with fixes
         if: steps.fixrun.outputs.changed == '1'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           branch: security/pip-audit-autofix
           delete-branch: true

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Validate PR title follows Conventional Commits
         id: semantic
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6.1.1
         continue-on-error: true  # Non-blocking - informational only
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semgrep-autofix.yml
+++ b/.github/workflows/semgrep-autofix.yml
@@ -24,7 +24,7 @@ jobs:
         run: semgrep scan --config auto --metrics=off --autofix || true
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           branch: chore/semgrep-autofix
           commit-message: 'chore: apply Semgrep autofixes'


### PR DESCRIPTION
# Summary

Five GitHub Actions in this repository still ran on the Node 20 runtime, which
the runner now force-migrates to Node 24 and reports as deprecated. This PR
moves them off it, one commit per action, so that `git revert` stays a
single-step operation per action.

- Type: ☑ ci
- Scope/Area: `.github/workflows/` only; no Python, no `custom_components/`, no `tests/`
- Linked issues: none

**Landed incrementally.** Each action was verified against a real workflow run
before the next one was pushed. All 5 of 5 commits are in. The warning that
triggered this PR is gone, measured rather than assumed.

## Motivation

The trigger was a concrete warning in the `Hassfest validation` job:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/cache@v3.
```

`actions/cache@v3` is not called by this repository. It is a transitive call
from `lewagon/wait-on-check-action@v1.3.3`, whose composite definition invokes
`ruby/setup-ruby@v1` plus an explicit `actions/cache@v3` step. v1.9.x drops the
cache step and pins `ruby/setup-ruby@3ff19f5e…` (tag `v1.299.0`), which declares
`runs.using: 'node24'`. Both facts were read from the upstream `action.yml` at
the respective tags, not inferred from version numbers.

The robustness of the hassfest wait point comes first here; the Node deadline is
the occasion, not the goal.

---

## Change Log (human-readable)

### Changed

| # | Action | From | To | File(s) | Breaking change for our inputs? | Verdict | Run |
|---|---|---|---|---|---|---|---|
| 1 | `lewagon/wait-on-check-action` | `v1.3.3` | `v1.9.1` | `ci.yml` | **No**, measured | **verified on a run** | [32178623619](https://github.com/jleinenbach/GoogleFindMy-HA/actions/runs/32178623619) |
| 2 | `codecov/codecov-action` | `v4` | `v7.0.0` | `ci.yml` | **No**, measured | **verified on a run** | [32180854668](https://github.com/jleinenbach/GoogleFindMy-HA/actions/runs/32180854668) |
| 3 | `peter-evans/create-pull-request` | `v7` | `v8.1.1` | `pip-audit.yml`, `semgrep-autofix.yml` | **No**, measured (24 inputs on both sides, delta zero) | **static proof only, see rests** | regression run [32183989440](https://github.com/jleinenbach/GoogleFindMy-HA/actions/runs/32183989440) |
| 4 | `amannn/action-semantic-pull-request` | `v5` | `v6.1.1` | `semantic-pr.yml` | **No** for the verdict, but not cosmetic, see below | **verified on a run** | [32186331180](https://github.com/jleinenbach/GoogleFindMy-HA/actions/runs/32186331180) |
| 5 | `stefanzweifel/git-auto-commit-action` | `v5` | `v7.2.0` | `hassfest-auto-fix.yml` | **No**, measured | **verified on a run, both sides of the coupling** | [32188345300](https://github.com/jleinenbach/GoogleFindMy-HA/actions/runs/32188345300) |

Notes per commit, all measured against the upstream `action.yml` of both tags:

- **1 `wait-on-check-action`.** Input surface 10 → 14, four new, none removed,
  all five keys we set still exist. Exit behaviour on "filter set, check list
  empty": `v1.3.3` exits 1; `v1.6.0`/`v1.6.1` regressed to exit 0; `v1.7.0`
  restored exit 1, and `v1.9.1` keeps it. This jump skips the regressed window
  entirely. `v1.9.1` over `v1.9.0`: identical input surface; the delta makes
  `BUNDLE_PATH` absolute in two unconditional steps, plus one step gated on
  `bundler-cache == 'false'`, which we do not set.
- **2 `codecov-action`.** `v6.0.2` and `v7.0.0` are the *same commit*
  (compare API: `status: identical`, `total_commits: 0`), so the major bump is a
  tag move without a code change. `v5.5.5` would not have reached the goal: it
  is already `composite`, but pins `actions/github-script@v7.0.1` and therefore
  `node20`. `v7.0.0` pins `actions/github-script@v8.0.0` (`node24`).
- **3 `create-pull-request`.** Input surface 24 → 24, delta zero; all keys we
  set exist on both sides. `runs.using` moves `node20` → `node24`, which is the
  exact field the deprecation warning is attached to.
- **4 `action-semantic-pull-request`.** Not cosmetic: in `v5`,
  `parseString(input) { return input; }` passed `headerPatternCorrespondence`
  through as a raw string; from `v6.1.1` it is split on commas and trimmed. The
  title verdict was therefore verified on the *step*, not on the job
  (`continue-on-error: true` would keep the job green either way). Step
  conclusion `success`, and the summary step evaluates
  `if [ "success" = "success" ]`.
- **5 `git-auto-commit-action`.** The detached-state check restored in `v7.0.0`
  emits `_log "warning"` and returns; it does not abort, contrary to what the
  release note suggests. It stayed silent here (checkout is attached). The new
  `pull_request_target` warning fires only on that event; this workflow triggers
  on `pull_request`. Normal path output is unchanged: `Working tree clean.
  Nothing to commit.`

### Compatibility

No user-facing change. Nothing outside `.github/workflows/` is touched; entity
IDs, config entries and the integration itself are unaffected.

---

## Measurement results

Node 20 warning census per workflow, baseline (before this PR) against the final
branch state `1d362970`. The census reads check-run annotations across all jobs
of a run and filters on the literal `Node.js 20 is deprecated`.

| Workflow | Baseline | Baseline run | Final state | Final run |
|---|---|---|---|---|
| `ci.yml` | 2 lines: `actions/cache@v3`, `codecov/codecov-action@v4` | 32170451676 | **empty** | [32188345301](https://github.com/jleinenbach/GoogleFindMy-HA/actions/runs/32188345301) |
| `semantic-pr.yml` | 1 line: `amannn/action-semantic-pull-request@v5` | 32171262841 | **empty** | [32188345285](https://github.com/jleinenbach/GoogleFindMy-HA/actions/runs/32188345285) |
| `hassfest-auto-fix.yml` | 1 line: `stefanzweifel/git-auto-commit-action@v5` | 32170451641 | **empty** | [32188345300](https://github.com/jleinenbach/GoogleFindMy-HA/actions/runs/32188345300) |
| `pip-audit.yml` | 1 line: `peter-evans/create-pull-request@v7` | 32097635350 (schedule) | empty, but a **null finding**: job `autofix` is `skipped` on the PR path | [32188345396](https://github.com/jleinenbach/GoogleFindMy-HA/actions/runs/32188345396) |
| `semgrep-autofix.yml` | none, the workflow has **zero recorded runs** | none | not measurable, see rests | none |

All job conclusions on the final state are `success` (9 of 9 in `ci.yml`;
`autofix` in `pip-audit.yml` is `skipped` by its own job guard).

**Positive control.** An empty census and a broken query produce the same empty
output, so the same command was run against a known-red reference run
(31112597333) in the same session. It returns exactly two lines. The channel
pulls, so the empty result at the target state is a finding, not a silence.

**The originating warning specifically.** In the baseline, the
`actions/cache@v3` annotation sat in the job `Hassfest validation`. That same
job on the final state carries **6** annotations (all of them pre-existing
`[TRANSLATIONS]` warnings) and **no** Node 20 line, so the channel is
demonstrably live for that job. `actions/cache` occurs **zero** times in its
log: the cache step is gone, exactly as `v1.9.1` promised.

---

## Non-goals

- **The `needs: hassfest` coupling in `ci.yml` is not touched.** Five of six
  jobs depend on that gate; whether to decouple them is an open CI-policy
  question for the repository owner, and a maintenance PR must not decide it by
  accident. No `needs:` line is modified (verified: 5 before, 5 after, and zero
  `needs` occurrences among the changed lines).
- **The `semgrep.yml` trigger is not touched.** Its `push` and `pull_request`
  triggers filter on `branches: [main]` while this PR targets `1.7`, so the SAST
  scan does not run here; that is the pre-existing state, not a regression
  introduced by this PR. Tracked separately. Note that `semgrep.yml` (the scan)
  and `semgrep-autofix.yml` (a bump site of commit 3) are two different files.
- Dependabot's effectiveness (a weekly `github-actions` group exists in
  `.github/dependabot.yml`, yet no action update was ever merged) is a separate
  investigation, not this PR.

## Declared rests

Four rests, each with (i) where, (ii) why it is not measurable, (iii) what is
established instead.

1. **`pip-audit.yml`, the `create-pull-request` step: not exercised on a
   runner.** Its job `autofix` is guarded by
   `if: github.event_name != 'pull_request'`, so on the PR path the action is
   never loaded. This was verified as a null finding, not read as a success: the
   census on the *predecessor* run was empty too. Established instead: the
   static causal proof, `runs.using` is `node20` at `v7` and `node24` at
   `v8.1.1`, and the warning is attached to exactly that field. **Terminable
   without any write access** on the first `schedule` run after the merge; the
   cron is `23 3 * * 2`, i.e. **weekly on Tuesdays**, not daily.
2. **`semgrep-autofix.yml`, the same action: not exercised, and not
   automatically terminable.** The workflow's only trigger is
   `workflow_dispatch`, and it has zero recorded runs in this repository. A
   dispatch was deliberately not fired: the step has no `if:` guard and can
   create a real pull request, which is a write risk on a branch whose entire
   premise is six changed lines. Established instead: the same static causal
   proof as above. Unlike rest 1, the merge does not resolve this one.
3. **`semgrep.yml` does not run on this PR** (see Non-goals). Recorded here so
   that the absence of a SAST run on this PR is not mistaken for a skipped gate.
4. **`R-CODECOV`, pre-existing and now changed state.** Until 21:19Z every
   Codecov upload in this repository ended in `HTTP 400`,
   `Token required - not valid tokenless upload`, and the job stayed green only
   because of `fail_ci_if_error: false`. The defect is **pre-existing**, not
   caused by commit 2: the same line appears in two comparison runs under `v4`,
   one of them from 2026-08-06. Cause: `CODECOV_TOKEN` does not exist as a
   repository secret, so the upload runs tokenless. **This changed during this
   PR**: the run at 21:41Z returned `status_code=200`, `error=None`, with the
   token length still `0` and with no change to `ci.yml` between the two runs.
   The report is now fully processed upstream (`state: complete`, 107 files,
   75.05% coverage, `sessions: 1`). **The cause of the change was not measured
   and is not claimed here.** Repository-level totals are still `null` because
   the default branch has no report yet, which is also what the Codecov bot
   comment says.

---

## Tests (MUST)

The diff touches **zero Python lines** (`git diff --numstat origin/1.7...HEAD`:
five workflow YAML files, six insertions, six deletions), so the Python test
obligations below do not apply to it. Marking them would be inaccurate rather
than thorough.

- ☐ `pytest -q` passes locally. **Not run, and deliberately so**: no Python
  file is in the diff. The real verification for this change is the workflow
  runs on this PR, which exercise the bumped steps themselves.
- ☐ New/updated unit/integration tests cover the change: not applicable; the
  change has no Python surface to cover.
- ☐ Minimal regression test for a bugfix: not applicable; these are dependency
  bumps, not bugfixes.
- Coverage targets: unchanged, no code removed.

### Expected areas

None of the listed areas is touched (no config flow, lifecycle, coordinator,
diagnostics, services, discovery or token-cache surface in the diff).

---

## Token Cache Safety (MUST)

Not applicable: no token-cache code is in the diff. `repo-token` in the bumped
wait step continues to receive `${{ secrets.GITHUB_TOKEN }}` exactly as before;
the input name and its handling are unchanged upstream.

---

## Docs & i18n

- ☑ No hard-coded UI strings in Python: no Python in the diff
- ☐ `translations/*.json`: not applicable
- ☐ README: not applicable, no user-visible behaviour changed

---

## Deprecation Check (concise)

- Versions scanned: upstream `action.yml` at the source and target tag of each
  of the five actions, plus `ruby/setup-ruby` at the pinned SHA (tag
  `v1.299.0`) and `actions/github-script@v8.0.0` reached transitively by
  `codecov-action@v7.0.0`.
- Notes found: the Node 20 runner deprecation
  (<https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>).
- Impact here: **resolved and measured**. The `actions/cache@v3` warning in
  `Hassfest validation` is gone, and the census is empty on every workflow that
  runs on this branch. No Node 20 deprecation warning remains that would need a
  follow-up issue.

---

## Risk & Rollback

- Risk level: ☑ medium
- The bumped wait step sits on the critical path: `hassfest` gates five of six
  jobs via `needs:`. If the wait point turns red, everything behind it is
  blocked. **It did not**: the job `Hassfest validation` is `success` on every
  run of this PR, and the wait step itself reported `success` rather than being
  skipped.
- Rollback plan: `git revert` of a single commit restores the previous version
  exactly. One commit per action is maintained precisely so that a revert never
  has to disentangle two actions. No revert was needed; no data, entity IDs or
  config entries are involved.
- Attribution rule applied before any revert: a red wait point **without a
  completed check** is not attributable to the bump; the run is repeated instead
  of the commit being reverted.

---

## Local Verification (run before pushing)

What was run, and what was not:

- ☑ `pre-commit run check-yaml --files <changed workflow>` → `Passed` for every
  commit; each changed file also parses under `yaml.safe_load`.
- ☐ `pre-commit run --all-files`: attempted; it is not usable as a gate in this
  environment: `pytest` is missing from the hook env, and `mypy` fails to parse
  two modules under the hook's Python 3.11. It also rewrites six unrelated files
  via `trailing-whitespace`/`end-of-file-fixer`/`doctoc`; those rewrites were
  reverted and are **not** part of this PR. They are a pre-existing hygiene
  backlog, not something a dependency bump should sweep in.
- ☐ `python3 -m script.hassfest`, `pytest -q`, `bandit`: not run: no Python in
  the diff.

---

## Reviewer Notes

- Diff discipline: `git diff --numstat origin/1.7...HEAD -- .github/workflows/`
  yields exactly five lines summing to `6` and `6`, one `uses:` line per file
  except `ci.yml`, which carries two. Five commits, one action owner each, no
  foreign committer.
- Edge cases to double-check:
  - The `git-auto-commit` step is guarded by
    `if: steps.hassfest_autofix.outputs.found == 'true'`. A `skipped` conclusion
    would mean the new version never executed; the verification therefore checks
    the step's conclusion, not merely that the job is green.
  - `allowed-conclusions` is set to `success,failure,neutral` here, while the
    upstream default is `success,skipped`. That is intentional and pre-existing.
  - Floating major tags are not maintained uniformly upstream: the `v5` tag of
    `action-semantic-pull-request` has not moved since 2024-06-10, while
    `v5.5.3` is three commits ahead of it. A stalled tag looks exactly like a
    maintained one. Pinning to SHAs is worth a separate discussion.
- Follow-up tasks: the two items under "Non-goals" (the `needs:` coupling and
  the `semgrep.yml` branch filter) and rest 2 above are tracked outside this PR.
