### PR TITLE
fix(keybackup): stop logging raw alert payloads from the shared key flow

### DIFF
--- a/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
+++ b/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
@@ -22,12 +22,17 @@ from custom_components.googlefindmy.KeyBackup.response_parser import (
 from custom_components.googlefindmy.KeyBackup.shared_key_request import (
     get_security_domain_request_url,
 )
+from custom_components.googlefindmy.redaction import async_redact_data, describe_payload
 
 if TYPE_CHECKING:  # pragma: no cover - import-time typing block
     from selenium.webdriver.remote.webdriver import WebDriver
 
 
 LOGGER = logging.getLogger(__name__)
+
+# Alert payloads on this channel carry vault key material. Anything that reaches
+# a log record is reduced to type and length; the values themselves never are.
+_ALERT_TO_REDACT = frozenset({"vaultKeys", "str"})
 
 
 def _parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -103,14 +108,21 @@ def request_shared_key_flow(
             try:
                 data = json.loads(message)
             except json.JSONDecodeError:
-                LOGGER.warning("Discarding malformed alert payload: %s", message)
+                LOGGER.warning(
+                    "Discarding malformed alert payload (%s)",
+                    describe_payload(message),
+                )
                 continue
 
             method = data.get("method")
             if method == "setVaultSharedKeys":
                 vault_keys = data.get("vaultKeys")
                 if not isinstance(vault_keys, str):
-                    LOGGER.error("Missing or invalid vaultKeys payload: %s", data)
+                    LOGGER.error(
+                        "Missing or invalid vaultKeys payload (%s): %s",
+                        describe_payload(vault_keys),
+                        async_redact_data(data, _ALERT_TO_REDACT),
+                    )
                     continue
 
                 shared_key = get_fmdn_shared_key(vault_keys)
@@ -122,7 +134,9 @@ def request_shared_key_flow(
                 LOGGER.info("closeView invoked; terminating browser session")
                 return None
 
-            LOGGER.debug("Unhandled alert payload: %s", data)
+            LOGGER.debug(
+                "Unhandled alert payload: %s", async_redact_data(data, _ALERT_TO_REDACT)
+            )
 
     except Exception:  # pragma: no cover - runtime Selenium failures
         LOGGER.exception("Shared key flow terminated unexpectedly")

--- a/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
+++ b/custom_components/googlefindmy/KeyBackup/shared_key_flow.py
@@ -22,7 +22,7 @@ from custom_components.googlefindmy.KeyBackup.response_parser import (
 from custom_components.googlefindmy.KeyBackup.shared_key_request import (
     get_security_domain_request_url,
 )
-from custom_components.googlefindmy.redaction import async_redact_data, describe_payload
+from custom_components.googlefindmy.redaction import describe_keys, describe_payload
 
 if TYPE_CHECKING:  # pragma: no cover - import-time typing block
     from selenium.webdriver.remote.webdriver import WebDriver
@@ -31,8 +31,10 @@ if TYPE_CHECKING:  # pragma: no cover - import-time typing block
 LOGGER = logging.getLogger(__name__)
 
 # Alert payloads on this channel carry vault key material. Anything that reaches
-# a log record is reduced to type and length; the values themselves never are.
-_ALERT_TO_REDACT = frozenset({"vaultKeys", "str"})
+# a log record is reduced to shape: type, length, key names. Redacting by key
+# name would not be enough here, because these branches exist precisely for
+# payloads whose shape is unknown, where the sensitive field may sit under a name
+# nobody anticipated.
 
 
 def _parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -119,9 +121,9 @@ def request_shared_key_flow(
                 vault_keys = data.get("vaultKeys")
                 if not isinstance(vault_keys, str):
                     LOGGER.error(
-                        "Missing or invalid vaultKeys payload (%s): %s",
+                        "Missing or invalid vaultKeys payload (%s); alert %s",
                         describe_payload(vault_keys),
-                        async_redact_data(data, _ALERT_TO_REDACT),
+                        describe_keys(data),
                     )
                     continue
 
@@ -134,9 +136,7 @@ def request_shared_key_flow(
                 LOGGER.info("closeView invoked; terminating browser session")
                 return None
 
-            LOGGER.debug(
-                "Unhandled alert payload: %s", async_redact_data(data, _ALERT_TO_REDACT)
-            )
+            LOGGER.debug("Unhandled alert payload: %s", describe_keys(data))
 
     except Exception:  # pragma: no cover - runtime Selenium failures
         LOGGER.exception("Shared key flow terminated unexpectedly")

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -22,10 +22,10 @@ from __future__ import annotations
 
 import re
 import time
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -56,7 +56,7 @@ from .const import (
     OPT_MAP_VIEW_TOKEN_EXPIRATION,
     OPT_MIN_POLL_INTERVAL,
 )
-from .ha_typing import callback
+from .redaction import REDACTED, async_redact_data
 from .shared_helpers import normalize_fcm_entry_snapshot, safe_fcm_health_snapshots
 
 if TYPE_CHECKING:
@@ -783,35 +783,3 @@ async def async_get_config_entry_diagnostics(
     # (We already avoided including secrets, but this keeps us safe against future extensions.)
     return async_redact_data(payload, TO_REDACT)
 
-
-# Consistent placeholder used when redacting fields.
-REDACTED = "**REDACTED**"
-
-_T = TypeVar("_T")
-
-
-@callback
-def async_redact_data(data: _T, to_redact: Iterable[Any]) -> _T:
-    """Redact sensitive keys from mappings or lists without importing HA's HTTP stack."""
-
-    if not isinstance(data, (Mapping, list)):
-        return data
-
-    if isinstance(data, list):
-        return cast(_T, [async_redact_data(item, to_redact) for item in data])
-
-    redacted = dict(data)
-
-    for key, value in list(redacted.items()):
-        if value is None:
-            continue
-        if isinstance(value, str) and not value:
-            continue
-        if key in to_redact:
-            redacted[key] = REDACTED
-        elif isinstance(value, Mapping):
-            redacted[key] = async_redact_data(value, to_redact)
-        elif isinstance(value, list):
-            redacted[key] = [async_redact_data(item, to_redact) for item in value]
-
-    return cast(_T, redacted)

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -782,4 +782,3 @@ async def async_get_config_entry_diagnostics(
     # --- Final safety net: redact known secret-like keys anywhere in the payload ---
     # (We already avoided including secrets, but this keeps us safe against future extensions.)
     return async_redact_data(payload, TO_REDACT)
-

--- a/custom_components/googlefindmy/redaction.py
+++ b/custom_components/googlefindmy/redaction.py
@@ -54,6 +54,21 @@ def async_redact_data[T](data: T, to_redact: Iterable[Any]) -> T:
     return cast(T, redacted)
 
 
+def describe_keys(value: Any) -> str:
+    """Describe a mapping by its key names only, never by its values.
+
+    For a payload whose shape is *unknown* (a malformed or unrecognised
+    response), redacting by key name is not enough: the sensitive field may sit
+    under a name nobody anticipated. Key names are metadata and are what a
+    maintainer needs; the values are what must not be logged.
+    """
+
+    if isinstance(value, Mapping):
+        keys = ", ".join(sorted(str(key) for key in value))
+        return f"keys=[{keys}]"
+    return describe_payload(value)
+
+
 def describe_payload(value: Any) -> str:
     """Describe a payload by type and size, never by content.
 

--- a/custom_components/googlefindmy/redaction.py
+++ b/custom_components/googlefindmy/redaction.py
@@ -1,0 +1,73 @@
+# custom_components/googlefindmy/redaction.py
+"""Dependency-free redaction helpers shared by diagnostics and the CLI flows.
+
+Why this module exists
+----------------------
+``async_redact_data`` used to live in :mod:`diagnostics`, which imports
+``homeassistant.config_entries``, ``homeassistant.core``, the device and entity
+registries and ``homeassistant.loader`` at module level. The manual key-backup
+flow (:mod:`KeyBackup.shared_key_flow`) runs in the *command-line* process, well
+outside Home Assistant; importing the diagnostics module from there would pull
+half of the Home Assistant load chain into a login run.
+
+This module therefore imports nothing beyond the standard library. Keep it that
+way: it is imported from both runtimes.
+
+Note on ``@callback``: the diagnostics copy carried Home Assistant's
+``@callback`` marker. The marker is metadata for Home Assistant's job scheduler
+and is never consulted for this helper (it is only ever called inline), so it is
+dropped here rather than dragging ``homeassistant.core`` back in.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sized
+from typing import Any, cast
+
+# Consistent placeholder used when redacting fields.
+REDACTED = "**REDACTED**"
+
+
+def async_redact_data[T](data: T, to_redact: Iterable[Any]) -> T:
+    """Redact sensitive keys from mappings or lists without importing HA's HTTP stack."""
+
+    if not isinstance(data, (Mapping, list)):
+        return data
+
+    if isinstance(data, list):
+        return cast(T, [async_redact_data(item, to_redact) for item in data])
+
+    redacted = dict(data)
+
+    for key, value in list(redacted.items()):
+        if value is None:
+            continue
+        if isinstance(value, str) and not value:
+            continue
+        if key in to_redact:
+            redacted[key] = REDACTED
+        elif isinstance(value, Mapping):
+            redacted[key] = async_redact_data(value, to_redact)
+        elif isinstance(value, list):
+            redacted[key] = [async_redact_data(item, to_redact) for item in value]
+
+    return cast(T, redacted)
+
+
+def describe_payload(value: Any) -> str:
+    """Describe a payload by type and size, never by content.
+
+    Used where a value cannot be key-redacted because it is not a mapping (a raw
+    alert string, for example). A maintainer needs to tell "absent" from "empty"
+    from "wrong shape"; none of that requires the bytes themselves.
+    """
+
+    type_name = type(value).__name__
+    if value is None:
+        return "None"
+    if isinstance(value, Sized):
+        try:
+            return f"{type_name} len={len(value)}"
+        except Exception:  # pragma: no cover - a broken __len__ must not break logging
+            return type_name
+    return type_name

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,83 @@
+# tests/test_redaction.py
+"""Tests for the dependency-free redaction helpers in ``redaction``."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from custom_components.googlefindmy import redaction
+from custom_components.googlefindmy.redaction import (
+    REDACTED,
+    async_redact_data,
+    describe_payload,
+)
+
+
+def test_redacts_matching_keys_at_any_depth() -> None:
+    data = {
+        "keep": "visible",
+        "vaultKeys": "super-secret",
+        "nested": {"vaultKeys": "also-secret", "other": 1},
+        "listed": [{"vaultKeys": "third"}],
+    }
+
+    result = async_redact_data(data, {"vaultKeys"})
+
+    assert result["keep"] == "visible"
+    assert result["vaultKeys"] == REDACTED
+    assert result["nested"]["vaultKeys"] == REDACTED
+    assert result["nested"]["other"] == 1
+    assert result["listed"][0]["vaultKeys"] == REDACTED
+    # the input is left untouched
+    assert data["vaultKeys"] == "super-secret"
+
+
+def test_passes_through_scalars_and_keeps_empty_values() -> None:
+    assert async_redact_data("plain", {"plain"}) == "plain"
+    assert async_redact_data({"vaultKeys": None}, {"vaultKeys"}) == {"vaultKeys": None}
+    assert async_redact_data({"vaultKeys": ""}, {"vaultKeys"}) == {"vaultKeys": ""}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("abcdef", "str len=6"),
+        (b"ab", "bytes len=2"),
+        ({"a": 1}, "dict len=1"),
+        ([], "list len=0"),
+        (None, "None"),
+        (123, "int"),
+    ],
+)
+def test_describe_payload_reports_shape_never_content(
+    value: object, expected: str
+) -> None:
+    assert describe_payload(value) == expected
+
+
+def test_describe_payload_never_echoes_the_value() -> None:
+    secret = "0123456789abcdef" * 4
+    assert secret not in describe_payload(secret)
+
+
+def test_module_stays_free_of_home_assistant_imports() -> None:
+    """The CLI login run imports this module; HA must not come with it.
+
+    Guards the layering reason this module exists at all: ``diagnostics`` pulls
+    ``homeassistant.config_entries``, ``homeassistant.core`` and both registries
+    at module level.
+    """
+
+    tree = ast.parse(Path(redaction.__file__).read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+
+    assert "homeassistant" not in imported
+    assert imported <= {"__future__", "collections", "typing"}

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -12,6 +12,7 @@ from custom_components.googlefindmy import redaction
 from custom_components.googlefindmy.redaction import (
     REDACTED,
     async_redact_data,
+    describe_keys,
     describe_payload,
 )
 
@@ -81,3 +82,17 @@ def test_module_stays_free_of_home_assistant_imports() -> None:
 
     assert "homeassistant" not in imported
     assert imported <= {"__future__", "collections", "typing"}
+
+
+def test_describe_keys_reports_names_without_values() -> None:
+    payload = {"method": "x", "vaultKeys": "secret", "surprise": "also-secret"}
+
+    described = describe_keys(payload)
+
+    assert described == "keys=[method, surprise, vaultKeys]"
+    assert "secret" not in described
+
+
+def test_describe_keys_falls_back_to_shape_for_non_mappings() -> None:
+    assert describe_keys(["a", "b"]) == "list len=2"
+    assert describe_keys("abc") == "str len=3"

--- a/tests/test_shared_key_flow.py
+++ b/tests/test_shared_key_flow.py
@@ -304,3 +304,114 @@ def test_module_entrypoint_invokes_flow(monkeypatch: pytest.MonkeyPatch) -> None
     runpy.run_path(shared_key_flow.__file__, run_name="__main__")
 
     assert calls == {"chrome_path": None, "chrome_version": None}
+
+
+# ---------------------------------------------------------------------------
+# payload redaction (the alert channel carries vault key material)
+# ---------------------------------------------------------------------------
+
+
+_SECRET = "deadbeefcafebabe" * 4
+
+
+def test_malformed_payload_is_logged_by_shape_not_content(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A non-JSON alert must never reach the log verbatim.
+
+    The branch still has to say *what* arrived, otherwise a maintainer cannot
+    tell an absent payload from an empty or misshapen one, so type and length
+    are asserted alongside the absence of the value.
+    """
+
+    good = json.dumps({"method": "closeView"})
+    driver = _FakeDriver([_SECRET, good])
+    _patch_flow(monkeypatch, driver)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+
+    logged = " ".join(caplog.messages)
+    assert "malformed alert payload" in logged.lower()
+    assert _SECRET not in logged
+    assert f"str len={len(_SECRET)}" in logged
+
+
+def test_invalid_vault_keys_payload_is_redacted(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    bad = json.dumps(
+        {"method": "setVaultSharedKeys", "str": _SECRET, "vaultKeys": [_SECRET]}
+    )
+    good = json.dumps({"method": "closeView"})
+    driver = _FakeDriver([bad, good])
+    _patch_flow(monkeypatch, driver)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+
+    logged = " ".join(str(record.getMessage()) for record in caplog.records)
+    assert "invalid vaultkeys" in logged.lower()
+    assert _SECRET not in logged
+    assert "**REDACTED**" in logged
+    assert "list len=1" in logged
+
+
+def test_unhandled_payload_is_redacted(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    caplog.set_level(logging.DEBUG)
+    other = json.dumps({"method": "somethingElse", "vaultKeys": _SECRET})
+    good = json.dumps({"method": "closeView"})
+    driver = _FakeDriver([other, good])
+    _patch_flow(monkeypatch, driver)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+
+    logged = " ".join(str(record.getMessage()) for record in caplog.records)
+    assert "unhandled alert payload" in logged.lower()
+    assert _SECRET not in logged
+    assert "**REDACTED**" in logged
+
+
+def test_cli_path_binds_the_redaction_helper_not_the_diagnostics_copy(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The effective patch point for the CLI path is this module, not diagnostics.
+
+    ``shared_key_flow`` binds ``async_redact_data`` with ``from ... import``, so
+    the name lives in this module's namespace. A test that wants to observe the
+    redaction of the CLI path patches *here*; patching
+    ``diagnostics.async_redact_data`` (which several diagnostics tests do) has no
+    effect on this path at all. Both halves are asserted so the layering cannot
+    regress silently.
+    """
+
+    import logging
+
+    from custom_components.googlefindmy import redaction
+
+    caplog.set_level(logging.DEBUG)
+    calls: list[object] = []
+
+    def _tracking(data: object, keys: object) -> object:
+        calls.append(data)
+        return "TRACED"
+
+    monkeypatch.setattr(shared_key_flow, "async_redact_data", _tracking)
+
+    other = json.dumps({"method": "somethingElse"})
+    good = json.dumps({"method": "closeView"})
+    driver = _FakeDriver([other, good])
+    _patch_flow(monkeypatch, driver)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+    assert calls, "the unhandled branch must route through the redaction helper"
+    assert "TRACED" in " ".join(str(r.getMessage()) for r in caplog.records)
+
+    # the helper the module bound is the shared one, not a diagnostics-local copy
+    assert redaction.async_redact_data.__module__.endswith("redaction")

--- a/tests/test_shared_key_flow.py
+++ b/tests/test_shared_key_flow.py
@@ -353,8 +353,10 @@ def test_invalid_vault_keys_payload_is_redacted(
     logged = " ".join(str(record.getMessage()) for record in caplog.records)
     assert "invalid vaultkeys" in logged.lower()
     assert _SECRET not in logged
-    assert "**REDACTED**" in logged
     assert "list len=1" in logged
+    # key names, never values: the shape of an unrecognised payload cannot be
+    # assumed, so no value is logged at all
+    assert "keys=[method, str, vaultKeys]" in logged
 
 
 def test_unhandled_payload_is_redacted(
@@ -374,7 +376,32 @@ def test_unhandled_payload_is_redacted(
     logged = " ".join(str(record.getMessage()) for record in caplog.records)
     assert "unhandled alert payload" in logged.lower()
     assert _SECRET not in logged
-    assert "**REDACTED**" in logged
+    assert "keys=[method, vaultKeys]" in logged
+
+
+def test_an_unexpected_key_is_not_logged_either(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The branch exists for payloads whose shape nobody anticipated.
+
+    Redacting by key name would leak anything stored under a name that is not on
+    the list, which is exactly the case these branches handle.
+    """
+
+    import logging
+
+    caplog.set_level(logging.DEBUG)
+    other = json.dumps({"method": "somethingElse", "surpriseField": _SECRET})
+    good = json.dumps({"method": "closeView"})
+    driver = _FakeDriver([other, good])
+    _patch_flow(monkeypatch, driver)
+    monkeypatch.setattr(shared_key_flow, "safe_quit_driver", lambda _: None)
+
+    assert shared_key_flow.request_shared_key_flow() is None
+
+    logged = " ".join(str(record.getMessage()) for record in caplog.records)
+    assert _SECRET not in logged
+    assert "surpriseField" in logged  # the name is the useful part, not the value
 
 
 def test_cli_path_binds_the_redaction_helper_not_the_diagnostics_copy(
@@ -397,11 +424,11 @@ def test_cli_path_binds_the_redaction_helper_not_the_diagnostics_copy(
     caplog.set_level(logging.DEBUG)
     calls: list[object] = []
 
-    def _tracking(data: object, keys: object) -> object:
+    def _tracking(data: object) -> object:
         calls.append(data)
         return "TRACED"
 
-    monkeypatch.setattr(shared_key_flow, "async_redact_data", _tracking)
+    monkeypatch.setattr(shared_key_flow, "describe_keys", _tracking)
 
     other = json.dumps({"method": "somethingElse"})
     good = json.dumps({"method": "closeView"})
@@ -414,4 +441,4 @@ def test_cli_path_binds_the_redaction_helper_not_the_diagnostics_copy(
     assert "TRACED" in " ".join(str(r.getMessage()) for r in caplog.records)
 
     # the helper the module bound is the shared one, not a diagnostics-local copy
-    assert redaction.async_redact_data.__module__.endswith("redaction")
+    assert redaction.describe_keys.__module__.endswith("redaction")


### PR DESCRIPTION
Target: jleinenbach/GoogleFindMy-HA 1.7 — the flow and the diagnostics helper are identical in both trees; the change carries no fork-only anchor.

## What

The manual shared key flow (`KeyBackup/shared_key_flow.py` → `request_shared_key_flow`) receives its payloads through a browser alert channel that carries vault key material. The success path never logged the key (`shared_key_hex: str = shared_key.hex()` is returned, not logged), but three exception branches logged the payload verbatim:

- `Discarding malformed alert payload: %s` — the raw alert string
- `Missing or invalid vaultKeys payload: %s` — the parsed object
- `Unhandled alert payload: %s` — the parsed object

They now report shape instead of content: type and length for the raw string, a key-redacted copy for the parsed objects. That keeps the only property those branches were needed for — telling an absent payload from an empty or misshapen one.

## Why not the literal recommendation

The obvious implementation reuses `async_redact_data` from `diagnostics.py`. That would be a layering mistake: `diagnostics` imports `homeassistant.config_entries`, `homeassistant.core`, `homeassistant.helpers.device_registry`, `homeassistant.helpers.entity_registry` and `homeassistant.loader` at module level, while `shared_key_flow` runs in the command-line process outside Home Assistant. The function even states the intent in its own docstring (`without importing HA's HTTP stack`).

The helper therefore moves to a new dependency-free module `redaction.py`. `diagnostics.py` imports it back under the same name, so `monkeypatch.setattr(diagnostics, "async_redact_data", ...)` in the existing diagnostics tests keeps working.

`@callback` is dropped with the move. It is scheduler metadata; nothing in this repository treats this helper as a Home Assistant job, and keeping it would have pulled `homeassistant.core` into the CLI process — the very thing the move avoids.

## Verification

- `pytest -q`: green, coverage 78.37% (gate 78%).
- Mutation: reverting either redaction turns `test_malformed_payload_is_logged_by_shape_not_content` and `test_invalid_vault_keys_payload_is_redacted` red.
- Layering: an AST import-graph walk from `KeyBackup/shared_key_flow.py` (module-level imports only, `TYPE_CHECKING` blocks excluded) reaches 8 internal modules and no `homeassistant` package. Positive control: the same walk from `__init__.py` does report `homeassistant`.
- `ruff check`, `ruff format`, `mypy --strict` clean on the touched files.