### PR TITLE
fix(auth): classify a Nova refusal by its status, not by the exception type

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -169,8 +169,20 @@ This is a regression against the pre-change behaviour, named here rather than le
 status-based classification the mixed cycle DID surface, because the 4xx took the transient-auth branch and set
 `last_exception` there -- the same branch that fed the counter behind the false sign-in prompt. The signal was a
 side effect of the misclassification, not a contract, and it cannot be kept without keeping the defect. Buying it
-back by making the rejection branch stricter trades it for a worse defect: a healthy BLE-only account, whose tags
-legitimately return empty, would go unavailable on every cycle.
+back by gating the guard on positive success does not work at this layer either, and the reason is mechanical rather
+than a forecast about accounts: the only positive proof the poll loop holds is `_any_device_got_data`, which records
+that a device COMMITTED data, not that its request reached the server. Gating on it turns
+`test_a_rejected_device_does_not_make_every_tracker_unavailable` red, because the sibling in that test returns exactly
+`{}` -- so the stricter guard withdraws the very fix that test was written for. One rejection plus one empty sibling
+would have to stay silent for that test and surface for the mixed-failure one, from the same observable state. That is
+not a judgement call to be argued either way; it is an ambiguity, and only the layer that produced the empty result can
+resolve it.
+Where that resolution belongs is measured, so the follow-up does not start by re-deriving it:
+`location_request.py` logs `Location request accepted` once the RPC is through, and every `return []` BEFORE that point
+(no FCM token, FCM registration failure, 429, 5xx, `aiohttp.ClientError`, the generic guard around the Nova request,
+and the outer surfacing handler) is a failure, while every empty result AFTER it is legitimate. Note that
+`location_request` catches the 5xx itself, so the `NovaHTTPError` handler in `api.py` never sees that case: an
+intervention confined to `api.py` would be inert.
 Note what the mixed cycle is NOT: silent everywhere. The rejection still sets `cycle_failed`, so `last_poll_result`
 reports `failed` and the diagnostic binary sensor shows it; only entity availability is left alone.
 Six tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavailable`,

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -108,7 +108,9 @@ sequence arrives flagged `is_permanent=True`, which leaves 403 as the only plain
 `nova_request.is_credential_rejection` is the shared predicate: permanent first, then 401/403, an unreadable status keeps
 the conservative verdict, everything else is a server-side rejection. `api._classify_nova_auth_error` is its sound-path
 adapter and must not re-derive the status test -- a second copy is how the handlers drifted apart in the first place.
-Extent today, stated so it is not mistaken for coverage: six sites read it. The two sound handlers via
+Extent today, stated so it is not mistaken for coverage: six call sites in four files read it (`api.py` three times,
+`coordinator/polling.py`, `coordinator/locate.py`, `location_request.py`), and they serve seven handlers, because the two
+sound handlers share the `_classify_nova_auth_error` adapter. In order: the two sound handlers via
 `_classify_nova_auth_error`; the device-list handler (`api.py`, `except NovaAuthError` before `NovaProtobufDecodeError`),
 which now raises `UpdateFailed` for a non-credential rejection; the location handler, which returns `{}`;
 `coordinator/polling.py`, whose `except NovaAuthError` branch leaves the transient-auth counter alone in both directions;
@@ -119,16 +121,21 @@ Read those last two claims narrowly, they are about the BRANCH and not about the
 such a status, neither branch is reachable in production any more, and what the device actually takes is the SUCCESS
 path -- `polling.py` "Success path: ensure any previous auth error is cleared" and `locate.py` "Success path: clear any
 auth error state", both of which run BEFORE the `if not location` guard. So a 404 now RESETS the transient-auth counter
-and clears the auth state, which is the opposite of what the branch says and can mask a genuine 401 on another tracker in
-the same cycle. That reset is not new (every 5xx and 429 already returns `{}` and takes it), but it is newly reachable
-for a client rejection. Fixing it means deciding what an empty result is allowed to prove about credentials, which is a
-behaviour change of its own; it is tracked separately and must not be assumed done.
+and clears the auth state, which is the opposite of what the branch says. The mechanism is not new -- every 5xx and 429
+already returns `{}` and reaches it -- but what a client rejection adds is PERMANENCE, and that is a real behaviour
+change: a 5xx clears up, a device deleted from the account does not. With one deleted tracker in the list every cycle
+resets the counter, so a genuinely expired sign-in on another tracker never reaches `_MAX_TRANSIENT_AUTH_FAILURES` and
+the user never sees the reauth prompt at all. Before this change that 404 raised the counter itself, so the escalation
+did happen, for the wrong reason. Fixing it means deciding what an empty result is allowed to prove about credentials,
+which is a behaviour change of its own with a far wider blast radius (every healthy idle BLE poll takes the same path);
+it is tracked separately and must not be assumed done.
 What is NOT fixed, stated so the rule is not mistaken for a solved problem: `nova_request.py` still raises a type named
 "auth" for all of them, so a new handler that reads the type repeats the defect, and this paragraph is the only thing
 standing in its way. Giving the non-credential case its own exception class is the open follow-up; it needs an
-exhaustiveness test over `NovaError.__subclasses__()` first: measured, all eight `try` blocks that catch `NovaAuthError`
-carry a broad `except Exception` in the same block, so a new class would be swallowed at every one of them under a name
-that hides the status. Narrowing a handler is a behaviour change that needs its own regression test, not a
+exhaustiveness test over `NovaError.__subclasses__()` first. Measured over the AST: ten `try` blocks catch
+`NovaAuthError`. Eight carry a broad `except Exception` in the same block and would swallow a new class under a name that
+hides the status; the two sound-request handlers catch it in a tuple with no broad handler, so a new class would
+propagate uncaught there instead. Two opposite failure modes in one change. Narrowing a handler is a behaviour change that needs its own regression test, not a
 drive-by edit; do not assume a green suite proves the rest of the tree already follows this rule.
 
 ### Import deferral reminder

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -112,23 +112,26 @@ Extent today, stated so it is not mistaken for coverage: six call sites in four 
 `coordinator/polling.py`, `coordinator/locate.py`, `location_request.py`), and they serve seven handlers, because the two
 sound handlers share the `_classify_nova_auth_error` adapter. In order: the two sound handlers via
 `_classify_nova_auth_error`; the device-list handler (`api.py`, `except NovaAuthError` before `NovaProtobufDecodeError`),
-which now raises `UpdateFailed` for a non-credential rejection; the location handler, which returns `{}`;
-`coordinator/polling.py`, whose `except NovaAuthError` branch leaves the transient-auth counter alone in both directions;
-and `coordinator/locate.py`, whose branch does not flip the account-wide auth state. `location_request.py` names the
-status in its log records instead of calling every 4xx an authentication error, but still only re-raises -- it does not
-classify.
-Read those last two claims narrowly, they are about the BRANCH and not about the path: since `api.py` returns `{}` for
-such a status, neither branch is reachable in production any more, and what the device actually takes is the SUCCESS
-path -- `polling.py` "Success path: ensure any previous auth error is cleared" and `locate.py` "Success path: clear any
-auth error state", both of which run BEFORE the `if not location` guard. So a 404 now RESETS the transient-auth counter
-and clears the auth state, which is the opposite of what the branch says. The mechanism is not new -- every 5xx and 429
-already returns `{}` and reaches it -- but what a client rejection adds is PERMANENCE, and that is a real behaviour
-change: a 5xx clears up, a device deleted from the account does not. With one deleted tracker in the list every cycle
-resets the counter, so a genuinely expired sign-in on another tracker never reaches `_MAX_TRANSIENT_AUTH_FAILURES` and
-the user never sees the reauth prompt at all. Before this change that 404 raised the counter itself, so the escalation
-did happen, for the wrong reason. Fixing it means deciding what an empty result is allowed to prove about credentials,
-which is a behaviour change of its own with a far wider blast radius (every healthy idle BLE poll takes the same path);
-it is tracked separately and must not be assumed done.
+which now raises `UpdateFailed` for a non-credential rejection; the location handler, which passes the error on to its
+callers instead of returning `{}`; `coordinator/polling.py`, whose `except NovaAuthError` branch leaves the
+transient-auth counter alone in both directions; and `coordinator/locate.py`, whose branch does not flip the
+account-wide auth state. `location_request.py` names the status in its log records instead of calling every 4xx an
+authentication error, but still only re-raises -- it does not classify.
+Why the location handler raises rather than returning `{}`, since the empty return looks like the gentler option: both
+callers treat ANY non-raising return as positive proof that the credentials work. `polling.py` runs "Success path:
+ensure any previous auth error is cleared" and `locate.py` runs "Success path: clear any auth error state", and both run
+BEFORE the `if not location` guard. An empty return for a rejected device would therefore have RESET the transient-auth
+counter and cleared the auth state, which is the opposite of what those branches say. Worse, it would have done so
+PERMANENTLY: a 5xx clears up, a device deleted from the account does not, so one deleted tracker in the list would reset
+the counter every cycle and a genuinely expired sign-in on another tracker would never reach
+`_MAX_TRANSIENT_AUTH_FAILURES`. The user would never see the reauth prompt at all -- a worse outcome than the defect
+this change exists to fix. Raising keeps a rejected device out of that reset.
+What is still NOT fixed there, stated so it is not mistaken for solved: that success path still treats every empty
+result as proof of working credentials, and every 5xx, every 429 and every idle BLE tag reaches it. Deciding what an
+empty result may prove about credentials is a behaviour change of its own with a far wider blast radius (every healthy
+idle poll takes the same path); it is tracked separately and must not be assumed done. Two tests pin the current state
+so it cannot drift silently: `test_an_empty_return_still_clears_the_counter` characterises the reset that stays, and
+`test_a_non_credential_4xx_location_is_passed_through` pins the seam that keeps a rejection out of it.
 What is NOT fixed, stated so the rule is not mistaken for a solved problem: `nova_request.py` still raises a type named
 "auth" for all of them, so a new handler that reads the type repeats the defect, and this paragraph is the only thing
 standing in its way. Giving the non-credential case its own exception class is the open follow-up; it needs an

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -113,7 +113,12 @@ Extent today, stated so it is not mistaken for coverage: six call sites in four 
 sound handlers share the `_classify_nova_auth_error` adapter. In order: the two sound handlers via
 `_classify_nova_auth_error`; the device-list handler (`api.py`, `except NovaAuthError` before `NovaProtobufDecodeError`),
 which now raises `UpdateFailed` for a non-credential rejection; the location handler, which passes the error on to its
-callers instead of returning `{}`; `coordinator/polling.py`, whose `except NovaAuthError` branch leaves the
+callers instead of returning `{}` -- and which, unlike the device-list handler, also passes on a plain
+NON-permanent credential rejection (a 403) rather than converting it to `ConfigEntryAuthFailed`, because
+`polling.py` counts consecutive transient auth failures and escalates at its own threshold instead of
+prompting on the first one; only a PERMANENT auth failure (or an HTTP 401/403 `NovaHTTPError`) converts
+there. Both cases therefore leave that handler as `NovaAuthError`, which is precisely why a caller must ask
+the predicate and not the type; `coordinator/polling.py`, whose `except NovaAuthError` branch leaves the
 transient-auth counter alone in both directions; and `coordinator/locate.py`, whose branch does not flip the
 account-wide auth state. `location_request.py` names the status in its log records instead of calling every 4xx an
 authentication error, but still only re-raises -- it does not classify.

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -170,18 +170,28 @@ status-based classification the mixed cycle DID surface, because the 4xx took th
 `last_exception` there -- the same branch that fed the counter behind the false sign-in prompt. The signal was a
 side effect of the misclassification, not a contract, and it cannot be kept without keeping the defect. Buying it
 back by gating the guard on positive success does not work at this layer either, and the reason is mechanical rather
-than a forecast about accounts: the only positive proof the poll loop holds is `_any_device_got_data`, which records
-that a device COMMITTED data, not that its request reached the server. Gating on it turns
-`test_a_rejected_device_does_not_make_every_tracker_unavailable` red, because the sibling in that test returns exactly
-`{}` -- so the stricter guard withdraws the very fix that test was written for. One rejection plus one empty sibling
-would have to stay silent for that test and surface for the mixed-failure one, from the same observable state. That is
-not a judgement call to be argued either way; it is an ambiguity, and only the layer that produced the empty result can
-resolve it.
-Where that resolution belongs is measured, so the follow-up does not start by re-deriving it:
-`location_request.py` logs `Location request accepted` once the RPC is through, and every `return []` BEFORE that point
-(no FCM token, FCM registration failure, 429, 5xx, `aiohttp.ClientError`, the generic guard around the Nova request,
-and the outer surfacing handler) is a failure, while every empty result AFTER it is legitimate. Note that
-`location_request` catches the 5xx itself, so the `NovaHTTPError` handler in `api.py` never sees that case: an
+than a forecast about accounts. The only positive marker on the REQUEST path is `_any_device_got_data`; the
+neighbouring `cycle_had_successful_decrypt` is a positive proof as well, but about the shared key, and both are False
+for either kind of empty result. `_any_device_got_data` records that a device COMMITTED data, not that its request
+reached the server. Gating on it turns `test_a_rejected_device_does_not_make_every_tracker_unavailable` red, because
+the sibling in that test returns exactly `{}` -- the stricter guard withdraws the very fix that test was written for.
+One rejection plus one empty sibling would have to stay silent for that test and surface for the mixed-failure one,
+from the same observable state. That is not a judgement call to be argued either way; it is an ambiguity, and only the
+layer that produced the empty result can resolve it.
+What the earlier wording got right must not be thrown out with its wrong quantifier: an account with one deleted
+tracker and otherwise idle BLE tags WOULD go unavailable on every cycle under a stricter gate. That was never true of
+"every healthy BLE-only account" -- the guard is conjunctive with a rejection, so an account without one is untouched
+-- but it is exactly true of that one shape, and it is the concrete price of tightening here.
+Where the resolution belongs is measured, so the follow-up does not start by re-deriving it. `location_request.py`
+logs `Location request accepted` once the RPC is through, and the `return []` paths reachable only BEFORE that log
+(no FCM token, FCM registration failure, 429, 5xx, `aiohttp.ClientError`, the generic guard around the Nova request)
+are failures. Two qualifications, both measured, because the log line is not a clean split. The outer surfacing
+handler wraps the WHOLE body, so its own `return []` sits AFTER the log while the exceptions it catches may come from
+either side of it; a follow-up therefore needs a flag set at the log line, not a position in the file. And not every
+empty result after the log is benign either: the unexpected-device branch logs a WARNING and returns empty.
+Note also where the empty dict actually comes from. `location_request` catches the 5xx, the 429, the protobuf decode
+failure and the Nova logic error itself, so `api.py`'s handlers for those four never run on the locate path; the dict
+is produced by the no-location fallthrough instead. The outcome is as described above, the mechanism is not, and an
 intervention confined to `api.py` would be inert.
 Note what the mixed cycle is NOT: silent everywhere. The rejection still sets `cycle_failed`, so `last_poll_result`
 reports `failed` and the diagnostic binary sensor shows it; only entity availability is left alone.

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -131,23 +131,31 @@ PERMANENTLY: a 5xx clears up, a device deleted from the account does not, so one
 the counter every cycle and a genuinely expired sign-in on another tracker would never reach
 `_MAX_TRANSIENT_AUTH_FAILURES`. The user would never see the reauth prompt at all -- a worse outcome than the defect
 this change exists to fix. Raising keeps a rejected device out of that reset.
-Why the poll branch records the rejection without failing the cycle: in the cycle's `finally` block `cycle_failed`
-and `last_exception` drive two different things. `cycle_failed` only writes the `last_poll_result` diagnostic
-attribute that `binary_sensor.py` exposes; `last_exception` drives `async_set_update_error`, and
-`GoogleFindMyEntity.available` follows the coordinator's `last_update_success`. Recording a per-device client
-rejection as `last_exception` therefore marked EVERY tracker entity unavailable, and because a tracker deleted from
-the account never recovers the way a 5xx does, the outage repeated on every poll for as long as that tracker stayed
-in the cached device list -- trading a spurious re-auth prompt for a permanent availability outage. The branch keeps
-`cycle_failed` and leaves `last_exception` to the failures that are actually about the account, the same shape the
-`OwnerKeyLookupTransientError` branch below it already uses. A side effect worth naming: while the client branch held
-the `last_exception` slot, a rejected tracker polled BEFORE a genuinely expired one made the coordinator report the
-harmless 404 and hide the 401. Residual gap, stated so it is not mistaken for covered: if EVERY device is rejected
-the cycle now reports no error at all. That window is narrow, because an account-wide rejection already fails
-`async_get_basic_device_list` with `UpdateFailed` one layer up, and it is not silent (`last_poll_result` reads
-"failed", `note_error` records it, every rejected device gets its own WARNING). Three tests pin this:
-`test_a_rejected_device_does_not_make_every_tracker_unavailable`,
-`test_a_rejected_device_still_marks_the_poll_result_failed` and
-`test_a_rejected_device_does_not_hide_a_later_credential_failure`.
+Why the poll branch records the rejection without failing the coordinator UPDATE (it does fail the cycle): in the
+cycle's `finally` block `cycle_failed` and `last_exception` drive two different things. `cycle_failed` only writes
+the `last_poll_result` diagnostic attribute that `binary_sensor.py` exposes; `last_exception` drives
+`async_set_update_error`, and `GoogleFindMyEntity.available` follows the coordinator's `last_update_success`.
+Recording a per-device client rejection as `last_exception` therefore marked EVERY tracker entity unavailable, and
+because a tracker deleted from the account never recovers the way a 5xx does, the outage repeated on every poll for
+as long as that tracker stayed in the cached device list -- trading a spurious re-auth prompt for a permanent
+availability outage. The branch keeps `cycle_failed` and leaves `last_exception` to the failures that are actually
+about the account. It is the ONLY branch in that loop which sets one without the other, and that is deliberate, not
+an oversight: every other branch there reports a condition that says something about the account, this one does not.
+(The `OwnerKeyLookupTransientError` branch is close in spirit -- also an ordinary per-device skip -- but sets
+neither flag, so it is not the same shape.) A side effect worth naming: while the client branch held the
+`last_exception` slot, a rejected tracker polled BEFORE a genuinely expired one made the coordinator report the
+harmless 404 and hide the 401.
+The all-rejected case is handled after the loop, not in the branch: whether a rejection is per-device or
+account-wide is only knowable once every device has been tried, the same reasoning by which
+`_finalize_cycle_decrypt_state` defers the decrypt verdict. If `cycle_rejected_devices == len(devices)` there is no
+sibling success left to refute the rejections, and the cycle surfaces an `UpdateFailed`. Do NOT replace that check
+with "the device list would have caught it one layer up": `async_get_basic_device_list` is a different RPC
+(`nbe_list_devices`) from the per-device location request, and `DEVICE_LIST_POLL_INTERVAL` (300s, `const.py`) means
+most cycles reuse the cached list without calling it at all. That claim was written here once and was wrong.
+Four tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavailable`,
+`test_a_rejected_device_still_marks_the_poll_result_failed`,
+`test_a_rejected_device_does_not_hide_a_later_credential_failure` and
+`test_a_cycle_where_every_device_is_rejected_still_reports_an_error`.
 What is still NOT fixed there, stated so it is not mistaken for solved: that success path still treats every empty
 result as proof of working credentials, and every 5xx, every 429 and every idle BLE tag reaches it. Deciding what an
 empty result may prove about credentials is a behaviour change of its own with a far wider blast radius (every healthy

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -147,15 +147,32 @@ neither flag, so it is not the same shape.) A side effect worth naming: while th
 harmless 404 and hide the 401.
 The all-rejected case is handled after the loop, not in the branch: whether a rejection is per-device or
 account-wide is only knowable once every device has been tried, the same reasoning by which
-`_finalize_cycle_decrypt_state` defers the decrypt verdict. If `cycle_rejected_devices == len(devices)` there is no
-sibling success left to refute the rejections, and the cycle surfaces an `UpdateFailed`. Do NOT replace that check
-with "the device list would have caught it one layer up": `async_get_basic_device_list` is a different RPC
-(`nbe_list_devices`) from the per-device location request, and `DEVICE_LIST_POLL_INTERVAL` (300s, `const.py`) means
-most cycles reuse the cached list without calling it at all. That claim was written here once and was wrong.
-Four tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavailable`,
+`_finalize_cycle_decrypt_state` defers the decrypt verdict. If `cycle_rejected_devices == len(devices)` every device
+was refused, which is account-wide on the rejections' own terms, and the cycle surfaces an `UpdateFailed`. Do NOT
+replace that check with "the device list would have caught it one layer up": `async_get_basic_device_list` is a
+different RPC (`nbe_list_devices`) from the per-device location request, and `DEVICE_LIST_POLL_INTERVAL` (300s,
+`const.py`) means most cycles reuse the cached list without calling it at all. That claim was written here once and
+was wrong.
+Read the check for exactly what it tests, and no more. It does NOT say that a cycle failing the equality had a sibling
+success: a non-rejected sibling proves nothing, because `api.async_get_device_location` returns the same empty dict for
+a healthy idle BLE tag and for a 5xx, a 429, a protobuf decode failure and a Nova logic error. So a mixed cycle -- one
+tracker refused, the others back empty from a server outage -- stays silent, and so does that same outage with no
+rejection in it at all: measured, a cycle in which EVERY device returns empty reports `success` and leaves every entity
+available with its cached position. That is pre-existing and independent of the rejection branch, and it is why the
+rejection branch must not be made stricter on its own: making the error signal depend on whether some unrelated tracker
+happens to have been deleted is a coincidence, not a contract. The empty result is what has to become distinguishable
+(`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`), and until it is, both states are pinned:
+`test_a_cycle_of_only_empty_results_reports_success` holds the reference case and
+`test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent` holds the mixed one. When that change lands they are
+expected to flip deliberately, not silently.
+Note what the mixed cycle is NOT: silent everywhere. The rejection still sets `cycle_failed`, so `last_poll_result`
+reports `failed` and the diagnostic binary sensor shows it; only entity availability is left alone.
+Six tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavailable`,
 `test_a_rejected_device_still_marks_the_poll_result_failed`,
-`test_a_rejected_device_does_not_hide_a_later_credential_failure` and
-`test_a_cycle_where_every_device_is_rejected_still_reports_an_error`.
+`test_a_rejected_device_does_not_hide_a_later_credential_failure`,
+`test_a_cycle_where_every_device_is_rejected_still_reports_an_error`,
+`test_a_cycle_of_only_empty_results_reports_success` and
+`test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`.
 What is still NOT fixed there, stated so it is not mistaken for solved: that success path still treats every empty
 result as proof of working credentials, and every 5xx, every 429 and every idle BLE tag reaches it. Deciding what an
 empty result may prove about credentials is a behaviour change of its own with a far wider blast radius (every healthy

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -119,8 +119,8 @@ NON-permanent credential rejection (a 403) rather than converting it to `ConfigE
 prompting on the first one; only a PERMANENT auth failure (or an HTTP 401/403 `NovaHTTPError`) converts
 there. Both cases therefore leave that handler as `NovaAuthError`, which is precisely why a caller must ask
 the predicate and not the type; `coordinator/polling.py`, whose `except NovaAuthError` branch leaves the
-transient-auth counter alone in both directions; and `coordinator/locate.py`, whose branch does not flip the
-account-wide auth state. `location_request.py` names the status in its log records instead of calling every 4xx an
+transient-auth counter alone in both directions AND does not record the rejection as the cycle's `last_exception`;
+and `coordinator/locate.py`, whose branch does not flip the account-wide auth state. `location_request.py` names the status in its log records instead of calling every 4xx an
 authentication error, but still only re-raises -- it does not classify.
 Why the location handler raises rather than returning `{}`, since the empty return looks like the gentler option: both
 callers treat ANY non-raising return as positive proof that the credentials work. `polling.py` runs "Success path:
@@ -131,6 +131,23 @@ PERMANENTLY: a 5xx clears up, a device deleted from the account does not, so one
 the counter every cycle and a genuinely expired sign-in on another tracker would never reach
 `_MAX_TRANSIENT_AUTH_FAILURES`. The user would never see the reauth prompt at all -- a worse outcome than the defect
 this change exists to fix. Raising keeps a rejected device out of that reset.
+Why the poll branch records the rejection without failing the cycle: in the cycle's `finally` block `cycle_failed`
+and `last_exception` drive two different things. `cycle_failed` only writes the `last_poll_result` diagnostic
+attribute that `binary_sensor.py` exposes; `last_exception` drives `async_set_update_error`, and
+`GoogleFindMyEntity.available` follows the coordinator's `last_update_success`. Recording a per-device client
+rejection as `last_exception` therefore marked EVERY tracker entity unavailable, and because a tracker deleted from
+the account never recovers the way a 5xx does, the outage repeated on every poll for as long as that tracker stayed
+in the cached device list -- trading a spurious re-auth prompt for a permanent availability outage. The branch keeps
+`cycle_failed` and leaves `last_exception` to the failures that are actually about the account, the same shape the
+`OwnerKeyLookupTransientError` branch below it already uses. A side effect worth naming: while the client branch held
+the `last_exception` slot, a rejected tracker polled BEFORE a genuinely expired one made the coordinator report the
+harmless 404 and hide the 401. Residual gap, stated so it is not mistaken for covered: if EVERY device is rejected
+the cycle now reports no error at all. That window is narrow, because an account-wide rejection already fails
+`async_get_basic_device_list` with `UpdateFailed` one layer up, and it is not silent (`last_poll_result` reads
+"failed", `note_error` records it, every rejected device gets its own WARNING). Three tests pin this:
+`test_a_rejected_device_does_not_make_every_tracker_unavailable`,
+`test_a_rejected_device_still_marks_the_poll_result_failed` and
+`test_a_rejected_device_does_not_hide_a_later_credential_failure`.
 What is still NOT fixed there, stated so it is not mistaken for solved: that success path still treats every empty
 result as proof of working credentials, and every 5xx, every 429 and every idle BLE tag reaches it. Deciding what an
 empty result may prove about credentials is a behaviour change of its own with a far wider blast radius (every healthy

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -105,12 +105,31 @@ Classify an auth rejection by the HTTP **status**, never by the exception type. 
 non-retryable 4xx (`nova_request.py` raises it for 400, 404, 405, 409, 422 as well; `HTTP_RETRY_ELIGIBLE` holds no 4xx
 besides 408 and 429), so a type check reads "device not found" as "your sign-in expired". A 401 that survived the refresh
 sequence arrives flagged `is_permanent=True`, which leaves 403 as the only plain credential rejection a handler sees.
-`api._classify_nova_auth_error` is the shared predicate: permanent first, then 401/403, everything else is a server-side
-rejection. Extent today, stated so it is not mistaken for coverage: the two sound handlers use it; the device-list handler
-(`api.py`, `except NovaAuthError` before `NovaProtobufDecodeError`), the location handler, `coordinator/polling.py` and
-`coordinator/locate.py` still key off the type, and each of those turns a 404 into `ConfigEntryAuthFailed` or a reauth
-countdown. Narrowing them is a behaviour change that needs its own regression test, not a drive-by edit; do not assume a
-green suite proves the rest of the tree already follows this rule.
+`nova_request.is_credential_rejection` is the shared predicate: permanent first, then 401/403, an unreadable status keeps
+the conservative verdict, everything else is a server-side rejection. `api._classify_nova_auth_error` is its sound-path
+adapter and must not re-derive the status test -- a second copy is how the handlers drifted apart in the first place.
+Extent today, stated so it is not mistaken for coverage: six sites read it. The two sound handlers via
+`_classify_nova_auth_error`; the device-list handler (`api.py`, `except NovaAuthError` before `NovaProtobufDecodeError`),
+which now raises `UpdateFailed` for a non-credential rejection; the location handler, which returns `{}`;
+`coordinator/polling.py`, whose `except NovaAuthError` branch leaves the transient-auth counter alone in both directions;
+and `coordinator/locate.py`, whose branch does not flip the account-wide auth state. `location_request.py` names the
+status in its log records instead of calling every 4xx an authentication error, but still only re-raises -- it does not
+classify.
+Read those last two claims narrowly, they are about the BRANCH and not about the path: since `api.py` returns `{}` for
+such a status, neither branch is reachable in production any more, and what the device actually takes is the SUCCESS
+path -- `polling.py` "Success path: ensure any previous auth error is cleared" and `locate.py` "Success path: clear any
+auth error state", both of which run BEFORE the `if not location` guard. So a 404 now RESETS the transient-auth counter
+and clears the auth state, which is the opposite of what the branch says and can mask a genuine 401 on another tracker in
+the same cycle. That reset is not new (every 5xx and 429 already returns `{}` and takes it), but it is newly reachable
+for a client rejection. Fixing it means deciding what an empty result is allowed to prove about credentials, which is a
+behaviour change of its own; it is tracked separately and must not be assumed done.
+What is NOT fixed, stated so the rule is not mistaken for a solved problem: `nova_request.py` still raises a type named
+"auth" for all of them, so a new handler that reads the type repeats the defect, and this paragraph is the only thing
+standing in its way. Giving the non-credential case its own exception class is the open follow-up; it needs an
+exhaustiveness test over `NovaError.__subclasses__()` first: measured, all eight `try` blocks that catch `NovaAuthError`
+carry a broad `except Exception` in the same block, so a new class would be swallowed at every one of them under a name
+that hides the status. Narrowing a handler is a behaviour change that needs its own regression test, not a
+drive-by edit; do not assume a green suite proves the rest of the tree already follows this rule.
 
 ### Import deferral reminder
 

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -161,22 +161,28 @@ rejection in it at all: measured, a cycle in which EVERY device returns empty re
 available with its cached position. That is pre-existing and independent of the rejection branch, and it is why the
 rejection branch must not be made stricter on its own: making the error signal depend on whether some unrelated tracker
 happens to have been deleted is a coincidence, not a contract. The empty result is what has to become distinguishable
-(`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`), and until it is, both states are pinned:
-`test_a_cycle_of_only_empty_results_reports_success` holds the reference case and
-`test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent` holds the mixed one. When that change lands they are
+(`PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`), and until it is, both states are pinned:
+`test_known_gap_a_cycle_of_only_empty_results_reports_success` holds the reference case and
+`test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent` holds the mixed one. When that change lands they are
 expected to flip deliberately, not silently.
+This is a regression against the pre-change behaviour, named here rather than left to be discovered: before the
+status-based classification the mixed cycle DID surface, because the 4xx took the transient-auth branch and set
+`last_exception` there -- the same branch that fed the counter behind the false sign-in prompt. The signal was a
+side effect of the misclassification, not a contract, and it cannot be kept without keeping the defect. Buying it
+back by making the rejection branch stricter trades it for a worse defect: a healthy BLE-only account, whose tags
+legitimately return empty, would go unavailable on every cycle.
 Note what the mixed cycle is NOT: silent everywhere. The rejection still sets `cycle_failed`, so `last_poll_result`
 reports `failed` and the diagnostic binary sensor shows it; only entity availability is left alone.
 Six tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavailable`,
 `test_a_rejected_device_still_marks_the_poll_result_failed`,
 `test_a_rejected_device_does_not_hide_a_later_credential_failure`,
 `test_a_cycle_where_every_device_is_rejected_still_reports_an_error`,
-`test_a_cycle_of_only_empty_results_reports_success` and
-`test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`.
+`test_known_gap_a_cycle_of_only_empty_results_reports_success` and
+`test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`.
 What is still NOT fixed there, stated so it is not mistaken for solved: that success path still treats every empty
 result as proof of working credentials, and every 5xx, every 429 and every idle BLE tag reaches it. Deciding what an
 empty result may prove about credentials is a behaviour change of its own with a far wider blast radius (every healthy
-idle poll takes the same path); it is tracked separately and must not be assumed done. Two tests pin the current state
+idle poll takes the same path); it is tracked separately (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`) and must not be assumed done. Two tests pin the current state
 so it cannot drift silently: `test_an_empty_return_still_clears_the_counter` characterises the reset that stays, and
 `test_a_non_credential_4xx_location_is_passed_through` pins the seam that keeps a rejection out of it.
 What is NOT fixed, stated so the rule is not mistaken for a solved problem: `nova_request.py` still raises a type named

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -193,6 +193,12 @@ Note also where the empty dict actually comes from. `location_request` catches t
 failure and the Nova logic error itself, so `api.py`'s handlers for those four never run on the locate path; the dict
 is produced by the no-location fallthrough instead. The outcome is as described above, the mechanism is not, and an
 intervention confined to `api.py` would be inert.
+Two constraints on the follow-up fall out of that, stated here because a plausible reading of the paragraph above
+gets the second one backwards. First, the accepted-versus-failed outcome has to be preserved ACROSS the
+`location_request.py` boundary -- a typed result, for example -- rather than reconstructed downstream once the empty
+collection has flattened it. Second, the layer that flattens it is `location_request.py` itself, NOT `api.py`: aiming
+the follow-up at the file where the empty dict is built would put the fix behind the point where the evidence is
+already gone.
 Note what the mixed cycle is NOT: silent everywhere. The rejection still sets `cycle_failed`, so `last_poll_result`
 reports `failed` and the diagnostic binary sensor shows it; only entity availability is left alone.
 Six tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavailable`,

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -140,6 +140,11 @@ exhaustiveness test over `NovaError.__subclasses__()` first. Measured over the A
 hides the status; the two sound-request handlers catch it in a tuple with no broad handler, so a new class would
 propagate uncaught there instead. Two opposite failure modes in one change. Narrowing a handler is a behaviour change that needs its own regression test, not a
 drive-by edit; do not assume a green suite proves the rest of the tree already follows this rule.
+Every count in the two paragraphs above (six call sites in four files, ten `try` blocks, eight of them with a broad
+handler) is enforced by `tests/test_nova_request.py::TestTheDocumentedExtentStaysTrue`, which derives them from the AST
+rather than from grep, following the rule `tests/AGENTS.md` states for shared tuples. Prose that carries a number and
+calls itself "the only thing standing in its way" must not be the only copy of that number: change the extent and this
+paragraph in the same commit, and let the test tell you when one of them went stale.
 
 ### Import deferral reminder
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -47,6 +47,7 @@ from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaHTTPError,
     NovaRateLimitError,
     async_nova_request,
+    is_credential_rejection,
 )
 from custom_components.googlefindmy.NovaApi.scopes import NOVA_ACTION_API_SCOPE
 from custom_components.googlefindmy.NovaApi.util import generate_random_uuid
@@ -791,9 +792,26 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
             # Re-raise auth errors so api.py can convert to ConfigEntryAuthFailed
             # and trigger re-authentication flow. Previously this was swallowed,
             # causing users to see only "No location data" without re-auth prompt.
+            # This layer still does not classify -- api.py decides between
+            # ConfigEntryAuthFailed and an ordinary empty result. The records
+            # below must not pre-empt that decision, though: the class covers
+            # every non-retryable 4xx, so calling a 404 an authentication error
+            # contradicted the very line api.py logs a moment later. Both the
+            # WARNING and the DEBUG record are branched; naming only one of them
+            # would leave the same false claim standing in the other channel.
             # R6 (AGENTS.md Section 5): device name to DEBUG only.
-            _LOGGER.warning("Authentication error while requesting location: %s", e)
-            _LOGGER.debug("Authentication error while requesting location for %s", name)
+            if is_credential_rejection(e):
+                _LOGGER.warning("Authentication error while requesting location: %s", e)
+                _LOGGER.debug(
+                    "Authentication error while requesting location for %s", name
+                )
+            else:
+                _LOGGER.warning(
+                    "Client error (HTTP %s) while requesting location: %s",
+                    getattr(e, "status", "unknown"),
+                    e,
+                )
+                _LOGGER.debug("Client error while requesting location for %s", name)
             raise
         except aiohttp.ClientError as e:
             # R6 (AGENTS.md Section 5): device name to DEBUG only.

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -893,8 +893,9 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         # Re-raise so api.py can handle appropriately: it, not this layer, tells
         # a credential rejection from a rejected request. The second half of this
         # note used to say transient errors are tracked by the coordinator. That
-        # holds for a credential rejection only -- a non-credential 4xx never
-        # reaches a counter, because api.py returns {} for it.
+        # holds for a credential rejection only -- api.py passes a
+        # non-credential 4xx on to its callers, whose branches skip the counter
+        # deliberately.
         raise
     except DecryptionError:
         # Auth-fatal crypto failure surfaced from ctx.error above: must propagate so

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -890,8 +890,11 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         # Permanent auth failure (AAS token invalid) - must re-raise for immediate reauth.
         raise
     except NovaAuthError:
-        # Re-raise auth errors (permanent or transient) so api.py can handle appropriately.
-        # Transient errors will be tracked by the coordinator; permanent ones trigger reauth.
+        # Re-raise so api.py can handle appropriately: it, not this layer, tells
+        # a credential rejection from a rejected request. The second half of this
+        # note used to say transient errors are tracked by the coordinator. That
+        # holds for a credential rejection only -- a non-credential 4xx never
+        # reaches a counter, because api.py returns {} for it.
         raise
     except DecryptionError:
         # Auth-fatal crypto failure surfaced from ctx.error above: must propagate so

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/start_sound_request.py
@@ -191,7 +191,9 @@ async def async_submit_start_sound_request(  # noqa: PLR0913
         # Propagate all errors to caller for proper handling and logging.
         # - CancelledError: Must propagate for proper task cancellation.
         # - NovaAuthPermanentError: Permanent auth failure - immediate reauth required.
-        # - NovaAuthError: Transient auth error - let coordinator track consecutive failures.
+        # - NovaAuthError: every non-retryable 4xx, not only a credential
+        #   rejection; api.py asks nova_request.is_credential_rejection and
+        #   maps the rest to REJECTED_SERVER. Nothing here feeds a counter.
         # - NovaRateLimitError/NovaHTTPError/ClientError: Transient errors with details.
         raise
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/PlaySound/stop_sound_request.py
@@ -178,7 +178,9 @@ async def async_submit_stop_sound_request(  # noqa: PLR0913
         # Propagate all errors to caller for proper handling and logging.
         # - CancelledError: Must propagate for proper task cancellation.
         # - NovaAuthPermanentError: Permanent auth failure - immediate reauth required.
-        # - NovaAuthError: Transient auth error - let coordinator track consecutive failures.
+        # - NovaAuthError: every non-retryable 4xx, not only a credential
+        #   rejection; api.py asks nova_request.is_credential_rejection and
+        #   maps the rest to REJECTED_SERVER. Nothing here feeds a counter.
         # - NovaRateLimitError/NovaHTTPError/ClientError: Transient errors with details.
         raise
 

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -422,6 +422,50 @@ class NovaAuthPermanentError(NovaAuthError):
         super().__init__(status, detail, is_permanent=True)
 
 
+_CREDENTIAL_REJECTION_STATUSES = frozenset({401, 403})
+
+
+def is_credential_rejection(err: NovaAuthError) -> bool:
+    """Answer whether this NovaAuthError really names a credential problem.
+
+    The type is wider than its name. This module raises it for EVERY
+    non-retryable 4xx (see the raise below the HTTP_RETRY_ELIGIBLE branch,
+    whose own comment names "403 Forbidden, 404 Not Found"), and
+    HTTP_RETRY_ELIGIBLE holds no 4xx besides 408 and 429, so 400, 404, 405,
+    409 and 422 all arrive as "auth". A 401 that survived the refresh
+    sequence is raised separately with is_permanent=True, which leaves 403
+    as the only plain credential rejection a handler sees.
+
+    Reading the type alone therefore tells a user with a deleted device to
+    check their sign-in. Every handler in this integration branches on THIS
+    predicate instead; api._classify_nova_auth_error is its sound-path
+    adapter. Keep them in step when either moves.
+
+    Permanence outranks the status: NovaAuthPermanentError exists to say
+    "re-authentication is definitively required", so it stays a credential
+    rejection whatever status it carries.
+
+    An error without a readable status keeps the conservative verdict. That
+    case is a test double or a future subclass, not an observed server
+    answer, and the conservative reading of a type named "auth" is auth.
+
+    Args:
+        err: The error the transport raised.
+
+    Returns:
+        True when the refusal names the credentials (permanent, 401, 403, or
+        no readable status), False for every other client rejection.
+
+    Example:
+        >>> is_credential_rejection(NovaAuthError(404, "gone"))
+        False
+    """
+    if getattr(err, "is_permanent", False):
+        return True
+    status = getattr(err, "status", None)
+    return status is None or status in _CREDENTIAL_REJECTION_STATUSES
+
+
 class NovaRateLimitError(NovaError):
     """Raised on 429 rate-limiting errors after retries."""
 

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -1808,11 +1808,15 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                     # Consumers MUST call is_credential_rejection instead of
                     # reading the type. Splitting a separate exception class off
                     # here would let the typing carry the truth, but it is a
-                    # behaviour change of its own: a new class is uncaught at
-                    # every site that catches this one, and each of those eight
-                    # try blocks has a broad `except Exception` below it, so the
-                    # new class would be swallowed under a name that hides the
-                    # status. Needs an exhaustiveness test first.
+                    # behaviour change of its own. Measured over the AST: ten
+                    # try blocks catch this class. Eight carry a broad
+                    # `except Exception` in the same block and would swallow a
+                    # new class under a name that hides the status; the two
+                    # sound-request handlers catch it in a tuple with no broad
+                    # handler at all, so there a new class would propagate
+                    # uncaught instead. Two opposite failure modes, which is why
+                    # the follow-up needs an exhaustiveness test over
+                    # NovaError.__subclasses__() before it is attempted.
                     if status >= HTTP_INTERNAL_SERVER_ERROR:
                         raise NovaHTTPError(status, text_snippet)
                     raise NovaAuthError(status, text_snippet)

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -462,9 +462,11 @@ def is_credential_rejection(err: NovaAuthError) -> bool:
         True when the refusal names the credentials (permanent, 401, 403, or
         no readable status), False for every other client rejection.
 
-    Example:
-        >>> is_credential_rejection(NovaAuthError(404, "gone"))
-        False
+    The doctest form is deliberately avoided here: `pyproject.toml` does not
+    pass `--doctest-modules`, so a `>>>` block would read like a verified
+    assurance while never running. The behaviour is pinned by
+    `tests/test_nova_request.py` instead, which asserts among other rows that a
+    `NovaAuthError(404, "gone")` yields False.
     """
     if getattr(err, "is_permanent", False):
         return True

--- a/custom_components/googlefindmy/NovaApi/nova_request.py
+++ b/custom_components/googlefindmy/NovaApi/nova_request.py
@@ -384,14 +384,20 @@ class NovaError(Exception):
 
 
 class NovaAuthError(NovaError):
-    """Raised on 4xx client errors after retries.
+    """Raised on every non-retryable 4xx client error after retries.
 
-    This is the base class for authentication errors. It may be transient
-    (e.g., temporary 401 after token refresh due to backend propagation delay)
-    or permanent (e.g., AAS token invalidated by Google).
+    The name is narrower than the type. This is the base class for
+    authentication errors, but the transport raises it for any 4xx that
+    ``HTTP_RETRY_ELIGIBLE`` does not cover, which is every one except 408 and
+    429. Do NOT read the type as a verdict on the credentials: ask
+    :func:`is_credential_rejection`, which is what every handler in this
+    integration does. It may be transient (e.g., temporary 401 after token
+    refresh due to backend propagation delay) or permanent (e.g., AAS token
+    invalidated by Google).
 
     Attributes:
-        status: HTTP status code (typically 401 or 403).
+        status: HTTP status code. Any non-retryable 4xx: 401 and 403 name the
+            credentials, 400, 404, 405, 409 and 422 name a rejected request.
         detail: Human-readable error detail.
         is_permanent: If True, re-authentication is required. If False,
             the error may resolve on its own in subsequent poll cycles.
@@ -1384,7 +1390,9 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
 
     Raises:
         ValueError: if the hex_payload is invalid or username is unavailable.
-        NovaAuthError: on 4xx client errors.
+        NovaAuthError: on non-retryable 4xx client errors; use
+            is_credential_rejection to tell a credential rejection from a
+            rejected request.
         NovaRateLimitError: on 429 errors after all retries.
         NovaHTTPError: on 5xx server errors after all retries.
         NovaError: on other unrecoverable errors like network issues after retries.
@@ -1794,6 +1802,17 @@ async def async_nova_request(  # noqa: PLR0913,PLR0912,PLR0915
                     # Non-retryable errors: distinguish between client (4xx) and server (5xx)
                     # - 4xx: Client errors (e.g., 403 Forbidden, 404 Not Found) → NovaAuthError
                     # - 5xx: Server errors (e.g., 501 Not Implemented, 505) → NovaHTTPError
+                    #
+                    # This raise is why the type name is wider than its content:
+                    # 400, 404, 405, 409 and 422 all leave here as "auth".
+                    # Consumers MUST call is_credential_rejection instead of
+                    # reading the type. Splitting a separate exception class off
+                    # here would let the typing carry the truth, but it is a
+                    # behaviour change of its own: a new class is uncaught at
+                    # every site that catches this one, and each of those eight
+                    # try blocks has a broad `except Exception` below it, so the
+                    # new class would be swallowed under a name that hides the
+                    # status. Needs an exhaustiveness test first.
                     if status >= HTTP_INTERNAL_SERVER_ERROR:
                         raise NovaHTTPError(status, text_snippet)
                     raise NovaAuthError(status, text_snippet)

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -1438,8 +1438,9 @@ class GoogleFindMyAPI:
                 #
                 # The 5xx branch below still returns {} and still reaches that
                 # reset. That is pre-existing, it is wrong on its own terms, and
-                # it is tracked as a separate finding -- not fixed here, and not
-                # made worse here either.
+                # it is tracked as a separate finding
+                # (`PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`) -- not fixed here,
+                # and not made worse here either.
                 #
                 # DEBUG, not WARNING: both callers already log a WARNING naming
                 # the device, so a WARNING here would print the same event twice

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -279,7 +279,9 @@ class GoogleFindMyAPIProtocol(Protocol):  # pylint: disable=unnecessary-ellipsis
     ) -> dict[str, Any]:
         """Request location for a specific device (async).
 
-        Returns location data dict or empty dict on failure.
+        Returns location data on success and an empty dict on a transient
+        failure. A credential rejection raises `ConfigEntryAuthFailed`; a
+        non-credential refusal (non-retryable 4xx) raises `NovaAuthError`.
         """
         ...
 
@@ -1281,7 +1283,10 @@ class GoogleFindMyAPI:
               or no readable status).
             - Any OTHER `NovaAuthError` is the server refusing the request, not
               the credentials -- a device removed from the account, a malformed
-              body -- and returns `{}` like a 5xx does.
+              body -- and is re-raised unchanged. It is deliberately NOT turned
+              into an empty result: a normal return is what both callers read as
+              "the credentials worked", and they clear the account auth state on
+              it. Only a transient/5xx failure returns `{}`.
             - Rate limit / other server issues are treated as transient and return `{}`.
 
         Args:
@@ -1289,8 +1294,19 @@ class GoogleFindMyAPI:
             device_name: The human-readable name of the device for logging.
 
         Returns:
-            A dictionary containing the best available location data for the device.
-            Returns an empty dictionary on failure.
+            A dictionary containing the best available location data for the
+            device, or an empty dictionary on a transient failure (5xx, rate
+            limit, timeout). A normal return therefore means the credentials
+            were accepted; callers rely on that.
+
+        Raises:
+            ConfigEntryAuthFailed: The credentials were rejected (401/403, or a
+                `NovaAuthError` for which `nova_request.is_credential_rejection`
+                holds). The coordinator starts re-authentication.
+            NovaAuthError: The server refused this request without rejecting the
+                credentials (a non-retryable 4xx such as 400/404/422). Callers
+                must classify it with `nova_request.is_credential_rejection`
+                rather than by its type.
         """
 
         # Register cache provider for multi-entry support

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -1358,6 +1358,25 @@ class GoogleFindMyAPI:
             raise exc from err
 
         except NovaAuthError as err:
+            # Branch on the STATUS, never on the type. Same criterion as the
+            # device-list handler and the two sound handlers; see
+            # nova_request.is_credential_rejection.
+            if not is_credential_rejection(err):
+                # The server refused the REQUEST, not the credentials: a device
+                # removed from the account, a malformed body. Take the exact exit
+                # the 5xx branch below takes -- return {} and keep polling the
+                # other devices -- instead of raising into the coordinator's
+                # transient-auth counter, where three cycles of a permanently
+                # missing device produced a re-auth prompt for an intact login.
+                _LOGGER.warning(
+                    "Client error (HTTP %s) while getting location for %s (%s): %s",
+                    getattr(err, "status", "unknown"),
+                    device_name,
+                    device_id,
+                    _short_err(err),
+                )
+                return {}
+
             # Transient auth failure - may self-heal in subsequent poll cycles.
             # Re-raise so coordinator can track consecutive failures before triggering reauth.
             if err.is_permanent:

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -18,8 +18,12 @@ Token/Auth handling (Step 5.1-D):
   transport raises `NovaAuthError` for every non-retryable 4xx (400, 404, 405,
   409, 422 included), so a type check reads "device not found" as "your sign-in
   expired". A non-credential rejection therefore leaves the device list as
-  `UpdateFailed` and the location request as an empty result, and neither starts
-  a re-auth flow. `_classify_nova_auth_error` is the sound-path adapter over the
+  `UpdateFailed`, and the location request passes the error on to its callers,
+  whose own branches skip the device without touching the re-auth machinery. It
+  is deliberately NOT collapsed to an empty result: both callers read a
+  non-raising return as proof that the credentials work and clear the auth state
+  before they check for emptiness, so a permanently rejected tracker would have
+  masked a real 401 on another tracker. `_classify_nova_auth_error` is the sound-path adapter over the
   same predicate. Still open, stated so it is not mistaken for coverage: the
   transport keeps raising a type named "auth" for all of them, so a future
   handler that reads the type instead of the predicate repeats the defect.
@@ -1374,19 +1378,38 @@ class GoogleFindMyAPI:
             # nova_request.is_credential_rejection.
             if not is_credential_rejection(err):
                 # The server refused the REQUEST, not the credentials: a device
-                # removed from the account, a malformed body. Take the exact exit
-                # the 5xx branch below takes -- return {} and keep polling the
-                # other devices -- instead of raising into the coordinator's
-                # transient-auth counter, where three cycles of a permanently
-                # missing device produced a re-auth prompt for an intact login.
-                _LOGGER.warning(
+                # removed from the account, a malformed body. Pass it through so
+                # each caller can take its own non-auth exit; both of them have a
+                # branch for exactly this status.
+                #
+                # Do NOT collapse this to `return {}`. That was the first attempt
+                # and it traded one defect for another: a non-raising return is
+                # what both callers read as positive proof that the sign-in
+                # works. coordinator/polling.py clears the auth state and resets
+                # the transient-auth counter, and coordinator/locate.py clears
+                # the auth state, each BEFORE looking at whether the result is
+                # empty. A permanently rejected tracker would then wipe a real
+                # 401 from another tracker in every cycle, and the re-auth prompt
+                # that this whole change exists to postpone would never appear at
+                # all. Raising keeps that reset out of reach.
+                #
+                # The 5xx branch below still returns {} and still reaches that
+                # reset. That is pre-existing, it is wrong on its own terms, and
+                # it is tracked as a separate finding -- not fixed here, and not
+                # made worse here either.
+                #
+                # DEBUG, not WARNING: both callers already log a WARNING naming
+                # the device, so a WARNING here would print the same event twice
+                # per device per poll cycle. This line exists for the sync
+                # wrapper, which has no handler behind it.
+                _LOGGER.debug(
                     "Client error (HTTP %s) while getting location for %s (%s): %s",
                     getattr(err, "status", "unknown"),
                     device_name,
                     device_id,
                     _short_err(err),
                 )
-                return {}
+                raise
 
             # Transient auth failure - may self-heal in subsequent poll cycles.
             # Re-raise so coordinator can track consecutive failures before triggering reauth.

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -11,7 +11,12 @@ backend and exposes a small, HA-oriented API surface:
 Token/Auth handling (Step 5.1-D):
 - **401/403 (auth failures)** raised by Nova helpers are mapped to
   `homeassistant.exceptions.ConfigEntryAuthFailed` so the *coordinator* can
-  trigger HA’s re-auth UX and Repairs issue workflow.
+  trigger HA’s re-auth UX and Repairs issue workflow. One documented
+  asymmetry: the per-device location path converts only a PERMANENT auth
+  failure (and an HTTP 401/403). A plain non-permanent 403 is re-raised as
+  `NovaAuthError` on purpose, because the polling coordinator counts
+  consecutive transient auth failures and escalates at its own threshold
+  rather than on the first occurrence.
   Every handler branches on the STATUS, via
   `NovaApi.nova_request.is_credential_rejection`: permanent first, then 401/403,
   an unreadable status keeps the conservative verdict. That matters because the
@@ -280,8 +285,14 @@ class GoogleFindMyAPIProtocol(Protocol):  # pylint: disable=unnecessary-ellipsis
         """Request location for a specific device (async).
 
         Returns location data on success and an empty dict on a transient
-        failure. A credential rejection raises `ConfigEntryAuthFailed`; a
-        non-credential refusal (non-retryable 4xx) raises `NovaAuthError`.
+        failure. `ConfigEntryAuthFailed` is raised only where re-auth must
+        start at once: an HTTP 401/403 (`NovaHTTPError`), or a PERMANENT Nova
+        auth failure. Every other `NovaAuthError` is re-raised unchanged --
+        including a plain, non-permanent credential rejection such as a 403,
+        which the polling coordinator counts against its own threshold instead
+        of prompting on the first occurrence. Callers must therefore classify
+        a `NovaAuthError` with `nova_request.is_credential_rejection` rather
+        than assume the type already means "credentials rejected".
         """
         ...
 
@@ -1276,17 +1287,28 @@ class GoogleFindMyAPI:
         relevant location record from the response.
 
         **Auth mapping (5.1-D):**
-            - A credential rejection raises `ConfigEntryAuthFailed` so the
-              coordinator can start re-auth. That means a `NovaHTTPError` with
-              status 401/403, or a `NovaAuthError` for which
-              `nova_request.is_credential_rejection` holds (permanent, 401, 403,
-              or no readable status).
+            - `ConfigEntryAuthFailed` is raised ONLY where re-auth must start
+              immediately, without a threshold in front of it: a `NovaHTTPError`
+              with status 401/403, or a PERMANENT Nova auth failure (the
+              `NovaAuthPermanentError` subclass, or a base `NovaAuthError`
+              flagged `is_permanent=True` after the refresh sequence).
+            - A plain, NON-permanent credential rejection -- in practice a 403,
+              since a 401 that survives the refresh arrives flagged permanent --
+              is re-raised as `NovaAuthError`, NOT converted. That is deliberate:
+              the polling coordinator counts consecutive transient auth failures
+              and escalates only at its own threshold, so converting here would
+              prompt the user on the first occurrence. This asymmetry is the one
+              difference to the device-list handler, which converts every
+              credential rejection because it has no such counter behind it.
             - Any OTHER `NovaAuthError` is the server refusing the request, not
               the credentials -- a device removed from the account, a malformed
               body -- and is re-raised unchanged. It is deliberately NOT turned
               into an empty result: a normal return is what both callers read as
               "the credentials worked", and they clear the account auth state on
               it. Only a transient/5xx failure returns `{}`.
+            - Because the previous two bullets BOTH arrive as `NovaAuthError`,
+              the type alone never tells a caller which one it holds. Every
+              caller must ask `nova_request.is_credential_rejection`.
             - Rate limit / other server issues are treated as transient and return `{}`.
 
         Args:
@@ -1300,13 +1322,18 @@ class GoogleFindMyAPI:
             were accepted; callers rely on that.
 
         Raises:
-            ConfigEntryAuthFailed: The credentials were rejected (401/403, or a
-                `NovaAuthError` for which `nova_request.is_credential_rejection`
-                holds). The coordinator starts re-authentication.
-            NovaAuthError: The server refused this request without rejecting the
-                credentials (a non-retryable 4xx such as 400/404/422). Callers
-                must classify it with `nova_request.is_credential_rejection`
-                rather than by its type.
+            ConfigEntryAuthFailed: Re-auth must start at once -- an HTTP 401/403
+                (`NovaHTTPError`), or a permanent Nova auth failure. The
+                coordinator starts re-authentication.
+            NovaAuthError: Everything else the transport raised under that name,
+                re-raised unchanged. Two distinct cases share this exit: a
+                NON-permanent credential rejection (403), which the polling
+                coordinator counts toward its own threshold, and a server-side
+                refusal of this request (a non-retryable 4xx such as 400/404/422)
+                that says nothing about the credentials. Callers MUST tell them
+                apart with `nova_request.is_credential_rejection`; the type does
+                not, and reading the type is the defect this contract exists to
+                prevent.
         """
 
         # Register cache provider for multi-entry support

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -76,6 +76,7 @@ from .NovaApi.nova_request import (
     NovaLogicError,
     NovaProtobufDecodeError,
     NovaRateLimitError,
+    is_credential_rejection,
 )
 from .NovaApi.util import generate_random_uuid
 from .ProtoDecoders.decoder import (
@@ -114,33 +115,18 @@ def _short_err(e: Exception | str) -> str:
 def _classify_nova_auth_error(err: NovaAuthError) -> SoundDispatchOutcome:
     """Name who refused when the transport raised ``NovaAuthError``.
 
-    The exception type is wider than its name. ``nova_request`` raises it for
-    EVERY non-retryable 4xx, not only for credential rejections -- the comment
-    above that raise names "403 Forbidden, 404 Not Found" itself, and
-    ``HTTP_RETRY_ELIGIBLE`` holds no 4xx besides 408 and 429, so 400, 404, 405,
-    409 and 422 all arrive here. A 401 that survived the refresh sequence is
-    raised separately with ``is_permanent=True``, which leaves 403 as the only
-    plain credential rejection reaching this handler.
+    The criterion lives in ``nova_request.is_credential_rejection``; this is
+    only its sound-path adapter. That predicate carries the full reasoning:
+    the type is wider than its name, permanence outranks the status, and an
+    unreadable status keeps the conservative verdict.
 
-    Reading the type alone therefore told a user with a deleted device to check
-    their sign-in. ``REJECTED_AUTH`` is for a refusal "on credentials: HTTP 401
-    or 403", so a missing device or a malformed request belongs in
-    ``REJECTED_SERVER``, which names the non-credential client rejections
-    alongside the 5xx. Both docstrings state the criterion as the STATUS, not
-    the exception type; keep the three in step when any of them moves.
-
-    Permanence outranks the status: ``NovaAuthPermanentError`` exists to say
-    "re-authentication is definitively required", so it stays ``REJECTED_AUTH``
-    even if it ever carries a status outside 401/403.
-
-    An error without a readable status keeps the old classification. That case
-    is a test double or a future subclass, not an observed server answer, and
-    the conservative reading of a type named "auth" is auth.
+    ``REJECTED_AUTH`` is for a refusal "on credentials: HTTP 401 or 403", so a
+    missing device or a malformed request belongs in ``REJECTED_SERVER``, which
+    names the non-credential client rejections alongside the 5xx. Do NOT
+    re-derive the status test here: a second copy is exactly how the two sound
+    handlers and the four other handlers drifted apart in the first place.
     """
-    if getattr(err, "is_permanent", False):
-        return SoundDispatchOutcome.REJECTED_AUTH
-    status = getattr(err, "status", None)
-    if status is None or status in (401, 403):
+    if is_credential_rejection(err):
         return SoundDispatchOutcome.REJECTED_AUTH
     return SoundDispatchOutcome.REJECTED_SERVER
 
@@ -1124,6 +1110,21 @@ class GoogleFindMyAPI:
             raise UpdateFailed(_short_err(err)) from err
 
         except NovaAuthError as err:
+            # Branch on the STATUS, never on the type. The transport raises this
+            # class for every non-retryable 4xx, so a deleted device or a
+            # malformed request arrived here as "your sign-in expired" and
+            # produced an immediate re-auth prompt with no threshold in front of
+            # it. A non-credential rejection is a server-side refusal and takes
+            # the same exit as a 5xx one branch up: UpdateFailed,
+            # ApiStatus.ERROR, no reauth reason, no Repairs issue.
+            if not is_credential_rejection(err):
+                _LOGGER.warning(
+                    "Device list rejected by the server (HTTP %s): %s",
+                    getattr(err, "status", "unknown"),
+                    _short_err(err),
+                )
+                raise UpdateFailed(_short_err(err)) from err
+
             # Mirror the location path's base handler: a permanent credential
             # failure (NovaAuthPermanentError subclass, or a base NovaAuthError
             # flagged is_permanent=True after token refresh) must record the

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -12,12 +12,17 @@ Token/Auth handling (Step 5.1-D):
 - **401/403 (auth failures)** raised by Nova helpers are mapped to
   `homeassistant.exceptions.ConfigEntryAuthFailed` so the *coordinator* can
   trigger HA’s re-auth UX and Repairs issue workflow.
-  Known gap, stated so it is not mistaken for the current behaviour: the device
-  list and location handlers still key off the `NovaAuthError` TYPE, which the
-  transport also raises for non-credential 4xx (400, 404, 405, 409, 422), so a
-  deleted device can currently reach the re-auth flow. The sound handlers were
-  narrowed to the status; see `_classify_nova_auth_error`. Extending that to the
-  other two is a behaviour change of its own and is tracked separately.
+  Every handler branches on the STATUS, via
+  `NovaApi.nova_request.is_credential_rejection`: permanent first, then 401/403,
+  an unreadable status keeps the conservative verdict. That matters because the
+  transport raises `NovaAuthError` for every non-retryable 4xx (400, 404, 405,
+  409, 422 included), so a type check reads "device not found" as "your sign-in
+  expired". A non-credential rejection therefore leaves the device list as
+  `UpdateFailed` and the location request as an empty result, and neither starts
+  a re-auth flow. `_classify_nova_auth_error` is the sound-path adapter over the
+  same predicate. Still open, stated so it is not mistaken for coverage: the
+  transport keeps raising a type named "auth" for all of them, so a future
+  handler that reads the type instead of the predicate repeats the defect.
 - **gpsoauth/ADM failures** (e.g., "BadAuthentication", "Missing 'Token' in gpsoauth")
   are normalized to `ConfigEntryAuthFailed` as well, even if they bubble up as a
   `RuntimeError`/`ValueError` rather than a `NovaAuthError`.
@@ -1265,8 +1270,14 @@ class GoogleFindMyAPI:
         relevant location record from the response.
 
         **Auth mapping (5.1-D):**
-            - If `NovaAuthError` or `NovaHTTPError` with status 401/403 occurs,
-              raise `ConfigEntryAuthFailed` so the coordinator can start re-auth.
+            - A credential rejection raises `ConfigEntryAuthFailed` so the
+              coordinator can start re-auth. That means a `NovaHTTPError` with
+              status 401/403, or a `NovaAuthError` for which
+              `nova_request.is_credential_rejection` holds (permanent, 401, 403,
+              or no readable status).
+            - Any OTHER `NovaAuthError` is the server refusing the request, not
+              the credentials -- a device removed from the account, a malformed
+              body -- and returns `{}` like a 5xx does.
             - Rate limit / other server issues are treated as transient and return `{}`.
 
         Args:

--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -71,8 +71,9 @@ class SoundDispatchOutcome(StrEnum):
     network outage and hide it behind a self-clearing timer.
 
     The criterion is the STATUS, not the exception type. ``NovaAuthError`` is
-    raised for every non-retryable 4xx (its own docstring says "4xx client
-    errors", and ``HTTP_RETRY_ELIGIBLE`` holds no 4xx besides 408 and 429), so
+    raised for every non-retryable 4xx (its own docstring says "every
+    non-retryable 4xx client error", and ``HTTP_RETRY_ELIGIBLE`` holds no 4xx
+    besides 408 and 429), so
     reading the type alone filed a deleted device under "check your sign-in".
     ``NovaAuthPermanentError`` and any error flagged ``is_permanent`` belong
     here whatever their status: they say re-authentication is required.

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -41,6 +41,7 @@ from ..NovaApi.nova_request import (
     NovaLogicError,
     NovaProtobufDecodeError,
     NovaRateLimitError,
+    is_credential_rejection,
 )
 from ..SpotApi.spot_request import SpotAuthPermanentError
 from ._mixin_typing import _MixinBase
@@ -558,6 +559,20 @@ class LocateOperations(_MixinBase):
                     pass
                 return {}
             except NovaAuthError as auth_err:
+                # Branch on the STATUS, never on the type. A device removed from
+                # the account arrived here as an auth error and flipped the
+                # integration-wide auth state: Repairs issue, EVENT_AUTH_ERROR,
+                # diagnostic sensor on. The sign-in was fine the whole time.
+                if not is_credential_rejection(auth_err):
+                    _LOGGER.warning(
+                        "Manual locate for %s failed (client error): HTTP %s - %s",
+                        name,
+                        getattr(auth_err, "status", "?"),
+                        auth_err,
+                    )
+                    self.note_error(auth_err, where="async_locate_device", device=name)
+                    return {}
+
                 # Expected: Authentication/permission issue from Nova API
                 _LOGGER.warning(
                     "Manual locate for %s failed (authentication): HTTP %s - %s",

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -563,6 +563,12 @@ class LocateOperations(_MixinBase):
                 # the account arrived here as an auth error and flipped the
                 # integration-wide auth state: Repairs issue, EVENT_AUTH_ERROR,
                 # diagnostic sensor on. The sign-in was fine the whole time.
+                # Narrow claim, about this branch only: api returns {} for such a
+                # status, so a manual locate on a deleted tracker now takes the
+                # success path above, which calls _set_auth_state(failed=False)
+                # before the empty guard and therefore CLEARS a pending auth
+                # error. Pre-existing for every 5xx, newly reachable for a client
+                # rejection, tracked separately.
                 if not is_credential_rejection(auth_err):
                     _LOGGER.warning(
                         "Manual locate for %s failed (client error): HTTP %s - %s",

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -563,12 +563,13 @@ class LocateOperations(_MixinBase):
                 # the account arrived here as an auth error and flipped the
                 # integration-wide auth state: Repairs issue, EVENT_AUTH_ERROR,
                 # diagnostic sensor on. The sign-in was fine the whole time.
-                # Narrow claim, about this branch only: api returns {} for such a
-                # status, so a manual locate on a deleted tracker now takes the
-                # success path above, which calls _set_auth_state(failed=False)
-                # before the empty guard and therefore CLEARS a pending auth
-                # error. Pre-existing for every 5xx, newly reachable for a client
-                # rejection, tracked separately.
+                # api passes such a status through instead of returning {}, so a
+                # manual locate on a deleted tracker reaches this branch and not
+                # the success path above -- which calls _set_auth_state(failed=
+                # False) before the empty guard and would therefore CLEAR a
+                # pending auth error. That clearing still happens for every 5xx
+                # and every empty result; it is pre-existing and tracked as a
+                # finding of its own.
                 if not is_credential_rejection(auth_err):
                     _LOGGER.warning(
                         "Manual locate for %s failed (client error): HTTP %s - %s",

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1697,9 +1697,17 @@ class PollingOperations(_MixinBase):
                 # (a cycle of pure timeouts must not flicker a stale key to OK).
                 cycle_had_successful_decrypt = False
                 # Devices this cycle whose location request the server refused
-                # with a non-credential 4xx. A single rejection is a per-device
-                # skip because a sibling's success refutes it as account-wide;
-                # with no sibling left to refute it, the cycle really did fail.
+                # with a non-credential 4xx. A single rejection stays a
+                # per-device skip; only a cycle in which EVERY device was
+                # refused is account-wide on the rejections' own terms.
+                # Deliberately NOT the same shape as the decrypt verdict above:
+                # that one gates on `cycle_had_successful_decrypt`, a positive
+                # proof. The request path has no such proof to gate on, because
+                # `api.async_get_device_location` returns the same empty dict
+                # for a healthy idle BLE tag and for a 5xx, a 429, a protobuf
+                # decode failure or a Nova logic error. So a non-rejected
+                # sibling is NOT evidence that anything worked, and this counter
+                # must not be read as if it were.
                 cycle_rejected_devices = 0
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
@@ -2283,12 +2291,26 @@ class PollingOperations(_MixinBase):
                         await asyncio.sleep(self.device_poll_delay)
 
                 _LOGGER.debug("Completed polling cycle for %d devices", len(devices))
-                # No device survived its request: there is no sibling success
-                # left to refute the rejections as account-wide, so the cycle
-                # must surface. Do NOT lean on the device list to catch this one
-                # layer up -- it is a different RPC (`nbe_list_devices`), and
+                # Every device was refused: on the rejections' own terms
+                # that is account-wide, so the cycle must surface. Do NOT lean
+                # on the device list to catch this one layer up -- it is a
+                # different RPC (`nbe_list_devices`), and
                 # DEVICE_LIST_POLL_INTERVAL means most cycles reuse the cached
                 # list without calling it at all.
+                #
+                # What this guard does NOT claim, stated so the next reader does
+                # not infer it: that a cycle which fails the check had a
+                # sibling success. A mixed cycle -- one tracker refused, the
+                # others back empty from a 5xx -- stays silent here, and so does
+                # that same 5xx outage with no rejection in it at all
+                # (`test_a_cycle_of_only_empty_results_reports_success` pins
+                # that reference case). Hanging the error signal on whether some
+                # unrelated tracker happens to be deleted would be a
+                # coincidence, not a contract; the empty result is what has to
+                # become distinguishable, and that is tracked separately
+                # (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`).
+                # `test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`
+                # pins the current state so it cannot drift unnoticed.
                 if (
                     cycle_rejected_devices
                     and cycle_rejected_devices == len(devices)

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2098,9 +2098,23 @@ class PollingOperations(_MixinBase):
                                 device=dev_name,
                             )
                             cycle_failed = True
-                            # Deliberately NOT touched: the transient-auth counter
-                            # is neither raised nor reset. A client rejection says
-                            # nothing about the credentials in either direction.
+                            # Deliberately NOT touched HERE: the transient-auth
+                            # counter is neither raised nor reset. A client
+                            # rejection says nothing about the credentials in
+                            # either direction.
+                            # Read that narrowly. api.async_get_device_location
+                            # returns {} for such a status, so in production the
+                            # device takes the success path above instead, which
+                            # DOES reset the counter and clear the auth state
+                            # before it ever looks at whether the result is
+                            # empty. That reset predates this branch (every 5xx
+                            # and 429 already reaches it), but a client rejection
+                            # newly reaches it too, and it can mask a genuine 401
+                            # on another tracker in the same cycle. Deciding what
+                            # an empty result may prove about credentials is a
+                            # behaviour change of its own and is tracked
+                            # separately -- do not read this branch as if it were
+                            # already done.
                             if last_exception is None:
                                 last_exception = transient_err
                             continue

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2351,7 +2351,13 @@ class PollingOperations(_MixinBase):
                 # []` sits after the log while its exceptions come from
                 # either side, and the unexpected-device branch after the
                 # log returns empty on a WARNING. A follow-up needs a flag
-                # set at the log line. See
+                # set at the log line, and has to carry that outcome ACROSS
+                # the boundary (a typed result, for example) rather than
+                # reconstruct it here, where the empty collection has
+                # already flattened it. The layer that flattens it is
+                # `location_request.py`, not `api.py`: aiming a fix at the
+                # file where the empty dict is built would sit behind the
+                # point where the evidence is gone. See
                 # `PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`.
                 # `test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`
                 # pins the current state so it cannot drift unnoticed.

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2321,24 +2321,38 @@ class PollingOperations(_MixinBase):
                 # cannot be kept without keeping the defect. Gating this
                 # guard on positive success instead fails at this layer for
                 # a mechanical reason, not a forecast about accounts: the
-                # only positive proof the loop holds is
-                # `_any_device_got_data`, and it records that a device
-                # COMMITTED data, not that its request reached the server.
-                # Gating on it turns
+                # only positive marker on the REQUEST path is
+                # `_any_device_got_data` (`cycle_had_successful_decrypt`
+                # above is a positive proof too, but about the shared key,
+                # and both are False for either empty result), and it
+                # records that a device COMMITTED data, not that its
+                # request reached the server. Gating on it turns
                 # `test_a_rejected_device_does_not_make_every_tracker_unavailable`
                 # red, because that test's sibling returns exactly `{}` --
                 # the stricter guard would withdraw the very fix that test
                 # was written for. One rejection plus one empty sibling
                 # would have to stay silent there and surface here, from
                 # the same observable state. That is an ambiguity, not a
-                # judgement call, and only the layer that produced the
-                # empty result can resolve it: `location_request.py` logs
+                # judgement call.
+                #
+                # The concrete price of tightening anyway, stated so it is
+                # not lost: an account with one deleted tracker and
+                # otherwise idle BLE tags would go unavailable on EVERY
+                # cycle. Not "every healthy BLE-only account" (this guard
+                # is conjunctive with a rejection, so an account without
+                # one is untouched), but exactly that one shape.
+                #
+                # Only the layer that produced the empty result can resolve
+                # this. Where, is measured: `location_request.py` logs
                 # `Location request accepted` once the RPC is through, and
-                # every `return []` before that point is a failure while
-                # every empty result after it is legitimate. It catches the
-                # 5xx itself, so `api.py`'s `NovaHTTPError` handler never
-                # sees that case and an intervention confined to `api.py`
-                # would be inert.
+                # the `return []` paths reachable only before that log are
+                # failures. The split is not positional -- the outer
+                # surfacing handler wraps the whole body, so its `return
+                # []` sits after the log while its exceptions come from
+                # either side, and the unexpected-device branch after the
+                # log returns empty on a WARNING. A follow-up needs a flag
+                # set at the log line. See
+                # `PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`.
                 # `test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`
                 # pins the current state so it cannot drift unnoticed.
                 if (

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -60,7 +60,11 @@ from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     StaleOwnerKeyError,
     is_real_location_record,
 )
-from ..NovaApi.nova_request import NovaAuthError, NovaAuthPermanentError
+from ..NovaApi.nova_request import (
+    NovaAuthError,
+    NovaAuthPermanentError,
+    is_credential_rejection,
+)
 from ..SpotApi.GetEidInfoForE2eeDevices.get_eid_info_request import (
     SpotApiEmptyResponseError,
 )
@@ -2070,6 +2074,37 @@ class PollingOperations(_MixinBase):
                         self._request_poll_reauth(reauth_exc)
                         return
                     except NovaAuthError as transient_err:
+                        # Branch on the STATUS, never on the type. The transport
+                        # raises this class for every non-retryable 4xx, so a
+                        # device removed from the account fed the transient-auth
+                        # counter and produced a re-auth prompt after exactly
+                        # three cycles, with the sign-in intact the whole time.
+                        # api.async_get_device_location already returns {} for
+                        # such a status, so this branch is the local statement of
+                        # the rule rather than the only place it holds. Do not
+                        # remove it as dead code: it is the reason the next
+                        # feeder cannot bring the cascade back.
+                        if not is_credential_rejection(transient_err):
+                            _LOGGER.warning(
+                                "Client error (HTTP %s) for %s: %s. "
+                                "Skipping this device; the sign-in is not in question.",
+                                getattr(transient_err, "status", "unknown"),
+                                dev_name,
+                                transient_err,
+                            )
+                            self.note_error(
+                                transient_err,
+                                where="poll_client_error",
+                                device=dev_name,
+                            )
+                            cycle_failed = True
+                            # Deliberately NOT touched: the transient-auth counter
+                            # is neither raised nor reset. A client rejection says
+                            # nothing about the credentials in either direction.
+                            if last_exception is None:
+                                last_exception = transient_err
+                            continue
+
                         # Transient auth failure - may self-heal in subsequent poll cycles.
                         # Only trigger reauth after multiple consecutive failures.
                         self._consecutive_transient_auth_failures += 1

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1696,6 +1696,11 @@ class PollingOperations(_MixinBase):
                 # requires this proof, not merely the absence of a decrypt error
                 # (a cycle of pure timeouts must not flicker a stale key to OK).
                 cycle_had_successful_decrypt = False
+                # Devices this cycle whose location request the server refused
+                # with a non-credential 4xx. A single rejection is a per-device
+                # skip because a sibling's success refutes it as account-wide;
+                # with no sibling left to refute it, the cycle really did fail.
+                cycle_rejected_devices = 0
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
                     dev_name = dev.get("name", dev_id)
@@ -2116,10 +2121,13 @@ class PollingOperations(_MixinBase):
                             # availability outage is not a fix. So: keep
                             # ``cycle_failed`` (the cycle really did not poll
                             # every device) and leave ``last_exception`` to the
-                            # failures that are about the account. Same shape as
-                            # the OwnerKeyLookupTransientError branch below --
-                            # an ordinary per-device skip.
+                            # failures that are about the account. This is the
+                            # only branch here that sets one without the other,
+                            # deliberately: every other one reports a condition
+                            # that says something about the account, this one
+                            # does not.
                             cycle_failed = True
+                            cycle_rejected_devices += 1
                             # Deliberately NOT touched HERE: the transient-auth
                             # counter is neither raised nor reset. A client
                             # rejection says nothing about the credentials in
@@ -2133,15 +2141,12 @@ class PollingOperations(_MixinBase):
                             # wrong on its own terms, and it is tracked as a
                             # finding of its own -- a client rejection is kept out
                             # of it by raising in api.py, nothing more.
-                            # Residual gap, named so it is not mistaken for
-                            # covered: if EVERY device is rejected the cycle now
-                            # reports no error at all. That window is narrow --
-                            # an account-wide rejection already fails
-                            # ``async_get_basic_device_list`` with
-                            # ``UpdateFailed`` one layer up -- and it is not
-                            # silent: ``last_poll_result`` reads "failed",
-                            # ``note_error`` records it and every rejected device
-                            # gets its own WARNING.
+                            # The all-rejected case is caught after the loop,
+                            # not here: whether a rejection is per-device or
+                            # account-wide is only knowable once every device
+                            # has been tried. Same reasoning as
+                            # _finalize_cycle_decrypt_state, which defers the
+                            # decrypt verdict for exactly that reason.
                             continue
 
                         # Transient auth failure - may self-heal in subsequent poll cycles.
@@ -2278,6 +2283,21 @@ class PollingOperations(_MixinBase):
                         await asyncio.sleep(self.device_poll_delay)
 
                 _LOGGER.debug("Completed polling cycle for %d devices", len(devices))
+                # No device survived its request: there is no sibling success
+                # left to refute the rejections as account-wide, so the cycle
+                # must surface. Do NOT lean on the device list to catch this one
+                # layer up -- it is a different RPC (`nbe_list_devices`), and
+                # DEVICE_LIST_POLL_INTERVAL means most cycles reuse the cached
+                # list without calling it at all.
+                if (
+                    cycle_rejected_devices
+                    and cycle_rejected_devices == len(devices)
+                    and last_exception is None
+                ):
+                    last_exception = UpdateFailed(
+                        f"Every device ({cycle_rejected_devices}) was rejected by "
+                        "the server this cycle"
+                    )
                 # Resolve the cycle's decrypt verdict AND reconcile the cycle's
                 # failure state with it in one place (positive proof dominates: a
                 # sibling success refutes a single device's failure as account-wide).

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2303,13 +2303,26 @@ class PollingOperations(_MixinBase):
                 # sibling success. A mixed cycle -- one tracker refused, the
                 # others back empty from a 5xx -- stays silent here, and so does
                 # that same 5xx outage with no rejection in it at all
-                # (`test_a_cycle_of_only_empty_results_reports_success` pins
+                # (`test_known_gap_a_cycle_of_only_empty_results_reports_success` pins
                 # that reference case). Hanging the error signal on whether some
                 # unrelated tracker happens to be deleted would be a
                 # coincidence, not a contract; the empty result is what has to
                 # become distinguishable, and that is tracked separately
-                # (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`).
-                # `test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`
+                # (`PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`).
+                #
+                # Named because it is a real regression and not a neutral
+                # gap: BEFORE this change the mixed cycle did surface. The
+                # 4xx took the transient-auth branch, which set
+                # `last_exception` -- and fed the counter that produced the
+                # false sign-in prompt this whole change exists to remove.
+                # That signal was a side effect of the misclassification,
+                # not a contract: a tracker deleted from the account says
+                # nothing about whether its siblings reached the server. It
+                # cannot be kept without keeping the defect, and buying it
+                # back by making the rejection branch stricter would trade
+                # it for a worse one -- every healthy BLE-only account
+                # would go unavailable on every cycle.
+                # `test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`
                 # pins the current state so it cannot drift unnoticed.
                 if (
                     cycle_rejected_devices

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2079,11 +2079,12 @@ class PollingOperations(_MixinBase):
                         # device removed from the account fed the transient-auth
                         # counter and produced a re-auth prompt after exactly
                         # three cycles, with the sign-in intact the whole time.
-                        # api.async_get_device_location already returns {} for
-                        # such a status, so this branch is the local statement of
-                        # the rule rather than the only place it holds. Do not
-                        # remove it as dead code: it is the reason the next
-                        # feeder cannot bring the cascade back.
+                        # api.async_get_device_location passes such a status
+                        # through rather than collapsing it to {}, precisely so
+                        # this branch is the one that runs. A non-raising return
+                        # would take the success path above, which clears the
+                        # auth state and resets the counter before it looks at
+                        # whether the result is empty.
                         if not is_credential_rejection(transient_err):
                             _LOGGER.warning(
                                 "Client error (HTTP %s) for %s: %s. "
@@ -2102,19 +2103,15 @@ class PollingOperations(_MixinBase):
                             # counter is neither raised nor reset. A client
                             # rejection says nothing about the credentials in
                             # either direction.
-                            # Read that narrowly. api.async_get_device_location
-                            # returns {} for such a status, so in production the
-                            # device takes the success path above instead, which
-                            # DOES reset the counter and clear the auth state
-                            # before it ever looks at whether the result is
-                            # empty. That reset predates this branch (every 5xx
-                            # and 429 already reaches it), but a client rejection
-                            # newly reaches it too, and it can mask a genuine 401
-                            # on another tracker in the same cycle. Deciding what
-                            # an empty result may prove about credentials is a
-                            # behaviour change of its own and is tracked
-                            # separately -- do not read this branch as if it were
-                            # already done.
+                            # The neighbouring success path still treats ANY
+                            # non-raising return as proof that the credentials
+                            # work: it resets this counter and clears the auth
+                            # state before it looks at whether the result is
+                            # empty. Every 5xx, every 429 and every idle BLE tag
+                            # still reaches that reset. It is pre-existing, it is
+                            # wrong on its own terms, and it is tracked as a
+                            # finding of its own -- a client rejection is kept out
+                            # of it by raising in api.py, nothing more.
                             if last_exception is None:
                                 last_exception = transient_err
                             continue

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2098,6 +2098,27 @@ class PollingOperations(_MixinBase):
                                 where="poll_client_error",
                                 device=dev_name,
                             )
+                            # Recorded, but deliberately NOT account-wide.
+                            # ``cycle_failed`` and ``last_exception`` drive two
+                            # different things in the ``finally`` block:
+                            # ``cycle_failed`` only writes the
+                            # ``last_poll_result`` diagnostic attribute, while
+                            # ``last_exception`` drives
+                            # ``async_set_update_error`` -- and
+                            # ``GoogleFindMyEntity.available`` follows the
+                            # coordinator's ``last_update_success``. Setting it
+                            # here made ONE rejected tracker mark EVERY tracker
+                            # entity unavailable, and unlike a 5xx a device
+                            # deleted from the account never recovers, so the
+                            # outage repeated on every poll for as long as the
+                            # tracker stayed in the cached list. Trading a
+                            # spurious re-auth prompt for a permanent
+                            # availability outage is not a fix. So: keep
+                            # ``cycle_failed`` (the cycle really did not poll
+                            # every device) and leave ``last_exception`` to the
+                            # failures that are about the account. Same shape as
+                            # the OwnerKeyLookupTransientError branch below --
+                            # an ordinary per-device skip.
                             cycle_failed = True
                             # Deliberately NOT touched HERE: the transient-auth
                             # counter is neither raised nor reset. A client
@@ -2112,8 +2133,15 @@ class PollingOperations(_MixinBase):
                             # wrong on its own terms, and it is tracked as a
                             # finding of its own -- a client rejection is kept out
                             # of it by raising in api.py, nothing more.
-                            if last_exception is None:
-                                last_exception = transient_err
+                            # Residual gap, named so it is not mistaken for
+                            # covered: if EVERY device is rejected the cycle now
+                            # reports no error at all. That window is narrow --
+                            # an account-wide rejection already fails
+                            # ``async_get_basic_device_list`` with
+                            # ``UpdateFailed`` one layer up -- and it is not
+                            # silent: ``last_poll_result`` reads "failed",
+                            # ``note_error`` records it and every rejected device
+                            # gets its own WARNING.
                             continue
 
                         # Transient auth failure - may self-heal in subsequent poll cycles.

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2318,10 +2318,27 @@ class PollingOperations(_MixinBase):
                 # That signal was a side effect of the misclassification,
                 # not a contract: a tracker deleted from the account says
                 # nothing about whether its siblings reached the server. It
-                # cannot be kept without keeping the defect, and buying it
-                # back by making the rejection branch stricter would trade
-                # it for a worse one -- every healthy BLE-only account
-                # would go unavailable on every cycle.
+                # cannot be kept without keeping the defect. Gating this
+                # guard on positive success instead fails at this layer for
+                # a mechanical reason, not a forecast about accounts: the
+                # only positive proof the loop holds is
+                # `_any_device_got_data`, and it records that a device
+                # COMMITTED data, not that its request reached the server.
+                # Gating on it turns
+                # `test_a_rejected_device_does_not_make_every_tracker_unavailable`
+                # red, because that test's sibling returns exactly `{}` --
+                # the stricter guard would withdraw the very fix that test
+                # was written for. One rejection plus one empty sibling
+                # would have to stay silent there and surface here, from
+                # the same observable state. That is an ambiguity, not a
+                # judgement call, and only the layer that produced the
+                # empty result can resolve it: `location_request.py` logs
+                # `Location request accepted` once the RPC is through, and
+                # every `return []` before that point is a failure while
+                # every empty result after it is legitimate. It catches the
+                # 5xx itself, so `api.py`'s `NovaHTTPError` handler never
+                # sees that case and an intervention confined to `api.py`
+                # would be inert.
                 # `test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`
                 # pins the current state so it cannot drift unnoticed.
                 if (

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -1243,6 +1243,62 @@ class TestAsyncDeviceLocationErrorMapping:
         api = _make_api_with_session()
         assert run_coro(api.async_get_device_location("d", "name")) == {}
 
+    def test_a_non_credential_4xx_location_returns_empty_instead_of_raising(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A device removed from the account is not a rejected sign-in.
+
+        Raising here fed the coordinator's transient-auth counter, and three
+        cycles of a permanently missing device produced a re-auth prompt while
+        the sign-in was intact the whole time. This takes the exact exit the
+        5xx branch below already takes.
+        """
+
+        self._patch_request(monkeypatch, NovaAuthError(404, "gone"))
+        api = _make_api_with_session()
+        assert run_coro(api.async_get_device_location("d", "name")) == {}
+
+    def test_a_non_credential_4xx_location_does_not_log_an_authentication_error(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        self._patch_request(monkeypatch, NovaAuthError(404, "gone"))
+        api = _make_api_with_session()
+        with caplog.at_level(logging.DEBUG):
+            assert run_coro(api.async_get_device_location("d", "name")) == {}
+        assert "Client error (HTTP 404)" in caplog.text
+        assert "Transient authentication error" not in caplog.text
+        levels = {
+            r.levelno for r in caplog.records if "Client error (HTTP 404)" in r.message
+        }
+        assert levels == {logging.WARNING}
+
+    def test_a_credential_rejection_location_is_still_reraised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The counterpart: 403 must still reach the coordinator's counter.
+
+        Without this row the previous two are satisfied by a branch that always
+        returns {}, which would silence a real expired sign-in.
+        """
+
+        self._patch_request(monkeypatch, NovaAuthError(403, "denied"))
+        api = _make_api_with_session()
+        with pytest.raises(NovaAuthError):
+            run_coro(api.async_get_device_location("d", "name"))
+
+    def test_a_permanent_non_credential_status_still_maps_to_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Permanence outranks the status, at the place it is easiest to lose."""
+        self._patch_request(monkeypatch, NovaAuthError(404, "perm", is_permanent=True))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+            run_coro(api.async_get_device_location("d", "name"))
+        assert (
+            getattr(excinfo.value, "reauth_code", None)
+            is ReauthReasonCode.NOVA_AUTH_PERMANENT
+        )
+
 
 class TestAsyncPlaySoundErrorMapping:
     """Each documented exception class for the play-sound branch."""

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -1243,48 +1243,73 @@ class TestAsyncDeviceLocationErrorMapping:
         api = _make_api_with_session()
         assert run_coro(api.async_get_device_location("d", "name")) == {}
 
-    def test_a_non_credential_4xx_location_returns_empty_instead_of_raising(
+    def test_a_non_credential_4xx_location_is_passed_through(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A device removed from the account is not a rejected sign-in.
+        """A device removed from the account is not a rejected sign-in, and it is
+        not an empty result either.
 
-        Raising here fed the coordinator's transient-auth counter, and three
-        cycles of a permanently missing device produced a re-auth prompt while
-        the sign-in was intact the whole time. This takes the exact exit the
-        5xx branch below already takes.
+        Collapsing it to ``{}`` was the first attempt and it traded one defect for
+        another. Both production callers read a NON-RAISING return as positive
+        proof that the sign-in works: ``coordinator/polling.py`` clears the auth
+        state and resets the transient-auth counter, and ``coordinator/locate.py``
+        clears the auth state, each BEFORE it looks at whether the result is
+        empty. A permanently rejected tracker would therefore have wiped a real
+        401 on another tracker in every cycle.
+
+        Passing the error through keeps that reset out of reach and lets each
+        handler state the rule at its own site, which is what those two branches
+        were written for. The counterpart lives in
+        ``test_an_empty_return_still_clears_the_counter``: the pre-existing reset
+        on an empty result is deliberately NOT changed here.
         """
 
         self._patch_request(monkeypatch, NovaAuthError(404, "gone"))
         api = _make_api_with_session()
-        assert run_coro(api.async_get_device_location("d", "name")) == {}
+        with pytest.raises(NovaAuthError) as excinfo:
+            run_coro(api.async_get_device_location("d", "name"))
+        assert excinfo.value.status == 404
 
     def test_a_non_credential_4xx_location_does_not_log_an_authentication_error(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
+        """The wording stays, the level drops.
+
+        Each caller writes its own WARNING for this device, so a WARNING here too
+        would print the same event twice per device per poll cycle. DEBUG keeps
+        the trail for the sync wrapper, which has no handler behind it.
+        """
         self._patch_request(monkeypatch, NovaAuthError(404, "gone"))
         api = _make_api_with_session()
         with caplog.at_level(logging.DEBUG):
-            assert run_coro(api.async_get_device_location("d", "name")) == {}
+            with pytest.raises(NovaAuthError):
+                run_coro(api.async_get_device_location("d", "name"))
         assert "Client error (HTTP 404)" in caplog.text
         assert "Transient authentication error" not in caplog.text
         levels = {
             r.levelno for r in caplog.records if "Client error (HTTP 404)" in r.message
         }
-        assert levels == {logging.WARNING}
+        assert levels == {logging.DEBUG}
 
-    def test_a_credential_rejection_location_is_still_reraised(
-        self, monkeypatch: pytest.MonkeyPatch
+    def test_a_credential_rejection_location_takes_the_auth_exit(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
         """The counterpart: 403 must still reach the coordinator's counter.
 
-        Without this row the previous two are satisfied by a branch that always
-        returns {}, which would silence a real expired sign-in.
+        Both exits now raise ``NovaAuthError``, so ``pytest.raises`` alone no
+        longer tells them apart -- it would pass even if every status took the
+        client-rejection branch and a real expired sign-in went unescalated. The
+        log record is what separates them: the auth exit announces a transient
+        authentication error at WARNING, the client exit does not.
         """
 
         self._patch_request(monkeypatch, NovaAuthError(403, "denied"))
         api = _make_api_with_session()
-        with pytest.raises(NovaAuthError):
-            run_coro(api.async_get_device_location("d", "name"))
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(NovaAuthError):
+                run_coro(api.async_get_device_location("d", "name"))
+        assert "Transient authentication error" in caplog.text
+        assert "Client error (HTTP 403)" not in caplog.text
 
     def test_a_permanent_non_credential_status_still_maps_to_auth_failed(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -1098,6 +1098,36 @@ class TestAsyncBasicDeviceListErrorMapping:
             is ReauthReasonCode.NOVA_AUTH_FAILED
         )
 
+    def test_a_rejected_probe_reaches_the_config_flow_as_a_non_auth_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The user-visible end of the device-list narrowing, driven end to end.
+
+        The config flow probes the account with this very call and maps whatever
+        it raises through `_map_api_exc_to_error_key`. Asserting the mapper alone
+        does not pin this change: the mapper is untouched, and both of its rows
+        were already true before. Only by taking the exception FROM the narrowed
+        handler does the assertion break when the handler is reverted, which is
+        the whole point of pinning a moved user-facing message.
+        """
+        from custom_components.googlefindmy import config_flow as cf
+
+        self._patch_request(monkeypatch, NovaAuthError(404, "gone"))
+        api = _make_api_with_session()
+        with pytest.raises(Exception) as excinfo:  # noqa: PT011 - class is the assertion
+            run_coro(api.async_get_basic_device_list())
+        # 404 is a refusal of the request, not of the credentials: the probe now
+        # ends at "unknown" instead of sending an intact sign-in to the re-auth
+        # form. Revert api.py's client-error branch and this becomes
+        # "invalid_auth" again.
+        assert cf._map_api_exc_to_error_key(excinfo.value) == "unknown"
+
+        self._patch_request(monkeypatch, NovaAuthError(403, "denied"))
+        api = _make_api_with_session()
+        with pytest.raises(Exception) as excinfo:  # noqa: PT011 - class is the assertion
+            run_coro(api.async_get_basic_device_list())
+        assert cf._map_api_exc_to_error_key(excinfo.value) == "invalid_auth"
+
     def test_the_sound_classifier_follows_the_shared_predicate(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -1043,6 +1043,77 @@ class TestAsyncBasicDeviceListErrorMapping:
         with pytest.raises(UpdateFailed):
             run_coro(api.async_get_basic_device_list())
 
+    def test_a_non_credential_4xx_on_the_device_list_is_not_a_reauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A rejected REQUEST must not read as a rejected sign-in.
+
+        The transport raises NovaAuthError for every non-retryable 4xx, so a
+        device removed from the account arrived here as "your sign-in expired"
+        and produced an immediate re-auth prompt with no threshold in front of
+        it. It takes the same exit a 5xx takes one branch up.
+        """
+
+        self._patch_request(monkeypatch, NovaAuthError(404, "gone"))
+        api = _make_api_with_session()
+        with pytest.raises(UpdateFailed) as excinfo:
+            run_coro(api.async_get_basic_device_list())
+        assert not hasattr(excinfo.value, "reauth_code")
+
+    def test_a_non_credential_4xx_on_the_device_list_does_not_log_an_authentication_failure(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        self._patch_request(monkeypatch, NovaAuthError(404, "gone"))
+        api = _make_api_with_session()
+        with caplog.at_level(logging.DEBUG), pytest.raises(UpdateFailed):
+            run_coro(api.async_get_basic_device_list())
+        assert "Device list rejected by the server (HTTP 404)" in caplog.text
+        assert "Authentication failed" not in caplog.text
+        # The level is part of the user-visible effect: HA's log panel and its
+        # error counter treat ERROR differently from WARNING, so a silent
+        # promotion would put a deleted device back among the alarms.
+        levels = {
+            r.levelno
+            for r in caplog.records
+            if "Device list rejected by the server (HTTP 404)" in r.message
+        }
+        assert levels == {logging.WARNING}
+
+    def test_a_credential_rejection_on_the_device_list_still_starts_reauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The counterpart: 403 must keep reaching the re-auth flow.
+
+        Without this row the previous two are satisfied by a branch that never
+        raises ConfigEntryAuthFailed at all, which would bury a real expired
+        sign-in instead of the reverse.
+        """
+
+        self._patch_request(monkeypatch, NovaAuthError(403, "denied"))
+        api = _make_api_with_session()
+        with pytest.raises(ConfigEntryAuthFailed) as excinfo:
+            run_coro(api.async_get_basic_device_list())
+        assert (
+            getattr(excinfo.value, "reauth_code", None)
+            is ReauthReasonCode.NOVA_AUTH_FAILED
+        )
+
+    def test_the_sound_classifier_follows_the_shared_predicate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_classify_nova_auth_error must READ the predicate, not re-derive it.
+
+        A second copy of the status test is exactly how the sound handlers and
+        the four other handlers drifted apart in the first place. Patching the
+        predicate to lie proves the classifier asks it.
+        """
+
+        monkeypatch.setattr(api_module, "is_credential_rejection", lambda _e: False)
+        assert (
+            api_module._classify_nova_auth_error(NovaAuthError(401, "x"))
+            is SoundDispatchOutcome.REJECTED_SERVER
+        )
+
 
 class TestAsyncDeviceLocationErrorMapping:
     """Each documented exception class for the location request branch."""

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -1331,6 +1331,14 @@ class TestAsyncDeviceLocationErrorMapping:
         client-rejection branch and a real expired sign-in went unescalated. The
         log record is what separates them: the auth exit announces a transient
         authentication error at WARNING, the client exit does not.
+
+        This is also the guard on the documented contract of
+        ``async_get_device_location``: a plain, non-permanent credential
+        rejection is re-raised, NOT converted to ``ConfigEntryAuthFailed``.
+        ``ConfigEntryAuthFailed`` does not inherit from ``NovaAuthError``, so
+        anyone who "aligns" the code with a docstring that promises conversion
+        for every credential rejection turns this test red. The docstring said
+        exactly that until an external review caught it.
         """
 
         self._patch_request(monkeypatch, NovaAuthError(403, "denied"))

--- a/tests/test_config_flow_basics.py
+++ b/tests/test_config_flow_basics.py
@@ -390,8 +390,16 @@ class TestMapApiExcToErrorKey:
     def test_plain_runtime_error_unknown(self) -> None:
         assert cf._map_api_exc_to_error_key(RuntimeError("boom")) == "unknown"
 
-    def test_a_rejected_device_probe_no_longer_reads_as_a_bad_sign_in(self) -> None:
-        """Characterisation: the device-list narrowing moves this error key.
+    def test_the_two_mapper_rows_the_device_list_narrowing_relies_on(self) -> None:
+        """Characterisation of the MAPPER only; it does not pin the narrowing.
+
+        Read the name literally: this asserts the two rows of
+        `_map_api_exc_to_error_key` that the device-list change depends on, and
+        nothing more. Both rows are true with or without that change, so
+        reverting `api.py`'s client-error branch leaves this test green. The end
+        to end pin lives in
+        `tests/test_api_basics.py::TestAsyncBasicDeviceListErrorMapping::test_a_rejected_probe_reaches_the_config_flow_as_a_non_auth_key`,
+        which takes the exception from the narrowed handler itself.
 
         The device-list handler used to raise ConfigEntryAuthFailed for every
         non-retryable 4xx. That class carries "auth" in its name, so a probe

--- a/tests/test_config_flow_basics.py
+++ b/tests/test_config_flow_basics.py
@@ -390,6 +390,30 @@ class TestMapApiExcToErrorKey:
     def test_plain_runtime_error_unknown(self) -> None:
         assert cf._map_api_exc_to_error_key(RuntimeError("boom")) == "unknown"
 
+    def test_a_rejected_device_probe_no_longer_reads_as_a_bad_sign_in(self) -> None:
+        """Characterisation: the device-list narrowing moves this error key.
+
+        The device-list handler used to raise ConfigEntryAuthFailed for every
+        non-retryable 4xx. That class carries "auth" in its name, so a probe
+        rejected with 400/404/422 showed the user ``invalid_auth`` and sent an
+        intact sign-in to the re-authentication form. It now raises
+        UpdateFailed, which matches neither the name test nor the status test
+        above and therefore ends at ``unknown``.
+
+        Both rows are already true today; this test pins the pair so the shift
+        is a recorded decision rather than a silent change of a user-facing
+        message. Retire it when a dedicated error key for "the server refused
+        the request" exists, which needs strings.json and the full translation
+        sync of its own.
+        """
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        assert cf._map_api_exc_to_error_key(UpdateFailed("x")) == "unknown"
+        assert (
+            cf._map_api_exc_to_error_key(ConfigEntryAuthFailed("x")) == "invalid_auth"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Block F: secrets extractors (cf.py lines 1167-1251)

--- a/tests/test_coordinator_locate_basics.py
+++ b/tests/test_coordinator_locate_basics.py
@@ -401,6 +401,14 @@ class TestAsyncLocateDeviceNovaAuthClassification:
     async def test_manual_locate_client_error_leaves_the_auth_state_alone(
         self, coord: LocateStub
     ) -> None:
+        """Neither direction: the state is not flagged AND not cleared.
+
+        Flagging it was the original defect. Clearing it is the mirror image and
+        just as wrong: a manual locate on a tracker the server rejects proves
+        nothing about the credentials, so it must not wipe a pending auth error
+        raised by some other device. Only the second half of this assertion pair
+        depends on api.py passing the error through rather than returning {}.
+        """
         coord.api.async_get_device_location.side_effect = NovaAuthError(404, "gone")
 
         result = await coord.async_locate_device("dev-1")
@@ -409,15 +417,19 @@ class TestAsyncLocateDeviceNovaAuthClassification:
         assert not [
             c for c in coord._set_auth_state.call_args_list if c.kwargs.get("failed")
         ]
+        assert not [
+            c
+            for c in coord._set_auth_state.call_args_list
+            if c.kwargs.get("failed") is False
+        ]
 
     async def test_manual_locate_client_error_is_still_recorded(
         self, coord: LocateStub
     ) -> None:
         """This branch keeps the failure on record; a silent {} would be worse.
 
-        Same scope caveat as the poll-cycle counterpart: api.py returns {} for
-        such a status, so a real manual locate on a deleted tracker takes the
-        success path and records nothing. The assertion is about the branch.
+        api.py passes a non-credential rejection through, so a real manual
+        locate on a deleted tracker reaches exactly this branch.
         """
         coord.api.async_get_device_location.side_effect = NovaAuthError(404, "gone")
 

--- a/tests/test_coordinator_locate_basics.py
+++ b/tests/test_coordinator_locate_basics.py
@@ -413,7 +413,12 @@ class TestAsyncLocateDeviceNovaAuthClassification:
     async def test_manual_locate_client_error_is_still_recorded(
         self, coord: LocateStub
     ) -> None:
-        """Quiet is not invisible: a silent {} would be worse than today."""
+        """This branch keeps the failure on record; a silent {} would be worse.
+
+        Same scope caveat as the poll-cycle counterpart: api.py returns {} for
+        such a status, so a real manual locate on a deleted tracker takes the
+        success path and records nothing. The assertion is about the branch.
+        """
         coord.api.async_get_device_location.side_effect = NovaAuthError(404, "gone")
 
         await coord.async_locate_device("dev-1")

--- a/tests/test_coordinator_locate_basics.py
+++ b/tests/test_coordinator_locate_basics.py
@@ -13,6 +13,7 @@ and stay for Phase 4.
 from __future__ import annotations
 
 import asyncio
+import logging
 import math
 import time
 from unittest.mock import MagicMock
@@ -33,6 +34,7 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_
     SharedKeyMismatchError,
     StaleOwnerKeyError,
 )
+from custom_components.googlefindmy.NovaApi.nova_request import NovaAuthError
 from tests.helpers.config_entries_stub import make_config_entry
 from tests.helpers.locate_mixin_stub import LocateStub
 
@@ -362,6 +364,79 @@ class TestAsyncLocateDeviceDecryptFailure:
         coord._set_auth_state.assert_called_once()
         assert coord._set_auth_state.call_args.kwargs.get("failed") is True
         coord.config_entry.async_start_reauth.assert_called_once()
+
+
+class TestAsyncLocateDeviceNovaAuthClassification:
+    """Manual locate must classify a Nova refusal by its STATUS, not its type.
+
+    NovaAuthError covers every non-retryable 4xx, so a device removed from the
+    account flipped the integration-wide auth state: Repairs issue,
+    EVENT_AUTH_ERROR, diagnostic sensor on -- with the sign-in intact. The
+    403 row is a characterisation test: it was green before this change and
+    must stay green, otherwise the narrowing is satisfied by a branch that
+    never names credentials at all.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _pass_cooldown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Move the clock past every cooldown gate so the Nova call is reached."""
+        monkeypatch.setattr(
+            "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+            lambda: 1000.0,
+        )
+
+    async def test_manual_locate_credential_rejection_sets_the_auth_state(
+        self, coord: LocateStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord.api.async_get_device_location.side_effect = NovaAuthError(403, "denied")
+
+        with caplog.at_level(logging.DEBUG):
+            result = await coord.async_locate_device("dev-1")
+
+        assert result == {}
+        coord._set_auth_state.assert_called_once()
+        assert coord._set_auth_state.call_args.kwargs.get("failed") is True
+        assert "failed (authentication)" in caplog.text
+
+    async def test_manual_locate_client_error_leaves_the_auth_state_alone(
+        self, coord: LocateStub
+    ) -> None:
+        coord.api.async_get_device_location.side_effect = NovaAuthError(404, "gone")
+
+        result = await coord.async_locate_device("dev-1")
+
+        assert result == {}
+        assert not [
+            c for c in coord._set_auth_state.call_args_list if c.kwargs.get("failed")
+        ]
+
+    async def test_manual_locate_client_error_is_still_recorded(
+        self, coord: LocateStub
+    ) -> None:
+        """Quiet is not invisible: a silent {} would be worse than today."""
+        coord.api.async_get_device_location.side_effect = NovaAuthError(404, "gone")
+
+        await coord.async_locate_device("dev-1")
+
+        coord.note_error.assert_called_once()
+        assert coord.note_error.call_args.kwargs.get("where") == "async_locate_device"
+
+    async def test_manual_locate_client_error_does_not_say_authentication(
+        self, coord: LocateStub, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coord.api.async_get_device_location.side_effect = NovaAuthError(404, "gone")
+
+        with caplog.at_level(logging.DEBUG):
+            await coord.async_locate_device("dev-1")
+
+        assert "failed (client error): HTTP 404" in caplog.text
+        assert "failed (authentication)" not in caplog.text
+        levels = {
+            r.levelno
+            for r in caplog.records
+            if "failed (client error): HTTP 404" in r.message
+        }
+        assert levels == {logging.WARNING}
 
 
 # One row per ``SoundDispatchOutcome`` member: (outcome, accepted, may arm the

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -871,7 +871,14 @@ async def test_poll_cycle_client_error_never_starts_reauth() -> None:
 
 @pytest.mark.asyncio
 async def test_poll_cycle_client_error_is_recorded_as_an_ordinary_error() -> None:
-    """Quiet is not the same as invisible: the skip stays in the diagnostics."""
+    """Quiet is not the same as invisible: this branch keeps the skip on record.
+
+    Scope, stated so the assertion is not read as more than it is: api.py
+    returns {} for such a status, so in production the device takes the poll
+    loop's empty-result path, which calls no note_error at all. What this pins
+    is that the branch does not degrade into a silent skip -- not that a
+    rejected device shows up in the diagnostics today. It does not.
+    """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
     coordinator.api = _DecryptFailAPI(NovaAuthError(404, "gone"))
     coordinator.config_entry.async_start_reauth = MagicMock()

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1418,7 +1418,7 @@ async def test_a_cycle_where_every_device_is_rejected_still_reports_an_error() -
 
 
 @pytest.mark.asyncio
-async def test_a_cycle_of_only_empty_results_reports_success() -> None:
+async def test_known_gap_a_cycle_of_only_empty_results_reports_success() -> None:
     """The reference measurement, with NOT ONE rejection involved.
 
     ``api.async_get_device_location`` collapses four distinct outcomes into the
@@ -1433,7 +1433,7 @@ async def test_a_cycle_of_only_empty_results_reports_success() -> None:
     that the neighbouring rejection branch should surface a mixed
     rejection-plus-empty cycle has to explain why THIS cycle, in which just as
     little worked, may stay silent. Deciding what an empty result may prove is
-    tracked as its own change (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`); when it
+    tracked as its own change (`PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`); when it
     lands, this test is expected to flip deliberately, not silently.
     """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
@@ -1454,7 +1454,9 @@ async def test_a_cycle_of_only_empty_results_reports_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent() -> None:
+async def test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent() -> (
+    None
+):
     """One rejected tracker plus siblings that came back empty: still silent.
 
     The post-loop guard fires only when EVERY device was rejected. Here one was

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1311,9 +1311,16 @@ async def test_a_rejected_device_does_not_make_every_tracker_unavailable() -> No
     layer is indistinguishable from a 5xx. That is deliberate -- it is the
     cheapest shape of the case, and it is also why the guard cannot be tightened
     to require positive success. ``_any_device_got_data`` is the only positive
-    proof the loop holds, and gating on it would turn THIS test red. The two
-    demands meet in one observable state, so the ambiguity has to be resolved
-    where the empty result is produced, not here.
+    marker on the REQUEST path (``cycle_had_successful_decrypt`` is a positive
+    proof too, but about the shared key), and gating on it would turn THIS test
+    red. The two demands meet in one observable state, so the ambiguity has to
+    be resolved where the empty result is produced, not here.
+
+    This test and ``test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent``
+    use the same stub and the same three assertions; only the display name
+    differs. That is not sloppiness left unnoticed but the very point: they are
+    the SAME observable state, read once as "must stay silent" and once as
+    "should have surfaced". Whoever resolves the ambiguity should merge them.
     """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
     coordinator.api = _PerDeviceAPI({"dev-1": NovaAuthError(404, "gone"), "dev-2": {}})
@@ -1476,7 +1483,8 @@ async def test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_sil
     the request path has no counterpart for. ``_any_device_got_data`` is not
     that counterpart: it records that a device COMMITTED data, so gating on it
     would turn ``test_a_rejected_device_does_not_make_every_tracker_unavailable``
-    red, whose sibling returns the same ``{}`` as this one.
+    red -- which uses the same stub and the same assertions as this test, only
+    read with the opposite expectation. Two names, one observable state.
 
     Not silent everywhere, and that is the point: the rejection still sets
     ``cycle_failed``, so ``last_poll_result`` reports ``failed`` and the

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import ast
 import asyncio
+import re
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -1412,3 +1415,142 @@ async def test_a_cycle_where_every_device_is_rejected_still_reports_an_error() -
 
     assert recorded, "every device was rejected and the cycle still reported success"
     assert coordinator.last_poll_result == "failed"
+
+
+@pytest.mark.asyncio
+async def test_a_cycle_of_only_empty_results_reports_success() -> None:
+    """The reference measurement, with NOT ONE rejection involved.
+
+    ``api.async_get_device_location`` collapses four distinct outcomes into the
+    same empty dict: a 5xx, a 429, a protobuf decode failure and a Nova logic
+    error all ``return {}``, and so does the healthy idle BLE tag whose inner
+    FCM wait simply found no reporter nearby. The poll loop cannot tell them
+    apart, so a cycle in which every single request failed server-side reports
+    ``success`` and leaves every entity available with its cached position.
+
+    This is pre-existing and has nothing to do with the client-rejection branch
+    -- it is pinned here precisely so that claim stays checkable: any argument
+    that the neighbouring rejection branch should surface a mixed
+    rejection-plus-empty cycle has to explain why THIS cycle, in which just as
+    little worked, may stay silent. Deciding what an empty result may prove is
+    tracked as its own change (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`); when it
+    lands, this test is expected to flip deliberately, not silently.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI({"dev-1": {}, "dev-2": {}})
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "A"}, {"id": "dev-2", "name": "B"}]
+    )
+
+    assert not recorded, f"an all-empty cycle surfaced an error: {recorded}"
+    assert coordinator.last_poll_result == "success"
+    # Reachability, so neither assertion can pass vacuously.
+    assert coordinator.api.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent() -> None:
+    """One rejected tracker plus siblings that came back empty: still silent.
+
+    The post-loop guard fires only when EVERY device was rejected. Here one was
+    and the other returned empty, so ``cycle_rejected_devices != len(devices)``
+    and the cycle surfaces nothing. Whether that empty sibling was a healthy
+    idle tag or a 5xx is not knowable at this layer, so the guard cannot lean on
+    it as evidence either way -- and the neighbouring decrypt verdict shows the
+    difference: it gates on ``cycle_had_successful_decrypt``, a positive proof
+    the request path has no counterpart for.
+
+    Not silent everywhere, and that is the point: the rejection still sets
+    ``cycle_failed``, so ``last_poll_result`` reports ``failed`` and the
+    diagnostic binary sensor shows it. Only entity availability is left alone,
+    which is the deliberate trade -- one deleted tracker must not take the whole
+    account offline on every poll.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI({"dev-1": NovaAuthError(404, "gone"), "dev-2": {}})
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Gone"}, {"id": "dev-2", "name": "Idle"}]
+    )
+
+    assert not recorded, f"the mixed cycle surfaced an error: {recorded}"
+    # The failure IS recorded, just not account-wide.
+    assert coordinator.last_poll_result == "failed"
+    assert coordinator.api.calls == 2
+
+
+class TestTheDocumentedRejectionGuardStaysTrue:
+    """The AGENTS.md paragraph on the rejection guard names its tests and counts them.
+
+    That count is load-bearing in the same way `tests/AGENTS.md` describes for
+    shared tuples: the paragraph is what stops the next reader from inferring
+    that a non-rejected sibling proved something, and it points at the tests
+    that hold the two states apart. A hand-maintained "Six tests pin this" goes
+    stale the moment one is renamed or added -- it already had to be corrected
+    from four to six once -- and nothing would turn red.
+
+    Derived from the AST, not from grep: a name in a docstring or a comment
+    must not count as a test.
+
+    When the set legitimately changes, update BOTH the paragraph and nothing
+    else -- this row reads the number out of the prose itself, so the prose
+    stays the single source.
+    """
+
+    _AGENTS = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "googlefindmy"
+        / "AGENTS.md"
+    )
+    _NUMBER_WORDS = {
+        "Two": 2,
+        "Three": 3,
+        "Four": 4,
+        "Five": 5,
+        "Six": 6,
+        "Seven": 7,
+        "Eight": 8,
+    }
+
+    def _claim(self) -> tuple[int, list[str]]:
+        text = self._AGENTS.read_text(encoding="utf-8")
+        match = re.search(
+            r"^(\w+) tests pin this:(.*?)\.\n", text, re.MULTILINE | re.DOTALL
+        )
+        assert match is not None, (
+            "the 'N tests pin this' sentence vanished from AGENTS.md"
+        )
+        claimed = self._NUMBER_WORDS.get(match.group(1))
+        assert claimed is not None, f"unhandled number word: {match.group(1)!r}"
+        return claimed, re.findall(r"`([A-Za-z0-9_]+)`", match.group(2))
+
+    def _defined_test_names(self) -> set[str]:
+        names: set[str] = set()
+        for path in sorted(Path(__file__).resolve().parent.rglob("test_*.py")):
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+                if isinstance(
+                    node, ast.FunctionDef | ast.AsyncFunctionDef
+                ) and node.name.startswith("test_"):
+                    names.add(node.name)
+        return names
+
+    def test_the_stated_number_matches_the_names_it_lists(self) -> None:
+        claimed, listed = self._claim()
+        assert claimed == len(listed), (claimed, listed)
+
+    def test_every_named_test_exists(self) -> None:
+        _, listed = self._claim()
+        defined = self._defined_test_names()
+        assert not [name for name in listed if name not in defined], [
+            name for name in listed if name not in defined
+        ]

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -980,13 +980,19 @@ async def test_a_rejected_device_never_clears_the_auth_state() -> None:
     auth_calls: list[dict[str, Any]] = []
     coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
     coordinator._consecutive_transient_auth_failures = 2
-    coordinator._last_transient_auth_error = NovaAuthError(401, "earlier")
+    # Seed the declared type, not an exception object: `_last_transient_auth_error`
+    # is `str | None` (polling.py:189) and its only production writer stores
+    # `str(transient_err)`. `mypy` does not catch a wrong shape here because
+    # `pyproject.toml` sets `ignore_errors` for `tests.*`.
+    coordinator._last_transient_auth_error = "earlier"
 
     await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
 
     assert not [kw for kw in auth_calls if kw.get("failed") is False]
     assert coordinator._consecutive_transient_auth_failures == 2
-    assert coordinator._last_transient_auth_error is not None
+    # Unchanged, not merely non-empty: a client error must not overwrite the
+    # message that a real transient auth failure left behind.
+    assert coordinator._last_transient_auth_error == "earlier"
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -846,10 +846,11 @@ async def test_poll_cycle_client_error_never_starts_reauth() -> None:
     account raised the counter once per cycle and produced a re-auth prompt
     after exactly three of them, with the sign-in intact throughout.
 
-    Reachability note: after the api.py narrowing this branch is production-
-    unreachable, because async_get_device_location returns {} for such a status.
-    The API double bypasses api.py entirely, so what this test proves is that
-    the rule holds locally in the file that owns the counter -- not that the
+    Reachability note: async_get_device_location passes such a status through,
+    so this branch is what a rejected device really takes. The API double
+    bypasses api.py entirely, so what this test proves is that the rule holds
+    locally in the file that owns the counter; the seam itself is pinned by
+    test_a_non_credential_4xx_location_is_passed_through. Not proved here: the
     path is still walked.
     """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
@@ -873,11 +874,9 @@ async def test_poll_cycle_client_error_never_starts_reauth() -> None:
 async def test_poll_cycle_client_error_is_recorded_as_an_ordinary_error() -> None:
     """Quiet is not the same as invisible: this branch keeps the skip on record.
 
-    Scope, stated so the assertion is not read as more than it is: api.py
-    returns {} for such a status, so in production the device takes the poll
-    loop's empty-result path, which calls no note_error at all. What this pins
-    is that the branch does not degrade into a silent skip -- not that a
-    rejected device shows up in the diagnostics today. It does not.
+    api.py passes such a status through, so a rejected device really does take
+    this branch and really does show up in the diagnostics. What this pins is
+    that the branch does not degrade into a silent skip.
     """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
     coordinator.api = _DecryptFailAPI(NovaAuthError(404, "gone"))
@@ -941,6 +940,105 @@ async def test_a_client_error_does_not_clear_a_pending_auth_countdown() -> None:
     coordinator.config_entry.async_start_reauth.assert_called_once_with(
         coordinator.hass
     )
+
+
+class _PerDeviceAPI:
+    """Location stub that answers per device id: raise, or return a payload.
+
+    ``_DecryptFailAPI`` always raises the same error for every device, which
+    cannot express "one tracker is rejected while another one is fine" -- the
+    exact shape in which a rejected device masks a real credential failure.
+    """
+
+    def __init__(self, answers: dict[str, Any]) -> None:
+        self._answers = answers
+        self.calls = 0
+
+    async def async_get_device_location(
+        self, device_id: str, *_args: Any, **_kwargs: Any
+    ) -> dict[str, Any]:
+        self.calls += 1
+        answer = self._answers[device_id]
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_device_never_clears_the_auth_state() -> None:
+    """The reported defect, at the seam where it lives.
+
+    ``api.async_get_device_location`` passes a non-credential 4xx through
+    instead of returning ``{}``, so the poll loop never reaches the success
+    path for that device. Were it to return ``{}``, the loop would call
+    ``_set_auth_state(failed=False)`` and reset the transient counter BEFORE
+    the empty guard, and a permanently deleted tracker would wipe a pending
+    401 from another tracker in every single cycle.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(NovaAuthError(404, "gone"))
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator._consecutive_transient_auth_failures = 2
+    coordinator._last_transient_auth_error = NovaAuthError(401, "earlier")
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    assert not [kw for kw in auth_calls if kw.get("failed") is False]
+    assert coordinator._consecutive_transient_auth_failures == 2
+    assert coordinator._last_transient_auth_error is not None
+
+
+@pytest.mark.asyncio
+async def test_an_empty_return_still_clears_the_counter() -> None:
+    """Characterisation of the reset this change deliberately leaves alone.
+
+    An empty result still counts as success: the counter goes back to zero and
+    the auth state is cleared. That is true today for every 5xx and every 429,
+    it predates this work, and it is wrong on its own terms -- an empty result
+    proves only that nothing raised, not that the credentials work. It is
+    tracked as a finding of its own with its own approval gate. This test is
+    here so the day it changes, it changes on purpose.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI({"dev-1": {}})
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator._consecutive_transient_auth_failures = 2
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    assert [kw for kw in auth_calls if kw.get("failed") is False]
+    assert coordinator._consecutive_transient_auth_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_a_client_error_does_not_overwrite_an_earlier_failure() -> None:
+    """``last_exception`` keeps the FIRST failure of the cycle.
+
+    A credential failure on one tracker must stay the reported cause even when
+    a rejected tracker follows it in the same cycle; otherwise the surviving
+    error names the harmless device and hides the one that needs attention.
+    Covers the false side of the ``if last_exception is None`` guard.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {
+            "dev-1": NovaAuthError(401, "expired"),
+            "dev-2": NovaAuthError(404, "gone"),
+        }
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = lambda exc: recorded.append(exc)
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Hub"}, {"id": "dev-2", "name": "Gone"}]
+    )
+
+    assert recorded, "the cycle reported no error at all"
+    assert getattr(recorded[-1], "status", None) == 401
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1025,7 +1025,11 @@ async def test_a_client_error_does_not_overwrite_an_earlier_failure() -> None:
     A credential failure on one tracker must stay the reported cause even when
     a rejected tracker follows it in the same cycle; otherwise the surviving
     error names the harmless device and hides the one that needs attention.
-    Covers the false side of the ``if last_exception is None`` guard.
+    This is the easy order. The hard one -- rejection first, credential failure
+    second -- is
+    ``test_a_rejected_device_does_not_hide_a_later_credential_failure``, and it
+    is the one that used to fail: the client branch no longer claims the
+    ``last_exception`` slot at all, so the order stopped mattering.
     """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
     coordinator.api = _PerDeviceAPI(
@@ -1275,3 +1279,90 @@ async def test_manual_locate_stale_shared_key_tags_reauth_code() -> None:
     )
     assert coordinator._reauth_reason is not None
     assert coordinator._reauth_reason.code is ReauthReasonCode.DECRYPT_STALE_KEY
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_device_does_not_make_every_tracker_unavailable() -> None:
+    """A per-device rejection must not take the whole account offline.
+
+    ``last_exception`` is the sole driver of ``async_set_update_error`` in the
+    cycle's ``finally`` block, and ``GoogleFindMyEntity.available`` follows the
+    coordinator's ``last_update_success``. Recording a client rejection there
+    therefore marked EVERY tracker entity unavailable -- and unlike a 5xx, a
+    tracker deleted from the account never recovers, so the outage would repeat
+    on every single poll until the device left the cached list. The sibling
+    device polled fine; a rejection of one device says nothing about the others.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI({"dev-1": NovaAuthError(404, "gone"), "dev-2": {}})
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Gone"}, {"id": "dev-2", "name": "Hub"}]
+    )
+
+    assert not recorded, (
+        "a rejected device failed the coordinator update, which makes every "
+        f"tracker entity unavailable: {recorded}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_device_still_marks_the_poll_result_failed() -> None:
+    """The rejection is recorded, it is only not made account-wide.
+
+    ``cycle_failed`` and ``last_exception`` drive two different things:
+    ``cycle_failed`` only writes the ``last_poll_result`` diagnostic attribute
+    (``binary_sensor.py`` reads it), while ``last_exception`` drives
+    ``async_set_update_error`` and with it entity availability. The branch keeps
+    the former so the cycle stays honest about not having polled every device,
+    and drops the latter so one device cannot take the account offline.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI({"dev-1": NovaAuthError(404, "gone"), "dev-2": {}})
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    coordinator.async_set_update_error = lambda _exc: None
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Gone"}, {"id": "dev-2", "name": "Hub"}]
+    )
+
+    assert coordinator.last_poll_result == "failed"
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_device_does_not_hide_a_later_credential_failure() -> None:
+    """Order matters: the reported cause must name the device that needs help.
+
+    ``last_exception`` keeps the FIRST failure of a cycle. While the client
+    rejection claimed that slot, a rejected tracker polled before a genuinely
+    expired one made the coordinator report "HTTP 404 gone" and hid the 401
+    entirely. This is the mirror image of
+    ``test_a_client_error_does_not_overwrite_an_earlier_failure``, which pins
+    the same guard from the other side.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {
+            "dev-1": NovaAuthError(404, "gone"),
+            "dev-2": NovaAuthError(401, "expired"),
+        }
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Gone"}, {"id": "dev-2", "name": "Hub"}]
+    )
+
+    assert recorded, "the cycle hid the credential failure entirely"
+    assert getattr(recorded[-1], "status", None) == 401, (
+        "the reported cause names the harmless rejected device instead of the "
+        f"tracker whose sign-in expired: {recorded[-1]!r}"
+    )

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1040,6 +1040,9 @@ async def test_a_client_error_does_not_overwrite_an_earlier_failure() -> None:
     )
     coordinator._set_auth_state = lambda **kwargs: None
     coordinator.config_entry.async_start_reauth = MagicMock()
+    # The polling fixture stubs note_error with a no-op; the reachability
+    # assertion below needs a recording double.
+    coordinator.note_error = MagicMock()
     recorded: list[Exception] = []
     coordinator.async_set_update_error = recorded.append
 
@@ -1049,6 +1052,14 @@ async def test_a_client_error_does_not_overwrite_an_earlier_failure() -> None:
 
     assert recorded, "the cycle reported no error at all"
     assert getattr(recorded[-1], "status", None) == 401
+    # The name says "client error", so pin that the client branch really ran.
+    # Without this the test passes even if that branch is deleted outright,
+    # because the 404 would then fall through to the transient-auth path whose
+    # own `if last_exception is None` guard preserves the 401 just the same.
+    assert any(
+        call.kwargs.get("where") == "poll_client_error"
+        for call in coordinator.note_error.call_args_list
+    )
 
 
 @pytest.mark.asyncio
@@ -1308,6 +1319,12 @@ async def test_a_rejected_device_does_not_make_every_tracker_unavailable() -> No
         "a rejected device failed the coordinator update, which makes every "
         f"tracker entity unavailable: {recorded}"
     )
+    # Reachability, so the negative assertion cannot pass vacuously: both
+    # devices were actually requested, and the cycle did enter the client
+    # branch (which is the only thing that can mark this cycle failed -- the
+    # empty success path of dev-2 leaves `cycle_failed` alone).
+    assert coordinator.api.calls == 2
+    assert coordinator.last_poll_result == "failed"
 
 
 @pytest.mark.asyncio
@@ -1366,3 +1383,32 @@ async def test_a_rejected_device_does_not_hide_a_later_credential_failure() -> N
         "the reported cause names the harmless rejected device instead of the "
         f"tracker whose sign-in expired: {recorded[-1]!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_a_cycle_where_every_device_is_rejected_still_reports_an_error() -> None:
+    """The sibling-success rule needs a sibling. With none, the cycle failed.
+
+    A rejection is treated as a per-device skip because another device's
+    success refutes it as an account-wide problem. When EVERY device is
+    rejected there is no such refutation, and staying silent would leave the
+    coordinator reporting healthy while it delivered nothing at all. The
+    device list cannot be relied on to catch this one layer up: it is a
+    different RPC, and `DEVICE_LIST_POLL_INTERVAL` (300s) means most cycles
+    reuse the cached list without calling it at all.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {"dev-1": NovaAuthError(404, "gone"), "dev-2": NovaAuthError(400, "bad")}
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Gone"}, {"id": "dev-2", "name": "Bad"}]
+    )
+
+    assert recorded, "every device was rejected and the cycle still reported success"
+    assert coordinator.last_poll_result == "failed"

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -839,6 +839,104 @@ async def test_poll_cycle_transient_nova_auth_starts_reauth_after_threshold() ->
 
 
 @pytest.mark.asyncio
+async def test_poll_cycle_client_error_never_starts_reauth() -> None:
+    """A rejected REQUEST must not feed the transient-auth countdown.
+
+    NovaAuthError covers every non-retryable 4xx, so a device removed from the
+    account raised the counter once per cycle and produced a re-auth prompt
+    after exactly three of them, with the sign-in intact throughout.
+
+    Reachability note: after the api.py narrowing this branch is production-
+    unreachable, because async_get_device_location returns {} for such a status.
+    The API double bypasses api.py entirely, so what this test proves is that
+    the rule holds locally in the file that owns the counter -- not that the
+    path is still walked.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(NovaAuthError(404, "gone"))
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    # The base fixture stubs _set_auth_state with a no-op, which would let a
+    # re-inserted call slip through unseen; bind it the way this file already
+    # does elsewhere so the assertion below can observe anything at all.
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+
+    for _ in range(_MAX_TRANSIENT_AUTH_FAILURES + 2):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_not_called()
+    assert coordinator._consecutive_transient_auth_failures == 0
+    assert not [c for c in auth_calls if c.get("failed")]
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_client_error_is_recorded_as_an_ordinary_error() -> None:
+    """Quiet is not the same as invisible: the skip stays in the diagnostics."""
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(NovaAuthError(404, "gone"))
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    # The polling fixture stubs note_error with a no-op as well.
+    coordinator.note_error = MagicMock()
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    assert coordinator.note_error.call_count == 1
+    assert coordinator.note_error.call_args.kwargs["where"] == "poll_client_error"
+
+
+@pytest.mark.asyncio
+async def test_poll_cycle_credential_rejection_still_escalates() -> None:
+    """The counterpart, and with 403: the existing test only covers 401.
+
+    Without this row the narrowing is satisfied by a branch that never counts
+    anything, which would bury a real expired sign-in.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _DecryptFailAPI(NovaAuthError(403, "denied"))
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    for _ in range(_MAX_TRANSIENT_AUTH_FAILURES):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+    assert coordinator._reauth_reason is not None
+    assert (
+        coordinator._reauth_reason.code
+        is ReauthReasonCode.NOVA_AUTH_TRANSIENT_EXHAUSTED
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_client_error_does_not_clear_a_pending_auth_countdown() -> None:
+    """The counter is untouched in BOTH directions.
+
+    A 404 says nothing about the credentials -- neither that they are broken
+    nor that they work. A test that only checks "stays at 0" would let a reset
+    through, and a reset would make a real 401/404/401 sequence unescalatable.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    api = _DecryptFailAPI(NovaAuthError(401, "transient"))
+    coordinator.api = api
+    coordinator.config_entry.async_start_reauth = MagicMock()
+
+    for _ in range(_MAX_TRANSIENT_AUTH_FAILURES - 1):
+        await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    coordinator.config_entry.async_start_reauth.assert_not_called()
+
+    api._exc = NovaAuthError(404, "gone")
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    coordinator.config_entry.async_start_reauth.assert_not_called()
+
+    api._exc = NovaAuthError(401, "transient")
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Hub"}])
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(
+        coordinator.hass
+    )
+
+
+@pytest.mark.asyncio
 async def test_poll_cycle_reauth_noop_without_config_entry() -> None:
     """Defensive guard: with no config entry bound the poll cycle cannot start
     reauth, but it must not crash (``_request_poll_reauth`` no-entry branch)."""

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1304,8 +1304,16 @@ async def test_a_rejected_device_does_not_make_every_tracker_unavailable() -> No
     coordinator's ``last_update_success``. Recording a client rejection there
     therefore marked EVERY tracker entity unavailable -- and unlike a 5xx, a
     tracker deleted from the account never recovers, so the outage would repeat
-    on every single poll until the device left the cached list. The sibling
-    device polled fine; a rejection of one device says nothing about the others.
+    on every single poll until the device left the cached list. A rejection of
+    one device says nothing about the others.
+
+    Note precisely what the sibling here does: it returns ``{}``, which at this
+    layer is indistinguishable from a 5xx. That is deliberate -- it is the
+    cheapest shape of the case, and it is also why the guard cannot be tightened
+    to require positive success. ``_any_device_got_data`` is the only positive
+    proof the loop holds, and gating on it would turn THIS test red. The two
+    demands meet in one observable state, so the ambiguity has to be resolved
+    where the empty result is produced, not here.
     """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
     coordinator.api = _PerDeviceAPI({"dev-1": NovaAuthError(404, "gone"), "dev-2": {}})
@@ -1465,7 +1473,10 @@ async def test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_sil
     idle tag or a 5xx is not knowable at this layer, so the guard cannot lean on
     it as evidence either way -- and the neighbouring decrypt verdict shows the
     difference: it gates on ``cycle_had_successful_decrypt``, a positive proof
-    the request path has no counterpart for.
+    the request path has no counterpart for. ``_any_device_got_data`` is not
+    that counterpart: it records that a device COMMITTED data, so gating on it
+    would turn ``test_a_rejected_device_does_not_make_every_tracker_unavailable``
+    red, whose sibling returns the same ``{}`` as this one.
 
     Not silent everywhere, and that is the point: the rejection still sets
     ``cycle_failed``, so ``last_poll_result`` reports ``failed`` and the

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1037,7 +1037,7 @@ async def test_a_client_error_does_not_overwrite_an_earlier_failure() -> None:
     coordinator._set_auth_state = lambda **kwargs: None
     coordinator.config_entry.async_start_reauth = MagicMock()
     recorded: list[Exception] = []
-    coordinator.async_set_update_error = lambda exc: recorded.append(exc)
+    coordinator.async_set_update_error = recorded.append
 
     await coordinator._async_start_poll_cycle(
         [{"id": "dev-1", "name": "Hub"}, {"id": "dev-2", "name": "Gone"}]

--- a/tests/test_location_request_r6_name_sweep.py
+++ b/tests/test_location_request_r6_name_sweep.py
@@ -189,6 +189,34 @@ async def test_nova_auth_error_redacts_name_and_reraises(
             cache=_FakeTokenCache(),
         )
     _assert_name_only_at_debug(caplog)
+    # Pin the wording, not just the redaction: without this the branch could
+    # say anything at all about a 401 and stay green, which is exactly how the
+    # non-credential counterpart below would lose its only counter-test.
+    assert "Authentication error while requesting location" in caplog.text
+
+
+async def test_a_client_error_is_not_logged_as_an_authentication_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """NovaAuthError covers every non-retryable 4xx, so this WARNING must not
+    pre-empt api.py's verdict by calling a 404 an authentication problem. The
+    re-raise is unchanged: this layer still does not classify, it just stops
+    claiming to."""
+    _wire_nova_raises(monkeypatch, nova_exc=NovaAuthError(404, "gone"))
+    caplog.set_level(logging.DEBUG, logger=location_request.__name__)
+
+    with pytest.raises(NovaAuthError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id=_CANONIC,
+            name=_SENTINEL_NAME,
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
+    assert "Client error (HTTP 404) while requesting location" in caplog.text
+    assert "Authentication error" not in caplog.text
+    _assert_name_only_at_debug(caplog)
 
 
 async def test_fcm_registration_failure_redacts_name(

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -31,11 +31,13 @@ from custom_components.googlefindmy.NovaApi.ListDevices.nbe_list_devices import 
 from custom_components.googlefindmy.NovaApi.nova_request import (
     AsyncTTLPolicy,
     NovaAuthError,
+    NovaAuthPermanentError,
     NovaError,
     NovaHTTPError,
     NovaRateLimitError,
     TTLPolicy,
     async_nova_request,
+    is_credential_rejection,
     register_cache_provider,
     unregister_cache_provider,
 )
@@ -3094,3 +3096,46 @@ async def test_both_adm_and_aas_tokens_have_min_ttl_protection() -> None:
             await cache.close()
 
     await _run()
+
+
+class TestIsCredentialRejection:
+    """The shared status criterion every NovaAuthError handler reads.
+
+    The type covers every non-retryable 4xx, so only these rows may read as
+    "your sign-in expired"; every other client rejection is the server
+    refusing the REQUEST, not the credentials.
+    """
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (401, True),
+            (403, True),
+            (400, False),
+            (404, False),
+            (405, False),
+            (409, False),
+            (422, False),
+        ],
+    )
+    def test_the_status_alone_decides_for_a_plain_error(
+        self, status: int, expected: bool
+    ) -> None:
+        assert is_credential_rejection(NovaAuthError(status, "detail")) is expected
+
+    def test_permanence_outranks_a_non_credential_status(self) -> None:
+        """is_permanent means "re-authentication is definitively required"."""
+        assert is_credential_rejection(NovaAuthError(404, "perm", is_permanent=True))
+
+    def test_the_permanent_subclass_stays_a_credential_rejection(self) -> None:
+        assert is_credential_rejection(NovaAuthPermanentError(404, "aas rejected"))
+
+    def test_an_unreadable_status_keeps_the_conservative_verdict(self) -> None:
+        """A test double or a future subclass reads as auth, not as client error.
+
+        delattr, not ``= None``: the annotation says int, and removing the
+        instance attribute is exactly what makes getattr fall back.
+        """
+        err = NovaAuthError(404, "double without a status")
+        delattr(err, "status")
+        assert is_credential_rejection(err)

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any
 
 import aiohttp
@@ -3139,3 +3141,104 @@ class TestIsCredentialRejection:
         err = NovaAuthError(404, "double without a status")
         delattr(err, "status")
         assert is_credential_rejection(err)
+
+
+class TestTheDocumentedExtentStaysTrue:
+    """The AGENTS.md paragraph counts call sites and handlers; nothing enforced it.
+
+    `custom_components/googlefindmy/AGENTS.md` states the extent of the
+    status-based classification in prose ("six call sites in four files",
+    "ten try blocks catch NovaAuthError", "eight carry a broad except
+    Exception"). That paragraph calls itself "the only thing standing in
+    [the defect's] way", which makes an unenforced number the load-bearing
+    part of the contract: a seventh handler, or a refactor that drops one,
+    leaves the prose quietly wrong while every test stays green.
+
+    `tests/AGENTS.md` already establishes the remedy for exactly this shape --
+    a tuple that "must still equal the AST-derived set" rather than a
+    hand-maintained copy. These rows apply it to the numbers above. They are
+    deliberately AST-derived and not grep-derived: a comment mentioning the
+    predicate must not count as a call site.
+
+    When the extent legitimately changes, update BOTH this test and the
+    paragraph in the same commit. A failure here is not a bug in the code; it
+    is the contract telling you it went stale.
+    """
+
+    _ROOT = Path(__file__).resolve().parents[1] / "custom_components" / "googlefindmy"
+
+    def _modules(self) -> list[tuple[Path, ast.Module]]:
+        return [
+            (path, ast.parse(path.read_text(encoding="utf-8")))
+            for path in sorted(self._ROOT.rglob("*.py"))
+        ]
+
+    def test_the_predicate_has_the_documented_six_call_sites_in_four_files(
+        self,
+    ) -> None:
+        per_file: dict[str, int] = {}
+        for path, tree in self._modules():
+            calls = [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "is_credential_rejection"
+            ] + [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "is_credential_rejection"
+            ]
+            if calls:
+                per_file[path.relative_to(self._ROOT).as_posix()] = len(calls)
+
+        assert sum(per_file.values()) == 6, per_file
+        assert len(per_file) == 4, per_file
+        assert per_file.get("api.py") == 3, per_file
+
+    def test_ten_try_blocks_catch_the_auth_error_and_eight_have_a_broad_handler(
+        self,
+    ) -> None:
+        """The count that gates the open follow-up (a dedicated client-error class).
+
+        Splitting NovaAuthError is only safe once every catcher is known: the
+        eight blocks with a broad `except Exception` would swallow a new class
+        silently, the two sound handlers would let it escape. Both numbers are
+        the reason that follow-up is not a one-liner, so both are pinned.
+        """
+
+        def _names(handler: ast.ExceptHandler) -> set[str]:
+            node = handler.type
+            if node is None:
+                return {"Exception"}
+            parts = node.elts if isinstance(node, ast.Tuple) else [node]
+            out: set[str] = set()
+            for part in parts:
+                if isinstance(part, ast.Name):
+                    out.add(part.id)
+                elif isinstance(part, ast.Attribute):
+                    out.add(part.attr)
+            return out
+
+        catching: list[str] = []
+        with_broad: list[str] = []
+        for path, tree in self._modules():
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Try):
+                    continue
+                handlers = [_names(h) for h in node.handlers]
+                if not any("NovaAuthError" in names for names in handlers):
+                    continue
+                where = f"{path.relative_to(self._ROOT).as_posix()}:{node.lineno}"
+                catching.append(where)
+                if any(
+                    "Exception" in names or "BaseException" in names
+                    for names in handlers
+                ):
+                    with_broad.append(where)
+
+        assert len(catching) == 10, catching
+        assert len(with_broad) == 8, with_broad
+        assert len(catching) - len(with_broad) == 2, (catching, with_broad)


### PR DESCRIPTION
## What this fixes

`NovaApi/nova_request.py` raises `NovaAuthError` for **every** non-retryable 4xx, not only for credential rejections: `HTTP_RETRY_ELIGIBLE` holds no 4xx besides 408 and 429, so 400, 404, 405, 409 and 422 all arrive at a handler as "auth". A 401 that survived the refresh sequence is raised separately with `is_permanent=True`, which leaves **403 as the only plain credential rejection a handler ever sees**.

Four handlers read the **type** instead of the **status**, so a device removed from the Google account was reported as an expired sign-in:

| Site | Before | After |
|---|---|---|
| `api.py` device list | `ConfigEntryAuthFailed` on the **first** occurrence, no threshold: immediate re-auth prompt plus Repairs issue | `UpdateFailed`, `ApiStatus.ERROR`, no reauth reason |
| `api.py` location | re-raised into the coordinator, logged as "Transient authentication error" | `return {}` with the status named, like the 5xx sibling |
| `coordinator/polling.py` | fed the transient-auth counter; three cycles → re-auth cascade | device skip, counter untouched in either direction |
| `coordinator/locate.py` | `_set_auth_state(failed=True)`: Repairs issue, `EVENT_AUTH_ERROR`, diagnostic sensor on | `note_error` only, auth state left alone |

Plus a passthrough in `location_request.py` whose WARNING **and** DEBUG record both called a 404 an authentication error, one line above the record `api.py` writes about the same event.

The user-visible defect: an intact login plus one device removed from the account produced a re-authentication prompt.

## How

`nova_request.is_credential_rejection(err)` is the single home of the criterion: permanence first, then 401/403, an unreadable status keeps the conservative verdict. `api._classify_nova_auth_error` (from #1262) becomes its sound-path adapter instead of a second copy of the same test. Six call sites in four files read it, serving seven handlers.

This is deliberately **not** the cleaner architecture. Giving the non-credential case its own exception class is the better design and is tracked as follow-up, not as done. Measured over the AST: ten `try` blocks catch `NovaAuthError`; eight carry a broad `except Exception` that would swallow a new class under a name hiding the status, and the two sound-request handlers catch it in a tuple with no broad handler, where a new class would propagate uncaught. Two opposite failure modes in one change, and no per-site red test is possible because the class does not exist beforehand. Narrowing the six sites first makes that follow-up a mechanical type swap against a green guard row.

## Behaviour changes a reviewer should weigh

1. **Config-flow error key.** A device probe rejected with 400/404/422 now shows `unknown` instead of `invalid_auth`, because `_map_api_exc_to_error_key` classifies on the class name and `UpdateFailed` carries no "auth". Intended (the sign-in is intact), pinned by a characterisation test. A dedicated key would need `strings.json` plus the full translation sync and is out of scope.
2. **A pre-existing reset is newly reachable, and this is the one thing I would not merge without a decision.** `polling.py` and `locate.py` clear the auth state and reset the transient-auth counter on their success path, **before** they check whether the result was empty. Since `api.py` now returns `{}` for a non-credential rejection, a deleted device takes that path. The mechanism is old (every 5xx and 429 already reaches it); what a client rejection adds is **permanence**: a 5xx clears up, a deleted device does not. With one deleted tracker in the list, every cycle resets the counter, so a genuinely expired sign-in on another tracker never reaches `_MAX_TRANSIENT_AUTH_FAILURES`. Before this PR that 404 raised the counter itself, so the escalation did happen, for the wrong reason. Fixing it means deciding what an empty result may prove about credentials, and every healthy idle BLE poll takes the same path, so the blast radius is far wider than this PR. It is documented in `AGENTS.md`, in both branch comments and in two test docstrings rather than left implicit.

## Verification

- Each of the six commits went through a three-stage red test: tests first against untouched production code, failure text recorded verbatim, then the change, then green.
- 26 named mutations across the five code commits, each with forced restore and a byte-level restore proof; every one killed the guard it was predicted to kill. Several killed **existing** tests from #1262, which is the evidence that the predicate is genuinely shared.
- Changed-code coverage measured per commit and reconciled against `git diff -U0`: no changed or added production line in the missing list.
- `ruff check .`, `ruff format --check .` and `mypy --strict` tree-wide green after **every** commit, not only at the end.
- Full suite green.
- Two rounds of an independent read-only terminal diff review over the whole diff. Both returned FAIL; both sets of findings are fixed. Stated plainly: the state after the round-two fixes (`92be8877`) has **not** itself been reviewed, because the review is capped at two rounds by design.

## Not in scope

Approach B (own exception class at the source), the empty-result reset above, `location_request.py`'s second handler (bare `raise`, no output), device cleanup for a permanently missing tracker, `strings.json` and the translations.
