### PR TITLE
fix(map): keep the tokenised map URL out of caches and search indexes

### DIFF
--- a/custom_components/googlefindmy/map_view.py
+++ b/custom_components/googlefindmy/map_view.py
@@ -307,6 +307,17 @@ def _resolve_parse_last_seen_timestamp() -> Any:
 # ------------------------------- HTML Helpers -------------------------------
 
 
+# The map URL carries its access token in the query string, so every response of
+# this view is as sensitive as the link itself. `no-store` keeps it out of shared
+# browser and proxy caches, `noindex, nofollow` keeps it out of search engines on
+# instances that are reachable from the internet. Both are pure response headers:
+# no migration, no effect on links already handed out.
+NO_STORE_HEADERS = {
+    "Cache-Control": "no-store",
+    "X-Robots-Tag": "noindex, nofollow",
+}
+
+
 def _html_response(title: str, body: str, status: int = 200) -> web.Response:
     """Return a minimal HTML response (no secrets, no stacktraces)."""
     return web.Response(
@@ -320,6 +331,7 @@ def _html_response(title: str, body: str, status: int = 200) -> web.Response:
 </html>""",
         content_type="text/html",
         status=status,
+        headers=NO_STORE_HEADERS,
     )
 
 
@@ -679,7 +691,12 @@ class GoogleFindMyMapView(HomeAssistantView):
         html = self._generate_map_html(
             device_name, locations, device_id, start_time, end_time, accuracy_filter
         )
-        return web.Response(text=html, content_type="text/html", charset="utf-8")
+        return web.Response(
+            text=html,
+            content_type="text/html",
+            charset="utf-8",
+            headers=NO_STORE_HEADERS,
+        )
 
     def _generate_map_html(
         self,
@@ -1041,4 +1058,4 @@ class GoogleFindMyMapRedirectView(HomeAssistantView):
         redirect_url = f"/api/googlefindmy/map/{device_id}?{urlencode(query_dict)}"
         _LOGGER.debug("Relative redirect prepared for device_id=%s", device_id)
 
-        raise web.HTTPFound(location=redirect_url)
+        raise web.HTTPFound(location=redirect_url, headers=NO_STORE_HEADERS)

--- a/tests/test_map_view_features.py
+++ b/tests/test_map_view_features.py
@@ -1139,3 +1139,78 @@ async def test_popup_coordinates_display_is_shortened_copy_stays_raw(
     ) in html
     # (f) copy path is untouched by rounding: no toFixed inside the copy handler
     assert 'gfmyCopyToClipboard(loc.lat + ", " + loc.lon, coBtn).toFixed' not in html
+
+
+# ---------------------------------------------------------------------------
+# Response hygiene headers: the map URL carries its token in the query string
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_map_response_carries_no_store_and_norobots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The rendered map must not be cached or indexed.
+
+    The access token travels in the query string, so a cached copy on a shared
+    machine, or an indexed URL on an instance reachable from the internet, is
+    the way such a link actually leaks.
+    """
+
+    device_id = "device123"
+    coordinator = SimpleNamespace(data=[{"id": device_id, "name": "Test Device"}])
+    entry = make_config_entry(entry_id="entry-id", runtime_data=coordinator)
+    hass = _StubHass([entry])
+
+    monkeypatch.setattr(map_view, "_resolve_coordinator_class", lambda: SimpleNamespace)
+
+    registry_entry = _StubRegistryEntry(
+        entity_id="device_tracker.device123",
+        unique_id=f"{entry.entry_id}:{device_id}",
+        config_entry_id=entry.entry_id,
+    )
+    monkeypatch.setattr(
+        map_view.er, "async_get", lambda _hass: _StubEntityRegistry([registry_entry])
+    )
+    _install_history_stub(
+        monkeypatch, registry_entry.entity_id, _StubState(latitude=10.0, longitude=20.0)
+    )
+
+    ha_uuid = hass.data["core.uuid"]
+    token = map_token_hex_digest(map_token_secret_seed(ha_uuid, entry.entry_id, False))
+
+    response = await map_view.GoogleFindMyMapView(hass).get(
+        SimpleNamespace(query={"token": token}), device_id=device_id
+    )
+
+    assert response.status == 200
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["X-Robots-Tag"] == "noindex, nofollow"
+
+
+@pytest.mark.asyncio
+async def test_error_pages_carry_the_same_headers() -> None:
+    """The 401 page is reached with the token in the URL as well."""
+
+    response = await map_view.GoogleFindMyMapView(_StubHass([])).get(
+        SimpleNamespace(query={}), device_id="device123"
+    )
+
+    assert response.status == 401
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["X-Robots-Tag"] == "noindex, nofollow"
+
+
+@pytest.mark.asyncio
+async def test_redirect_carries_the_same_headers() -> None:
+    """A cached 302 would hand the token to the next user of the browser."""
+
+    view = map_view.GoogleFindMyMapRedirectView(_StubHass([]))
+
+    with pytest.raises(map_view.web.HTTPFound) as ctx:
+        await view.get(SimpleNamespace(query={"token": "abc"}), device_id="device123")
+
+    assert ctx.value.headers["Cache-Control"] == "no-store"
+    assert ctx.value.headers["X-Robots-Tag"] == "noindex, nofollow"
+    # the relative Location contract is unchanged
+    assert ctx.value.location == "/api/googlefindmy/map/device123?token=abc"


### PR DESCRIPTION
Target: jleinenbach/GoogleFindMy-HA 1.7 — `map_view.py` is identical in both trees at the touched anchors.

## What

`map_view.py` → `GoogleFindMyMapView.get` returned the rendered map via `web.Response(text=html, content_type="text/html", charset="utf-8")` with no cache or robots directives, and `GoogleFindMyMapRedirectView.get` raised a bare `web.HTTPFound`. Since the view authenticates by `request.query.get("token")`, the URL *is* the credential.

Added: `Cache-Control: no-store` and `X-Robots-Tag: noindex, nofollow` on the rendered map, on `_html_response` (the 400/401 pages, reached with the token in the URL as well), and on the redirect, whose `Location` repeats the token.

## Why not the literal recommendation

Two adjacent proposals were dropped on purpose:

- **`<meta name="referrer" content="no-referrer">`.** It contradicts a deliberate setting in the same file: `_generate_map_html` sets `referrerPolicy: 'origin'` on the tile layer so the tile provider sees an origin. Two referrer rules pulling in opposite directions are not a gain, they are a trap for whoever tidies up one of them later. The referrer question belongs with the tile-source question and is decided once, not in passing.
- **Raising token entropy / `compare_digest`.** No guessing path exists against a 64-bit digest on a home network, and what is compared is set membership over a digest, not a password. Headers close the paths a link actually takes; a token migration would break links already distributed for no measured gain.

## Verification

- `tests/test_map_view_features.py`: three new tests, one per response path.
- Mutation: emptying `NO_STORE_HEADERS` turns all three red.
- `ruff check`, `ruff format --check`, `mypy --strict` clean.
- Full local suite was run on the sibling PR of this series; here the affected module's suite is green and CI carries the full run.

## Open

Neither header can stop a WebView from rendering (`no-store` governs storage, `X-Robots-Tag` is consumed by crawlers), so the Companion app is expected to be unaffected. That expectation is reasoned, not measured on a device; opening a device page in the Android and iOS app is the one check left, and it is cheap.