### PR TITLE
ci(security): only open a pip-audit autofix PR when it actually fixes something

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -181,6 +181,15 @@ jobs:
                 echo "pip-audit failed with exit code $status" >&2
                 exit "$status"
               fi
+              # Same guard as before the first audit, and for the same reason
+              # one level down: an empty re-audit yields fixable_after=0, which
+              # is less than any real prior count, so the job would open a pull
+              # request announcing a fix it never measured.
+              audited_after=$(jq '.dependencies | length' audit.json)
+              if [ "$audited_after" -eq 0 ]; then
+                echo "::error title=pip-audit measured nothing after the update::The re-audit lists zero packages, so its count cannot be compared with the pre-update count." >&2
+                exit 1
+              fi
               fixable_after=$(jq '[.dependencies[].vulns[] | select((.fix_versions|length)>0)] | length' audit.json)
 
               if [ "$fixable_after" -lt "$fixable" ]; then

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -71,8 +71,17 @@ jobs:
             echo "::warning title=pip-audit (no fix available)::${unfixable} vulnerability/vulnerabilities without a fix."
           fi
           if [ "$fixable" -gt 0 ]; then
-            echo "::notice title=pip-audit (fix available)::${fixable} vulnerability/vulnerabilities have fixes. They will be auto-fixed by the scheduled job."
+            # Deliberately not phrased as a promise. The scheduled job runs
+            # `poetry update --lock`, which can only move a package inside the
+            # constraints it is given. Home Assistant pins several of its
+            # dependencies exactly (aiohttp, cryptography, Pillow, PyJWT), and a
+            # finding in one of those cannot be resolved by any update run --
+            # only by a Home Assistant release whose own pin carries the fix.
+            # Claiming otherwise is what made four consecutive autofix pull
+            # requests look actionable when they were not.
+            echo "::notice title=pip-audit (fix available upstream)::${fixable} vulnerability/vulnerabilities report a fix version. The scheduled job will attempt an update; findings in packages Home Assistant pins exactly cannot be moved by it."
           fi
+          echo " - The blocking runtime gate is \`script/audit_manifest.py\` (pytest \`test_no_fixable_integration_owned_vulnerability\`), which audits the \`manifest.json\` requirements users actually install. This job is report-only over the dev/test lock." >> "$summary_tmp"
 
           cat "$summary_tmp" >> "$GITHUB_STEP_SUMMARY"
           rm "$summary_tmp"
@@ -82,9 +91,15 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      # Pinned to the default branch on purpose. Without `ref`, a manual
+      # `workflow_dispatch` from a topic branch makes the action open its pull
+      # request against that branch: #1237 landed on
+      # `fix/subentry-deletion-type-axis` instead of the release line, where
+      # nobody was looking for it.
       - name: Check out
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false  # use GITHUB_TOKEN via the PR action
 
       - name: Set up Python
@@ -131,6 +146,8 @@ jobs:
           fixable=$(jq '[.dependencies[].vulns[] | select((.fix_versions|length)>0)] | length' audit.json)
           unfixable=$(jq '[.dependencies[].vulns[] | select((.fix_versions|length)==0)] | length' audit.json)
 
+          fixable_after="$fixable"
+
           if [ "$fixable" -gt 0 ]; then
             echo "Found ${fixable} fixable vulnerabilities, updating Poetry dependencies..."
 
@@ -138,23 +155,56 @@ jobs:
             poetry update --lock
 
             if ! git diff --quiet -- pyproject.toml poetry.lock; then
-              changed=1
+              # A changed lock is not the same as a fixed vulnerability. An
+              # update run routinely moves unrelated packages while the finding
+              # that triggered it stays put, because Home Assistant pins it
+              # exactly. Re-audit and keep the change only if the fixable count
+              # actually went down; otherwise the weekly pull request is noise
+              # that has to be reviewed and closed by hand (#1191, #1212,
+              # #1223, #1237 were all of that kind).
+              poetry export -f requirements.txt --without-hashes -o poetry-requirements.txt --with dev,test
+              set +e
+              pip-audit -r poetry-requirements.txt -f json -o audit.json
+              status=$?
+              set -e
+              if [ "$status" -gt 1 ]; then
+                echo "pip-audit failed with exit code $status" >&2
+                exit "$status"
+              fi
+              fixable_after=$(jq '[.dependencies[].vulns[] | select((.fix_versions|length)>0)] | length' audit.json)
+
+              if [ "$fixable_after" -lt "$fixable" ]; then
+                changed=1
+              else
+                echo "::notice title=pip-audit (no effective fix)::The update run changed the lock but did not reduce the fixable count (${fixable} -> ${fixable_after}). No pull request is opened."
+                git checkout -- pyproject.toml poetry.lock poetry-requirements.txt audit.json
+                fixable_after="$fixable"
+              fi
             fi
           fi
 
           {
             echo "- Poetry dependencies: fixable=${fixable}, unfixable=${unfixable}"
+            echo "- After the update run: fixable=${fixable_after}"
+            echo "- A pull request is opened only when the fixable count drops. Findings in packages Home Assistant pins exactly (aiohttp, cryptography, Pillow, PyJWT) cannot be moved here; they need a Home Assistant release whose own pin carries the fix."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
+          echo "fixable_before=$fixable" >> "$GITHUB_OUTPUT"
+          echo "fixable_after=$fixable_after" >> "$GITHUB_OUTPUT"
 
       - name: Create pull request with fixes
         if: steps.fixrun.outputs.changed == '1'
         uses: peter-evans/create-pull-request@v8.1.1
         with:
+          base: ${{ github.event.repository.default_branch }}
           branch: security/pip-audit-autofix
           delete-branch: true
           commit-message: "pip-audit: apply available security updates"
           title: "pip-audit: automatic security updates"
           body: |
-            This PR was created automatically by `pip-audit`. It upgrades vulnerable dependencies where fixes exist by updating `pyproject.toml` and `poetry.lock`. Vulnerabilities with no available fix remain and are reported in the job summary.
+            This PR was created automatically by `pip-audit`. It updates `pyproject.toml` and `poetry.lock`.
+
+            It is opened **only because the number of fixable findings actually went down**: ${{ steps.fixrun.outputs.fixable_before }} -> ${{ steps.fixrun.outputs.fixable_after }}. An update run that changes the lock without reducing that count is discarded instead of proposed.
+
+            Remaining findings are listed in the job summary. Findings in packages Home Assistant pins exactly cannot be fixed here; they need a Home Assistant release whose own pin carries the fix. The blocking gate for what users actually install is `script/audit_manifest.py`, not this job.
           labels: security, dependencies, automated-pr

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -64,6 +64,11 @@ jobs:
             echo "pip-audit failed with exit code $status" >&2
             exit "$status"
           fi
+          audited=$(jq '.dependencies | length' audit.json)
+          if [ "$audited" -eq 0 ]; then
+            echo "::error title=pip-audit measured nothing::The report lists zero packages. The exported requirements carry environment markers (python_full_version >= \"3.14.2\"); running pip-audit under an older interpreter discards every line and reports a clean result that means nothing. Check the python-version of this job against the constraint in pyproject.toml." >&2
+            exit 1
+          fi
           fixable=$(jq '[.dependencies[].vulns[] | select((.fix_versions|length)>0)] | length' audit.json)
           unfixable=$(jq '[.dependencies[].vulns[] | select((.fix_versions|length)==0)] | length' audit.json)
           printf " - Poetry dependencies: fixable=%s, unfixable=%s\n" "$fixable" "$unfixable" >> "$summary_tmp"
@@ -143,6 +148,11 @@ jobs:
             exit "$status"
           fi
 
+          audited=$(jq '.dependencies | length' audit.json)
+          if [ "$audited" -eq 0 ]; then
+            echo "::error title=pip-audit measured nothing::The report lists zero packages. The exported requirements carry environment markers (python_full_version >= \"3.14.2\"); running pip-audit under an older interpreter discards every line and reports a clean result that means nothing. Check the python-version of this job against the constraint in pyproject.toml." >&2
+            exit 1
+          fi
           fixable=$(jq '[.dependencies[].vulns[] | select((.fix_versions|length)>0)] | length' audit.json)
           unfixable=$(jq '[.dependencies[].vulns[] | select((.fix_versions|length)==0)] | length' audit.json)
 


### PR DESCRIPTION
Companion to #1259. That PR removes the *cause* of the ineffective weekly autofix; this one makes the job itself honest, so the same class cannot come back through a different door.

## The observed failure

| PR | opened | base | outcome |
|---|---|---|---|
| #1191 | 2026-07-14 | `1.7` | merged, findings unchanged |
| #1212 | 2026-07-21 | `1.7` | merged, findings unchanged |
| #1223 | 2026-07-28 | `1.7` | closed by hand |
| #1237 | 2026-08-06 | `fix/subentry-deletion-type-axis` | still open, wrong base |

Each of them changed `poetry.lock` without moving a single one of the findings that triggered it, because those findings live in packages Home Assistant pins **exactly** (`aiohttp = "3.13.3"`, `cryptography = "46.0.5"`, `Pillow = "12.0.0"`, `PyJWT = "2.10.1"`). `poetry update` can only move a package inside the constraints it is given, so it was never able to fix them.

## Three changes

**1. Re-audit after the update; open a PR only if the count actually dropped.**
The job previously opened a pull request whenever `git diff` on the lock was non-empty. A changed lock is not the same as a fixed vulnerability: an update run routinely moves unrelated packages while the triggering finding stays put. The job now exports and audits again after `poetry update --lock` and compares `fixable_after` to `fixable_before`. If it did not drop, the working tree is reverted and the summary says why. The PR body reports both numbers.

**2. Pin the checkout and the base to the default branch.**
`actions/checkout` without `ref` takes the branch the run was triggered from. A manual `workflow_dispatch` from a topic branch therefore makes `peter-evans/create-pull-request` open its PR against that branch. That is exactly how #1237 ended up on `fix/subentry-deletion-type-axis`, where nobody was looking for it. Both `ref` and `base` are now `${{ github.event.repository.default_branch }}`, so the name is not hard-coded either.

**3. Drop a promise the job cannot keep.**
The report-only job printed `They will be auto-fixed by the scheduled job`. For a Home Assistant-pinned package that statement is false, and it is what made four unactionable pull requests look actionable. It now states what the job will attempt and names the limit. The summary additionally points at the real blocking runtime gate, `script/audit_manifest.py` with its `test_no_fixable_integration_owned_vulnerability` pytest gate, so a reader does not mistake this report-only job for one.

## Scope

Workflow file only. No production code, no dependency changes, no test changes. `script/audit_manifest.py` is untouched: it already separates the runtime axis correctly and is the gate that actually blocks.