### PR TITLE
docs: describe the CLI marker as landed, not as coming

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,11 +686,13 @@ you run yourself, from a terminal, on your own machine. No module Home Assistant
 loads imports Selenium or starts a browser: an import-graph walk from every
 module Home Assistant loads on its own reaches no browser package, while the
 same walk from `chrome_driver.py` does — so the check can fire. "Every module"
-means: the six Home Assistant looks up by filename (`__init__.py`,
-`config_flow.py`, `diagnostics.py`, `repairs.py`, `system_health.py`,
-`eid_resolver.py`), which the check lists explicitly because that convention is
-Home Assistant's rather than ours, plus the platform modules, which it reads
-from `PLATFORMS` because that list does change. From each of them it follows
+means: `__init__.py`, the entry point; the four Home Assistant looks up by
+filename (`config_flow.py`, `diagnostics.py`, `repairs.py`,
+`system_health.py`), which the check lists explicitly because that convention
+is Home Assistant's rather than ours; `eid_resolver.py`, which is an ordinary
+import of `__init__.py` and would be crawled anyway, seeded as its own entry
+because it is where the decryption path starts; and the platform modules, which
+the check reads from `PLATFORMS` because that list does change. From each of them it follows
 imports inside function bodies as well, and `importlib.import_module` calls
 whose target is a literal string, because a module reached only that way is
 reached all the same. A dynamic import whose target is assembled at run time

--- a/README.md
+++ b/README.md
@@ -691,8 +691,14 @@ means: the six Home Assistant looks up by filename (`__init__.py`,
 `eid_resolver.py`), which the check lists explicitly because that convention is
 Home Assistant's rather than ours, plus the platform modules, which it reads
 from `PLATFORMS` because that list does change. From each of them it follows
-imports inside function bodies and dynamic imports as well, because a module
-reached only that way is reached all the same.
+imports inside function bodies as well, and `importlib.import_module` calls
+whose target is a literal string, because a module reached only that way is
+reached all the same. A dynamic import whose target is assembled at run time
+is beyond it, which is a limit of reading source without executing it rather
+than an oversight. Three such calls exist here, and all three resolve from
+tables of constants in the package (`__init__.py` → `_PROTO_DECODER_PATHS`, and
+the two module names in `integration_modules.py`): protocol decoders and the
+integration's own API module, no browser among them.
 
 The interactive key-backup fallback used to be the one qualification here: it is
 loaded dynamically through `importlib`, and its guard asked whether a terminal

--- a/README.md
+++ b/README.md
@@ -470,8 +470,9 @@ What that means in practice:
   No module Home Assistant loads reaches `create_driver`. The exception is the
   interactive key-backup fallback: it is loaded dynamically and, in a Home
   Assistant process started in the foreground of a terminal whose bundle carries
-  no shared key, it could reach the same code. That guard is being tightened to
-  require the command-line tool itself.
+  no shared key, it used to be able to reach the same code. That guard now
+  requires the command-line tool itself, which identifies itself through the
+  `GOOGLEFINDMY_CLI_PROCESS` marker rather than through an attached terminal.
 
 ### Standalone login refuses to start (attended terminal required)
 The desktop login opens Chrome **on your own screen** and prints a "Press Enter
@@ -682,16 +683,24 @@ clear.
 
 Chrome and Selenium. The browser-based credential extraction is a manual step
 you run yourself, from a terminal, on your own machine. No module Home Assistant
-loads imports Selenium or starts a browser: an import-graph walk from
-`__init__.py`, `config_flow.py` and `eid_resolver.py` reaches no browser package,
-while the same walk from `chrome_driver.py` does — so the check can fire.
+loads imports Selenium or starts a browser: an import-graph walk from every
+module Home Assistant loads on its own reaches no browser package, while the
+same walk from `chrome_driver.py` does — so the check can fire. "Every module"
+is read from the code rather than listed by hand: the check seeds itself from
+`__init__.py`, `config_flow.py`, `diagnostics.py`, `repairs.py`,
+`system_health.py`, `eid_resolver.py` and the platform modules named in
+`PLATFORMS`, and it follows imports inside function bodies and dynamic imports
+as well, because a module reached only that way is reached all the same.
 
-One qualification, because it is real: the interactive key-backup fallback is
-guarded by a terminal check (`KeyBackup/shared_key_retrieval.py` →
-`_retrieve_shared_key_hex`, `is_tty = sys.stdin and sys.stdin.isatty()`), not by
-a check for "am I the CLI". A Home Assistant process running in the foreground
-on a terminal, whose bundle carries no shared key, can therefore reach it. The
-guard is being replaced by a signal the command-line process sets for itself.
+The interactive key-backup fallback used to be the one qualification here: it is
+loaded dynamically through `importlib`, and its guard asked whether a terminal
+was attached — a question a foreground Home Assistant answers with yes. It now
+asks two (`KeyBackup/shared_key_retrieval.py` → `_retrieve_shared_key_hex`):
+whether this process is the command-line tool, which it learns from the
+`GOOGLEFINDMY_CLI_PROCESS` marker that `main.py` sets on itself and Home
+Assistant never sets, and whether somebody is present to answer the browser
+prompt. Either answer missing is refused with a message that names what is
+missing.
 
 ### If your credential bundle leaks
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,8 @@ What that means in practice:
   no shared key, it used to be able to reach the same code. That guard now
   requires the command-line tool itself, which identifies itself through the
   `GOOGLEFINDMY_CLI_PROCESS` marker rather than through an attached terminal.
+  Exporting that marker into a Home Assistant process puts the old behaviour
+  back — it is an opt-in for wrappers, not a lock.
 
 ### Standalone login refuses to start (attended terminal required)
 The desktop login opens Chrome **on your own screen** and prints a "Press Enter
@@ -710,7 +712,12 @@ whether this process is the command-line tool, which it learns from the
 `GOOGLEFINDMY_CLI_PROCESS` marker that `main.py` sets on itself and Home
 Assistant never sets, and whether somebody is present to answer the browser
 prompt. Either answer missing is refused with a message that names what is
-missing.
+missing. Read that as the default rather than as a lock: the marker is an
+environment variable and is inherited, so a Home Assistant process started with
+it exported, on a terminal, has answered both questions itself. The refusal
+message says as much, because an unforeseen command-line wrapper has to be able
+to identify itself somehow. What changed is that this now takes a deliberate
+act instead of happening to anyone who starts Home Assistant in a terminal.
 
 ### If your credential bundle leaks
 

--- a/README.md
+++ b/README.md
@@ -686,11 +686,13 @@ you run yourself, from a terminal, on your own machine. No module Home Assistant
 loads imports Selenium or starts a browser: an import-graph walk from every
 module Home Assistant loads on its own reaches no browser package, while the
 same walk from `chrome_driver.py` does — so the check can fire. "Every module"
-is read from the code rather than listed by hand: the check seeds itself from
-`__init__.py`, `config_flow.py`, `diagnostics.py`, `repairs.py`,
-`system_health.py`, `eid_resolver.py` and the platform modules named in
-`PLATFORMS`, and it follows imports inside function bodies and dynamic imports
-as well, because a module reached only that way is reached all the same.
+means: the six Home Assistant looks up by filename (`__init__.py`,
+`config_flow.py`, `diagnostics.py`, `repairs.py`, `system_health.py`,
+`eid_resolver.py`), which the check lists explicitly because that convention is
+Home Assistant's rather than ours, plus the platform modules, which it reads
+from `PLATFORMS` because that list does change. From each of them it follows
+imports inside function bodies and dynamic imports as well, because a module
+reached only that way is reached all the same.
 
 The interactive key-backup fallback used to be the one qualification here: it is
 loaded dynamically through `importlib`, and its guard asked whether a terminal

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -620,9 +620,12 @@ def get_options(*, headless: bool = False) -> ChromeOptions:
     #   a terminal was attached, and a foreground Home Assistant answers yes, so
     #   these flags *could* be applied inside the Home Assistant process. That
     #   guard now asks two questions instead: ``GOOGLEFINDMY_CLI_PROCESS``, which
-    #   only ``main.py`` sets on its own process, and whether somebody is there to
-    #   answer the browser prompt. Either one alone is refused, so "CLI only" is
-    #   the guarantee it was previously only the intent of.
+    #   ``main.py`` sets on its own process and Home Assistant never sets, and
+    #   whether somebody is there to answer the browser prompt. Either one alone
+    #   is refused. That is a default, not a guarantee: the variable is inherited
+    #   like any other, and the refusal message deliberately tells an unforeseen
+    #   command-line wrapper to set it. Someone who exports it into a Home
+    #   Assistant process is answering the question the guard asks.
     # * Provenance. They arrived with commit 5219da9f, described as taken from
     #   the upstream tool. That is not accurate: leonboe1/GoogleFindMyTools sets
     #   exactly three arguments in its own ``get_options`` (``--start-maximized``,

--- a/custom_components/googlefindmy/chrome_driver.py
+++ b/custom_components/googlefindmy/chrome_driver.py
@@ -619,8 +619,10 @@ def get_options(*, headless: bool = False) -> ChromeOptions:
     #   graph sees. Its guard in ``_retrieve_shared_key_hex`` used to ask whether
     #   a terminal was attached, and a foreground Home Assistant answers yes, so
     #   these flags *could* be applied inside the Home Assistant process. That
-    #   guard is being replaced by a marker the command-line tool sets on its own
-    #   process; until that lands, "CLI only" is the intent, not a guarantee.
+    #   guard now asks two questions instead: ``GOOGLEFINDMY_CLI_PROCESS``, which
+    #   only ``main.py`` sets on its own process, and whether somebody is there to
+    #   answer the browser prompt. Either one alone is refused, so "CLI only" is
+    #   the guarantee it was previously only the intent of.
     # * Provenance. They arrived with commit 5219da9f, described as taken from
     #   the upstream tool. That is not accurate: leonboe1/GoogleFindMyTools sets
     #   exactly three arguments in its own ``get_options`` (``--start-maximized``,


### PR DESCRIPTION
## Why

#1254 replaced the terminal heuristic in `KeyBackup/shared_key_retrieval.py` with the `GOOGLEFINDMY_CLI_PROCESS` marker that `main.py` sets on its own process. Three texts still described the state before that merge:

- `chrome_driver.py` → `get_options`: *"guard is being replaced by a marker ... until that lands, `CLI only` is the intent, not a guarantee"*
- `README.md`, Chrome cleanup section: *"That guard is being tightened to require the command-line tool itself"*
- `README.md`, security section: *"The guard is being replaced by a signal the command-line process sets for itself"*

The latter two also quote an expression that no longer exists in the tree (`is_tty = sys.stdin and sys.stdin.isatty()`).

This matters beyond tidiness: a reader auditing the security section finds a documented open edge that has in fact been closed, and would reasonably report it again.

## What changed

- All three passages describe the merged state: the guard asks two questions (marker present, and somebody present to answer the browser prompt) and refuses either one alone.
- The boundary-check description in the security section is widened while it is being touched. It named three seed modules; the check reads its seeds from `PLATFORMS` plus six modules by convention and follows function-body and dynamic imports as well.

No code behaviour changes: one comment and two prose passages.

## Verification

- `grep -rn "being replaced|being tightened|is not a guarantee|is_tty"` over `custom_components/`, `README.md` and `docs/`: no hits on this subject.
- `GOOGLEFINDMY_CLI_PROCESS` resolves in `KeyBackup/shared_key_retrieval.py`, so the identifier the text now names exists.
- Full suite green, 78.42% coverage; `ruff` clean; `mypy --strict` clean on the touched module.