### PR TITLE
ci(map): fail the build when the vendored Leaflet copy falls behind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,46 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  vendored_assets:
+    name: Vendored assets freshness
+    runs-on: ubuntu-latest
+    needs: hassfest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      # Dependabot reads manifests, never checked-in files. Without this gate a
+      # bump of the `leaflet` devDependency would leave the embedded copy behind
+      # and nothing would go red. No network and no Node needed: the check
+      # compares package.json against vendor/leaflet/VERSION and the recorded
+      # digests against the files themselves.
+      - name: Check the vendored Leaflet copy
+        id: vendor_leaflet
+        run: python script/vendor_leaflet.py --check
+
+      - name: Write vendored assets summary
+        if: always()
+        run: |
+          {
+            echo "## Vendored assets"
+            echo ""
+            if [ "${{ steps.vendor_leaflet.outcome }}" = "success" ]; then
+              echo "✅ **Leaflet copy matches the pinned version and its digests**"
+            else
+              echo "❌ **Vendored Leaflet is out of step**"
+              echo ""
+              echo "Run \`npm install && python script/vendor_leaflet.py\` and commit the result."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   lint:
     name: Lint (${{ matrix.check }})
     runs-on: ubuntu-latest
@@ -489,7 +529,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [hassfest, hacs, lint, test, translations]
+    needs: [hassfest, hacs, lint, test, translations, vendored_assets]
     if: always()
     steps:
       - name: Check all jobs passed
@@ -499,7 +539,8 @@ jobs:
              [[ "${{ needs.hacs.result }}" != "success" ]] || \
              [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
-             [[ "${{ needs.translations.result }}" != "success" ]]; then
+             [[ "${{ needs.translations.result }}" != "success" ]] || \
+             [[ "${{ needs.vendored_assets.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             echo "passed=false" >> "$GITHUB_OUTPUT"
             exit 1
@@ -526,6 +567,12 @@ jobs:
               echo "| HACS | ✅ Pass |"
             else
               echo "| HACS | ❌ Fail |"
+            fi
+
+            if [ "${{ needs.vendored_assets.result }}" = "success" ]; then
+              echo "| Vendored assets | ✅ Pass |"
+            else
+              echo "| Vendored assets | ❌ Fail |"
             fi
 
             if [ "${{ needs.lint.result }}" = "success" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "googlefindmy-ha",
       "version": "0.0.0",
       "devDependencies": {
-        "doctoc": "2.2.1"
+        "doctoc": "2.2.1",
+        "leaflet": "1.9.4"
       }
     },
     "node_modules/@textlint/ast-node-types": {
@@ -1346,6 +1347,13 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/longest-streak": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "Developer tooling for the Google Find My Home Assistant integration",
   "private": true,
   "devDependencies": {
-    "doctoc": "2.2.1"
+    "doctoc": "2.2.1",
+    "leaflet": "1.9.4"
   },
   "scripts": {
-    "doctoc": "doctoc"
+    "doctoc": "doctoc",
+    "vendor:leaflet": "python script/vendor_leaflet.py"
   }
 }

--- a/script/AGENTS.md
+++ b/script/AGENTS.md
@@ -27,3 +27,24 @@ These conventions apply to every file within this directory tree.
 * When iterating collections for display, sort deterministic output so diffs
   remain stable between runs.
 
+
+## Gate scripts that can turn CI red
+
+A script that fails a build and is documented nowhere is a riddle at the moment
+it fires. Every such script is listed here with its purpose, its invocation, and
+the condition under which it goes red.
+
+* `vendor_leaflet.py` — keeps the Leaflet copy embedded by the map view in step
+  with the version pinned in `package.json`.
+  * CI runs `python script/vendor_leaflet.py --check` in the `vendored_assets`
+    job. No network and no Node are needed for that mode.
+  * It goes **red** when the pinned version differs from
+    `custom_components/googlefindmy/vendor/leaflet/VERSION`, when a vendored file
+    no longer matches its recorded SHA-256, or when the `LICENSE` file is gone
+    (BSD-2-Clause attribution).
+  * Fix: `npm install && python script/vendor_leaflet.py`, then commit the
+    refreshed files and `VERSION`.
+  * Why it exists: Dependabot reads manifests, never checked-in files. Without
+    this gate a bump of the `leaflet` devDependency would leave the embedded copy
+    behind silently, which is precisely how a vendored library ages into a
+    vulnerability.

--- a/script/vendor_leaflet.py
+++ b/script/vendor_leaflet.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Keep the vendored Leaflet copy in step with the pinned npm version.
+
+Why this exists
+---------------
+`custom_components/googlefindmy/map_view.py` embeds Leaflet instead of loading it
+from a CDN. A vendored library ages silently: Dependabot reads manifests, never
+checked-in files, so a bump of the `leaflet` devDependency in `package.json`
+would leave the actual copy behind without anything going red.
+
+Two modes
+---------
+`--check` (what CI runs, no network, no Node):
+  * the version in `package.json` matches the one recorded in `VERSION`
+  * the digests in `VERSION` match the files actually checked in
+
+default (what a developer runs after a Dependabot bump):
+  * copy `node_modules/leaflet/dist/{leaflet.js,leaflet.css}` and `LICENSE` into
+    the vendor directory and rewrite `VERSION` with fresh digests
+  * requires `npm install` to have run first
+
+Exit codes: 0 = in step / updated, 1 = drift found, 2 = usage or environment error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VENDOR_DIR = REPO_ROOT / "custom_components" / "googlefindmy" / "vendor" / "leaflet"
+NODE_DIST = REPO_ROOT / "node_modules" / "leaflet" / "dist"
+NODE_LICENSE = REPO_ROOT / "node_modules" / "leaflet" / "LICENSE"
+ASSETS = ("leaflet.js", "leaflet.css")
+
+_VERSION_LINE = re.compile(r"^leaflet (?P<version>\S+)$", re.M)
+_DIGEST_LINE = re.compile(
+    r"^sha256 (?P<name>\S+)\s*=\s*(?P<digest>[0-9a-f]{64})$", re.M
+)
+
+
+def pinned_version() -> str:
+    """Return the `leaflet` version pinned in package.json devDependencies."""
+
+    package = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+    version = package.get("devDependencies", {}).get("leaflet")
+    if not isinstance(version, str) or not version:
+        raise SystemExit("package.json has no `leaflet` devDependency")
+    return version.lstrip("^~")
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def recorded() -> tuple[str, dict[str, str]]:
+    """Return (version, {asset: digest}) as recorded in VERSION."""
+
+    text = (VENDOR_DIR / "VERSION").read_text(encoding="utf-8")
+    match = _VERSION_LINE.search(text)
+    if match is None:
+        raise SystemExit(f"{VENDOR_DIR / 'VERSION'} has no `leaflet <version>` line")
+    digests = {m["name"]: m["digest"] for m in _DIGEST_LINE.finditer(text)}
+    return match["version"], digests
+
+
+def write_version(version: str, digests: dict[str, str]) -> None:
+    lines = [
+        f"leaflet {version}",
+        "license: BSD-2-Clause (see LICENSE)",
+        f"source: https://registry.npmjs.org/leaflet/-/leaflet-{version}.tgz (dist/)",
+    ]
+    lines += [f"sha256 {name:<11} = {digests[name]}" for name in ASSETS]
+    lines += [
+        "",
+        "Written by script/vendor_leaflet.py from node_modules/leaflet/dist.",
+        "The map page embeds these two files inline; it does not register a static",
+        "path and it does not fetch anything from a CDN. Only leaflet.js and",
+        "leaflet.css are vendored: the map draws with L.circleMarker and uses no",
+        "layers control, so the image assets those CSS rules reference are never",
+        "requested.",
+        "",
+    ]
+    (VENDOR_DIR / "VERSION").write_text("\n".join(lines), encoding="utf-8")
+
+
+def check() -> int:
+    problems: list[str] = []
+    want_version = pinned_version()
+    have_version, have_digests = recorded()
+
+    if want_version != have_version:
+        problems.append(
+            f"package.json pins leaflet {want_version}, "
+            f"but {VENDOR_DIR.name}/VERSION records {have_version}"
+        )
+
+    for name in ASSETS:
+        path = VENDOR_DIR / name
+        if not path.is_file():
+            problems.append(f"missing vendored asset: {path}")
+            continue
+        actual = digest(path)
+        expected = have_digests.get(name)
+        if expected is None:
+            problems.append(f"VERSION records no digest for {name}")
+        elif actual != expected:
+            problems.append(
+                f"{name} does not match its recorded digest "
+                f"(recorded {expected[:12]}…, actual {actual[:12]}…)"
+            )
+
+    if not (VENDOR_DIR / "LICENSE").is_file():
+        problems.append(f"missing {VENDOR_DIR / 'LICENSE'} (BSD-2-Clause attribution)")
+
+    if problems:
+        print("Vendored Leaflet copy is out of step:")
+        for problem in problems:
+            print(f"  - {problem}")
+        print()
+        print(
+            "Run `npm install && python script/vendor_leaflet.py` and commit the result."
+        )
+        return 1
+
+    print(f"Vendored Leaflet {have_version} matches package.json and its digests.")
+    return 0
+
+
+def update() -> int:
+    if not NODE_DIST.is_dir():
+        print(f"{NODE_DIST} not found; run `npm install` first.", file=sys.stderr)
+        return 2
+
+    version = pinned_version()
+    digests: dict[str, str] = {}
+    for name in ASSETS:
+        source = NODE_DIST / name
+        if not source.is_file():
+            print(f"missing {source}", file=sys.stderr)
+            return 2
+        shutil.copyfile(source, VENDOR_DIR / name)
+        digests[name] = digest(VENDOR_DIR / name)
+
+    if NODE_LICENSE.is_file():
+        shutil.copyfile(NODE_LICENSE, VENDOR_DIR / "LICENSE")
+
+    write_version(version, digests)
+    print(f"Vendored Leaflet {version} from {NODE_DIST}.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify only; do not touch the working tree (what CI runs)",
+    )
+    args = parser.parse_args(argv)
+    return check() if args.check else update()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/vendor_leaflet.py
+++ b/script/vendor_leaflet.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# script/vendor_leaflet.py
 """Keep the vendored Leaflet copy in step with the pinned npm version.
 
 Why this exists
@@ -132,12 +133,42 @@ def check() -> int:
     return 0
 
 
+def installed_version() -> str | None:
+    """Return the version of the Leaflet package actually present in node_modules."""
+
+    package_json = NODE_DIST.parent / "package.json"
+    if not package_json.is_file():
+        return None
+    installed = json.loads(package_json.read_text(encoding="utf-8")).get("version")
+    return installed if isinstance(installed, str) else None
+
+
 def update() -> int:
     if not NODE_DIST.is_dir():
         print(f"{NODE_DIST} not found; run `npm install` first.", file=sys.stderr)
         return 2
 
     version = pinned_version()
+
+    # Stamping the pinned version onto whatever happens to sit in node_modules
+    # would produce a copy that passes --check while carrying the previous
+    # release, which is precisely the drift this script exists to prevent.
+    present = installed_version()
+    if present != version:
+        print(
+            f"node_modules carries leaflet {present or 'an unknown version'}, "
+            f"but package.json pins {version}; run `npm install` first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not NODE_LICENSE.is_file():
+        print(
+            f"{NODE_LICENSE} not found; refusing to keep the previous licence file "
+            "next to new sources (BSD-2-Clause attribution).",
+            file=sys.stderr,
+        )
+        return 2
     digests: dict[str, str] = {}
     for name in ASSETS:
         source = NODE_DIST / name
@@ -147,8 +178,7 @@ def update() -> int:
         shutil.copyfile(source, VENDOR_DIR / name)
         digests[name] = digest(VENDOR_DIR / name)
 
-    if NODE_LICENSE.is_file():
-        shutil.copyfile(NODE_LICENSE, VENDOR_DIR / "LICENSE")
+    shutil.copyfile(NODE_LICENSE, VENDOR_DIR / "LICENSE")
 
     write_version(version, digests)
     print(f"Vendored Leaflet {version} from {NODE_DIST}.")

--- a/tests/test_vendor_leaflet_gate.py
+++ b/tests/test_vendor_leaflet_gate.py
@@ -1,0 +1,131 @@
+# tests/test_vendor_leaflet_gate.py
+"""Negative-path tests for the vendored-asset freshness gate.
+
+A gate that is only ever run against a known-good tree proves nothing: a
+regression that stops collecting problems would keep CI green. Each test below
+mutates one input and asserts the gate goes red for that reason.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "script" / "vendor_leaflet.py"
+
+
+def _load(tmp_root: Path) -> ModuleType:
+    """Load the script with its repository root pointed at a temporary copy."""
+
+    spec = importlib.util.spec_from_file_location("vendor_leaflet_under_test", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    module.REPO_ROOT = tmp_root
+    module.VENDOR_DIR = (
+        tmp_root / "custom_components" / "googlefindmy" / "vendor" / "leaflet"
+    )
+    module.NODE_DIST = tmp_root / "node_modules" / "leaflet" / "dist"
+    module.NODE_LICENSE = tmp_root / "node_modules" / "leaflet" / "LICENSE"
+    return module
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A minimal, self-consistent copy of the parts the gate looks at."""
+
+    vendor = tmp_path / "custom_components" / "googlefindmy" / "vendor" / "leaflet"
+    vendor.mkdir(parents=True)
+    (vendor / "leaflet.js").write_text("// js\n", encoding="utf-8")
+    (vendor / "leaflet.css").write_text("/* css */\n", encoding="utf-8")
+    (vendor / "LICENSE").write_text("BSD-2-Clause\n", encoding="utf-8")
+    (tmp_path / "package.json").write_text(
+        json.dumps({"devDependencies": {"leaflet": "1.9.4"}}), encoding="utf-8"
+    )
+
+    module = _load(tmp_path)
+    digests = {name: module.digest(vendor / name) for name in module.ASSETS}
+    module.write_version("1.9.4", digests)
+    return tmp_path
+
+
+def test_the_gate_passes_on_a_consistent_tree(tree: Path) -> None:
+    assert _load(tree).check() == 0
+
+
+def test_a_version_bump_without_re_vendoring_fails(tree: Path) -> None:
+    (tree / "package.json").write_text(
+        json.dumps({"devDependencies": {"leaflet": "1.9.5"}}), encoding="utf-8"
+    )
+
+    assert _load(tree).check() == 1
+
+
+def test_an_edited_asset_fails(tree: Path) -> None:
+    asset = (
+        tree
+        / "custom_components"
+        / "googlefindmy"
+        / "vendor"
+        / "leaflet"
+        / "leaflet.js"
+    )
+    asset.write_text("// tampered\n", encoding="utf-8")
+
+    assert _load(tree).check() == 1
+
+
+def test_a_missing_asset_fails(tree: Path) -> None:
+    (
+        tree
+        / "custom_components"
+        / "googlefindmy"
+        / "vendor"
+        / "leaflet"
+        / "leaflet.css"
+    ).unlink()
+
+    assert _load(tree).check() == 1
+
+
+def test_a_missing_licence_fails(tree: Path) -> None:
+    (
+        tree / "custom_components" / "googlefindmy" / "vendor" / "leaflet" / "LICENSE"
+    ).unlink()
+
+    assert _load(tree).check() == 1
+
+
+def test_update_refuses_a_stale_node_modules(tree: Path) -> None:
+    """Stamping the pin onto an old installation would pass --check afterwards."""
+
+    dist = tree / "node_modules" / "leaflet" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "leaflet.js").write_text("// old\n", encoding="utf-8")
+    (dist / "leaflet.css").write_text("/* old */\n", encoding="utf-8")
+    (tree / "node_modules" / "leaflet" / "LICENSE").write_text(
+        "BSD\n", encoding="utf-8"
+    )
+    (tree / "node_modules" / "leaflet" / "package.json").write_text(
+        json.dumps({"version": "1.9.3"}), encoding="utf-8"
+    )
+
+    assert _load(tree).update() == 2
+
+
+def test_update_refuses_a_package_without_a_licence(tree: Path) -> None:
+    dist = tree / "node_modules" / "leaflet" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "leaflet.js").write_text("// new\n", encoding="utf-8")
+    (dist / "leaflet.css").write_text("/* new */\n", encoding="utf-8")
+    (tree / "node_modules" / "leaflet" / "package.json").write_text(
+        json.dumps({"version": "1.9.4"}), encoding="utf-8"
+    )
+
+    assert _load(tree).update() == 2


### PR DESCRIPTION
Stacked on #1249 (base `security/vendor-leaflet`), which vendors the files this PR keeps fresh.

Target: jleinenbach/GoogleFindMy-HA 1.7 — via #1249.

## What

- `leaflet` pinned as a devDependency in `package.json` (and `package-lock.json`), inside the npm ecosystem `.github/dependabot.yml` already watches monthly.
- `script/vendor_leaflet.py`: refreshes the vendored copy from `node_modules/leaflet/dist` and rewrites `VERSION` with fresh digests; `--check` verifies without touching the tree.
- New CI job `vendored_assets` runs `--check` and is wired into `ci-success`.
- `script/AGENTS.md` documents the script: purpose, invocation, what makes it red, and the fix.

## Why this shape

The check deliberately needs no network and no Node. It compares three things that are all in the repository: the pinned version against `vendor/leaflet/VERSION`, the recorded digests against the files, and the presence of `LICENSE`. So a Dependabot bump of `leaflet` arrives as a red check naming the command to run, rather than as a silent no-op.

## Mutation evidence

Both failure modes were provoked and both go red:

- Appending one byte to `vendor/leaflet/leaflet.css` → `leaflet.css does not match its recorded digest`, exit 1.
- Setting the pin to `1.9.5` without re-vendoring → `package.json pins leaflet 1.9.5, but leaflet/VERSION records 1.9.4`, exit 1.
- Restoring either makes it green again.

## Note on the job id

The job is `vendored_assets`, not `vendored-assets`: a hyphenated job id cannot be read back as `${{ needs.<id>.result }}` in the `ci-success` gate without bracket syntax, and a gate that silently fails to reference a job is worse than no gate.