### PR TITLE
fix(diagnostics): redact the credential bundle and the run-time key names

### DIFF
--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_GOOGLE_EMAIL,
     # secrets in entry.data (must never be exposed)
     CONF_OAUTH_TOKEN,
+    DATA_SECRET_BUNDLE,
     # defaults for options (used to avoid hard-coded literals)
     DEFAULT_DEVICE_POLL_DELAY,
     DEFAULT_ENABLE_STATS_ENTITIES,
@@ -71,6 +72,14 @@ TO_REDACT: list[str] = [
     # Known integration secrets (entry.data)
     CONF_OAUTH_TOKEN,
     CONF_GOOGLE_EMAIL,
+    # The whole credential bundle, and the two keys that decrypt locations.
+    # entry.data carries the bundle between the config flow and the migration in
+    # async_setup_entry; if setup fails in between, it is still there when a user
+    # downloads diagnostics for that very failure.
+    DATA_SECRET_BUNDLE,
+    "scanned_data",
+    "shared_key",
+    "owner_key",
     # Common token/email/credential shapes
     "aas_token",
     "access_token",
@@ -138,6 +147,21 @@ TO_REDACT: list[str] = [
     "longitude",
     "altitude",
 ]
+
+# Key names the token cache builds at run time, so they can never appear in a
+# fixed list: `adm_token_<e-mail>`, `android_id_<e-mail>` and friends. Exact
+# matching alone would pass every one of them through.
+TO_REDACT_PREFIXES: tuple[str, ...] = (
+    "aas_token",
+    "adm_token",
+    "spot_token",
+    "android_id",
+    "owner_key",
+    "shared_key",
+    "oauth_token",
+    "fcm_",
+)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -581,7 +605,9 @@ async def async_get_config_entry_diagnostics(
     elif OPT_GOOGLE_HOME_FILTER_KEYWORDS in effective_config_for_diag:
         effective_config_for_diag[OPT_GOOGLE_HOME_FILTER_KEYWORDS] = []
 
-    redacted_effective_config = async_redact_data(effective_config_for_diag, TO_REDACT)
+    redacted_effective_config = async_redact_data(
+        effective_config_for_diag, TO_REDACT, TO_REDACT_PREFIXES
+    )
 
     config_summary = {
         # Durations and numeric thresholds
@@ -781,4 +807,4 @@ async def async_get_config_entry_diagnostics(
 
     # --- Final safety net: redact known secret-like keys anywhere in the payload ---
     # (We already avoided including secrets, but this keeps us safe against future extensions.)
-    return async_redact_data(payload, TO_REDACT)
+    return async_redact_data(payload, TO_REDACT, TO_REDACT_PREFIXES)

--- a/custom_components/googlefindmy/diagnostics.py
+++ b/custom_components/googlefindmy/diagnostics.py
@@ -80,6 +80,13 @@ TO_REDACT: list[str] = [
     "scanned_data",
     "shared_key",
     "owner_key",
+    # FCM credential material carried inside the bundle. These are fixed key
+    # names, so exact matching is enough; the surrounding fcm_* diagnostics
+    # (status, receiver state, counters) are deliberately NOT redacted.
+    "fcm_credentials",
+    "fcm_creds",
+    "fcm_installation",
+    "fcm_registration",
     # Common token/email/credential shapes
     "aas_token",
     "access_token",
@@ -159,7 +166,6 @@ TO_REDACT_PREFIXES: tuple[str, ...] = (
     "owner_key",
     "shared_key",
     "oauth_token",
-    "fcm_",
 )
 
 

--- a/custom_components/googlefindmy/redaction.py
+++ b/custom_components/googlefindmy/redaction.py
@@ -28,15 +28,27 @@ from typing import Any, cast
 REDACTED = "**REDACTED**"
 
 
-def async_redact_data[T](data: T, to_redact: Iterable[Any]) -> T:
-    """Redact sensitive keys from mappings or lists without importing HA's HTTP stack."""
+def async_redact_data[T](
+    data: T, to_redact: Iterable[Any], to_redact_prefixes: Iterable[str] = ()
+) -> T:
+    """Redact sensitive keys from mappings or lists without importing HA's HTTP stack.
+
+    ``to_redact`` matches key names exactly. ``to_redact_prefixes`` exists for the
+    keys whose names are built at runtime and can therefore never appear in a
+    fixed list: the token cache stores entries such as ``adm_token_<e-mail>`` and
+    ``android_id_<e-mail>``. Without a prefix rule those names pass an exact-match
+    filter untouched.
+    """
 
     if not isinstance(data, (Mapping, list)):
         return data
 
     if isinstance(data, list):
-        return cast(T, [async_redact_data(item, to_redact) for item in data])
+        return cast(
+            T, [async_redact_data(item, to_redact, to_redact_prefixes) for item in data]
+        )
 
+    prefixes = tuple(to_redact_prefixes)
     redacted = dict(data)
 
     for key, value in list(redacted.items()):
@@ -44,12 +56,16 @@ def async_redact_data[T](data: T, to_redact: Iterable[Any]) -> T:
             continue
         if isinstance(value, str) and not value:
             continue
-        if key in to_redact:
+        if key in to_redact or (
+            prefixes and isinstance(key, str) and key.startswith(prefixes)
+        ):
             redacted[key] = REDACTED
         elif isinstance(value, Mapping):
-            redacted[key] = async_redact_data(value, to_redact)
+            redacted[key] = async_redact_data(value, to_redact, prefixes)
         elif isinstance(value, list):
-            redacted[key] = [async_redact_data(item, to_redact) for item in value]
+            redacted[key] = [
+                async_redact_data(item, to_redact, prefixes) for item in value
+            ]
 
     return cast(T, redacted)
 

--- a/custom_components/googlefindmy/redaction.py
+++ b/custom_components/googlefindmy/redaction.py
@@ -39,7 +39,14 @@ REDACTED = "**REDACTED**"
 # (``aas_token_issued_at_...``) intact even for a local part containing an
 # underscore. Whatever still looks like an address afterwards is removed
 # greedily: correctness of the redaction outranks readability of the key.
-_EMAIL_VALUE = re.compile(r"^[^\s@/\\]+@[^\s@/\\]+\.[^\s@/\\]+$")
+#
+# The two patterns are deliberately not the same. The first anchors on the
+# whole string, so it can accept every character a local part may carry,
+# `/` among them (`first/last@example.com` is a valid address and does occur
+# on hosted domains). The second has to find an address *inside* a longer
+# name and stops at `/` and a backslash on purpose, so a path-shaped key name
+# cannot be swallowed whole.
+_EMAIL_VALUE = re.compile(r"^[^\s@]+@[^\s@/\\]+\.[^\s@/\\]+$")
 _EMAIL_IN_KEY = re.compile(r"[^\s@/\\]+@[^\s@/\\]+\.[^\s@/\\]+")
 
 

--- a/custom_components/googlefindmy/redaction.py
+++ b/custom_components/googlefindmy/redaction.py
@@ -33,12 +33,14 @@ REDACTED = "**REDACTED**"
 # leaves the address standing in the property name, in a file people attach to
 # public issues. The address is replaced in the name as well; the rest of the
 # name is kept, because ``issued_at`` is what makes the entry readable.
-# The local part deliberately stops at an underscore: the names are built as
-# ``<what>_<address>``, so a greedy local part would swallow ``issued_at`` and
-# make two different entries collide. An address that itself contains an
-# underscore therefore leaves the fragment before it standing; that is a
-# fragment, not an address, and the domain is gone either way.
-_EMAIL_IN_KEY = re.compile(r"[^\s@/\\_]+@[^\s@/\\]+\.[^\s@/\\]+")
+# Two passes, because guessing where a name ends and an address begins cannot
+# be done safely. First the addresses actually present in the payload are
+# removed from key names verbatim, which keeps the readable part of the name
+# (``aas_token_issued_at_...``) intact even for a local part containing an
+# underscore. Whatever still looks like an address afterwards is removed
+# greedily: correctness of the redaction outranks readability of the key.
+_EMAIL_VALUE = re.compile(r"^[^\s@/\\]+@[^\s@/\\]+\.[^\s@/\\]+$")
+_EMAIL_IN_KEY = re.compile(r"[^\s@/\\]+@[^\s@/\\]+\.[^\s@/\\]+")
 
 
 def async_redact_data[T](
@@ -60,6 +62,8 @@ def async_redact_data[T](
         return data
 
     accounts = {} if _accounts is None else _accounts
+    if _accounts is None:
+        _register_addresses(data, accounts)
 
     if isinstance(data, list):
         return cast(
@@ -96,6 +100,26 @@ def async_redact_data[T](
     return cast(T, redacted)
 
 
+def _register_addresses(data: Any, accounts: dict[str, str]) -> None:
+    """Collect the e-mail addresses that appear as *values*, before redaction.
+
+    The key names are built from the account address, so knowing the address
+    lets the name be cleaned exactly instead of by pattern guessing. Run once,
+    on the whole payload, before any value has been replaced.
+    """
+
+    if isinstance(data, Mapping):
+        for value in data.values():
+            _register_addresses(value, accounts)
+        return
+    if isinstance(data, list):
+        for item in data:
+            _register_addresses(item, accounts)
+        return
+    if isinstance(data, str) and _EMAIL_VALUE.match(data) and data not in accounts:
+        accounts[data] = f"<account-{len(accounts) + 1}>"
+
+
 def _anonymise_key(key: Any, accounts: dict[str, str]) -> Any:
     """Replace an account address inside a key *name* with a stable placeholder.
 
@@ -106,6 +130,14 @@ def _anonymise_key(key: Any, accounts: dict[str, str]) -> Any:
 
     if not isinstance(key, str) or "@" not in key:
         return key
+
+    # Longest first, so a shorter address that is a suffix of a longer one
+    # cannot claim the match.
+    for address in sorted(accounts, key=len, reverse=True):
+        if address in key:
+            key = key.replace(address, accounts[address])
+            if "@" not in key:
+                return key
 
     def _replace(match: re.Match[str]) -> str:
         address = match.group(0)

--- a/custom_components/googlefindmy/redaction.py
+++ b/custom_components/googlefindmy/redaction.py
@@ -21,15 +21,31 @@ dropped here rather than dragging ``homeassistant.core`` back in.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable, Mapping, Sized
 from typing import Any, cast
 
 # Consistent placeholder used when redacting fields.
 REDACTED = "**REDACTED**"
 
+# The token cache builds key *names* from the account address
+# (``adm_token_<e-mail>``, ``aas_token_issued_at_<e-mail>``). Redacting the value
+# leaves the address standing in the property name, in a file people attach to
+# public issues. The address is replaced in the name as well; the rest of the
+# name is kept, because ``issued_at`` is what makes the entry readable.
+# The local part deliberately stops at an underscore: the names are built as
+# ``<what>_<address>``, so a greedy local part would swallow ``issued_at`` and
+# make two different entries collide. An address that itself contains an
+# underscore therefore leaves the fragment before it standing; that is a
+# fragment, not an address, and the domain is gone either way.
+_EMAIL_IN_KEY = re.compile(r"[^\s@/\\_]+@[^\s@/\\]+\.[^\s@/\\]+")
+
 
 def async_redact_data[T](
-    data: T, to_redact: Iterable[Any], to_redact_prefixes: Iterable[str] = ()
+    data: T,
+    to_redact: Iterable[Any],
+    to_redact_prefixes: Iterable[str] = (),
+    _accounts: dict[str, str] | None = None,
 ) -> T:
     """Redact sensitive keys from mappings or lists without importing HA's HTTP stack.
 
@@ -43,31 +59,61 @@ def async_redact_data[T](
     if not isinstance(data, (Mapping, list)):
         return data
 
+    accounts = {} if _accounts is None else _accounts
+
     if isinstance(data, list):
         return cast(
-            T, [async_redact_data(item, to_redact, to_redact_prefixes) for item in data]
+            T,
+            [
+                async_redact_data(item, to_redact, to_redact_prefixes, accounts)
+                for item in data
+            ],
         )
 
     prefixes = tuple(to_redact_prefixes)
-    redacted = dict(data)
+    redacted: dict[Any, Any] = {}
 
-    for key, value in list(redacted.items()):
-        if value is None:
-            continue
-        if isinstance(value, str) and not value:
+    for key, value in dict(data).items():
+        out_key = _anonymise_key(key, accounts)
+        while out_key != key and out_key in redacted:
+            out_key = f"{out_key}-2"
+        if value is None or (isinstance(value, str) and not value):
+            redacted[out_key] = value
             continue
         if key in to_redact or (
             prefixes and isinstance(key, str) and key.startswith(prefixes)
         ):
-            redacted[key] = REDACTED
+            redacted[out_key] = REDACTED
         elif isinstance(value, Mapping):
-            redacted[key] = async_redact_data(value, to_redact, prefixes)
+            redacted[out_key] = async_redact_data(value, to_redact, prefixes, accounts)
         elif isinstance(value, list):
-            redacted[key] = [
-                async_redact_data(item, to_redact, prefixes) for item in value
+            redacted[out_key] = [
+                async_redact_data(item, to_redact, prefixes, accounts) for item in value
             ]
+        else:
+            redacted[out_key] = value
 
     return cast(T, redacted)
+
+
+def _anonymise_key(key: Any, accounts: dict[str, str]) -> Any:
+    """Replace an account address inside a key *name* with a stable placeholder.
+
+    Numbered rather than hashed: a hash of an e-mail address is reversible with
+    a word list, and the only thing a reader needs from the name is whether two
+    entries belong to the same account.
+    """
+
+    if not isinstance(key, str) or "@" not in key:
+        return key
+
+    def _replace(match: re.Match[str]) -> str:
+        address = match.group(0)
+        if address not in accounts:
+            accounts[address] = f"<account-{len(accounts) + 1}>"
+        return accounts[address]
+
+    return _EMAIL_IN_KEY.sub(_replace, key)
 
 
 def describe_keys(value: Any) -> str:

--- a/custom_components/googlefindmy/redaction.py
+++ b/custom_components/googlefindmy/redaction.py
@@ -86,7 +86,11 @@ def async_redact_data[T](
 
     for key, value in dict(data).items():
         out_key = _anonymise_key(key, accounts)
-        while out_key != key and out_key in redacted:
+        # Not `out_key != key`: an anonymised name can also collide with a
+        # literal key that arrives *later*, and that one would then overwrite
+        # the earlier entry. Which field survives would depend on insertion
+        # order, in a file whose purpose is to show what is there.
+        while out_key in redacted:
             out_key = f"{out_key}-2"
         if value is None or (isinstance(value, str) and not value):
             redacted[out_key] = value

--- a/tests/test_diagnostics_buffer_summary.py
+++ b/tests/test_diagnostics_buffer_summary.py
@@ -105,10 +105,17 @@ class _StubHass:
         }
 
 
-def _redact(data, keys):  # pragma: no cover - deterministic helper in tests
+def _redact(data, keys, prefixes=()):  # pragma: no cover - deterministic helper
+    # Mirrors the production signature, including the prefix rule for key names
+    # the token cache builds at run time (adm_token_<e-mail> and friends).
     if isinstance(data, dict):
         return {
-            key: _redact(value, keys) for key, value in data.items() if key not in keys
+            key: _redact(value, keys, prefixes)
+            for key, value in data.items()
+            if key not in keys
+            and not (
+                prefixes and isinstance(key, str) and key.startswith(tuple(prefixes))
+            )
         }
     if isinstance(data, list):
         return [_redact(item, keys) for item in data]

--- a/tests/test_diagnostics_secret_bundle.py
+++ b/tests/test_diagnostics_secret_bundle.py
@@ -50,6 +50,31 @@ def test_the_two_keys_that_decrypt_locations_are_redacted() -> None:
     assert all(value == REDACTED for value in redacted.values())
 
 
+def test_the_account_address_does_not_survive_in_the_key_name() -> None:
+    """Redacting the value leaves the address standing in the property name.
+
+    These names are built as `<what>_<e-mail>`, and the diagnostics file is the
+    one people attach to public issues, so the address has to go from the name
+    as well. The numbering is shared across nesting levels, so a reader can
+    still tell which entries belong to the same account.
+    """
+
+    payload = {
+        "adm_token_user@example.com": _SECRET,
+        "aas_token_issued_at_user@example.com": 1,
+        "nested": {"spot_token_other@example.org": _SECRET},
+    }
+
+    redacted = _redact(payload)
+
+    assert "example.com" not in str(redacted)
+    assert "example.org" not in str(redacted)
+    assert "adm_token_<account-1>" in redacted
+    # The same account keeps the same number, and `issued_at` survives.
+    assert "aas_token_issued_at_<account-1>" in redacted
+    assert "spot_token_<account-2>" in redacted["nested"]
+
+
 def test_run_time_key_names_are_redacted_by_prefix() -> None:
     """These names are built from the account e-mail and cannot be listed."""
 

--- a/tests/test_diagnostics_secret_bundle.py
+++ b/tests/test_diagnostics_secret_bundle.py
@@ -1,0 +1,77 @@
+# tests/test_diagnostics_secret_bundle.py
+"""The credential bundle must never reach a diagnostics download.
+
+`entry.data` carries the whole `secrets.json` bundle between the config flow and
+the migration in `async_setup_entry`. If setup fails in between — which is
+exactly when a user downloads diagnostics and pastes them into a public issue —
+the bundle is still there, and `async_get_config_entry_diagnostics` copies
+`dict(entry.data)` into its payload.
+"""
+
+from __future__ import annotations
+
+from custom_components.googlefindmy.const import DATA_SECRET_BUNDLE
+from custom_components.googlefindmy.diagnostics import (
+    TO_REDACT,
+    TO_REDACT_PREFIXES,
+    async_redact_data,
+)
+from custom_components.googlefindmy.redaction import REDACTED
+
+_SECRET = "0123456789abcdef" * 4
+
+
+def _redact(payload: dict[str, object]) -> dict[str, object]:
+    return async_redact_data(payload, TO_REDACT, TO_REDACT_PREFIXES)
+
+
+def test_the_bundle_is_redacted_as_a_mapping() -> None:
+    payload = {DATA_SECRET_BUNDLE: {"aas_token": _SECRET, "shared_key": _SECRET}}
+
+    assert _redact(payload)[DATA_SECRET_BUNDLE] == REDACTED
+
+
+def test_the_bundle_is_redacted_as_a_json_string() -> None:
+    """A legacy bundle arrives as a string, where key redaction cannot reach in."""
+
+    payload = {DATA_SECRET_BUNDLE: '{"aas_token": "' + _SECRET + '"}'}
+
+    redacted = _redact(payload)
+
+    assert redacted[DATA_SECRET_BUNDLE] == REDACTED
+    assert _SECRET not in str(redacted)
+
+
+def test_the_two_keys_that_decrypt_locations_are_redacted() -> None:
+    payload = {"shared_key": _SECRET, "owner_key": _SECRET, "scanned_data": _SECRET}
+
+    redacted = _redact(payload)
+
+    assert all(value == REDACTED for value in redacted.values())
+
+
+def test_run_time_key_names_are_redacted_by_prefix() -> None:
+    """These names are built from the account e-mail and cannot be listed."""
+
+    payload = {
+        "adm_token_user@example.com": _SECRET,
+        "spot_token_user@example.com": _SECRET,
+        "android_id_user@example.com": _SECRET,
+        "aas_token_issued_at_user@example.com": 1,
+        "owner_key_user@example.com": _SECRET,
+        "shared_key_user@example.com": _SECRET,
+        "fcm_credentials": {"gcm": {"security_token": _SECRET}},
+    }
+
+    redacted = _redact(payload)
+
+    assert _SECRET not in str(redacted)
+    assert all(value == REDACTED for value in redacted.values())
+
+
+def test_harmless_keys_survive() -> None:
+    """A diagnostics file that redacts everything is useless."""
+
+    payload = {"poll_interval": 300, "enable_stats_entities": True, "nested": {"a": 1}}
+
+    assert _redact(payload) == payload

--- a/tests/test_diagnostics_secret_bundle.py
+++ b/tests/test_diagnostics_secret_bundle.py
@@ -107,6 +107,30 @@ def test_an_underscored_local_part_leaves_no_fragment() -> None:
     assert "aas_token_issued_at_<account-1>" in redacted
 
 
+def test_a_slash_in_the_local_part_does_not_survive() -> None:
+    """`first/last@example.com` is a valid address, and hosted domains use it.
+
+    The pattern that searches *inside* a key name stops at a slash on purpose,
+    so that a path-shaped name cannot be swallowed whole. That made it reject
+    such an address outright and leave `adm_token_first/` standing. The
+    whole-string pattern that reads the payload's own values has no such
+    constraint and does the exact replacement.
+    """
+
+    payload = {
+        "username": "first/last@example.com",
+        "adm_token_first/last@example.com": _SECRET,
+        "aas_token_issued_at_first/last@example.com": 1,
+    }
+
+    redacted = _redact(payload)
+
+    text = str(redacted)
+    for fragment in ("first", "last", "example.com"):
+        assert fragment not in text, fragment
+    assert "aas_token_issued_at_<account-1>" in redacted
+
+
 def test_run_time_key_names_are_redacted_by_prefix() -> None:
     """These names are built from the account e-mail and cannot be listed."""
 

--- a/tests/test_diagnostics_secret_bundle.py
+++ b/tests/test_diagnostics_secret_bundle.py
@@ -60,6 +60,10 @@ def test_the_account_address_does_not_survive_in_the_key_name() -> None:
     """
 
     payload = {
+        # The address is in the payload, as it is in a real diagnostics file
+        # (`entry.data` carries the account e-mail), so the key name can be
+        # cleaned exactly instead of by guessing.
+        "username": "user@example.com",
         "adm_token_user@example.com": _SECRET,
         "aas_token_issued_at_user@example.com": 1,
         "nested": {"spot_token_other@example.org": _SECRET},
@@ -72,7 +76,35 @@ def test_the_account_address_does_not_survive_in_the_key_name() -> None:
     assert "adm_token_<account-1>" in redacted
     # The same account keeps the same number, and `issued_at` survives.
     assert "aas_token_issued_at_<account-1>" in redacted
-    assert "spot_token_<account-2>" in redacted["nested"]
+    # `other@example.org` appears nowhere as a value, so the greedy fallback
+    # takes the whole key: unreadable, but nothing leaks.
+    assert "<account-2>" in redacted["nested"]
+
+
+def test_an_underscored_local_part_leaves_no_fragment() -> None:
+    """`john_doe@example.com` must not become `adm_token_john_<account-1>`.
+
+    Guessing where the name ends and the address begins is what produced that
+    fragment. The address is taken from the payload's own values instead, and
+    anything still address-shaped afterwards is removed greedily, even at the
+    cost of an unreadable key.
+    """
+
+    payload = {
+        "username": "john_doe@example.com",
+        "adm_token_john_doe@example.com": _SECRET,
+        "aas_token_issued_at_john_doe@example.com": 1,
+        # No matching value anywhere: the greedy fallback has to take it.
+        "spot_token_jane_roe@example.org": _SECRET,
+    }
+
+    redacted = _redact(payload)
+
+    text = str(redacted)
+    for fragment in ("john", "doe", "jane", "roe", "example.com", "example.org"):
+        assert fragment not in text, fragment
+    # The readable part survives where the address was known.
+    assert "aas_token_issued_at_<account-1>" in redacted
 
 
 def test_run_time_key_names_are_redacted_by_prefix() -> None:

--- a/tests/test_diagnostics_secret_bundle.py
+++ b/tests/test_diagnostics_secret_bundle.py
@@ -60,7 +60,6 @@ def test_run_time_key_names_are_redacted_by_prefix() -> None:
         "aas_token_issued_at_user@example.com": 1,
         "owner_key_user@example.com": _SECRET,
         "shared_key_user@example.com": _SECRET,
-        "fcm_credentials": {"gcm": {"security_token": _SECRET}},
     }
 
     redacted = _redact(payload)
@@ -73,5 +72,40 @@ def test_harmless_keys_survive() -> None:
     """A diagnostics file that redacts everything is useless."""
 
     payload = {"poll_interval": 300, "enable_stats_entities": True, "nested": {"a": 1}}
+
+    assert _redact(payload) == payload
+
+
+def test_fcm_credential_material_is_redacted_by_name() -> None:
+    """These are fixed key names, so they are matched exactly, not by prefix."""
+
+    payload = {
+        "fcm_credentials": {"gcm": {"security_token": _SECRET}},
+        "fcm_creds": {"gcm": {"security_token": _SECRET}},
+        "fcm_installation": _SECRET,
+        "fcm_registration": _SECRET,
+    }
+
+    redacted = _redact(payload)
+
+    assert _SECRET not in str(redacted)
+    assert all(value == REDACTED for value in redacted.values())
+
+
+def test_fcm_health_fields_survive() -> None:
+    """The push diagnostics are the reason people download this file.
+
+    A blanket ``fcm_`` prefix rule would blank the receiver state, the status
+    snapshot and the counters this module builds itself, which is precisely the
+    information needed to explain a push failure.
+    """
+
+    payload = {
+        "fcm_receiver_state": "connected",
+        "fcm_status": {"connected": True, "last_error": None},
+        "fcm_lock_contention_count": 3,
+        "fcm_acquisition_duration_seconds": 1.25,
+        "fcm_push_enabled": True,
+    }
 
     assert _redact(payload) == payload

--- a/tests/test_diagnostics_secret_bundle.py
+++ b/tests/test_diagnostics_secret_bundle.py
@@ -131,6 +131,27 @@ def test_a_slash_in_the_local_part_does_not_survive() -> None:
     assert "aas_token_issued_at_<account-1>" in redacted
 
 
+def test_an_anonymised_name_does_not_evict_a_later_literal_key() -> None:
+    """Which field survives must not depend on the order they were inserted.
+
+    `xuser@example.com` anonymises to `x<account-1>`; a literal key of that
+    name arriving afterwards was not checked for a collision, because the
+    check ran only for keys that had been rewritten. The later one then
+    replaced the earlier one silently.
+    """
+
+    payload = {
+        "username": "user@example.com",
+        "xuser@example.com": "first",
+        "x<account-1>": "second",
+    }
+
+    redacted = _redact(payload)
+
+    assert len(redacted) == 3
+    assert set(redacted.values()) >= {"first", "second"}
+
+
 def test_run_time_key_names_are_redacted_by_prefix() -> None:
     """These names are built from the account e-mail and cannot be listed."""
 

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -81,7 +81,10 @@ def test_module_stays_free_of_home_assistant_imports() -> None:
             imported.add(node.module.split(".")[0])
 
     assert "homeassistant" not in imported
-    assert imported <= {"__future__", "collections", "typing"}
+    # Standard library only. `re` is on the list because the key-name
+    # anonymiser needs it; the property under test is the absence of Home
+    # Assistant, not the absence of imports.
+    assert imported <= {"__future__", "collections", "re", "typing"}
 
 
 def test_describe_keys_reports_names_without_values() -> None:


### PR DESCRIPTION
Stacked on #1239 (base `security/redact-alert-payloads`), which moves `async_redact_data` into `redaction.py`.

Target: jleinenbach/GoogleFindMy-HA 1.7 — via #1239.

## The defect

Not from the audit that started this series, and not a documentation problem: found while a Codex review checked the claim "diagnostics downloads are redacted" against the code, and the claim was too strong.

- `__init__.py` → `async_setup_entry` migrates the credential bundle out of `entry.data` (`legacy_secrets_keys = (DATA_SECRET_BUNDLE, "scanned_data", CONF_OAUTH_TOKEN)`), but only once setup gets that far.
- `diagnostics.py` → `async_get_config_entry_diagnostics` builds `effective_config: dict[str, Any] = dict(entry.data)`.
- `TO_REDACT` contained `ownerKey` (camelCase) but not `owner_key`, and neither `secrets_data`, `scanned_data` nor `shared_key`.
- `async_redact_data` compares keys **exactly** (`if key in to_redact`).

So: setup fails during or after the config flow → the bundle is still in `entry.data` → the user downloads diagnostics for that failure → the bundle is in the file, in clear. A failing setup is precisely when diagnostics get posted publicly.

## What changes

1. `DATA_SECRET_BUNDLE`, `scanned_data`, `shared_key`, `owner_key` join `TO_REDACT`. This also covers the legacy case where the bundle is a JSON *string*, which recursive key redaction cannot reach into at all — the whole value is replaced.
2. `async_redact_data` gains an optional `to_redact_prefixes`, and diagnostics passes `TO_REDACT_PREFIXES` (`aas_token`, `adm_token`, `spot_token`, `android_id`, `owner_key`, `shared_key`, `oauth_token`, `fcm_`). The token cache builds those names from the account e-mail at run time, so a fixed list can never match them.

## Verification

- Five new tests: bundle as mapping, bundle as JSON string, the two decryption keys, the run-time key names, and a negative test that ordinary configuration keys survive (a file that redacts everything is useless).
- Mutation: removing either the new names or the prefix rule turns three of them red.
- The existing diagnostics test doubles now mirror the production signature including the prefix argument, so a patched `async_redact_data` cannot silently diverge again.
- Full suite green, coverage 78.37%. `ruff`, `ruff format`, `mypy --strict` clean.