### PR TITLE
ci(semgrep): scan pull requests on the version branches, not only main

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
+  # No branch filter: development happens on the version branches (1.7), not on
+  # main, and a pull request there must be scanned like any other. Matches the
+  # `on:` blocks of ci.yml and pip-audit.yml.
   pull_request:
-    branches:
-      - main
   schedule:
     # Runs daily at 02:12 UTC-only
     - cron: '12 2 * * *'


### PR DESCRIPTION
Target: jleinenbach/GoogleFindMy-HA 1.7 — the workflow file is identical upstream; the same one-line change applies there.

## What

`.github/workflows/semgrep.yml` filtered `pull_request` to branch `main`. Development happens on the version branches (`1.7`), so no pull request that carries actual code changes was ever scanned. The filter is removed, which is how `ci.yml` and `pip-audit.yml` already declare their `pull_request` trigger.

## Why not more than that

Two neighbouring changes were considered and deliberately left out of this PR:

- **Extending `push` to `1.7`.** It would have no effect. The job carries `if: ${{ github.event_name == 'pull_request' }}` at job level, so push and schedule events already resolve to a skipped job. The branch filter is not what stops them.
- **The fail gate.** `Fail on high or critical findings` exits 1 when `high_count` is **at or below** `SEMGREP_HIGH_FAIL_THRESHOLD: 25` and warns-and-continues above it. Whatever the intent (the comment says large batches should stay non-blocking), this PR is what produces the first measurement on `1.7` at all. Changing the gate in the same PR would make a red run unattributable. It is tracked separately and decided once the first number exists.

## Verification

- YAML parses; the `on:` block keeps `push`, `pull_request`, `schedule`, `workflow_dispatch`.
- Control point for this PR: the Semgrep check appears in this PR's own check list and reports a finding count rather than `skipped`.