### PR TITLE
docs(cli): warn that the standalone login closes other Chrome windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,14 +435,21 @@ What that means in practice:
   or `main.py`). Unsaved tabs are lost as with any forced quit.
 - **Do not start a login while other automation is using Chrome** on the same
   machine and user account (scraping jobs, kiosk displays, printing services).
+- **The match is on the whole command line, not on the program name.** The
+  cleanup uses `pgrep -f chrome`, so anything whose command line contains
+  `chrome` is terminated too — a monitoring script called
+  `chrome_metrics.py`, for example. If you run such a process, stop it or rename
+  it before a login run.
 - The scripts protect their own process and its parents, so running them from a
   terminal or a test runner does not terminate that terminal.
 - Inside the provided login container the cleanup is skipped, because there it
   would tear down the container's own browser stack.
-- **None of this happens in Home Assistant.** No Home Assistant code path starts
-  a browser or terminates a process; the cleanup is reached only through
-  `create_driver`, and `create_driver` is reached only from the manual
-  command-line scripts above.
+- **In Home Assistant this does not happen — with one exception worth knowing.**
+  No module Home Assistant loads reaches `create_driver`. The exception is the
+  interactive key-backup fallback: it is loaded dynamically and, in a Home
+  Assistant process started in the foreground of a terminal whose bundle carries
+  no shared key, it could reach the same code. That guard is being tightened to
+  require the command-line tool itself.
 
 ### Standalone login refuses to start (attended terminal required)
 The desktop login opens Chrome **on your own screen** and prints a "Press Enter

--- a/README.md
+++ b/README.md
@@ -421,6 +421,29 @@ export GOOGLEFINDMY_CHROME_PATH=/usr/bin/google-chrome
 
 Run any of the scripts with `--help` to list the available options.
 
+### The standalone login closes your other Chrome windows
+
+**Before it starts its own browser, the standalone login terminates the Chrome
+processes it finds running.** This is deliberate, not a bug: the login has to
+drive a browser session it controls end to end, and an already running Chrome
+would otherwise capture the sign-in and keep the credentials out of reach.
+
+What that means in practice:
+
+- **Close your Chrome windows before you run any of the helper scripts**
+  (`get_oauth_token.py`, `Auth/auth_flow.py`, `KeyBackup/shared_key_flow.py`,
+  or `main.py`). Unsaved tabs are lost as with any forced quit.
+- **Do not start a login while other automation is using Chrome** on the same
+  machine and user account (scraping jobs, kiosk displays, printing services).
+- The scripts protect their own process and its parents, so running them from a
+  terminal or a test runner does not terminate that terminal.
+- Inside the provided login container the cleanup is skipped, because there it
+  would tear down the container's own browser stack.
+- **None of this happens in Home Assistant.** No Home Assistant code path starts
+  a browser or terminates a process; the cleanup is reached only through
+  `create_driver`, and `create_driver` is reached only from the manual
+  command-line scripts above.
+
 ### Standalone login refuses to start (attended terminal required)
 The desktop login opens Chrome **on your own screen** and prints a "Press Enter
 to continue" prompt first, so you decide when a browser window takes over. When


### PR DESCRIPTION
Target: jleinenbach/GoogleFindMy-HA 1.7 — the README section and the cleanup function are present in both trees.

## What

A troubleshooting subsection documenting that the standalone login terminates running Chrome processes before it starts its own, what that means for the user, and where it does *not* happen.

## Why documentation and not a code change

A review recommended narrowing the cleanup to the process tree the script creates itself. That inverts the purpose of the function. `chrome_driver.py` → `_kill_existing_chrome_processes` runs **before** the own driver exists (`_create_driver_inner` calls it as its first statement) and its job is to remove *other*, already running Chrome instances, which would otherwise capture the sign-in session. Its docstring says so: `Terminate any existing Chrome processes to avoid conflicts`. A cleanup restricted to the script's own, not yet existing process tree would clean up nothing, and the login would fail in exactly the case the function exists for.

The same logic sits in the tool upstream this code came from (`leonboe1/GoogleFindMyTools`, `chrome_driver.py`, `taskkill /f /im chrome.exe` and `os.system("pkill -f chrome")`), i.e. in the credential-extraction procedure itself, not in the integration.

So: document the behaviour, do not break the procedure.

## Verification

`grep -rn "_kill_existing_chrome_processes" custom_components/` returns exactly two hits: the module-level definition and one call, in `chrome_driver.py` → `_create_driver_inner`, which is reachable only through `create_driver`. `create_driver` in turn is reached only from `Auth/auth_flow.py` → `request_oauth_account_token_flow`, `KeyBackup/shared_key_flow.py` → `request_shared_key_flow` and `get_oauth_token.py` → `main`, all command-line entry points.

Not claimed, because it is not measured: that a login run *fails* without the cleanup. What is documented is the purpose and the reach.