### PR TITLE
fix(keybackup): a terminal is not a command line

### DIFF
--- a/custom_components/googlefindmy/KeyBackup/shared_key_retrieval.py
+++ b/custom_components/googlefindmy/KeyBackup/shared_key_retrieval.py
@@ -185,11 +185,29 @@ _browser_flow_attempted = False
 # Assistant answers yes.
 _ENV_CLI_PROCESS = "GOOGLEFINDMY_CLI_PROCESS"
 
+# Same opt-in `Auth/auth_flow.py` already uses for consoles that carry a user but
+# report no tty (IDE run windows).
+_ENV_ASSUME_INTERACTIVE = "GOOGLEFINDMY_ASSUME_INTERACTIVE"
+
 
 def _cli_process() -> bool:
     """Return True when this process identified itself as the CLI tool."""
 
     return os.environ.get(_ENV_CLI_PROCESS) == "1"
+
+
+def _attended_session() -> bool:
+    """Return True when somebody can answer the browser prompt.
+
+    The browser flow waits for a human to sign in. A command-line run is a
+    necessary condition, not a sufficient one: `main.py` sets its marker
+    unconditionally, so an unattended run with redirected stdin (cron, a
+    container entrypoint) would otherwise open Chrome and wait forever.
+    """
+
+    if os.environ.get(_ENV_ASSUME_INTERACTIVE) == "1":
+        return True
+    return bool(sys.stdin and sys.stdin.isatty())
 
 
 async def _retrieve_shared_key_hex() -> str:
@@ -215,10 +233,10 @@ async def _retrieve_shared_key_hex() -> str:
     """
     global _browser_flow_attempted  # noqa: PLW0603
 
-    is_tty = bool(sys.stdin and sys.stdin.isatty())
+    is_attended = _attended_session()
     is_cli = _cli_process()
 
-    if is_tty and not is_cli:
+    if is_attended and not is_cli:
         # A terminal is not a command line. Home Assistant started in the
         # foreground of a terminal answers `isatty()` with True, and would then
         # have opened a browser from inside the Home Assistant process. Say what
@@ -229,6 +247,16 @@ async def _retrieve_shared_key_hex() -> str:
             "attached, but this process is not the Google Find My command-line "
             f"tool. Run `python main.py`, or set {_ENV_CLI_PROCESS}=1 if you are "
             "driving the extraction from your own wrapper."
+        )
+
+    if is_cli and not is_attended:
+        # The marker says "command-line tool", the session says "nobody here".
+        # Opening Chrome now would hang until the timeout with no way to answer.
+        raise SharedKeyUnavailableError(
+            "Refusing to open the interactive browser flow: this is the command-line "
+            "tool, but no terminal is attached. Run it from an interactive terminal, "
+            f"or set {_ENV_ASSUME_INTERACTIVE}=1 if you are at a console that reports "
+            "no tty."
         )
 
     if is_cli:

--- a/custom_components/googlefindmy/KeyBackup/shared_key_retrieval.py
+++ b/custom_components/googlefindmy/KeyBackup/shared_key_retrieval.py
@@ -23,8 +23,10 @@ Normalization & validation:
 - Decoded key must be exactly 32 bytes (256 bit).
 
 Retrieval strategy (when not cached):
-- In CLI/TTY mode: interactive browser flow via ``shared_key_flow.py`` (the only
-  authoritative source — retrieves the real vault key from Google's Key Backup service).
+- In the command-line tool: interactive browser flow via ``shared_key_flow.py``
+  (the only authoritative source — retrieves the real vault key from Google's Key
+  Backup service). The command-line entry point marks its own process; a
+  terminal alone is not enough (see ``_cli_process``).
 - In non-interactive / HA mode: the key must be pre-populated from the secrets
   bundle during ``async_setup_entry()``.  If missing, a descriptive error is raised.
 """
@@ -34,6 +36,7 @@ from __future__ import annotations
 import base64
 import importlib
 import logging
+import os
 import re
 import sys
 from binascii import Error as BinasciiError
@@ -176,6 +179,19 @@ async def _interactive_flow_hex() -> str:
 _browser_flow_attempted = False
 
 
+# Set by the command-line entry point on its own process (``main.py`` does it
+# before anything else). Home Assistant never sets it, which is the whole point:
+# the previous guard asked "is a terminal attached", and a foreground Home
+# Assistant answers yes.
+_ENV_CLI_PROCESS = "GOOGLEFINDMY_CLI_PROCESS"
+
+
+def _cli_process() -> bool:
+    """Return True when this process identified itself as the CLI tool."""
+
+    return os.environ.get(_ENV_CLI_PROCESS) == "1"
+
+
 async def _retrieve_shared_key_hex() -> str:
     """Obtain a hex-encoded shared key (32 bytes) via the interactive browser flow.
 
@@ -199,9 +215,23 @@ async def _retrieve_shared_key_hex() -> str:
     """
     global _browser_flow_attempted  # noqa: PLW0603
 
-    is_tty = sys.stdin and sys.stdin.isatty()
+    is_tty = bool(sys.stdin and sys.stdin.isatty())
+    is_cli = _cli_process()
 
-    if is_tty:
+    if is_tty and not is_cli:
+        # A terminal is not a command line. Home Assistant started in the
+        # foreground of a terminal answers `isatty()` with True, and would then
+        # have opened a browser from inside the Home Assistant process. Say what
+        # is missing rather than failing silently: someone running an unforeseen
+        # command-line wrapper can set the marker themselves.
+        raise SharedKeyUnavailableError(
+            "Refusing to open the interactive browser flow: a terminal is "
+            "attached, but this process is not the Google Find My command-line "
+            f"tool. Run `python main.py`, or set {_ENV_CLI_PROCESS}=1 if you are "
+            "driving the extraction from your own wrapper."
+        )
+
+    if is_cli:
         if _browser_flow_attempted:
             raise RuntimeError(
                 "Shared key browser flow already attempted in this session. "

--- a/custom_components/googlefindmy/main.py
+++ b/custom_components/googlefindmy/main.py
@@ -935,6 +935,16 @@ def _main(argv: Sequence[str] | None = None) -> None:
     """
     import asyncio  # noqa: PLC0415
 
+    # Mark this process as the command-line tool before anything else runs. The
+    # interactive key-backup fallback used to ask "is a terminal attached",
+    # which a foreground Home Assistant also answers with yes; it now asks for
+    # this marker instead. Home Assistant never sets it, the user never has to.
+    from custom_components.googlefindmy.KeyBackup.shared_key_retrieval import (  # noqa: PLC0415
+        _ENV_CLI_PROCESS,
+    )
+
+    os.environ[_ENV_CLI_PROCESS] = "1"
+
     args = _build_cli_parser().parse_args(argv)
     _configure_cli_logging(debug_flag=args.debug, env=os.environ)
 

--- a/tests/test_shared_key_retrieval.py
+++ b/tests/test_shared_key_retrieval.py
@@ -17,6 +17,7 @@ line/branch coverage and lock in three previously fixed bugs:
 from __future__ import annotations
 
 import base64
+import os
 import sys
 from collections.abc import Awaitable, Callable
 from types import ModuleType, SimpleNamespace
@@ -91,14 +92,28 @@ def _reset_browser_guard() -> Any:
 
 @pytest.fixture
 def tty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Pretend we run in an interactive TTY (CLI mode)."""
+    """Pretend we are the command-line tool: a terminal *and* the CLI marker.
+
+    A terminal alone is no longer enough. `main.py` sets the marker on its own
+    process, because a foreground Home Assistant also has a terminal attached
+    and must not reach the browser flow through it.
+    """
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setenv(skr._ENV_CLI_PROCESS, "1")
+
+
+@pytest.fixture
+def tty_stdin_without_cli_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A terminal, but not the CLI tool: the Home Assistant foreground case."""
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.delenv(skr._ENV_CLI_PROCESS, raising=False)
 
 
 @pytest.fixture
 def no_tty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pretend we run head-less (Home Assistant / non-interactive mode)."""
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
+    monkeypatch.delenv(skr._ENV_CLI_PROCESS, raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -389,3 +404,84 @@ async def test_async_get_shared_key_isolates_accounts() -> None:
     # Account B's read never wrote into account A's cache and vice versa.
     assert cache_a.set_calls == []
     assert cache_b.set_calls == []
+
+
+# ---------------------------------------------------------------------------
+# The CLI marker: a terminal is not a command line
+# ---------------------------------------------------------------------------
+
+
+async def test_foreground_home_assistant_cannot_open_the_browser_flow(
+    tty_stdin_without_cli_marker: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The regression this guard exists for.
+
+    Home Assistant run in the foreground of a terminal answers ``isatty()`` with
+    True. Under the old guard that was enough to open Chrome from inside the
+    Home Assistant process, on a bundle without a shared key.
+    """
+
+    async def must_not_run() -> str:
+        raise AssertionError("the browser flow must not be reached")
+
+    monkeypatch.setattr(skr, "_interactive_flow_hex", must_not_run)
+    skr._browser_flow_attempted = False
+
+    with pytest.raises(skr.SharedKeyUnavailableError, match="not the Google Find My"):
+        await skr._retrieve_shared_key_hex()
+
+
+async def test_the_refusal_names_the_way_out(
+    tty_stdin_without_cli_marker: None,
+) -> None:
+    """A silent loss would be the worse bug; the message has to be actionable."""
+
+    skr._browser_flow_attempted = False
+    with pytest.raises(skr.SharedKeyUnavailableError) as excinfo:
+        await skr._retrieve_shared_key_hex()
+
+    message = str(excinfo.value)
+    assert "main.py" in message
+    assert skr._ENV_CLI_PROCESS in message
+
+
+async def test_cli_marker_alone_admits_the_browser_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The marker, not the terminal, is the criterion.
+
+    A command-line run with redirected stdin is still a command-line run; the
+    browser flow needs Chrome and a user, not a tty on stdin.
+    """
+
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
+    monkeypatch.setenv(skr._ENV_CLI_PROCESS, "1")
+    skr._browser_flow_attempted = False
+
+    async def fake_flow() -> str:
+        return _HEX_KEY
+
+    monkeypatch.setattr(skr, "_interactive_flow_hex", fake_flow)
+
+    assert await skr._retrieve_shared_key_hex() == _HEX_KEY
+
+
+def test_the_cli_entry_point_sets_the_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`main.py` marks its own process, so no user has to know the variable."""
+
+    from custom_components.googlefindmy import main as cli_main
+
+    monkeypatch.delenv(skr._ENV_CLI_PROCESS, raising=False)
+
+    class _Stop(Exception):
+        pass
+
+    def _stop_after_marker(_argv: object = None) -> object:
+        raise _Stop
+
+    monkeypatch.setattr(cli_main, "_build_cli_parser", _stop_after_marker)
+
+    with pytest.raises(_Stop):
+        cli_main._main([])
+
+    assert os.environ.get(skr._ENV_CLI_PROCESS) == "1"

--- a/tests/test_shared_key_retrieval.py
+++ b/tests/test_shared_key_retrieval.py
@@ -107,6 +107,7 @@ def tty_stdin_without_cli_marker(monkeypatch: pytest.MonkeyPatch) -> None:
     """A terminal, but not the CLI tool: the Home Assistant foreground case."""
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: True))
     monkeypatch.delenv(skr._ENV_CLI_PROCESS, raising=False)
+    monkeypatch.delenv(skr._ENV_ASSUME_INTERACTIVE, raising=False)
 
 
 @pytest.fixture
@@ -114,6 +115,7 @@ def no_tty_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pretend we run head-less (Home Assistant / non-interactive mode)."""
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
     monkeypatch.delenv(skr._ENV_CLI_PROCESS, raising=False)
+    monkeypatch.delenv(skr._ENV_ASSUME_INTERACTIVE, raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -445,17 +447,38 @@ async def test_the_refusal_names_the_way_out(
     assert skr._ENV_CLI_PROCESS in message
 
 
-async def test_cli_marker_alone_admits_the_browser_flow(
+async def test_an_unattended_cli_run_is_refused(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The marker, not the terminal, is the criterion.
+    """The marker is necessary, not sufficient.
 
-    A command-line run with redirected stdin is still a command-line run; the
-    browser flow needs Chrome and a user, not a tty on stdin.
+    `main.py` sets it unconditionally, so a cron job or a container entrypoint
+    with redirected stdin carries it too. Opening Chrome there would wait for a
+    sign-in nobody can perform.
     """
 
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
     monkeypatch.setenv(skr._ENV_CLI_PROCESS, "1")
+    monkeypatch.delenv(skr._ENV_ASSUME_INTERACTIVE, raising=False)
+    skr._browser_flow_attempted = False
+
+    async def must_not_run() -> str:
+        raise AssertionError("the browser flow must not be reached unattended")
+
+    monkeypatch.setattr(skr, "_interactive_flow_hex", must_not_run)
+
+    with pytest.raises(skr.SharedKeyUnavailableError, match="no terminal is attached"):
+        await skr._retrieve_shared_key_hex()
+
+
+async def test_the_assume_interactive_opt_in_admits_a_tty_less_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same opt-in `Auth/auth_flow.py` already offers for IDE run windows."""
+
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
+    monkeypatch.setenv(skr._ENV_CLI_PROCESS, "1")
+    monkeypatch.setenv(skr._ENV_ASSUME_INTERACTIVE, "1")
     skr._browser_flow_attempted = False
 
     async def fake_flow() -> str:


### PR DESCRIPTION
Target: jleinenbach/GoogleFindMy-HA 1.7 — the guard and the CLI entry point are identical in both trees. The related opt-in `GOOGLEFINDMY_ASSUME_INTERACTIVE` in `Auth/auth_flow.py` already exists here and is the precedent this follows.

## What

`KeyBackup/shared_key_retrieval.py` → `_retrieve_shared_key_hex` decided by `is_tty = sys.stdin and sys.stdin.isatty()`. That is a terminal test, not a caller test.

Reachability, measured rather than assumed: `eid_resolver.py` imports `async_get_shared_key`, which reaches `_retrieve_shared_key_hex`, and `eid_resolver` is on the Home Assistant path. The browser flow itself is loaded through `importlib.import_module` inside `_interactive_flow_hex`, so no static import graph shows this edge. A foreground Home Assistant on a terminal, with a bundle that carries no shared key, could therefore open Chrome inside the Home Assistant process.

Now the criterion is a marker the CLI sets on itself (`main.py` → `_main`, before argument parsing). Home Assistant never sets it; no user has to know about it.

## Why not "require an environment variable"

That was the first design and it was wrong: it would have bound the credential path to a *user action*, so anyone who did not know the variable would have lost access to the key-backup flow, silently. The marker is set by the process that is already the right one.

The remaining edge is handled explicitly rather than silently: terminal present, marker absent → a refusal that names `python main.py` and the variable, for someone driving the extraction from their own wrapper.

## Deliberate deviation from the sketch

The plan also called for refusing when the call arrives from a running Home Assistant event loop. Not implemented: this code is async, a loop is always running, and no signal available at that point distinguishes Home Assistant's loop from the CLI's. The marker answers the same question directly, so the extra check would have been a heuristic layered on top of a fact.

Also: the marker alone now admits the flow, without a tty. A command-line run with redirected stdin is still a command-line run, and the flow needs Chrome and a person at the screen, not a terminal on stdin.

## Tests

- The regression itself: terminal present, marker absent → `SharedKeyUnavailableError`, and the patched browser flow asserts it is never called.
- The refusal message names both ways out.
- Marker without tty admits the flow.
- `main.py` sets the marker (the entry point is driven far enough to prove it, then stopped).
- Mutation: restoring the old `is_tty` criterion turns the first two red.

Full suite green, coverage 78.36% (gate 78%). `ruff`, `ruff format`, `mypy --strict` clean.