### PR TITLE
docs(map): point at the service that repairs an expired Map View link

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,23 @@ Accessible via the ⚙️ cogwheel button on the main Google Find My Device Inte
 | `stale_threshold` | 3900 | seconds | After this many seconds (default: 65 minutes) without a location update, the tracker state becomes `unknown`. Use the "Last Location" entity to always see the last known position. |
 | `show_location_age` | true | toggle | Adds a `location_age` attribute (in seconds, rounded to 60s) to each tracker entity. Excluded from Recorder history to keep DB size predictable. |
 
+### Map View link expiry (`map_view_token_expiration`)
+
+With this option **off** (the default), the Map View link on a device page is
+stable and keeps working indefinitely.
+
+With it **on**, the token rotates weekly. The map accepts the current and the
+previous week, so there is a full week of grace, but the link stored on the
+device page is only rebuilt when the integration starts up. If Home Assistant
+runs for more than two week boundaries without a restart and without a reload of
+the entry, the device page's own Map View link goes stale and returns
+"Unauthorized".
+
+You do not have to restart to fix that. Call the service
+**`googlefindmy.refresh_device_urls`** (Developer tools → Actions → *Refresh
+Device URLs*); it rewrites the configuration URL of every device with a current
+token, and the link works again immediately.
+
 ### Google Home filter behavior
 
 The Google Home filter helps prevent noisy location updates from speakers and displays that frequently report "Home":

--- a/README.md
+++ b/README.md
@@ -239,16 +239,21 @@ With this option **off** (the default), the Map View link on a device page is
 stable and keeps working indefinitely.
 
 With it **on**, the token rotates weekly. The map accepts the current and the
-previous week, so there is a full week of grace, but the link stored on the
-device page is only rebuilt when the integration starts up. If Home Assistant
-runs for more than two week boundaries without a restart and without a reload of
-the entry, the device page's own Map View link goes stale and returns
-"Unauthorized".
+previous bucket, but the link stored on the device page is only rebuilt when the
+integration starts up. The stored link therefore dies the moment the **second**
+weekly boundary is crossed — if the instance started shortly before a boundary,
+that can be little more than a week later — and the device page's own Map View
+link then returns "Unauthorized".
 
 You do not have to restart to fix that. Call the service
 **`googlefindmy.refresh_device_urls`** (Developer tools → Actions → *Refresh
 Device URLs*); it rewrites the configuration URL of every device with a current
 token, and the link works again immediately.
+
+One prerequisite: Home Assistant must have a reachable base URL. If none is
+configured, the service logs a warning and updates nothing, so the stale link
+stays. If the action appears to do nothing, set an internal or external URL
+under Settings → System → Network and check the log.
 
 ### Google Home filter behavior
 


### PR DESCRIPTION
Target: jleinenbach/GoogleFindMy-HA 1.7 — the option table and the service table are identical in both trees.

## What

New README subsection `### Map View link expiry (map_view_token_expiration)` describing what the option actually does and how to repair its one visible side effect.

Measured, not assumed:

- `__init__.py` → `_async_refresh_device_urls` has exactly one caller, `async_setup_entry` (`await _async_refresh_device_urls(hass)`); there is no timer.
- `map_view.py` → `_entry_accept_tokens` accepts the current **and** the previous weekly bucket, so the grace period is one week, not zero.
- `services.py` registers `refresh_device_urls`, declared in `services.yaml` as *Refresh Device URLs*, and it performs exactly this refresh.

Consequence: with the option on, an instance that keeps running across two week boundaries without a restart or entry reload shows a stale link on its own device page. That is an ergonomics gap, not a loss of function — the service fixes it without a restart — and the cheapest fix for an ergonomics gap is documentation.

## Why this and not a timer

A daily timer is the obvious other answer and is tracked separately. It is not free: `_async_refresh_device_urls` logs a warning when no reachable URL exists and an info line when only the internal URL is available, both written for a once-per-startup context. Turning that into a daily line in every installation without an external URL trades one annoyance for another, so the timer only ships with a repeat suppressor, and the documentation lands first.

## Control point

`grep -c "refresh_device_urls" README.md` → `2` (the new subsection plus the existing service table row), and the name matches `services.yaml` verbatim.