### PR TITLE
fix(map): refresh the device configuration URLs once a day

### DIFF
--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -2968,6 +2968,8 @@ class GoogleFindMyDomainData(TypedDict, total=False):
     restart_check_registered: bool
     restart_check_unsub: Callable[[], None] | None
     restart_check_initial_unsub: Callable[[], None] | None
+    url_refresh_registered: bool
+    url_refresh_unsub: Callable[[], None] | None
     providers_registered: bool
     views_registered: bool
     _subentry_forward_helper_logs: set[str]
@@ -7061,6 +7063,53 @@ def _register_restart_required_check(
     )
 
 
+_URL_REFRESH_INTERVAL = timedelta(days=1)
+
+
+def _register_url_refresh_timer(
+    hass: HomeAssistant, bucket: GoogleFindMyDomainData
+) -> None:
+    """Refresh the device configuration URLs once a day.
+
+    Without this the URLs are rebuilt only during setup. With the weekly token
+    expiry enabled, an instance that runs across two week boundaries without a
+    restart or reload ends up with a dead Map View link on its own device page;
+    the map accepts the current and the previous week, so two boundaries is the
+    first point at which the stored link is certainly stale.
+
+    A run that changes nothing costs nothing: the device registry returns early
+    when the value is unchanged, and the periodic path reports an unreachable or
+    internal-only URL only when that situation *changes* (see
+    ``_async_refresh_device_urls``).
+    """
+
+    @callback
+    def _scheduled_refresh(_now: Any) -> None:
+        _async_create_task(
+            hass,
+            _async_refresh_device_urls(hass, periodic=True),
+            name=f"{DOMAIN}.refresh_device_urls",
+        )
+
+    bucket["url_refresh_unsub"] = async_track_time_interval(
+        hass, _scheduled_refresh, _URL_REFRESH_INTERVAL
+    )
+
+
+@callback
+def _teardown_url_refresh_timer(
+    hass: HomeAssistant, bucket: GoogleFindMyDomainData
+) -> None:
+    """Cancel the daily URL refresh (last-entry teardown)."""
+
+    unsub = bucket.pop("url_refresh_unsub", None)
+    if callable(unsub):
+        with suppress(Exception):
+            unsub()
+    bucket.pop("url_refresh_registered", None)
+    hass.data.pop(_URL_STATE_MARKER, None)
+
+
 @callback
 def _teardown_restart_required_check(
     hass: HomeAssistant, bucket: GoogleFindMyDomainData
@@ -7106,6 +7155,14 @@ async def _async_ensure_restart_required_check(
             _register_restart_required_check(hass, bucket)
             bucket["restart_check_registered"] = True
             _LOGGER.debug("Registered %s restart-required watchdog", DOMAIN)
+
+        url_refresh_registered = bucket.get("url_refresh_registered")
+        if not isinstance(url_refresh_registered, bool):
+            url_refresh_registered = False
+        if not url_refresh_registered:
+            _register_url_refresh_timer(hass, bucket)
+            bucket["url_refresh_registered"] = True
+            _LOGGER.debug("Registered %s daily map URL refresh", DOMAIN)
 
 
 def _log_ecdsa_acceleration(info: dict[str, str | None]) -> None:
@@ -8996,8 +9053,37 @@ async def _async_normalize_device_names(hass: HomeAssistant) -> None:
         _LOGGER.debug("Device name normalization skipped due to: %s", err)
 
 
-async def _async_refresh_device_urls(hass: HomeAssistant) -> None:
-    """Refresh configuration URLs for all Google Find My devices."""
+# Marker under which the last observed URL situation is remembered, so a periodic
+# refresh can report a *change* instead of repeating the same line every day.
+_URL_STATE_MARKER = f"{DOMAIN}_url_refresh_state"
+
+
+@callback
+def _url_state_changed(hass: HomeAssistant, state: str) -> bool:
+    """Return True when the URL situation differs from the previous refresh."""
+
+    previous: object = hass.data.get(_URL_STATE_MARKER)
+    hass.data[_URL_STATE_MARKER] = state
+    return bool(previous != state)
+
+
+async def _async_refresh_device_urls(
+    hass: HomeAssistant, *, periodic: bool = False
+) -> None:
+    """Refresh configuration URLs for all Google Find My devices.
+
+    ``periodic`` marks the daily timer run. Those runs report an unreachable or
+    internal-only URL once per state change instead of once per run: the two
+    messages were written for a single startup, and a timer would otherwise turn
+    each of them into a daily line in every installation that has no external
+    URL. A user-triggered refresh (the ``refresh_device_urls`` service) keeps
+    reporting unconditionally, because there somebody is waiting for the answer.
+    """
+
+    def _report_once(state: str) -> bool:
+        """Return True when this run should log above debug level."""
+
+        return not periodic or _url_state_changed(hass, state)
 
     try:
         base_url = cast(
@@ -9010,14 +9096,16 @@ async def _async_refresh_device_urls(hass: HomeAssistant) -> None:
             ),
         )
     except (HomeAssistantError, NoURLAvailableError) as err:
-        _LOGGER.warning(
+        _LOGGER.log(
+            logging.WARNING if _report_once("no-url") else logging.DEBUG,
             "Skipping configuration URL refresh; no reachable URL available: %s",
             err,
         )
         return
 
     if not base_url or "://" not in base_url:
-        _LOGGER.warning(
+        _LOGGER.log(
+            logging.WARNING if _report_once("no-url") else logging.DEBUG,
             "Skipping configuration URL refresh; no reachable URL available",
         )
         return
@@ -9032,10 +9120,13 @@ async def _async_refresh_device_urls(hass: HomeAssistant) -> None:
     except (HomeAssistantError, NoURLAvailableError):
         internal_url = None
     if base_url.rstrip("/") == (internal_url or "").rstrip("/"):
-        _LOGGER.info(
+        _LOGGER.log(
+            logging.INFO if _report_once("internal-only") else logging.DEBUG,
             "Using internal URL for map view links; "
             "set an external URL in Home Assistant settings for remote access",
         )
+    else:
+        _report_once("external")
 
     base_url = base_url.rstrip("/")
 
@@ -9679,6 +9770,7 @@ async def _async_unload_parent_entry(hass: HomeAssistant, entry: MyConfigEntry) 
             # and clear its issue, mirroring how other global singletons are released
             # here (Codex-P1 #1/#2).
             _teardown_restart_required_check(hass, bucket)
+            _teardown_url_refresh_timer(hass, bucket)
 
         try:
             await _maybe_close_spot_transport(entries_bucket)

--- a/custom_components/googlefindmy/__init__.py
+++ b/custom_components/googlefindmy/__init__.py
@@ -2970,6 +2970,7 @@ class GoogleFindMyDomainData(TypedDict, total=False):
     restart_check_initial_unsub: Callable[[], None] | None
     url_refresh_registered: bool
     url_refresh_unsub: Callable[[], None] | None
+    url_refresh_state: str
     providers_registered: bool
     views_registered: bool
     _subentry_forward_helper_logs: set[str]
@@ -7107,7 +7108,7 @@ def _teardown_url_refresh_timer(
         with suppress(Exception):
             unsub()
     bucket.pop("url_refresh_registered", None)
-    hass.data.pop(_URL_STATE_MARKER, None)
+    bucket.pop("url_refresh_state", None)
 
 
 @callback
@@ -9053,17 +9054,18 @@ async def _async_normalize_device_names(hass: HomeAssistant) -> None:
         _LOGGER.debug("Device name normalization skipped due to: %s", err)
 
 
-# Marker under which the last observed URL situation is remembered, so a periodic
-# refresh can report a *change* instead of repeating the same line every day.
-_URL_STATE_MARKER = f"{DOMAIN}_url_refresh_state"
-
-
 @callback
 def _url_state_changed(hass: HomeAssistant, state: str) -> bool:
-    """Return True when the URL situation differs from the previous refresh."""
+    """Record the URL situation and return whether it differs from the last one.
 
-    previous: object = hass.data.get(_URL_STATE_MARKER)
-    hass.data[_URL_STATE_MARKER] = state
+    The marker lives in the typed domain bucket, next to the timer that reads it
+    and the teardown that clears it, rather than in a second top-level
+    ``hass.data`` key: one owner, one lifecycle.
+    """
+
+    bucket = _domain_data(hass)
+    previous: object = bucket.get("url_refresh_state")
+    bucket["url_refresh_state"] = state
     return bool(previous != state)
 
 
@@ -9081,9 +9083,16 @@ async def _async_refresh_device_urls(
     """
 
     def _report_once(state: str) -> bool:
-        """Return True when this run should log above debug level."""
+        """Record the state and return whether this run should log above debug.
 
-        return not periodic or _url_state_changed(hass, state)
+        The state is recorded on *every* run, the startup one included. Ordering
+        matters here: with the recording behind a short-circuiting ``or``, a
+        startup that logged the warning would not have stored it, and the first
+        daily tick would have logged the identical line again.
+        """
+
+        changed = _url_state_changed(hass, state)
+        return not periodic or changed
 
     try:
         base_url = cast(

--- a/tests/test_metadata_helpers.py
+++ b/tests/test_metadata_helpers.py
@@ -208,6 +208,35 @@ async def test_periodic_refresh_reports_an_unreachable_url_once(
 
 
 @pytest.mark.asyncio
+async def test_startup_state_is_recorded_so_the_first_tick_stays_quiet(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The startup run records the situation even though it always reports.
+
+    With the recording behind a short-circuiting ``or``, a startup that logged
+    the warning would not have stored it, and the first daily tick would have
+    logged the identical line again -- the very repetition the suppressor exists
+    to prevent.
+    """
+
+    hass = SimpleNamespace()
+    hass.data = {"core.uuid": "ha-uuid"}
+    hass.config_entries = SimpleNamespace(async_entries=lambda domain: [])
+
+    def _no_url(_hass: object, **_kwargs: object) -> str:
+        raise NoURLAvailableError
+
+    monkeypatch.setattr(integration, "get_url", _no_url)
+
+    caplog.set_level(logging.DEBUG)
+    await integration._async_refresh_device_urls(hass)  # startup, reports
+    caplog.clear()
+    await integration._async_refresh_device_urls(hass, periodic=True)  # first tick
+
+    assert not [record for record in caplog.records if record.levelno > logging.DEBUG]
+
+
+@pytest.mark.asyncio
 async def test_periodic_refresh_reports_again_after_the_situation_changes(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_metadata_helpers.py
+++ b/tests/test_metadata_helpers.py
@@ -15,6 +15,7 @@ from custom_components.googlefindmy.const import (
     map_token_secret_seed,
 )
 from custom_components.googlefindmy.entity import GoogleFindMyDeviceEntity
+from tests.helpers.config_entries_stub import make_config_entry
 
 
 @pytest.mark.asyncio
@@ -122,3 +123,119 @@ def test_device_configuration_url_warns_when_external_url_missing(
     ]
     assert len(warnings) == 1
     assert entity._base_url_warning_emitted is True
+
+
+@pytest.mark.asyncio
+async def test_periodic_refresh_follows_the_week_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two week rollovers must leave the device page with a usable link.
+
+    The map accepts the current and the previous weekly bucket, so two rollovers
+    is the first moment at which a link written at setup is certainly stale.
+    """
+
+    base_url = "https://example.test"
+    week = 7 * 24 * 3600
+    now = {"value": 1_209_600}
+
+    entry = make_config_entry(
+        entry_id="entry-1",
+        options={OPT_MAP_VIEW_TOKEN_EXPIRATION: True},
+    )
+    hass = SimpleNamespace()
+    hass.data = {"core.uuid": "ha-uuid"}
+    hass.config_entries = SimpleNamespace(async_entries=lambda domain: [entry])
+
+    monkeypatch.setattr(integration, "get_url", lambda _hass, **kwargs: base_url)
+    monkeypatch.setattr(integration.time, "time", lambda: now["value"])
+
+    registry = dr.async_get(hass)
+    device = registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"{entry.entry_id}:device-alpha")},
+        manufacturer="Google",
+        model="Nest",
+        name="Alpha",
+    )
+
+    await integration._async_refresh_device_urls(hass)
+    at_setup = device.configuration_url
+
+    now["value"] += 2 * week
+    await integration._async_refresh_device_urls(hass, periodic=True)
+
+    expected = map_token_hex_digest(
+        map_token_secret_seed("ha-uuid", entry.entry_id, True, now=now["value"])
+    )
+    assert device.configuration_url != at_setup
+    assert device.configuration_url == (
+        f"{base_url}/api/googlefindmy/map/device-alpha?token={expected}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_periodic_refresh_reports_an_unreachable_url_once(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A daily timer must not turn a startup warning into a daily warning."""
+
+    hass = SimpleNamespace()
+    hass.data = {"core.uuid": "ha-uuid"}
+    hass.config_entries = SimpleNamespace(async_entries=lambda domain: [])
+
+    def _no_url(_hass: object, **_kwargs: object) -> str:
+        raise NoURLAvailableError
+
+    monkeypatch.setattr(integration, "get_url", _no_url)
+
+    caplog.set_level(logging.DEBUG)
+    for _ in range(10):
+        await integration._async_refresh_device_urls(hass, periodic=True)
+
+    above_debug = [
+        record
+        for record in caplog.records
+        if record.levelno > logging.DEBUG
+        and "Skipping configuration URL refresh" in record.getMessage()
+    ]
+    assert len(above_debug) == 1
+
+    # A user-triggered refresh still reports every time: somebody is waiting.
+    caplog.clear()
+    await integration._async_refresh_device_urls(hass)
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_periodic_refresh_reports_again_after_the_situation_changes(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Suppression must not swallow a *new* state, only a repeated one."""
+
+    hass = SimpleNamespace()
+    hass.data = {"core.uuid": "ha-uuid"}
+    hass.config_entries = SimpleNamespace(async_entries=lambda domain: [])
+
+    state = {"url": "https://example.test"}
+
+    def _get_url(_hass: object, **kwargs: object) -> str:
+        if state["url"] is None:
+            raise NoURLAvailableError
+        return state["url"]
+
+    monkeypatch.setattr(integration, "get_url", _get_url)
+
+    caplog.set_level(logging.DEBUG)
+    await integration._async_refresh_device_urls(hass, periodic=True)
+    state["url"] = None
+    await integration._async_refresh_device_urls(hass, periodic=True)
+    await integration._async_refresh_device_urls(hass, periodic=True)
+
+    above_debug = [
+        record
+        for record in caplog.records
+        if record.levelno > logging.DEBUG
+        and "Skipping configuration URL refresh" in record.getMessage()
+    ]
+    assert len(above_debug) == 1

--- a/tests/test_restart_required_issue.py
+++ b/tests/test_restart_required_issue.py
@@ -295,14 +295,20 @@ async def test_single_timer_across_multiple_setups(
     hass = _Hass()
     monkeypatch.setattr(gfm, "_ensure_runtime_imports", lambda: None)
 
-    counts = {"later": 0, "interval": 0}
+    counts = {"later": 0, "interval": 0, "url_refresh": 0}
 
     def _fake_later(_hass: Any, _delay: Any, _cb: Any) -> Any:
         counts["later"] += 1
         return lambda: None
 
     def _fake_interval(_hass: Any, _cb: Any, _interval: Any) -> Any:
-        counts["interval"] += 1
+        # `_async_ensure_restart_required_check` arms two independent timers:
+        # the restart watchdog and the daily map-URL refresh. Counting them
+        # apart keeps this test about the watchdog.
+        if getattr(_cb, "__name__", "") == "_scheduled_refresh":
+            counts["url_refresh"] += 1
+        else:
+            counts["interval"] += 1
         return lambda: None
 
     monkeypatch.setattr(gfm, "async_call_later", _fake_later)
@@ -316,6 +322,7 @@ async def test_single_timer_across_multiple_setups(
 
     assert counts["later"] == 1
     assert counts["interval"] == 1
+    assert counts["url_refresh"] == 1  # armed once as well, not once per setup
     assert bucket["restart_check_registered"] is True
     assert callable(bucket["restart_check_initial_unsub"])
     assert callable(bucket["restart_check_unsub"])
@@ -402,14 +409,20 @@ async def test_ensure_rearms_watchdog_after_teardown(
     """
 
     hass = _Hass()
-    counts = {"later": 0, "interval": 0}
+    counts = {"later": 0, "interval": 0, "url_refresh": 0}
 
     def _fake_later(_hass: Any, _delay: Any, _cb: Any) -> Any:
         counts["later"] += 1
         return lambda: None
 
     def _fake_interval(_hass: Any, _cb: Any, _interval: Any) -> Any:
-        counts["interval"] += 1
+        # `_async_ensure_restart_required_check` arms two independent timers:
+        # the restart watchdog and the daily map-URL refresh. Counting them
+        # apart keeps this test about the watchdog.
+        if getattr(_cb, "__name__", "") == "_scheduled_refresh":
+            counts["url_refresh"] += 1
+        else:
+            counts["interval"] += 1
         return lambda: None
 
     monkeypatch.setattr(gfm, "async_call_later", _fake_later)


### PR DESCRIPTION
Target: jleinenbach/GoogleFindMy-HA 1.7 — `_async_refresh_device_urls` and the watchdog pattern are identical in both trees.

## The defect

Found while checking a security report, not in it. `__init__.py` → `_async_refresh_device_urls` had exactly one caller — `async_setup_entry`, `await _async_refresh_device_urls(hass)` — and no timer (`async_track_time_interval` appeared only in `_register_restart_required_check`). `entity.py` → `GoogleFindMyDeviceEntity._get_map_token` builds the token when the entity is created. Meanwhile `map_view.py` → `_entry_accept_tokens` accepts the current **and** the previous weekly bucket.

So with `map_view_token_expiration` on, two week boundaries without a restart or reload leave a stale link in `configuration_url`, on the user's own device page.

## Why not the literal fix

The obvious patch is the timer alone, and it would have made the log worse. `_async_refresh_device_urls` logs `Skipping configuration URL refresh` at warning and `Using internal URL for map view links` at info. Both are written for a once-per-startup context; a daily timer turns them into a daily line in every installation without an external URL.

So the timer ships with a repeat suppressor: periodic runs report a *change* of the URL situation and stay at debug otherwise. The service path passes `periodic=False` and is untouched — deliberately, because there a user is waiting for the answer and a suppressed warning would be a worse bug than a repeated one.

This is also why the duplicated logging in `services.py` is *not* pulled along: the flag makes that path unreachable for suppression by construction, so touching it would be change without effect.

## Cost of a run that finds nothing to do

Nothing is written: `homeassistant/helpers/device_registry.py` → `DeviceRegistry.async_update_device` returns the existing entry when no value differs (`if not new_values and not is_new: return old`).

## Tests

- Two week rollovers change the stored `configuration_url` to the current bucket's token (this is the regression itself; removing the periodic call makes it red).
- Ten periodic runs with no reachable URL produce exactly one record above debug; a service-triggered run right after still warns.
- A *changed* situation reports again, so the suppressor swallows repetition and not news.
- `test_restart_required_issue.py` now counts the two interval timers apart, by callback name, and asserts the new one is armed once across multiple setups rather than once per setup.

Full suite green, coverage 78.38% (gate 78%). `ruff`, `ruff format`, `mypy --strict` clean.