### PR TITLE
docs(chrome): record why the two origin-isolation flags are still there

### DIFF
--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -589,10 +589,17 @@ def get_options(*, headless: bool = False) -> ChromeOptions:
     # * Scope. ``get_options`` is reached only through ``create_driver``, and
     #   ``create_driver`` only from the manual command-line entry points
     #   (``Auth/auth_flow.py``, ``KeyBackup/shared_key_flow.py``,
-    #   ``get_oauth_token.py``). No Home Assistant code path imports this module,
-    #   so these flags never apply to a running Home Assistant instance. They
-    #   apply to a browser the user starts themselves, for the minutes it takes
-    #   to sign in to their own Google account.
+    #   ``get_oauth_token.py``). No module Home Assistant loads imports this one:
+    #   an import-graph walk from ``__init__.py``, ``config_flow.py`` and
+    #   ``eid_resolver.py`` reaches no browser package.
+    # * The one exception, stated rather than glossed over.
+    #   ``KeyBackup/shared_key_retrieval.py`` -> ``_interactive_flow_hex`` loads
+    #   the browser flow through ``importlib.import_module``, which no import
+    #   graph sees. Its guard in ``_retrieve_shared_key_hex`` used to ask whether
+    #   a terminal was attached, and a foreground Home Assistant answers yes, so
+    #   these flags *could* be applied inside the Home Assistant process. That
+    #   guard is being replaced by a marker the command-line tool sets on its own
+    #   process; until that lands, "CLI only" is the intent, not a guarantee.
     # * Provenance. They arrived with commit 5219da9f, described as taken from
     #   the upstream tool. That is not accurate: leonboe1/GoogleFindMyTools sets
     #   exactly three arguments in its own ``get_options`` (``--start-maximized``,

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -583,6 +583,32 @@ def get_options(*, headless: bool = False) -> ChromeOptions:
     chrome_options.add_argument("--disable-gpu")
     chrome_options.add_argument("--no-sandbox")
     chrome_options.add_argument("--disable-dev-shm-usage")
+    # The two flags below relax the browser's own origin isolation. They are
+    # under discussion (BSkando/GoogleFindMy-HA#214), so here is what is known:
+    #
+    # * Scope. ``get_options`` is reached only through ``create_driver``, and
+    #   ``create_driver`` only from the manual command-line entry points
+    #   (``Auth/auth_flow.py``, ``KeyBackup/shared_key_flow.py``,
+    #   ``get_oauth_token.py``). No Home Assistant code path imports this module,
+    #   so these flags never apply to a running Home Assistant instance. They
+    #   apply to a browser the user starts themselves, for the minutes it takes
+    #   to sign in to their own Google account.
+    # * Provenance. They arrived with commit 5219da9f, described as taken from
+    #   the upstream tool. That is not accurate: leonboe1/GoogleFindMyTools sets
+    #   exactly three arguments in its own ``get_options`` (``--start-maximized``,
+    #   ``--no-sandbox``, ``--disable-dev-shm-usage``) and obtains the same keys
+    #   through the same flow without these two.
+    # * Second sign that they may be dispensable: our own fallback path,
+    #   ``_try_webdriver_manager_fallback``, starts Chrome for the same purpose
+    #   and sets neither.
+    #
+    # Not removed on that evidence alone. Verifying a removal takes a real Google
+    # sign-in with 2FA on a real desktop; it cannot be automated, cannot be
+    # repeated in CI, and one successful run would not prove it holds for every
+    # account and Chrome build. The gain would be zero (no attack path in the
+    # Home Assistant runtime, see scope), the loss on a mistake is every user's
+    # only route to their own credentials. Whoever removes them owes that
+    # measurement.
     chrome_options.add_argument("--disable-web-security")
     chrome_options.add_argument("--allow-running-insecure-content")
 

--- a/tests/test_chrome_driver.py
+++ b/tests/test_chrome_driver.py
@@ -73,7 +73,16 @@ def _reset_uc(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_get_options_headless_uses_expected_arguments(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Ensure headless options populate the expected Chrome arguments."""
+    """Ensure headless options populate the expected Chrome arguments.
+
+    The list is frozen deliberately, including the last two entries. Those relax
+    the browser's origin isolation and are periodically proposed for removal;
+    ``chrome_driver.get_options`` carries the reasoning. Short version: they only
+    ever apply to the manual, user-started extraction browser, never to a Home
+    Assistant runtime, and removing them cannot be verified without a real Google
+    sign-in with 2FA. If this assertion fails, the flags were changed without
+    that measurement.
+    """
 
     uc_module = chrome_driver._get_uc_module()
     monkeypatch.setattr(uc_module, "ChromeOptions", FakeChromeOptions)


### PR DESCRIPTION
Target: jleinenbach/GoogleFindMy-HA 1.7 — `get_options` and the frozen argument list are identical in both trees.

## What

Comments only. No executable line changes; `test_get_options_headless_uses_expected_arguments` still asserts the same seven arguments.

## Why not the literal recommendation ("remove the two flags")

Three measurements, all reproducible:

1. **Scope.** `chrome_driver.py` → `get_options` is reached only through `create_driver`, and `create_driver` only from `Auth/auth_flow.py` → `request_oauth_account_token_flow`, `KeyBackup/shared_key_flow.py` → `request_shared_key_flow` and `get_oauth_token.py` → `main` — all command-line entry points. An AST walk over module-level imports from `__init__.py` and `config_flow.py` reaches 73 and 6 internal modules and neither `selenium`, `undetected_chromedriver` nor `webdriver_manager`; the same walk from `Auth/auth_flow.py` does report them, so the check can fire. The flags therefore never apply to a running Home Assistant instance.
2. **Provenance.** They arrived with `5219da9f`, described as taken from the upstream tool. `leonboe1/GoogleFindMyTools`, `chrome_driver.py` → `get_options` sets exactly `--start-maximized`, `--no-sandbox`, `--disable-dev-shm-usage` and obtains the same keys through the same flow.
3. **Second sign.** Our own `_try_webdriver_manager_fallback` starts Chrome for the same purpose and sets neither.

That is enough to suspect the flags are dispensable and not enough to remove them. The removal check requires a real Google sign-in with 2FA on a real desktop: not automatable, not repeatable in CI, and a single successful run would not generalise across accounts and Chrome builds. Gain if it works: zero, per (1). Cost if it does not: every user loses the only route to their own credentials.

So the finding is recorded where the next reader will hit it, and whoever removes the flags owes the measurement.