### PR TITLE
fix: make an unaccepted locate request distinguishable from an empty one

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -166,12 +166,23 @@ rejection is the server's answer ABOUT that device and is permanent, a non-accep
 device at all and is transient.
 What an empty sibling proves is narrower than it looks, and the guard is built so that it never has to prove much. The
 transport failures that used to flatten into `{}` -- the 5xx, the 429, the `aiohttp.ClientError`, the generic Nova
-failure -- now raise `LocationRequestNotAcceptedError`. Three pre-accept failures still arrive as an empty dict,
-because they are raised BEFORE the outer handler that would convert them: the FCM provider being unregistered or
-returning `None` (`RuntimeError`), a missing token cache (`MissingTokenCacheError`), and a failure while binding the
-lazily imported decrypt / eid-info modules (`ImportError` / `AttributeError`), whose binding sits ABOVE the outer `try`
-even though the same import inside the FCM callback is guarded. `api.py` flattens all four, and for the first it does
-so deliberately, as a documented cold-boot race that retries on the next cycle. An empty dict is therefore WEAK
+failure -- now raise `LocationRequestNotAcceptedError`. FOUR pre-accept failures still arrive as an empty dict,
+because they are raised BEFORE the outer handler that would convert them: an unregistered FCM receiver provider
+(`RuntimeError`), a provider that returns `None` (`RuntimeError`), a missing token cache
+(`MissingTokenCacheError`), and a failure while binding the lazily imported decrypt / eid-info modules (`ImportError` /
+`AttributeError`), whose binding sits ABOVE the outer `try` even though the same import inside the FCM callback is
+guarded. Count the FAILURE MODES above that `try`, not the clauses of this sentence and not the `raise` statements
+either: an earlier revision grouped the two provider failures into one clause, wrote "three", and then said "all four"
+two lines later. Three of the four are an explicit `raise` (the two provider guards and the token cache); the fourth is
+implicit, raised by the module bindings themselves. A fourth explicit `raise` does sit above that `try` -- the `Cache
+accessors could not be initialized` guard -- and is deliberately NOT one of the four: both branches preceding it
+assign the accessors when they are unset, so it is defensive and constructively unreachable. Counting `raise`
+statements therefore yields four with the WRONG membership, which is why the unit of the count is named here. This
+number is prose only: unlike the extent counts guarded by
+`tests/test_nova_request.py::TestTheDocumentedExtentStaysTrue`, no AST test derives it, so it is on whoever adds a
+pre-accept failure to come back here and to the enumeration at the post-loop guard in `coordinator/polling.py` that
+this paragraph restates. `api.py` flattens all four, and for the first it does so deliberately, as a
+documented cold-boot race that retries on the next cycle. An empty dict is therefore WEAK
 evidence of acceptance, never proof, and the sum guard is conservative for exactly that reason: an unrecognised failure
 makes it stay silent, never fire wrongly.
 Do not sharpen the rejection/non-acceptance distinction into "permanent versus transient" either. It holds for the
@@ -222,7 +233,7 @@ Eight tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavai
 `test_a_mixed_cycle_of_rejection_and_unaccepted_siblings_now_surfaces`.
 What is still NOT fixed there, stated so it is not mistaken for solved: that success path still treats every empty
 result as proof of working credentials. The 5xx and the 429 no longer reach it -- they raise before they can -- but
-every idle BLE tag still does, and so do the three pre-accept failures named above. Deciding what an
+every idle BLE tag still does, and so do the four pre-accept failures named above. Deciding what an
 empty result may prove about credentials is a behaviour change of its own with a far wider blast radius (every healthy
 idle poll takes the same path); it is tracked separately (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`) and must not be assumed done. Three tests pin the
 current state so it cannot drift silently: `test_an_empty_return_still_clears_the_counter` characterises the reset that

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -221,11 +221,14 @@ unexpected-device branch logs a WARNING and returns empty -- and those were deli
 drawn here is `accepted` against `not accepted`, not `succeeded` against `failed`.
 Note where the empty dict actually comes from, and note what is NOT in that list. `location_request` catches the 5xx
 and the 429 itself, so `api.py`'s handlers for those never run on the locate path. The protobuf decode failure and the
-Nova logic error do not belong in the same sentence, measured: `parse_device_update_protobuf` is called only from the
-FCM callback, whose own `except Exception` sets `ctx.data = []` after the accept line, and no `NovaLogicError` is
-raised anywhere in the tree. On the locate path the dict is produced by the no-location fallthrough instead, which is
-why an intervention confined to `api.py` would have been inert: the outcome had to be carried ACROSS the
-`location_request.py` boundary, not reconstructed downstream once the empty collection had flattened it.
+Nova logic error do not belong in the same sentence, measured: WITHIN `location_request.py`, the only call of
+`parse_device_update_protobuf` sits in the FCM callback, whose own `except Exception` sets `ctx.data = []` after the
+accept line, and no `NovaLogicError` is raised anywhere in the tree. The scope matters and was wrong here once: that
+decoder has further callers in `Auth/fcm_receiver_ha.py` and a `__main__` self-check in `decrypt_locations.py`, none
+of them on the locate request, so the unscoped claim reads as a tree-wide statement and is false as one. On the
+locate path the dict is produced by the no-location fallthrough instead, which is why an intervention confined to
+`api.py` would have been inert: the outcome had to be carried ACROSS the `location_request.py` boundary, not
+reconstructed downstream once the empty collection had flattened it.
 Note what the mixed cycle is NOT: silent everywhere. The rejection still sets `cycle_failed`, so `last_poll_result`
 reports `failed` and the diagnostic binary sensor shows it; only entity availability is left alone.
 Eight tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavailable`,

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -158,7 +158,7 @@ success. It is one of TWO post-loop guards, and the other one is what closed the
 open. `cycle_unaccepted_devices` counts the devices whose locate request was never accepted, and the sum guard
 (`unaccepted + rejected == len(devices)`, with at least one unaccepted) surfaces a cycle in which no device's request
 got through. The two are kept apart so the reported message names the condition: a deleted tracker is a configuration
-change, an unreachable server is an outage.
+change, a cycle in which no request was accepted is an outage.
 That difference is NOT flow position, and writing it that way would be measurably wrong. `location_request.py`
 re-raises the non-credential 4xx from the same `try` that produces the 5xx and the 429, all of them BEFORE the
 `Location request accepted` line, so neither kind reached the accept point. The difference is what the outcome
@@ -208,7 +208,7 @@ back by gating the guard on positive success does not work at this layer either,
 than a forecast about accounts. The only positive marker on the REQUEST path is `_any_device_got_data`; the
 neighbouring `cycle_had_successful_decrypt` is a positive proof as well, but about the shared key, and both are False
 for either kind of empty result. `_any_device_got_data` records that a device COMMITTED data, not that its request
-reached the server. Gating on it turns `test_a_rejected_device_does_not_make_every_tracker_unavailable` red, because
+was accepted. Gating on it turns `test_a_rejected_device_does_not_make_every_tracker_unavailable` red, because
 the sibling in that test returns exactly `{}` -- the stricter guard withdraws the very fix that test was written for.
 One rejection plus one empty sibling would have to stay silent for that test and surface for the mixed-failure one,
 from the same observable state. That is not a judgement call to be argued either way; it is an ambiguity, and only the

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -154,17 +154,29 @@ different RPC (`nbe_list_devices`) from the per-device location request, and `DE
 `const.py`) means most cycles reuse the cached list without calling it at all. That claim was written here once and
 was wrong.
 Read the check for exactly what it tests, and no more. It does NOT say that a cycle failing the equality had a sibling
-success: a non-rejected sibling proves nothing, because `api.async_get_device_location` returns the same empty dict for
-a healthy idle BLE tag and for a 5xx, a 429, a protobuf decode failure and a Nova logic error. So a mixed cycle -- one
-tracker refused, the others back empty from a server outage -- stays silent, and so does that same outage with no
-rejection in it at all: measured, a cycle in which EVERY device returns empty reports `success` and leaves every entity
-available with its cached position. That is pre-existing and independent of the rejection branch, and it is why the
-rejection branch must not be made stricter on its own: making the error signal depend on whether some unrelated tracker
-happens to have been deleted is a coincidence, not a contract. The empty result is what has to become distinguishable
-(`PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`), and until it is, both states are pinned:
-`test_known_gap_a_cycle_of_only_empty_results_reports_success` holds the reference case and
-`test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent` holds the mixed one. When that change lands they are
-expected to flip deliberately, not silently.
+success. It is one of TWO post-loop guards, and the other one is what closed the gap this paragraph used to describe as
+open. `cycle_unaccepted_devices` counts the devices whose locate request was never accepted, and the sum guard
+(`unaccepted + rejected == len(devices)`, with at least one unaccepted) surfaces a cycle in which no device's request
+got through. The two are kept apart so the reported message names the condition: a deleted tracker is a configuration
+change, an unreachable server is an outage.
+That difference is NOT flow position, and writing it that way would be measurably wrong. `location_request.py`
+re-raises the non-credential 4xx from the same `try` that produces the 5xx and the 429, all of them BEFORE the
+`Location request accepted` line, so neither kind reached the accept point. The difference is what the outcome says: a
+rejection is the server's answer ABOUT that device and is permanent, a non-accepted request says nothing about the
+device at all and is transient.
+What an empty sibling proves is narrower than it looks, and the guard is built so that it never has to prove much. The
+transport failures that used to flatten into `{}` -- the 5xx, the 429, the `aiohttp.ClientError`, the generic Nova
+failure -- now raise `LocationRequestNotAcceptedError`. Three pre-accept failures still arrive as an empty dict,
+because they are raised BEFORE the outer handler that would convert them: the FCM provider being unregistered or
+returning `None` (`RuntimeError`), a missing token cache (`MissingTokenCacheError`), and a failure while binding the
+lazily imported decrypt / eid-info modules (`ImportError` / `AttributeError`), whose binding sits ABOVE the outer `try`
+even though the same import inside the FCM callback is guarded. `api.py` flattens all four, and for the first it does
+so deliberately, as a documented cold-boot race that retries on the next cycle. An empty dict is therefore WEAK
+evidence of acceptance, never proof, and the sum guard is conservative for exactly that reason: an unrecognised failure
+makes it stay silent, never fire wrongly.
+Do not sharpen the rejection/non-acceptance distinction into "permanent versus transient" either. It holds for the
+common cases and breaks on the `no_fcm_token` stage, whose source returns `None` for a canonic id the receiver does not
+know -- device-specific and not transient. What the two counts share is only "this device contributed no evidence".
 This is a regression against the pre-change behaviour, named here rather than left to be discovered: before the
 status-based classification the mixed cycle DID surface, because the 4xx took the transient-auth branch and set
 `last_exception` there -- the same branch that fed the counter behind the false sign-in prompt. The signal was a
@@ -182,37 +194,40 @@ What the earlier wording got right must not be thrown out with its wrong quantif
 tracker and otherwise idle BLE tags WOULD go unavailable on every cycle under a stricter gate. That was never true of
 "every healthy BLE-only account" -- the guard is conjunctive with a rejection, so an account without one is untouched
 -- but it is exactly true of that one shape, and it is the concrete price of tightening here.
-Where the resolution belongs is measured, so the follow-up does not start by re-deriving it. `location_request.py`
-logs `Location request accepted` once the RPC is through, and the `return []` paths reachable only BEFORE that log
-(no FCM token, FCM registration failure, 429, 5xx, `aiohttp.ClientError`, the generic guard around the Nova request)
-are failures. Two qualifications, both measured, because the log line is not a clean split. The outer surfacing
-handler wraps the WHOLE body, so its own `return []` sits AFTER the log while the exceptions it catches may come from
-either side of it; a follow-up therefore needs a flag set at the log line, not a position in the file. And not every
-empty result after the log is benign either: the unexpected-device branch logs a WARNING and returns empty.
-Note also where the empty dict actually comes from. `location_request` catches the 5xx, the 429, the protobuf decode
-failure and the Nova logic error itself, so `api.py`'s handlers for those four never run on the locate path; the dict
-is produced by the no-location fallthrough instead. The outcome is as described above, the mechanism is not, and an
-intervention confined to `api.py` would be inert.
-Two constraints on the follow-up fall out of that, stated here because a plausible reading of the paragraph above
-gets the second one backwards. First, the accepted-versus-failed outcome has to be preserved ACROSS the
-`location_request.py` boundary -- a typed result, for example -- rather than reconstructed downstream once the empty
-collection has flattened it. Second, the layer that flattens it is `location_request.py` itself, NOT `api.py`: aiming
-the follow-up at the file where the empty dict is built would put the fix behind the point where the evidence is
-already gone.
+Where the resolution belongs was measured before it was built, and the measurement still governs how it may be
+changed. `location_request.py` logs `Location request accepted` once the RPC is through, and the `return []` paths
+reachable only BEFORE that log (no FCM token, FCM registration failure, 429, 5xx, `aiohttp.ClientError`, the generic
+guard around the Nova request) are failures. They now raise `LocationRequestNotAcceptedError` instead. The split is
+read off the `request_accepted` flag set AT the log line, NEVER off a position in the file, and that is not a style
+preference: the outer surfacing handler wraps the WHOLE body, so its own `return []` sits after the log while the
+exceptions it catches come from either side of it. Not every empty result after the log is benign either -- the
+unexpected-device branch logs a WARNING and returns empty -- and those were deliberately left alone, because the line
+drawn here is `accepted` against `not accepted`, not `succeeded` against `failed`.
+Note where the empty dict actually comes from, and note what is NOT in that list. `location_request` catches the 5xx
+and the 429 itself, so `api.py`'s handlers for those never run on the locate path. The protobuf decode failure and the
+Nova logic error do not belong in the same sentence, measured: `parse_device_update_protobuf` is called only from the
+FCM callback, whose own `except Exception` sets `ctx.data = []` after the accept line, and no `NovaLogicError` is
+raised anywhere in the tree. On the locate path the dict is produced by the no-location fallthrough instead, which is
+why an intervention confined to `api.py` would have been inert: the outcome had to be carried ACROSS the
+`location_request.py` boundary, not reconstructed downstream once the empty collection had flattened it.
 Note what the mixed cycle is NOT: silent everywhere. The rejection still sets `cycle_failed`, so `last_poll_result`
 reports `failed` and the diagnostic binary sensor shows it; only entity availability is left alone.
-Six tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavailable`,
+Eight tests pin this: `test_a_rejected_device_does_not_make_every_tracker_unavailable`,
 `test_a_rejected_device_still_marks_the_poll_result_failed`,
 `test_a_rejected_device_does_not_hide_a_later_credential_failure`,
 `test_a_cycle_where_every_device_is_rejected_still_reports_an_error`,
-`test_known_gap_a_cycle_of_only_empty_results_reports_success` and
-`test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`.
+`test_a_cycle_of_only_empty_results_still_reports_success`,
+`test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`,
+`test_a_cycle_where_no_request_was_accepted_reports_an_error` and
+`test_a_mixed_cycle_of_rejection_and_unaccepted_siblings_now_surfaces`.
 What is still NOT fixed there, stated so it is not mistaken for solved: that success path still treats every empty
-result as proof of working credentials, and every 5xx, every 429 and every idle BLE tag reaches it. Deciding what an
+result as proof of working credentials. The 5xx and the 429 no longer reach it -- they raise before they can -- but
+every idle BLE tag still does, and so do the three pre-accept failures named above. Deciding what an
 empty result may prove about credentials is a behaviour change of its own with a far wider blast radius (every healthy
-idle poll takes the same path); it is tracked separately (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`) and must not be assumed done. Two tests pin the current state
-so it cannot drift silently: `test_an_empty_return_still_clears_the_counter` characterises the reset that stays, and
-`test_a_non_credential_4xx_location_is_passed_through` pins the seam that keeps a rejection out of it.
+idle poll takes the same path); it is tracked separately (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`) and must not be assumed done. Three tests pin the
+current state so it cannot drift silently: `test_an_empty_return_still_clears_the_counter` characterises the reset that
+stays, `test_an_unaccepted_request_no_longer_clears_the_counter` is its contract pair for the requests that no longer
+reach it, and `test_a_non_credential_4xx_location_is_passed_through` pins the seam that keeps a rejection out of it.
 What is NOT fixed, stated so the rule is not mistaken for a solved problem: `nova_request.py` still raises a type named
 "auth" for all of them, so a new handler that reads the type repeats the defect, and this paragraph is the only thing
 standing in its way. Giving the non-credential case its own exception class is the open follow-up; it needs an

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -267,6 +267,14 @@ handler) is enforced by `tests/test_nova_request.py::TestTheDocumentedExtentStay
 rather than from grep, following the rule `tests/AGENTS.md` states for shared tuples. Prose that carries a number and
 calls itself "the only thing standing in its way" must not be the only copy of that number: change the extent and this
 paragraph in the same commit, and let the test tell you when one of them went stale.
+That class has since been given two further duties, because the same shape kept recurring. It derives the guard count
+stated in `LocationRequestNotAcceptedError`'s docstring, and it resolves the test names cited in every `AGENTS.md`
+under this component against the test tree, class names included. The name half is only PART new, and saying otherwise
+would repeat the defect: `TestTheDocumentedRejectionGuardStaysTrue` has always read the "Eight tests pin this:"
+sentence above and checked both its number and its names. What was loose until now is the rest -- the second list
+("Three tests pin the current state"), one-off citations outside any list, the class names this file leans on, and the
+other contracts under this component. A name may therefore not be written into any of them before the test exists.
+Citations of a FILE (`tests/foo.py`) stay unchecked by design, so renaming a test module still dangles silently.
 
 ### Import deferral reminder
 

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -162,11 +162,18 @@ change, an unreachable server is an outage.
 That difference is NOT flow position, and writing it that way would be measurably wrong. `location_request.py`
 re-raises the non-credential 4xx from the same `try` that produces the 5xx and the 429, all of them BEFORE the
 `Location request accepted` line, so neither kind reached the accept point. The difference is what the outcome
-says: a rejection carries the SERVER'S answer about that device -- it was asked, and it answered -- while a non-accepted
-request carries no answer from the server at all, because the question never arrived. Say it that way and nothing more.
-Two compressions are wrong and both have been written here before. NOT "permanent versus transient": a later paragraph
-measures where that breaks (`no_fcm_token`), and an earlier revision of THIS sentence asserted the compression while
-that paragraph already forbade it. NOT "about the device versus not about the device" either: `no_fcm_token` is
+says: a rejection carries the SERVER'S answer ABOUT THAT DEVICE -- it was asked, and it answered -- while a
+non-accepted request carries no answer FROM THE SERVER about that device. (That is not the forbidden "about the
+device versus not about the device" compression below: it is about who spoke, not about whom the failure concerns.)
+Say it that way and nothing more.
+Three compressions are wrong and all three have been written here before. NOT "the question never arrived": for the
+429 and the 5xx it did arrive and the server did answer, only about ITSELF -- one refusing to serve, the other
+reporting its own failure -- while `no_fcm_token` and the failed registration never left this integration. What the
+seven stages share is the ACCEPT POINT, not the wire: none of them got past `Location request accepted`, which is why
+the class is named for acceptance and not for delivery. Writing it as "never reached the server" invites a later
+handler to assume pre-dispatch semantics that two of the stages do not have.
+NOT "permanent versus transient": a later paragraph measures where that breaks (`no_fcm_token`), and an earlier
+revision of THIS sentence asserted the compression while that paragraph already forbade it. NOT "about the device versus not about the device" either: `no_fcm_token` is
 non-acceptance and IS device-specific, it is just not the server saying so. What the two share is only that this device
 contributed no evidence.
 What an empty sibling proves is narrower than it looks, and the guard is built so that it never has to prove much. The

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -161,9 +161,14 @@ got through. The two are kept apart so the reported message names the condition:
 change, an unreachable server is an outage.
 That difference is NOT flow position, and writing it that way would be measurably wrong. `location_request.py`
 re-raises the non-credential 4xx from the same `try` that produces the 5xx and the 429, all of them BEFORE the
-`Location request accepted` line, so neither kind reached the accept point. The difference is what the outcome says: a
-rejection is the server's answer ABOUT that device and is permanent, a non-accepted request says nothing about the
-device at all and is transient.
+`Location request accepted` line, so neither kind reached the accept point. The difference is what the outcome
+says: a rejection carries the SERVER'S answer about that device -- it was asked, and it answered -- while a non-accepted
+request carries no answer from the server at all, because the question never arrived. Say it that way and nothing more.
+Two compressions are wrong and both have been written here before. NOT "permanent versus transient": a later paragraph
+measures where that breaks (`no_fcm_token`), and an earlier revision of THIS sentence asserted the compression while
+that paragraph already forbade it. NOT "about the device versus not about the device" either: `no_fcm_token` is
+non-acceptance and IS device-specific, it is just not the server saying so. What the two share is only that this device
+contributed no evidence.
 What an empty sibling proves is narrower than it looks, and the guard is built so that it never has to prove much. The
 transport failures that used to flatten into `{}` -- the 5xx, the 429, the `aiohttp.ClientError`, the generic Nova
 failure -- now raise `LocationRequestNotAcceptedError`. FOUR pre-accept failures still arrive as an empty dict,

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -56,6 +56,117 @@ from custom_components.googlefindmy.SpotApi.spot_request import SpotAuthPermanen
 _LOGGER = logging.getLogger(__name__)
 
 
+# Flow-position markers for ``LocationRequestNotAcceptedError``. This is a CLOSED
+# set of POSITIONS in the request flow, never a cause taxonomy. Deciding what a
+# failure MEANS is api.py's job: this module names the status in its log records
+# but "still only re-raises -- it does not classify"
+# (``custom_components/googlefindmy/AGENTS.md``, the paragraph on how this layer
+# treats a Nova auth error).
+# Six markers name a ``return []`` reachable ONLY before the accept log line. The
+# seventh, ``surfacing_before_accept``, belongs to the outer handler, whose own
+# return sits AFTER that line; telling its two sides apart therefore needs a flag
+# set AT the log line rather than a position in the file. That flag does not exist
+# yet -- AP-3 introduces it together with the raise sites, and until then nothing
+# enforces this set either: the AST test over the raise sites is xfail.
+LOCATION_REQUEST_NOT_ACCEPTED_STAGES: frozenset[str] = frozenset(
+    {
+        "no_fcm_token",
+        "fcm_registration_failed",
+        "rate_limited",
+        "server_error",
+        "network_error",
+        "nova_request_failed",
+        "surfacing_before_accept",
+    }
+)
+
+
+class LocationRequestNotAcceptedError(Exception):
+    """Raised when a locate request never reached the server's accept point.
+
+    ``get_location_data_for_device`` returned ``[]`` for two states that have
+    nothing in common: a request the server ACCEPTED that simply had nothing to
+    report (no reporter in range -- the healthy idle outcome of a BLE tag), and
+    a request that never got that far (no FCM token, a failed FCM registration,
+    a 429, a 5xx, a network error, an unclassified Nova failure, or a surfacing
+    error before the accept line). ``api.async_get_device_location`` mapped both
+    to ``{}``, so both coordinator callers read every non-raising return as
+    positive proof that the credentials work. This type carries the second state
+    across the ``location_request.py`` boundary -- the layer that flattens it --
+    instead of leaving it to be reconstructed downstream once the evidence is
+    already gone.
+
+    What it claims is a POSITION in the flow, not a CAUSE: the
+    ``Location request accepted`` log line was not reached. That position cannot
+    be read off the file layout, because the outer surfacing handler wraps the
+    whole body and its own return sits AFTER the log line; it has to be read off
+    a flag set AT the line. AP-3 introduces that flag when it arms the raise
+    sites -- as of this commit the class exists and nothing raises it yet.
+    ``stage`` is a flow-position marker from the closed set
+    ``LOCATION_REQUEST_NOT_ACCEPTED_STAGES``; growing it into a cause taxonomy
+    would break the classifier discipline this layer is held to.
+
+    Base class is ``Exception`` deliberately, mirroring
+    ``OwnerKeyLookupTransientError``, and explicitly NOT:
+
+    * NOT ``RuntimeError``: the tree carries broad ``except RuntimeError`` blocks
+      in over twenty places, ``api.py``'s locate path among them, and a base must
+      not depend on every one of them being ordered correctly against a
+      pass-through that a later edit might move or forget. (In ``api.py`` today
+      the pass-throughs DO sit ahead of it, which is why ``DecryptionError`` --
+      itself a ``RuntimeError`` -- survives there; that ordering is a property of
+      the handler, not of the type, and is exactly what must not be relied on.)
+      ``OwnerKeyLookupTransientError`` states the same reason for the same base.
+    * NOT ``DecryptionError``: the coordinator's ``except DecryptionError``
+      blocks route into the account-wide reauth verdict, but the credentials are
+      presumed valid here -- an unreachable server says nothing about them.
+    * NOT ``NovaError``/``NovaAuthError``: ten ``try`` blocks name
+      ``NovaAuthError`` in a handler (the count ``TestTheDocumentedExtentStaysTrue``
+      derives from the AST, and it is that name it counts, not the base
+      ``NovaError``, of which there are more). Eight carry a broad
+      ``except Exception`` in the same block that would swallow the signal; the
+      two sound-REQUEST handlers catch a fixed tuple with no broad fallback,
+      where it would instead propagate uncaught. Two opposite failure modes in
+      one inheritance choice (AGENTS.md, the two-opposite-failure-modes
+      paragraph).
+    * NOT ``HomeAssistantError``: ``exceptions.py`` reserves that base for
+      conditions that already ARE a finished user-facing message. Measured,
+      ``coordinator/locate.py`` carries no ``except HomeAssistantError`` at all;
+      its broad handler re-wraps whatever arrives into a new one. Inheriting it
+      would therefore buy no routing, only a false promise about the message.
+
+    Choosing the base is necessary but NOT sufficient, and reading it as
+    sufficient is exactly how this change becomes inert: every broad
+    ``except Exception`` on the path catches this type as well, because
+    ``Exception`` IS the base. Measured, three sit on the raise path (the inner
+    FCM handler and the outer surfacing handler in this module, and the handler
+    in ``api.py`` before its ``return {}``) and two more downstream
+    (the per-device handler in ``coordinator/polling.py`` and the one in
+    ``coordinator/locate.py``). Every one of them needs an explicit
+    ``except LocationRequestNotAcceptedError: raise`` -- or a dedicated branch --
+    placed BEFORE it. One more sits a level up: the cycle-level handler in
+    ``polling.py``'s update method turns anything escaping the per-device loop
+    into an ``UpdateFailed`` for the WHOLE cycle, so the per-device branch must
+    not re-raise. The base class only guarantees that no NARROW handler
+    misroutes the signal along the way.
+
+    The payload is ``stage`` plus an optional HTTP ``status`` -- carried wherever
+    the failing layer knows one, in practice the server error and the rate limit.
+    The device display name is deliberately absent: the raw name belongs at DEBUG
+    (AGENTS.md Section 5 redaction, "Name@DEBUG"), and this message reaches
+    user-facing records.
+    """
+
+    def __init__(self, *, stage: str, status: int | None = None) -> None:
+        """Record the flow position and, for a server error, its HTTP status."""
+        self.stage = stage
+        self.status = status
+        detail = (
+            f"stage={stage}" if status is None else f"stage={stage}, status={status}"
+        )
+        super().__init__(f"Location request not accepted ({detail})")
+
+
 def _format_cause_chain(exc: BaseException, *, max_depth: int = 8) -> str:
     """Render the full exception cause chain as a ``Type: msg -> Type: msg`` string.
 

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -163,7 +163,13 @@ class LocationRequestNotAcceptedError(Exception):
     placed BEFORE it, and all five carry one. Deleting any of them, or moving it
     behind its broad neighbour, silently restores the empty result this type was
     introduced to replace; that is what the seam tests in
-    ``tests/test_location_request_not_accepted.py`` exist to catch.
+    ``tests/test_location_request_not_accepted.py`` exist to catch. The count and
+    the ordering are not prose alone: ``TestTheDocumentedExtentStaysTrue`` in
+    ``tests/test_nova_request.py`` derives both from the AST, so change the
+    extent and this paragraph in the same commit. What it derives is the set of
+    blocks that CARRY a guard -- a broad handler newly added on this path
+    WITHOUT one never enters that set and leaves "all five carry one" quietly
+    wrong, which is the direction the seam tests above cover instead.
 
     A SIXTH broad handler exists and deliberately has no guard:
     ``api._run_sync_helper`` flattens every exception to the caller's default, so
@@ -172,7 +178,11 @@ class LocationRequestNotAcceptedError(Exception):
     than an oversight, and it is pinned as such by
     ``test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict``. Counting
     it among the five would be wrong; leaving it out of the count without saying
-    so would read as a completeness claim the path does not support.
+    so would read as a completeness claim the path does not support. Its
+    guardlessness is pinned too, and by the same AST rows in
+    ``TestTheDocumentedExtentStaysTrue``: adding a guard there is a behaviour
+    change at a public sync entry point, and it must not happen while this
+    paragraph still says otherwise.
 
     One more handler sits a level UP rather than on the path: the cycle-level one
     in ``polling.py``'s update method turns anything escaping the per-device loop

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -85,7 +85,16 @@ LOCATION_REQUEST_NOT_ACCEPTED_STAGES: frozenset[str] = frozenset(
 
 
 class LocationRequestNotAcceptedError(Exception):
-    """Raised when a locate request never reached the server's accept point.
+    """Raised when a locate request never got past this integration's accept point.
+
+    "Accept point", not "the server": the marker is the ``Location request
+    accepted`` line below, which this module writes once ``async_nova_request``
+    returns without raising. It is an application-level judgement of this
+    integration, not a place on the wire. Two of the seven stages prove the
+    difference: ``rate_limited`` and ``server_error`` are raised FROM an HTTP 429
+    and an HTTP 5xx, so the request did reach the server and the server did
+    answer. Reading the class as "never dispatched" would give a future consumer
+    pre-dispatch semantics that those two stages do not have.
 
     ``get_location_data_for_device`` returned ``[]`` for two states that have
     nothing in common: a request the server ACCEPTED that simply had nothing to
@@ -701,8 +710,9 @@ async def get_location_data_for_device(  # noqa: PLR0912, PLR0913, PLR0915
         that is the whole of the distinction this function draws.
 
     Raises:
-        LocationRequestNotAcceptedError: The request never reached the server's
-            accept point (no FCM token, failed FCM registration, 429, 5xx, network
+        LocationRequestNotAcceptedError: The request never got past this
+            integration's accept point (no FCM token, failed FCM registration, 429,
+            5xx, network
             error, an unclassified Nova failure, or a surfacing error before the
             accept line). Callers that only need a location may treat it as an
             empty result, but must not read it as proof that the credentials work.

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -1167,10 +1167,20 @@ if __name__ == "__main__":
         async def async_set_cached_value(self, key: str, value: Any) -> None:
             self._values[key] = value
 
-    asyncio.run(
-        get_location_data_for_device(
-            get_example_data("sample_canonic_device_id"),
-            "Test",
-            cache=cast(TokenCache, _CliTokenCache()),
+    # Same reason as the interactive CLI in `nbe_list_devices.py`: a request the
+    # server never accepted raises, and an uncaught raise here would end this
+    # experiment on a traceback whose top frame is an implementation detail. The
+    # exit code is deliberately non-zero -- unlike the interactive loop there is
+    # no next prompt to return to, and a script wrapping this must be able to
+    # tell "no location" from "the request never got out".
+    try:
+        asyncio.run(
+            get_location_data_for_device(
+                get_example_data("sample_canonic_device_id"),
+                "Test",
+                cache=cast(TokenCache, _CliTokenCache()),
+            )
         )
-    )
+    except LocationRequestNotAcceptedError as not_accepted:
+        print(str(not_accepted))
+        raise SystemExit(1) from not_accepted

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -42,6 +42,7 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.nbe_execute_action imp
     serialize_action_request,
 )
 from custom_components.googlefindmy.NovaApi.nova_request import (
+    HTTP_TOO_MANY_REQUESTS,
     NovaAuthError,
     NovaAuthPermanentError,
     NovaHTTPError,
@@ -62,12 +63,14 @@ _LOGGER = logging.getLogger(__name__)
 # but "still only re-raises -- it does not classify"
 # (``custom_components/googlefindmy/AGENTS.md``, the paragraph on how this layer
 # treats a Nova auth error).
-# Six markers name a ``return []`` reachable ONLY before the accept log line. The
-# seventh, ``surfacing_before_accept``, belongs to the outer handler, whose own
-# return sits AFTER that line; telling its two sides apart therefore needs a flag
-# set AT the log line rather than a position in the file. That flag does not exist
-# yet -- AP-3 introduces it together with the raise sites, and until then nothing
-# enforces this set either: the AST test over the raise sites is xfail.
+# Six markers name a former ``return []`` reachable ONLY before the accept log
+# line. The seventh, ``surfacing_before_accept``, belongs to the outer handler,
+# whose own return sits AFTER that line; telling its two sides apart therefore
+# needs a flag set AT the log line rather than a position in the file. That flag
+# is ``request_accepted`` in ``get_location_data_for_device``. The set is enforced
+# in both directions by ``test_the_stage_markers_are_a_closed_set``, which reads
+# the raise sites out of the AST: a marker added here without a raise site fails
+# it just as a raise site with an undeclared marker does.
 LOCATION_REQUEST_NOT_ACCEPTED_STAGES: frozenset[str] = frozenset(
     {
         "no_fcm_token",
@@ -100,8 +103,9 @@ class LocationRequestNotAcceptedError(Exception):
     ``Location request accepted`` log line was not reached. That position cannot
     be read off the file layout, because the outer surfacing handler wraps the
     whole body and its own return sits AFTER the log line; it has to be read off
-    a flag set AT the line. AP-3 introduces that flag when it arms the raise
-    sites -- as of this commit the class exists and nothing raises it yet.
+    a flag set AT the line. That flag is ``request_accepted``; the outer handler
+    reads it to decide whether the failure it caught fell before or after the
+    accept point.
     ``stage`` is a flow-position marker from the closed set
     ``LOCATION_REQUEST_NOT_ACCEPTED_STAGES``; growing it into a cause taxonomy
     would break the classifier discipline this layer is held to.
@@ -144,14 +148,31 @@ class LocationRequestNotAcceptedError(Exception):
     (the per-device handler in ``coordinator/polling.py`` and the one in
     ``coordinator/locate.py``). Every one of them needs an explicit
     ``except LocationRequestNotAcceptedError: raise`` -- or a dedicated branch --
-    placed BEFORE it. One more sits a level up: the cycle-level handler in
-    ``polling.py``'s update method turns anything escaping the per-device loop
+    placed BEFORE it, and all five carry one. Deleting any of them, or moving it
+    behind its broad neighbour, silently restores the empty result this type was
+    introduced to replace; that is what the seam tests in
+    ``tests/test_location_request_not_accepted.py`` exist to catch.
+
+    A SIXTH broad handler exists and deliberately has no guard:
+    ``api._run_sync_helper`` flattens every exception to the caller's default, so
+    the synchronous ``api.get_device_location`` still hands back ``{}`` for this
+    signal too. That is the documented contract of the sync entry point rather
+    than an oversight, and it is pinned as such by
+    ``test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict``. Counting
+    it among the five would be wrong; leaving it out of the count without saying
+    so would read as a completeness claim the path does not support.
+
+    One more handler sits a level UP rather than on the path: the cycle-level one
+    in ``polling.py``'s update method turns anything escaping the per-device loop
     into an ``UpdateFailed`` for the WHOLE cycle, so the per-device branch must
     not re-raise. The base class only guarantees that no NARROW handler
     misroutes the signal along the way.
 
     The payload is ``stage`` plus an optional HTTP ``status`` -- carried wherever
-    the failing layer knows one, in practice the server error and the rate limit.
+    the failing layer knows one, measured today at exactly two sites: the server
+    error, which reads it off ``NovaHTTPError.status``, and the rate limit, which
+    has no such attribute and takes the transport's ``HTTP_TOO_MANY_REQUESTS``
+    because 429 is definitional for that class.
     The device display name is deliberately absent: the raw name belongs at DEBUG
     (AGENTS.md Section 5 redaction, "Name@DEBUG"), and this message reaches
     user-facing records.
@@ -625,7 +646,7 @@ def _make_location_callback(  # noqa: PLR0915, PLR0913
 # -----------------------------------------------------------------------------
 # Public API
 # -----------------------------------------------------------------------------
-async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0915
+async def get_location_data_for_device(  # noqa: PLR0912, PLR0913, PLR0915
     canonic_device_id: str,
     name: str,
     session: aiohttp.ClientSession | None = None,
@@ -670,7 +691,28 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         last_mode_switch: Epoch timestamp when the contributor mode last changed.
 
     Returns:
-        A list of dictionaries containing location data, or an empty list on failure.
+        A list of dictionaries containing location data, or an empty list when the
+        server ACCEPTED the request and no usable record came back. That is the
+        healthy idle outcome of a BLE tag, but not only that: a failure after the
+        accept line returns empty too -- the unexpected-device mismatch, anything
+        the outer surfacing handler catches from there on, and every error the FCM
+        callback absorbs on its own. What an empty list no longer means is "the
+        request never got there"; that is what the exception below is for, and
+        that is the whole of the distinction this function draws.
+
+    Raises:
+        LocationRequestNotAcceptedError: The request never reached the server's
+            accept point (no FCM token, failed FCM registration, 429, 5xx, network
+            error, an unclassified Nova failure, or a surfacing error before the
+            accept line). Callers that only need a location may treat it as an
+            empty result, but must not read it as proof that the credentials work.
+        MissingTokenCacheError: No entry-scoped cache was supplied. A configuration
+            defect, raised before any request is built.
+        RuntimeError: No FCM receiver provider is registered, or it returned None.
+            Likewise a programming/configuration defect rather than a locate outcome.
+        NovaAuthError / NovaAuthPermanentError / SpotAuthPermanentError /
+            SpotApiEmptyResponseError / DecryptionError / OwnerKeyLookupTransientError:
+            re-raised unchanged; this layer still does not classify them.
     """
     _LOGGER.info("Requesting location data for %s...", name)
 
@@ -693,6 +735,13 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         raise RuntimeError("FCM receiver provider returned None.")
 
     registered = False
+    # The accept line below is the only thing that tells a request the server took
+    # from one it never got. The outer handler wraps the WHOLE body, so its own
+    # return sits AFTER that line while the exceptions it catches come from both
+    # sides of it -- the split has to be read off a flag set AT the line, never off
+    # a position in the file (``custom_components/googlefindmy/AGENTS.md``, the
+    # paragraph beginning "Where the resolution belongs is measured").
+    request_accepted = False
     ctx = _CallbackContext()
     loop = asyncio.get_running_loop()
 
@@ -851,15 +900,28 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
                     "(see the preceding warning for the specific cause)",
                 )
                 _LOGGER.debug("No FCM token for %s; skipping this locate", name)
-                return []
+                # No exception to chain from: the register call returned a falsy
+                # token rather than raising, so ``from`` would have nothing to
+                # attach. The stage marker IS the whole cause here.
+                raise LocationRequestNotAcceptedError(stage="no_fcm_token")
             registered = True
             _LOGGER.debug("FCM token obtained for %s (len=%d)", name, len(fcm_token))
+        except LocationRequestNotAcceptedError:
+            # The no-FCM-token branch above raises INSIDE this try body, so the
+            # broad handler below would catch the signal and flatten it right back
+            # into the empty result this change exists to tell apart. ``Exception``
+            # is its base by design (see the class docstring), which is precisely
+            # why the base cannot buy this and an explicit re-raise must sit ahead
+            # of every broad handler on the path.
+            raise
         except Exception as fcm_error:
             # R6 (AGENTS.md Section 5): device name to DEBUG only.
             _LOGGER.error("FCM registration failed: %s", fcm_error)
             _LOGGER.debug("FCM registration failed for %s", name)
             _LOGGER.debug("FCM registration traceback: %s", traceback.format_exc())
-            return []
+            raise LocationRequestNotAcceptedError(
+                stage="fcm_registration_failed"
+            ) from fcm_error
 
         # Create location request payload
         hex_payload = create_location_request(
@@ -891,14 +953,22 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
             # R6 (AGENTS.md Section 5): device name to DEBUG only.
             _LOGGER.warning("Rate limited while requesting location: %s", e)
             _LOGGER.debug("Rate limited while requesting location for %s", name)
-            return []
+            # Measured: ``NovaRateLimitError`` carries ``detail`` but no ``status``
+            # attribute -- the status is definitional for the class ("Raised on 429
+            # rate-limiting errors after retries"), so it comes from the transport's
+            # own constant rather than from a getattr that would silently yield None.
+            raise LocationRequestNotAcceptedError(
+                stage="rate_limited", status=HTTP_TOO_MANY_REQUESTS
+            ) from e
         except NovaHTTPError as e:
             # R6 (AGENTS.md Section 5): device name to DEBUG only.
             _LOGGER.warning(
                 "Server error (%s) while requesting location: %s", e.status, e
             )
             _LOGGER.debug("Server error while requesting location for %s", name)
-            return []
+            raise LocationRequestNotAcceptedError(
+                stage="server_error", status=e.status
+            ) from e
         except NovaAuthError as e:
             # Re-raise auth errors so api.py can convert to ConfigEntryAuthFailed
             # and trigger re-authentication flow. Previously this was swallowed,
@@ -928,15 +998,19 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
             # R6 (AGENTS.md Section 5): device name to DEBUG only.
             _LOGGER.warning("Network/client error while requesting location: %s", e)
             _LOGGER.debug("Network/client error while requesting location for %s", name)
-            return []
+            raise LocationRequestNotAcceptedError(stage="network_error") from e
         except Exception as e:
             # R6 (AGENTS.md Section 5): device name to DEBUG only.
             _LOGGER.error("Nova API request failed: %s", e)
             _LOGGER.debug("Nova API request failed for %s", name)
-            return []
+            raise LocationRequestNotAcceptedError(stage="nova_request_failed") from e
 
         # For this RPC the server often returns HTTP 200 with empty body (FCM delivers the data).
         _LOGGER.info("Location request accepted for %s; awaiting FCM data...", name)
+        # Everything from here on is an ACCEPTED request. An empty result below is
+        # the healthy idle outcome of a BLE tag, and the outer handler must stop
+        # calling it "not accepted" from this point.
+        request_accepted = True
 
         # Wait efficiently for FCM callback to signal completion
         timeout = LOCATION_REQUEST_TIMEOUT_S
@@ -951,6 +1025,10 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
             _LOGGER.info(
                 "No location response received for %s (timeout: %ss)", name, timeout
             )
+            # Deliberately still an empty return: the server ACCEPTED this request,
+            # no reporter was in range within the window. This is the very outcome
+            # LocationRequestNotAcceptedError exists to keep distinguishable from a
+            # request that never arrived -- raising here would re-merge them.
             return []
 
         if ctx.error:
@@ -987,6 +1065,13 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
                 "Received location data for an unexpected device; ignoring."
             )
             _LOGGER.debug("Unexpected-device mismatch in locate flow for %s", name)
+        # Also unchanged, and for the branch above only half by right: the request
+        # was accepted, so it is out of this plan's scope by definition. But the
+        # ``else`` arm is a FAILURE, not an idle outcome -- data arrived for the
+        # wrong device. It escapes only because the line drawn here is
+        # accepted-versus-not-accepted, not healthy-versus-failed
+        # (``custom_components/googlefindmy/AGENTS.md``: "not every empty result
+        # after the log is benign either").
         return []
 
     except asyncio.CancelledError:
@@ -1020,6 +1105,13 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         # (DEBUG skip, no counter touch) instead of being swallowed by the broad
         # ``except Exception`` into ``return []``.
         raise
+    except LocationRequestNotAcceptedError:
+        # Second and last swallow guard. Six of the seven raise sites are inside
+        # this try body, so without it the broad handler below would catch the
+        # signal and hand back the empty result again -- and worse, the branch at
+        # the end of that handler would re-wrap it under ``surfacing_before_accept``,
+        # discarding the stage that named the real position.
+        raise
     except Exception as e:
         # R6 (AGENTS.md Section 5 redaction): the raw device display name must not
         # leak into a user-facing WARNING/ERROR. Surface only the error type and
@@ -1035,6 +1127,16 @@ async def get_location_data_for_device(  # noqa: PLR0911, PLR0912, PLR0913, PLR0
         )
         _LOGGER.debug("Location request failure detail for %s", name)
         _LOGGER.debug("Traceback: %s", traceback.format_exc())
+        # Both records above stay on BOTH sides of the branch: they are the R6 and
+        # R9c diagnostics, and which side of the accept line the failure fell on
+        # says nothing about whether the operator needs them.
+        if not request_accepted:
+            # This handler wraps the whole body, so its position in the file cannot
+            # tell the two sides apart -- only the flag can. Anything reaching here
+            # before the accept line means the request never got to the server.
+            raise LocationRequestNotAcceptedError(
+                stage="surfacing_before_accept"
+            ) from e
         return []
     finally:
         # Clean up - unregister callback only (receiver lifecycle is owned by integration)

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -92,9 +92,11 @@ class LocationRequestNotAcceptedError(Exception):
     returns without raising. It is an application-level judgement of this
     integration, not a place on the wire. Two of the seven stages prove the
     difference: ``rate_limited`` and ``server_error`` are raised FROM an HTTP 429
-    and an HTTP 5xx, so the request did reach the server and the server did
-    answer. Reading the class as "never dispatched" would give a future consumer
-    pre-dispatch semantics that those two stages do not have.
+    and from an error status the server itself returned (a 5xx, or a 408 once
+    retries are exhausted -- ``server_error`` carries ``e.status``), so the
+    request did reach the server and the server did answer. Reading the class
+    as "never dispatched" would give a future consumer pre-dispatch semantics
+    that those two stages do not have.
 
     ``get_location_data_for_device`` returned ``[]`` for two states that have
     nothing in common: a request the server ACCEPTED that simply had nothing to
@@ -132,7 +134,8 @@ class LocationRequestNotAcceptedError(Exception):
       ``OwnerKeyLookupTransientError`` states the same reason for the same base.
     * NOT ``DecryptionError``: the coordinator's ``except DecryptionError``
       blocks route into the account-wide reauth verdict, but the credentials are
-      presumed valid here -- an unreachable server says nothing about them.
+      presumed valid here -- a request that was not accepted says nothing about
+      them.
     * NOT ``NovaError``/``NovaAuthError``: ten ``try`` blocks name
       ``NovaAuthError`` in a handler (the count ``TestTheDocumentedExtentStaysTrue``
       derives from the AST, and it is that name it counts, not the base
@@ -745,8 +748,8 @@ async def get_location_data_for_device(  # noqa: PLR0912, PLR0913, PLR0915
         raise RuntimeError("FCM receiver provider returned None.")
 
     registered = False
-    # The accept line below is the only thing that tells a request the server took
-    # from one it never got. The outer handler wraps the WHOLE body, so its own
+    # The accept line below is the only thing that tells an ACCEPTED request from
+    # one that never got past it. The outer handler wraps the WHOLE body, so its own
     # return sits AFTER that line while the exceptions it catches come from both
     # sides of it -- the split has to be read off a flag set AT the line, never off
     # a position in the file (``custom_components/googlefindmy/AGENTS.md``, the
@@ -1145,7 +1148,10 @@ async def get_location_data_for_device(  # noqa: PLR0912, PLR0913, PLR0915
         if not request_accepted:
             # This handler wraps the whole body, so its position in the file cannot
             # tell the two sides apart -- only the flag can. Anything reaching here
-            # before the accept line means the request never got to the server.
+            # before the accept line failed with that flag unset, and it is the flag
+            # alone that decides non-acceptance versus an empty result. What the
+            # signal then claims is a position at THIS integration's accept point,
+            # never one on the wire (see the class docstring).
             raise LocationRequestNotAcceptedError(
                 stage="surfacing_before_accept"
             ) from e
@@ -1179,12 +1185,12 @@ if __name__ == "__main__":
         async def async_set_cached_value(self, key: str, value: Any) -> None:
             self._values[key] = value
 
-    # Same reason as the interactive CLI in `nbe_list_devices.py`: a request the
-    # server never accepted raises, and an uncaught raise here would end this
-    # experiment on a traceback whose top frame is an implementation detail. The
-    # exit code is deliberately non-zero -- unlike the interactive loop there is
-    # no next prompt to return to, and a script wrapping this must be able to
-    # tell "no location" from "the request never got out".
+    # Same reason as the interactive CLI in `nbe_list_devices.py`: a request that
+    # never got past this integration's accept point raises, and an uncaught raise
+    # here would end this experiment on a traceback whose top frame is an
+    # implementation detail. The exit code is deliberately non-zero -- unlike the
+    # interactive loop there is no next prompt to return to, and a script wrapping
+    # this must be able to tell "no location" from "the request was not accepted".
     try:
         asyncio.run(
             get_location_data_for_device(

--- a/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
+++ b/custom_components/googlefindmy/NovaApi/ExecuteAction/LocateTracker/location_request.py
@@ -1028,7 +1028,9 @@ async def get_location_data_for_device(  # noqa: PLR0912, PLR0913, PLR0915
             # Deliberately still an empty return: the server ACCEPTED this request,
             # no reporter was in range within the window. This is the very outcome
             # LocationRequestNotAcceptedError exists to keep distinguishable from a
-            # request that never arrived -- raising here would re-merge them.
+            # request that never got PAST THIS LINE -- raising here would re-merge
+            # them. (Past this line, not "never arrived": a 429 and a 5xx did
+            # arrive and were answered.)
             return []
 
         if ctx.error:

--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -368,9 +368,11 @@ async def _async_cli_main(
             )
 
             # `get_location_data_for_device` raises
-            # `LocationRequestNotAcceptedError` for a request the server never
-            # accepted (a 5xx, a 429, a network error, a failed FCM
-            # registration) where it used to return an empty list. Caught here
+            # `LocationRequestNotAcceptedError` for a request that never got past
+            # this integration's accept point (no FCM token, a failed FCM
+            # registration, a 429, a server error status, a network error, an
+            # unclassified Nova failure, or a surfacing error before the accept
+            # line) where it used to return an empty list. Caught here
             # rather than left to escape: this is an interactive loop, a routine
             # service failure must not end the whole session on a traceback, and
             # the user is meant to be able to pick another device and try again.

--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -355,6 +355,17 @@ async def _async_cli_main(
                 "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request"
             ).get_location_data_for_device
 
+            # Known open edge, stated so it is not mistaken for an oversight:
+            # since PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE this call raises
+            # `LocationRequestNotAcceptedError` for a request the server never
+            # accepted (a 5xx, a 429, a network error, a failed FCM
+            # registration) where it used to return an empty list. Nothing here
+            # catches it, so the interactive loop ends on a traceback instead of
+            # printing "no location". Turning that into a readable CLI line is
+            # the job of the step that tightens the CLI edges; it is deliberately
+            # not done inside the change that armed the raise sites, because the
+            # coordinator paths and the CLI paths fail for different reasons and
+            # want different words.
             locations = await get_location_data_for_device(
                 selected_canonic_id,
                 selected_device_name,

--- a/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
+++ b/custom_components/googlefindmy/NovaApi/ListDevices/nbe_list_devices.py
@@ -350,29 +350,59 @@ async def _async_cli_main(
 
             print("Fetching location...")
 
-            # Lazy import: only needed for the CLI branch
-            get_location_data_for_device = import_module(
+            # Lazy import: only needed for the CLI branch. The signal type is
+            # read off the SAME module object simply because the function is --
+            # one lookup, one source. Do NOT read this as "a module-scope import
+            # would be expensive": measured, `location_request` is already in
+            # `sys.modules` by the time this module is imported (the package
+            # `__init__` reaches it through `api.py`), and `api.py`, `locate.py`
+            # and `polling.py` all import the class at module scope.
+            location_request_module = import_module(
                 "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request"
-            ).get_location_data_for_device
+            )
+            get_location_data_for_device = (
+                location_request_module.get_location_data_for_device
+            )
+            LocationRequestNotAcceptedError = (
+                location_request_module.LocationRequestNotAcceptedError
+            )
 
-            # Known open edge, stated so it is not mistaken for an oversight:
-            # since PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE this call raises
+            # `get_location_data_for_device` raises
             # `LocationRequestNotAcceptedError` for a request the server never
             # accepted (a 5xx, a 429, a network error, a failed FCM
-            # registration) where it used to return an empty list. Nothing here
-            # catches it, so the interactive loop ends on a traceback instead of
-            # printing "no location". Turning that into a readable CLI line is
-            # the job of the step that tightens the CLI edges; it is deliberately
-            # not done inside the change that armed the raise sites, because the
-            # coordinator paths and the CLI paths fail for different reasons and
-            # want different words.
-            locations = await get_location_data_for_device(
-                selected_canonic_id,
-                selected_device_name,
-                session=session,
-                cache=cache,
-                namespace=namespace,
-            )
+            # registration) where it used to return an empty list. Caught here
+            # rather than left to escape: this is an interactive loop, a routine
+            # service failure must not end the whole session on a traceback, and
+            # the user is meant to be able to pick another device and try again.
+            #
+            # The wording is the point of the change, not an afterthought. The
+            # empty-list path below says "the tracker may be out of range",
+            # which for a 503 would be a plain lie about which side is at
+            # fault; that conflation is what the signal exists to end. The
+            # device name is absent from the line because the signal does not
+            # carry one, and it is not missed: the user picked the device from
+            # the numbered list this loop printed a moment ago. This is NOT an
+            # R6 redaction -- that rule (`AGENTS.md` Section 5) governs logs and
+            # diagnostics, and this same loop prints names and canonic ids to
+            # the console by design.
+            try:
+                locations = await get_location_data_for_device(
+                    selected_canonic_id,
+                    selected_device_name,
+                    session=session,
+                    cache=cache,
+                    namespace=namespace,
+                )
+            except LocationRequestNotAcceptedError as not_accepted:
+                # `str(...)` already reads "Location request not accepted
+                # (stage=..., status=...)", so the sentence around it must not
+                # repeat that or the line ends up saying it twice inside nested
+                # brackets.
+                print(
+                    f"\n{not_accepted}. Nothing was learned about the tracker's "
+                    "position; try again, or pick another device."
+                )
+                continue
 
             _print_locations(locations)
 

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -1323,8 +1323,8 @@ class GoogleFindMyAPI:
             were accepted; callers rely on that.
 
             That reliance is only as sound as the layer below. It holds exactly
-            to the extent that a request which never reached the server's ACCEPT
-            POINT raises rather than returning empty -- see
+            to the extent that a request which never got past this integration's
+            ACCEPT POINT raises rather than returning empty -- see
             `LocationRequestNotAcceptedError`
             below. Those raise sites now exist: a 5xx, a 429, a network error and
             a failed FCM registration leave `location_request.py` as that
@@ -1353,8 +1353,10 @@ class GoogleFindMyAPI:
                 apart with `nova_request.is_credential_rejection`; the type does
                 not, and reading the type is the defect this contract exists to
                 prevent.
-            LocationRequestNotAcceptedError: The locate request never reached the
-                server's accept point. Re-raised unchanged so the accepted-versus-
+            LocationRequestNotAcceptedError: The locate request never got past this
+                integration's accept point (which a 429 and a 5xx also miss, having
+                reached the server and been answered). Re-raised unchanged so the
+                accepted-versus-
                 failed outcome survives this boundary instead of being flattened
                 into `{}` and reconstructed downstream once the evidence is gone.
                 It claims a POSITION in the request flow, never a cause, so it is
@@ -1584,7 +1586,7 @@ class GoogleFindMyAPI:
             raise
 
         except LocationRequestNotAcceptedError:
-            # The locate request never reached the server's accept point (no FCM
+            # The locate request never got past this integration's accept point (no FCM
             # token, a failed FCM registration, a 429, a 5xx, a network error, an
             # unclassified Nova failure, or a surfacing error before the accept
             # line). This layer must stay transparent for it, exactly like the two

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -1323,8 +1323,9 @@ class GoogleFindMyAPI:
             were accepted; callers rely on that.
 
             That reliance is only as sound as the layer below. It holds exactly
-            to the extent that a request which never reached the server raises
-            rather than returning empty -- see `LocationRequestNotAcceptedError`
+            to the extent that a request which never reached the server's ACCEPT
+            POINT raises rather than returning empty -- see
+            `LocationRequestNotAcceptedError`
             below. Those raise sites now exist: a 5xx, a 429, a network error and
             a failed FCM registration leave `location_request.py` as that
             exception, not through this exit. What still arrives here as an empty

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -1360,9 +1360,9 @@ class GoogleFindMyAPI:
                 failed outcome survives this boundary instead of being flattened
                 into `{}` and reconstructed downstream once the evidence is gone.
                 It claims a POSITION in the request flow, never a cause, so it is
-                NOT an auth verdict: an unreachable server says nothing about the
-                credentials, and this exit must not be folded into the auth
-                mapping above.
+                NOT an auth verdict: a request that was not accepted says nothing
+                about the credentials, and this exit must not be folded into the
+                auth mapping above.
         """
 
         # Register cache provider for multi-entry support

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -1325,11 +1325,19 @@ class GoogleFindMyAPI:
             That reliance is only as sound as the layer below. It holds exactly
             to the extent that a request which never reached the server raises
             rather than returning empty -- see `LocationRequestNotAcceptedError`
-            below. As of this step the raise sites do not exist yet, so a 5xx, a
-            429, a network error or a failed FCM registration still arrive here
-            as an empty list and leave through this exit indistinguishable from
-            a healthy idle BLE tag. That is the defect the signal is being
-            introduced to close, not a property to design against.
+            below. Those raise sites now exist: a 5xx, a 429, a network error and
+            a failed FCM registration leave `location_request.py` as that
+            exception, not through this exit. What still arrives here as an empty
+            list is what the layer below vouches for as ACCEPTED, which is not
+            the same as healthy, and is deliberately NOT a closed list: the idle
+            BLE tag; the post-accept branches of the locate flow (the
+            unexpected-device mismatch, and any error the outer surfacing handler
+            catches once the accept line has been passed); and every failure the
+            FCM callback absorbs on its own, which is a fully-catching layer of
+            its own after that line -- an unreadable push, a decode failure, a
+            push for another device. Reading an empty result as "healthy" was the
+            defect; reading it as "one of exactly three things" would be the next
+            one.
 
         Raises:
             ConfigEntryAuthFailed: Re-auth must start at once -- an HTTP 401/403
@@ -1351,7 +1359,7 @@ class GoogleFindMyAPI:
                 It claims a POSITION in the request flow, never a cause, so it is
                 NOT an auth verdict: an unreachable server says nothing about the
                 credentials, and this exit must not be folded into the auth
-                mapping above. Nothing raises it yet as of this step.
+                mapping above.
         """
 
         # Register cache provider for multi-entry support
@@ -1593,12 +1601,16 @@ class GoogleFindMyAPI:
             # auth mapping documented above is untouched by it -- an unreachable
             # server says nothing about the credentials.
             #
-            # As of this step nothing raises this type yet; the raise sites in
-            # `location_request.py` follow. The receivers are installed first on
-            # purpose: with the sender armed first, the signal would reach the
-            # coordinator's broad per-device handler, which sets both
-            # `cycle_failed` and `last_exception`, and a single 5xx on a single
-            # tracker would mark every entity of the account unavailable.
+            # This receiver was installed one step BEFORE the seven raise sites in
+            # `location_request.py` existed. The order is deliberate, though not
+            # for the reason it is tempting to state: with NO receiver anywhere,
+            # a sender-first step would have been INERT rather than dangerous,
+            # because the broad `except Exception` below flattens the signal to
+            # `{}` before any coordinator sees it. The danger is the half-wired
+            # state -- this pass-through present and the coordinator's not: the
+            # signal then reaches the poll loop's broad per-device handler, which
+            # sets both `cycle_failed` and `last_exception`, and a single 5xx on a
+            # single tracker would mark every entity of the account unavailable.
             raise
 
         except RuntimeError as err:

--- a/custom_components/googlefindmy/api.py
+++ b/custom_components/googlefindmy/api.py
@@ -73,6 +73,7 @@ from .NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     any_real_location_record,
 )
 from .NovaApi.ExecuteAction.LocateTracker.location_request import (
+    LocationRequestNotAcceptedError,
     get_location_data_for_device,
 )
 from .NovaApi.ExecuteAction.PlaySound.start_sound_request import (
@@ -1321,6 +1322,15 @@ class GoogleFindMyAPI:
             limit, timeout). A normal return therefore means the credentials
             were accepted; callers rely on that.
 
+            That reliance is only as sound as the layer below. It holds exactly
+            to the extent that a request which never reached the server raises
+            rather than returning empty -- see `LocationRequestNotAcceptedError`
+            below. As of this step the raise sites do not exist yet, so a 5xx, a
+            429, a network error or a failed FCM registration still arrive here
+            as an empty list and leave through this exit indistinguishable from
+            a healthy idle BLE tag. That is the defect the signal is being
+            introduced to close, not a property to design against.
+
         Raises:
             ConfigEntryAuthFailed: Re-auth must start at once -- an HTTP 401/403
                 (`NovaHTTPError`), or a permanent Nova auth failure. The
@@ -1334,6 +1344,14 @@ class GoogleFindMyAPI:
                 apart with `nova_request.is_credential_rejection`; the type does
                 not, and reading the type is the defect this contract exists to
                 prevent.
+            LocationRequestNotAcceptedError: The locate request never reached the
+                server's accept point. Re-raised unchanged so the accepted-versus-
+                failed outcome survives this boundary instead of being flattened
+                into `{}` and reconstructed downstream once the evidence is gone.
+                It claims a POSITION in the request flow, never a cause, so it is
+                NOT an auth verdict: an unreachable server says nothing about the
+                credentials, and this exit must not be folded into the auth
+                mapping above. Nothing raises it yet as of this step.
         """
 
         # Register cache provider for multi-entry support
@@ -1554,6 +1572,33 @@ class GoogleFindMyAPI:
             # `except Exception` below would otherwise turn it into an empty result,
             # hiding the transient from the coordinator. Analog to the A1
             # `except DecryptionError: raise` guard above.
+            raise
+
+        except LocationRequestNotAcceptedError:
+            # The locate request never reached the server's accept point (no FCM
+            # token, a failed FCM registration, a 429, a 5xx, a network error, an
+            # unclassified Nova failure, or a surfacing error before the accept
+            # line). This layer must stay transparent for it, exactly like the two
+            # guards above: the broad `except Exception` below would turn it back
+            # into `return {}`, and an empty dict is precisely the evidence loss
+            # the signal exists to prevent. That one handler is the whole reason
+            # this branch exists -- `except RuntimeError` in between never sees the
+            # type, whose base is `Exception` and deliberately NOT `RuntimeError`
+            # (see the class docstring). Placement is therefore load-bearing
+            # against the broad handler specifically: being LAST would make this
+            # branch unreachable, while sitting anywhere ahead of it suffices.
+            #
+            # Note what this pass-through does NOT do: it does not classify. The
+            # signal names a POSITION in the request flow, never a cause, so the
+            # auth mapping documented above is untouched by it -- an unreachable
+            # server says nothing about the credentials.
+            #
+            # As of this step nothing raises this type yet; the raise sites in
+            # `location_request.py` follow. The receivers are installed first on
+            # purpose: with the sender armed first, the signal would reach the
+            # coordinator's broad per-device handler, which sets both
+            # `cycle_failed` and `last_exception`, and a single 5xx on a single
+            # tracker would mark every entity of the account unavailable.
             raise
 
         except RuntimeError as err:

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -719,7 +719,7 @@ class LocateOperations(_MixinBase):
                 )
                 raise HomeAssistantError(message) from dec_err
             except LocationRequestNotAcceptedError as not_accepted_err:
-                # The request never reached the server's accept point. For the
+                # The request never got past this integration's accept point. For the
                 # manual path that is an ordinary empty result, exactly as it
                 # looks to the user today -- a locate that found nothing. What
                 # changes is what does NOT happen on the way there: the

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -35,6 +35,9 @@ from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     OwnerKeyLookupTransientError,
     StaleOwnerKeyError,
 )
+from ..NovaApi.ExecuteAction.LocateTracker.location_request import (
+    LocationRequestNotAcceptedError,
+)
 from ..NovaApi.nova_request import (
     NovaAuthError,
     NovaHTTPError,
@@ -715,6 +718,31 @@ class LocateOperations(_MixinBase):
                     "(the shared key is stale); please re-authenticate."
                 )
                 raise HomeAssistantError(message) from dec_err
+            except LocationRequestNotAcceptedError as not_accepted_err:
+                # The request never reached the server's accept point. For the
+                # manual path that is an ordinary empty result, exactly as it
+                # looks to the user today -- a locate that found nothing. What
+                # changes is what does NOT happen on the way there: the
+                # `_set_auth_state(failed=False)` on the success path above is
+                # skipped by construction, so a 5xx can no longer clear the
+                # account's auth-failure state on its way through. That skip is
+                # the whole point of catching this here.
+                #
+                # Returns rather than raises, unlike the broad handler below: a
+                # failed request is not an "unexpected error" worth a red toast
+                # in the UI, and re-wrapping it into a `HomeAssistantError` would
+                # be a behaviour change this step does not intend. It must still
+                # sit BEFORE that handler, though -- `Exception` is the base, so
+                # the broad branch would otherwise claim it first.
+                _LOGGER.debug(
+                    "Manual locate for %s skipped (request not accepted): %s",
+                    name,
+                    not_accepted_err,
+                )
+                self.note_error(
+                    not_accepted_err, where="async_locate_device", device=name
+                )
+                return {}
             except Exception as err:
                 short_err = self._short_error_message(err)
                 _LOGGER.error("Manual locate for %s failed: %s", name, short_err)

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -758,7 +758,7 @@ class LocateOperations(_MixinBase):
                 # which api.py does re-raise and which logs at DEBUG; the line
                 # between them is subject, not severity. That one is a miss on one
                 # tracker's owner key while the account is otherwise fine. This
-                # one is a request that never reached the server at all, which is
+                # one is a request that never got past the accept point, which is
                 # what the same operation already treats as WARNING when it
                 # refuses to start (the in-flight/cooldown and push-recovery
                 # guards near the top of this method).

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -734,8 +734,53 @@ class LocateOperations(_MixinBase):
                 # be a behaviour change this step does not intend. It must still
                 # sit BEFORE that handler, though -- `Exception` is the base, so
                 # the broad branch would otherwise claim it first.
-                _LOGGER.debug(
-                    "Manual locate for %s skipped (request not accepted): %s",
+                #
+                # WARNING, not DEBUG. This path runs because someone asked for
+                # it -- a button press, an automation, or the `locate_device` /
+                # `locate_external` service -- so the failure has an audience and
+                # a moment. The poll loop logs the SAME condition at DEBUG, and
+                # that is the same rule rather than an inconsistency: it runs
+                # unattended and repeatedly. Leaving it at DEBUG here would have
+                # made a user ask for a locate, get nothing, and find nothing in
+                # the log at the default level.
+                #
+                # Two neighbours could be read as precedent, and exactly one of
+                # them is. NOT the `NovaRateLimitError` / `NovaHTTPError` handlers
+                # a few branches up, however tempting the symmetry: `api.py`
+                # answers both with `return {}` of its own (api.py:1535 for the
+                # 429, api.py:1526 for the non-401/403 5xx), so neither type ever
+                # reaches this method and those two branches are dead on this
+                # path. Nor did this branch inherit their traffic -- before the
+                # request layer started raising, a 5xx returned `[]` from
+                # `location_request` and arrived here on the SUCCESS path, which
+                # is precisely the defect this catch exists to end. The live
+                # neighbour is `OwnerKeyLookupTransientError` a few branches up,
+                # which api.py does re-raise and which logs at DEBUG; the line
+                # between them is subject, not severity. That one is a miss on one
+                # tracker's owner key while the account is otherwise fine. This
+                # one is a request that never reached the server at all, which is
+                # what the same operation already treats as WARNING when it
+                # refuses to start (the in-flight/cooldown and push-recovery
+                # guards near the top of this method).
+                #
+                # Two costs of the promotion, both weighed rather than discovered
+                # later. First, this is the SECOND warning for the same incident:
+                # `location_request` already logs one for the 429, the 5xx and the
+                # network error before it raises. That one is deliberately
+                # redacted and says only that A location request failed; it names
+                # neither the device nor the operation, so it cannot tell the user
+                # who just pressed a button that THEIR request is the one that
+                # failed. The duplicate is one line per user-initiated action, and
+                # the poll path stays at DEBUG, so nothing repeats unattended.
+                # Second, `name` falls back to the raw canonical id when no
+                # display name is cached, which the transport layer avoids by
+                # keeping the identified sentence at DEBUG (AGENTS.md section 5).
+                # It is logged here anyway because every sibling branch of this
+                # method and both guards above it already do -- singling out this
+                # one branch would buy inconsistency, not privacy. Changing that
+                # is a decision about the whole method, not about this catch.
+                _LOGGER.warning(
+                    "Manual locate for %s failed (request not accepted): %s",
                     name,
                     not_accepted_err,
                 )

--- a/custom_components/googlefindmy/coordinator/locate.py
+++ b/custom_components/googlefindmy/coordinator/locate.py
@@ -764,22 +764,43 @@ class LocateOperations(_MixinBase):
                 # guards near the top of this method).
                 #
                 # Two costs of the promotion, both weighed rather than discovered
-                # later. First, this is the SECOND warning for the same incident:
-                # `location_request` already logs one for the 429, the 5xx and the
-                # network error before it raises. That one is deliberately
-                # redacted and says only that A location request failed; it names
-                # neither the device nor the operation, so it cannot tell the user
-                # who just pressed a button that THEIR request is the one that
-                # failed. The duplicate is one line per user-initiated action, and
-                # the poll path stays at DEBUG, so nothing repeats unattended.
+                # later. First, this is not the first record for the incident:
+                # `location_request` writes one before every raise of this type --
+                # measured six, four WARNING and two ERROR, not just the three
+                # transport rungs. Those records are PATH-AGNOSTIC: the identical
+                # sentence appears for an unattended poll. What this line adds is
+                # that the failed request was a USER-INITIATED one, plus the stage
+                # that says where it stopped. That is the whole of its value, and
+                # it is thin for `no_fcm_token`, whose transport record already
+                # names the operation. It does NOT tell the user WHICH device --
+                # that half is at DEBUG, see below -- so do not defend this line
+                # with an identification it no longer performs. It is one line per
+                # user action, and the poll path stays at DEBUG, so nothing
+                # repeats unattended.
                 # Second, `name` falls back to the raw canonical id when no
-                # display name is cached, which the transport layer avoids by
-                # keeping the identified sentence at DEBUG (AGENTS.md section 5).
-                # It is logged here anyway because every sibling branch of this
-                # method and both guards above it already do -- singling out this
-                # one branch would buy inconsistency, not privacy. Changing that
-                # is a decision about the whole method, not about this catch.
-                _LOGGER.warning(
+                # display name is cached (see where it is bound above). The rule
+                # is AGENTS.md section 5 (never log device ids, redact derived
+                # identifying information); the LEVEL split is the tree's own
+                # reading of it, the "R6 / Count@WARNING, Name@DEBUG" pattern that
+                # `test_location_request_r6_name_sweep.py` states and that the
+                # signal class itself cites in its docstring. Section 5 alone
+                # carries no level caveat, so citing only it would overstate the
+                # licence. That is why the sentence is split the way the transport
+                # layer splits its own:
+                # the WARNING carries the operation and the reason, the identified
+                # half stays at DEBUG. An earlier revision of this step logged
+                # `name` in the WARNING and defended it as consistent with the
+                # sibling branches of this method, which do the same. The defence
+                # does not hold, and the reason is worth keeping: it was THIS step
+                # that raised the line from DEBUG to WARNING, so it was this step
+                # that put a possible device id into the default log. Matching
+                # neighbours is not a licence to promote a leak; what a branch
+                # does at DEBUG and what it may do at WARNING are two different
+                # questions. The neighbours stay as they are -- lowering them is a
+                # decision about the whole method -- but this branch does not add
+                # to them.
+                _LOGGER.warning("Manual locate failed: %s", not_accepted_err)
+                _LOGGER.debug(
                     "Manual locate for %s failed (request not accepted): %s",
                     name,
                     not_accepted_err,

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2440,13 +2440,16 @@ class PollingOperations(_MixinBase):
                 # It does NOT prove that the request was accepted, and the guard
                 # must not be read as if it did. Measured, four failures still
                 # reach this loop as `{}`, because they are raised BEFORE the
-                # outer handler that would convert them: the FCM provider being
-                # unregistered or returning None (`RuntimeError`), a missing
-                # token cache (`MissingTokenCacheError`), and a failure while
-                # binding the lazily imported decrypt / eid-info modules
-                # (`ImportError` / `AttributeError`) -- that binding sits above
-                # the `try`, unlike the same import inside the FCM callback, which
-                # IS guarded. All of them are flattened by `api.py`'s
+                # outer handler that would convert them: an unregistered FCM
+                # receiver provider (`RuntimeError`), a provider that returns
+                # None (`RuntimeError`), a missing token cache
+                # (`MissingTokenCacheError`), and a failure while binding the
+                # lazily imported decrypt / eid-info modules (`ImportError` /
+                # `AttributeError`) -- that binding sits above the `try`, unlike
+                # the same import inside the FCM callback, which IS guarded. Four
+                # modes in four clauses on purpose: grouping the two provider
+                # guards into one is how a reader of this list, and then a
+                # docstring quoting it, arrived at "three". All of them are flattened by `api.py`'s
                 # `except RuntimeError` / `except Exception` arms. The first is
                 # deliberate and documented there as a cold-boot race that retries
                 # on the next cycle; turning it into an outage would report every

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -287,7 +287,7 @@ class PollingOperations(_MixinBase):
         Only rendered at DEBUG level, so this stays silent during normal
         operation and adds no WARNING/INFO noise. ``source`` distinguishes the
         inner empty result (``empty-result``) from the outer poll-guard timeout
-        (``outer-timeout``) and from a request the server never accepted
+        (``outer-timeout``) and from a request that was never accepted
         (``not-accepted``).
 
         The rendered line still opens with "Idle poll", which for the third

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1727,15 +1727,44 @@ class PollingOperations(_MixinBase):
                 # protobuf decode failure does NOT: on this path it is raised
                 # inside the FCM callback, i.e. AFTER the accept line, and the
                 # callback catches it itself and hands back an empty result. The
-                # Nova logic error is not raised anywhere in the tree at all
-                # (`grep -rn "raise NovaLogicError" custom_components/`), so it
-                # never told us anything either way.
+                # Nova logic error is not raised anywhere in the tree at all,
+                # so it never told us anything either way. Measured with a
+                # pattern this comment does not itself match, because the naive
+                # grep for the raise statement now finds this very line:
+                # `grep -rn 'raise NovaLogic''Error' custom_components/`.
                 # So an empty result is narrower evidence than it was, and still
                 # not proof that anything worked. It remains the outcome of the
                 # idle tag, of every failure the FCM callback absorbs, and of the
                 # post-accept branches of the locate flow -- not a closed list,
                 # which is the point: this counter must not be read as evidence.
                 cycle_rejected_devices = 0
+                # Counted separately from `cycle_rejected_devices` rather than
+                # folded into it, because the two say different things and only
+                # their SUM answers the cycle-level question.
+                #
+                # The difference is NOT flow position, and saying so would be
+                # measurably wrong: `location_request.py` re-raises the
+                # non-credential 4xx from the same `try` that produces the 5xx
+                # and the 429, all of them BEFORE the `Location request accepted`
+                # line. Neither kind reached the accept point.
+                #
+                # The difference is what the outcome says. A REJECTION is the
+                # server's answer ABOUT THIS DEVICE -- "not this one", typically
+                # a tracker deleted from the account. A NON-ACCEPTED request is
+                # the absence of such an answer: the request did not leave this
+                # integration as accepted, usually for a reason on the way to the
+                # server (a 5xx, a 429, a network error, a failed FCM
+                # registration).
+                #
+                # Resist sharpening that into "permanent versus transient". It
+                # holds for the common cases and breaks on `no_fcm_token`, whose
+                # source returns None for a canonic id that is not present in the
+                # receiver's device set -- device-specific and not transient at
+                # all. Both counts mean only "this device contributed no
+                # evidence", which is what the post-loop guard needs; they are
+                # kept apart so whoever reads the log can tell a configuration
+                # change from an outage.
+                cycle_unaccepted_devices = 0
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
                     dev_name = dev.get("name", dev_id)
@@ -2307,17 +2336,28 @@ class PollingOperations(_MixinBase):
                         # The request never reached the server's accept point, so
                         # this device produced no evidence in either direction --
                         # neither that the account is healthy nor that it is
-                        # broken. For now that stays a per-device skip: keep
-                        # polling the siblings and leave the cycle bookkeeping
-                        # alone. The cycle-level evaluation follows in a later
-                        # step; installing it here as well would make a single 5xx
-                        # on a single tracker mark every entity of the account
+                        # broken. It stays a PER-DEVICE skip: keep polling the
+                        # siblings, record the miss, and leave the account-wide
+                        # verdict to the post-loop guard. Recording
+                        # `last_exception` here instead would make a single 5xx on
+                        # a single tracker mark every entity of the account
                         # unavailable.
+                        #
+                        # The shape below is taken from the client-rejection
+                        # branch above, deliberately and for the same reason:
+                        # `cycle_failed` and `last_exception` drive two different
+                        # things. `cycle_failed` only writes the
+                        # `last_poll_result` diagnostic attribute, so the cycle
+                        # stays honest about not having polled every device.
+                        # `last_exception` drives `async_set_update_error` and
+                        # with it entity availability, which is an account-wide
+                        # claim this branch has no evidence for.
                         #
                         # Deliberately absent, each for its own measured reason:
                         #
-                        # * NO `cycle_failed` / `last_exception` -- see above; the
-                        #   cycle-wide verdict is not this branch's to cast.
+                        # * NO `last_exception`. See above. The count feeds the
+                        #   post-loop guard instead, which is the only place that
+                        #   can see whether ANY device got through.
                         # * NO `_set_auth_state(failed=False)` and NO reset of
                         #   `_consecutive_transient_auth_failures`. Those sit on
                         #   the success path above and are skipped by construction
@@ -2352,6 +2392,8 @@ class PollingOperations(_MixinBase):
                         self._log_idle_poll_diagnostics(
                             dev_id, dev_name, source="not-accepted"
                         )
+                        cycle_failed = True
+                        cycle_unaccepted_devices += 1
                         continue
                     except Exception as err:
                         _LOGGER.error(
@@ -2368,79 +2410,104 @@ class PollingOperations(_MixinBase):
                         await asyncio.sleep(self.device_poll_delay)
 
                 _LOGGER.debug("Completed polling cycle for %d devices", len(devices))
-                # Every device was refused: on the rejections' own terms
-                # that is account-wide, so the cycle must surface. Do NOT lean
-                # on the device list to catch this one layer up -- it is a
-                # different RPC (`nbe_list_devices`), and
+                # No device's request was accepted: the cycle must surface.
+                # Two counters, one verdict -- see their declaration above for
+                # why they are not the same thing. Either way the device produced
+                # no evidence, and when no device produced any, the coordinator
+                # has nothing to report success about.
+                #
+                # Do NOT lean on the device list to catch this one layer up -- it
+                # is a different RPC (`nbe_list_devices`), and
                 # DEVICE_LIST_POLL_INTERVAL means most cycles reuse the cached
                 # list without calling it at all.
                 #
-                # What this guard does NOT claim, stated so the next reader does
-                # not infer it: that a cycle which fails the check had a
-                # sibling success. A mixed cycle -- one tracker refused, the
-                # others back empty -- stays silent here, and so does an outage
-                # with no rejection in it at all
-                # (`test_known_gap_a_cycle_of_only_empty_results_reports_success` pins
-                # that reference case). Hanging the error signal on whether some
-                # unrelated tracker happens to be deleted would be a
-                # coincidence, not a contract; the empty result is what has to
-                # become distinguishable, and that is tracked separately
-                # (`PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`).
+                # Read the check for exactly what it tests. The equality is over
+                # the SUM, so a cycle in which one tracker was rejected and every
+                # other one was refused by the server surfaces, while a cycle with
+                # a single surviving sibling stays silent.
                 #
-                # Named because it is a real regression and not a neutral
-                # gap: BEFORE this change the mixed cycle did surface. The
-                # 4xx took the transient-auth branch, which set
-                # `last_exception` -- and fed the counter that produced the
-                # false sign-in prompt this whole change exists to remove.
-                # That signal was a side effect of the misclassification,
-                # not a contract: a tracker deleted from the account says
-                # nothing about whether its siblings reached the server. It
-                # cannot be kept without keeping the defect. Gating this
-                # guard on positive success instead fails at this layer for
-                # a mechanical reason, not a forecast about accounts: the
-                # only positive marker on the REQUEST path is
-                # `_any_device_got_data` (`cycle_had_successful_decrypt`
-                # above is a positive proof too, but about the shared key,
-                # and both are False for either empty result), and it
-                # records that a device COMMITTED data, not that its
-                # request reached the server. Gating on it turns
-                # `test_a_rejected_device_does_not_make_every_tracker_unavailable`
-                # red, because that test's sibling returns exactly `{}` --
-                # the stricter guard would withdraw the very fix that test
-                # was written for. One rejection plus one empty sibling
-                # would have to stay silent there and surface here, from
-                # the same observable state. That is an ambiguity, not a
-                # judgement call.
+                # What an empty sibling proves is NARROWER than it was, and
+                # narrower than it is tempting to write. The transport failures
+                # that used to flatten into `{}` now raise:
+                # `location_request.py` turns the 5xx, the 429, the
+                # `aiohttp.ClientError` and the generic Nova failure into
+                # `LocationRequestNotAcceptedError` itself, so the `api.py`
+                # handlers that return `{}` for those four no longer stand
+                # between the failure and this loop, and the empty dict comes
+                # from the no-location fallthrough (`api.py:1427`), which sits
+                # after the request.
                 #
-                # The concrete price of tightening anyway, stated so it is
-                # not lost: an account with one deleted tracker and
-                # otherwise idle BLE tags would go unavailable on EVERY
-                # cycle. Not "every healthy BLE-only account" (this guard
-                # is conjunctive with a rejection, so an account without
-                # one is untouched), but exactly that one shape.
+                # It does NOT prove that the request was accepted, and the guard
+                # must not be read as if it did. Measured, four failures still
+                # reach this loop as `{}`, because they are raised BEFORE the
+                # outer handler that would convert them: the FCM provider being
+                # unregistered or returning None (`RuntimeError`), a missing
+                # token cache (`MissingTokenCacheError`), and a failure while
+                # binding the lazily imported decrypt / eid-info modules
+                # (`ImportError` / `AttributeError`) -- that binding sits above
+                # the `try`, unlike the same import inside the FCM callback, which
+                # IS guarded. All of them are flattened by `api.py`'s
+                # `except RuntimeError` / `except Exception` arms. The first is
+                # deliberate and documented there as a cold-boot race that retries
+                # on the next cycle; turning it into an outage would report every
+                # restart as one. The others are programming or packaging faults
+                # rather than operating states. They are named here so the next
+                # reader does not mistake this guard for exhaustive.
                 #
-                # Only the layer that produced the empty result can resolve
-                # this. Where, is measured: `location_request.py` logs
-                # `Location request accepted` once the RPC is through, and
-                # the `return []` paths reachable only before that log are
-                # failures. The split is not positional -- the outer
-                # surfacing handler wraps the whole body, so its `return
-                # []` sits after the log while its exceptions come from
-                # either side, and the unexpected-device branch after the
-                # log returns empty on a WARNING. That flag now exists --
-                # `request_accepted` in `get_location_data_for_device` -- and
-                # the outcome is carried ACROSS the boundary as
-                # `LocationRequestNotAcceptedError` rather than reconstructed
-                # here. What is NOT yet done is the cycle-level evaluation of
-                # that signal; the per-device branch below still only skips.
-                # Do not read the sentences around this one as an open
-                # instruction to build the flag a second time. The layer that flattens it is
-                # `location_request.py`, not `api.py`: aiming a fix at the
-                # file where the empty dict is built would sit behind the
-                # point where the evidence is gone. See
+                # That is also why the guard does NOT count empty siblings, and
+                # why it does not need to. It is deliberately conservative: it
+                # demands that EVERY device missed, so one surviving tracker is
+                # enough to keep the account available -- and an unrecognised
+                # failure makes it stay silent, never fire wrongly.
+                #
+                # Named because it is a real behaviour change and not a neutral
+                # gap: BEFORE the raise sites existed, a cycle in which every
+                # single request failed server-side reported `success` and left
+                # every entity available with its cached position. The reference
+                # case that must NOT flip with it is the healthy one --
+                # `test_a_cycle_of_only_empty_results_still_reports_success` holds
+                # idle BLE tags at `success`. The price of closing the gap is
+                # accepted in the plan: on a single-device account one failed
+                # request now takes that account's tracker unavailable for the
+                # cycle. It is not only single-device accounts, and that is worth
+                # stating rather than discovering: a forced cycle runs even
+                # without a ready push transport, so an account whose FCM
+                # registration fails for every device meets this guard at any
+                # device count. No consecutive-cycle threshold is applied, because a
+                # threshold without a field measurement would be a guessed
+                # number; `_finalize_cycle_decrypt_state` is the pattern to copy
+                # if flapping is ever observed. See
                 # `PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`.
-                # `test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`
-                # pins the current state so it cannot drift unnoticed.
+                #
+                # `last_exception is None` is defence in depth here, and is
+                # marked as such rather than left to look load-bearing: measured,
+                # it cannot currently be False when the equality holds. Every
+                # branch that sets `last_exception` (timeout, transient auth,
+                # stale key, the broad handler) increments NEITHER counter, so
+                # one of those devices already breaks the sum. A mutation that
+                # deletes the term therefore turns no test red -- deliberately,
+                # because writing a test for an unreachable state would only pin
+                # the reasoning, not the behaviour. The term stays because the
+                # obvious next edit is a branch that both counts and reports, and
+                # then it is the difference between reporting the expired
+                # credential and reporting the outage that hid it.
+                if (
+                    cycle_unaccepted_devices
+                    and (cycle_unaccepted_devices + cycle_rejected_devices)
+                    == len(devices)
+                    and last_exception is None
+                ):
+                    last_exception = UpdateFailed(
+                        f"No device's locate request was accepted this cycle "
+                        f"({cycle_unaccepted_devices} not accepted, "
+                        f"{cycle_rejected_devices} rejected)"
+                    )
+                # Every device was refused by name: on the rejections' own
+                # terms that is account-wide, so the cycle must surface. Kept as
+                # its own guard rather than folded into the sum above so the
+                # reported message names the condition; the two are mutually
+                # exclusive by construction, because this one requires the
+                # unaccepted count to be zero for the equality to hold.
                 if (
                     cycle_rejected_devices
                     and cycle_rejected_devices == len(devices)

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -60,6 +60,9 @@ from ..NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     StaleOwnerKeyError,
     is_real_location_record,
 )
+from ..NovaApi.ExecuteAction.LocateTracker.location_request import (
+    LocationRequestNotAcceptedError,
+)
 from ..NovaApi.nova_request import (
     NovaAuthError,
     NovaAuthPermanentError,
@@ -283,7 +286,17 @@ class PollingOperations(_MixinBase):
 
         Only rendered at DEBUG level, so this stays silent during normal
         operation and adds no WARNING/INFO noise. ``source`` distinguishes the
-        inner empty result from the outer poll-guard timeout.
+        inner empty result (``empty-result``) from the outer poll-guard timeout
+        (``outer-timeout``) and from a request the server never accepted
+        (``not-accepted``).
+
+        The rendered line still opens with "Idle poll", which for the third
+        source is the very conflation this diagnostic is meant to help take
+        apart. Left as it is on purpose: four assertions in
+        ``tests/test_poll_timeout_hardening.py`` match on that exact prefix, so
+        renaming it is a change with its own blast radius and does not belong to
+        the step that merely adds the source. ``source`` disambiguates it in the
+        meantime.
         """
         if not _LOGGER.isEnabledFor(logging.DEBUG):
             return
@@ -2274,6 +2287,54 @@ class PollingOperations(_MixinBase):
                         self._consecutive_timeouts = 0
                         cycle_decrypt_error = self._prefer_account_wide_decrypt_error(
                             cycle_decrypt_error, dec_err
+                        )
+                        continue
+                    except LocationRequestNotAcceptedError as not_accepted_err:
+                        # The request never reached the server's accept point, so
+                        # this device produced no evidence in either direction --
+                        # neither that the account is healthy nor that it is
+                        # broken. For now that stays a per-device skip: keep
+                        # polling the siblings and leave the cycle bookkeeping
+                        # alone. The cycle-level evaluation follows in a later
+                        # step; installing it here as well would make a single 5xx
+                        # on a single tracker mark every entity of the account
+                        # unavailable.
+                        #
+                        # Deliberately absent, each for its own measured reason:
+                        #
+                        # * NO `cycle_failed` / `last_exception` -- see above; the
+                        #   cycle-wide verdict is not this branch's to cast.
+                        # * NO `_set_auth_state(failed=False)` and NO reset of
+                        #   `_consecutive_transient_auth_failures`. Those sit on
+                        #   the success path above and are skipped by construction
+                        #   once the raise sites exist. That skip IS the fix for
+                        #   the counter being wiped by a 5xx on its way through;
+                        #   re-doing the reset here would hand it straight back.
+                        # * NO reset of `_consecutive_timeouts`. Measured: today
+                        #   a failed request reaches the `if not location:`
+                        #   branch, which does NOT reset that counter. Resetting
+                        #   it here would therefore not preserve current
+                        #   behaviour but invent a health signal the request
+                        #   never earned -- the same false-success reasoning this
+                        #   change exists to remove. Nor is the counter a general
+                        #   liveness mark to be refreshed by anything that ran:
+                        #   it is incremented in exactly one place, the outer
+                        #   timeout branch, and a refused request is not a
+                        #   timeout. Its only consumer is the connectivity binary
+                        #   sensor's attribute dict, so it feeds no verdict.
+                        #   The sibling handlers here are NOT unanimous, which is
+                        #   why their shape is a weak argument either way: eight
+                        #   of the ten clear it unconditionally, `TimeoutError`
+                        #   never does (it increments), and `NovaAuthError`
+                        #   clears it on only one of its three exits.
+                        _LOGGER.debug(
+                            "Location request for %s was not accepted (%s); "
+                            "skipping this device for this cycle",
+                            dev_name,
+                            not_accepted_err,
+                        )
+                        self._log_idle_poll_diagnostics(
+                            dev_id, dev_name, source="not-accepted"
                         )
                         continue
                     except Exception as err:

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -2333,7 +2333,7 @@ class PollingOperations(_MixinBase):
                         )
                         continue
                     except LocationRequestNotAcceptedError as not_accepted_err:
-                        # The request never reached the server's accept point, so
+                        # The request never got past this integration's accept point, so
                         # this device produced no evidence in either direction --
                         # neither that the account is healthy nor that it is
                         # broken. It stays a PER-DEVICE skip: keep polling the

--- a/custom_components/googlefindmy/coordinator/polling.py
+++ b/custom_components/googlefindmy/coordinator/polling.py
@@ -1715,12 +1715,26 @@ class PollingOperations(_MixinBase):
                 # refused is account-wide on the rejections' own terms.
                 # Deliberately NOT the same shape as the decrypt verdict above:
                 # that one gates on `cycle_had_successful_decrypt`, a positive
-                # proof. The request path has no such proof to gate on, because
-                # `api.async_get_device_location` returns the same empty dict
-                # for a healthy idle BLE tag and for a 5xx, a 429, a protobuf
-                # decode failure or a Nova logic error. So a non-rejected
-                # sibling is NOT evidence that anything worked, and this counter
-                # must not be read as if it were.
+                # proof. The request path has no such proof to gate on. It used
+                # to have none at all, because `api.async_get_device_location`
+                # returned the same empty dict for a healthy idle BLE tag as for
+                # a 5xx, a 429, a protobuf decode failure or a Nova logic error.
+                # PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE narrowed that, and
+                # measured, it narrowed LESS than the old list suggests: what now
+                # arrives as `LocationRequestNotAcceptedError` on the branch below
+                # is what `async_nova_request` raises -- the 5xx and the 429 on
+                # their own rungs, anything else through the generic guard. The
+                # protobuf decode failure does NOT: on this path it is raised
+                # inside the FCM callback, i.e. AFTER the accept line, and the
+                # callback catches it itself and hands back an empty result. The
+                # Nova logic error is not raised anywhere in the tree at all
+                # (`grep -rn "raise NovaLogicError" custom_components/`), so it
+                # never told us anything either way.
+                # So an empty result is narrower evidence than it was, and still
+                # not proof that anything worked. It remains the outcome of the
+                # idle tag, of every failure the FCM callback absorbs, and of the
+                # post-accept branches of the locate flow -- not a closed list,
+                # which is the point: this counter must not be read as evidence.
                 cycle_rejected_devices = 0
                 for idx, dev in enumerate(devices):
                     dev_id = dev["id"]
@@ -2307,12 +2321,14 @@ class PollingOperations(_MixinBase):
                         # * NO `_set_auth_state(failed=False)` and NO reset of
                         #   `_consecutive_transient_auth_failures`. Those sit on
                         #   the success path above and are skipped by construction
-                        #   once the raise sites exist. That skip IS the fix for
+                        #   now that the raise sites exist. That skip IS the fix for
                         #   the counter being wiped by a 5xx on its way through;
                         #   re-doing the reset here would hand it straight back.
-                        # * NO reset of `_consecutive_timeouts`. Measured: today
-                        #   a failed request reaches the `if not location:`
-                        #   branch, which does NOT reset that counter. Resetting
+                        # * NO reset of `_consecutive_timeouts`. Measured before
+                        #   the raise sites were armed: a failed request reached
+                        #   the `if not location:` branch, which does NOT reset
+                        #   that counter -- so leaving it alone here is what
+                        #   preserves the behaviour, not what changes it. Resetting
                         #   it here would therefore not preserve current
                         #   behaviour but invent a health signal the request
                         #   never earned -- the same false-success reasoning this
@@ -2362,8 +2378,8 @@ class PollingOperations(_MixinBase):
                 # What this guard does NOT claim, stated so the next reader does
                 # not infer it: that a cycle which fails the check had a
                 # sibling success. A mixed cycle -- one tracker refused, the
-                # others back empty from a 5xx -- stays silent here, and so does
-                # that same 5xx outage with no rejection in it at all
+                # others back empty -- stays silent here, and so does an outage
+                # with no rejection in it at all
                 # (`test_known_gap_a_cycle_of_only_empty_results_reports_success` pins
                 # that reference case). Hanging the error signal on whether some
                 # unrelated tracker happens to be deleted would be a
@@ -2411,11 +2427,14 @@ class PollingOperations(_MixinBase):
                 # surfacing handler wraps the whole body, so its `return
                 # []` sits after the log while its exceptions come from
                 # either side, and the unexpected-device branch after the
-                # log returns empty on a WARNING. A follow-up needs a flag
-                # set at the log line, and has to carry that outcome ACROSS
-                # the boundary (a typed result, for example) rather than
-                # reconstruct it here, where the empty collection has
-                # already flattened it. The layer that flattens it is
+                # log returns empty on a WARNING. That flag now exists --
+                # `request_accepted` in `get_location_data_for_device` -- and
+                # the outcome is carried ACROSS the boundary as
+                # `LocationRequestNotAcceptedError` rather than reconstructed
+                # here. What is NOT yet done is the cycle-level evaluation of
+                # that signal; the per-device branch below still only skips.
+                # Do not read the sentences around this one as an open
+                # instruction to build the flag a second time. The layer that flattens it is
                 # `location_request.py`, not `api.py`: aiming a fix at the
                 # file where the empty dict is built would sit behind the
                 # point where the evidence is gone. See

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -1165,7 +1165,7 @@ class TestAsyncDeviceLocationErrorMapping:
     custom_components/`` shows who produces and consumes this seam. Deleting a
     handler here would stay invisible until someone narrows a conversion one layer
     down, and would then restore precisely the defect this change set removed: a
-    request that never reached the server arriving as a healthy empty dict.
+    request that never got past the accept point arriving as a healthy empty dict.
 
     Two of the mapped classes are guarded here and by no other test ON THIS SEAM
     (both have branches elsewhere in the tree that other tests do cover):

--- a/tests/test_api_basics.py
+++ b/tests/test_api_basics.py
@@ -1146,7 +1146,48 @@ class TestAsyncBasicDeviceListErrorMapping:
 
 
 class TestAsyncDeviceLocationErrorMapping:
-    """Each documented exception class for the location request branch."""
+    """Each documented exception class for the location request branch.
+
+    Most of these classes can no longer arrive here from the production locate
+    path. ``location_request`` converts what its Nova ladder around the request
+    call catches into ``LocationRequestNotAcceptedError`` before this seam sees
+    it, and re-raises the rest. WHICH failure ends up on which side is not
+    restated here on purpose: it is maintained in
+    ``custom_components/googlefindmy/AGENTS.md`` (the sentence starting with
+    ``FOUR pre-accept failures``, today at line 174, plus the paragraph after it)
+    and pinned in ``tests/test_location_request_not_accepted.py``. A second copy in
+    a test docstring is a copy nobody comes back to, which is how the enumeration
+    it would copy was already miscounted once.
+
+    What the class is FOR, after that change, is the other direction. The branches
+    behind the converted classes are a REGRESSION GUARD, not coverage for a second
+    caller: ``grep -rnE "get_location_data_for_device|async_get_device_location"
+    custom_components/`` shows who produces and consumes this seam. Deleting a
+    handler here would stay invisible until someone narrows a conversion one layer
+    down, and would then restore precisely the defect this change set removed: a
+    request that never reached the server arriving as a healthy empty dict.
+
+    Two of the mapped classes are guarded here and by no other test ON THIS SEAM
+    (both have branches elsewhere in the tree that other tests do cover):
+    ``NovaLogicError``, which nothing in the tree raises, and
+    ``NovaProtobufDecodeError``, which nothing on the locate path raises outside
+    the FCM callback, where the callback's own handler flattens it to an empty
+    result before it could reach here. (Both classes have HANDLER branches
+    elsewhere in the tree, with their own tests; it is only the two branches on
+    THIS seam that hang on this test class.)
+
+    ``OwnerKeyLookupTransientError`` is a rung of the seam's own ladder but has no
+    case below; its pin is ``tests/test_api_transient_owner_key.py``.
+
+    The signal itself is not pinned here either. That lives in
+    ``tests/test_location_request_not_accepted.py``:
+    ``test_api_passes_the_signal_through_untouched`` for the pass-through
+    (asserted by identity, not merely by type) and
+    ``test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict`` for the
+    sync-wrapper edge that is deliberately left open. Those two names, the file
+    names above and the AGENTS.md line number are prose references that no test
+    derives; a rename or an edit there makes them silently wrong.
+    """
 
     def _patch_request(
         self,

--- a/tests/test_cli_entry_selection.py
+++ b/tests/test_cli_entry_selection.py
@@ -9,6 +9,9 @@ from typing import Any
 import pytest
 
 from custom_components.googlefindmy.exceptions import MissingTokenCacheError
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request import (
+    LocationRequestNotAcceptedError,
+)
 from custom_components.googlefindmy.NovaApi.ListDevices import nbe_list_devices
 
 
@@ -114,8 +117,13 @@ async def test_cli_main_passes_selected_cache(monkeypatch: pytest.MonkeyPatch) -
         nbe_list_devices, "get_canonic_ids", lambda _: [("Tracker", "id-1")]
     )
     fake_spot_module = types.SimpleNamespace(refresh_custom_trackers=lambda _: None)
+    # The signal type has to be on the stub, not just the function: the CLI reads
+    # both off the same lazily imported module object so that catching the signal
+    # costs nothing at import time. The REAL class is used rather than a
+    # placeholder, so an `except` clause aimed at something else would not pass.
     fake_location_module = types.SimpleNamespace(
-        get_location_data_for_device=fake_get_location_data_for_device
+        get_location_data_for_device=fake_get_location_data_for_device,
+        LocationRequestNotAcceptedError=LocationRequestNotAcceptedError,
     )
     monkeypatch.setitem(
         sys.modules,
@@ -207,3 +215,118 @@ class TestAsyncCliMainEntryResolution:
             await nbe_list_devices._async_cli_main("explicit")
 
         assert seen["hint"] == "explicit"
+
+
+def _install_cli_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    cache: _DummyCache,
+    fake_get_location_data_for_device: Any,
+) -> None:
+    """Wire up the minimum ``_async_cli_main`` needs to reach the locate call."""
+    monkeypatch.setattr(
+        nbe_list_devices, "get_registered_entry_ids", lambda: ["entry-one"]
+    )
+    monkeypatch.setattr(nbe_list_devices, "get_cache_for_entry", lambda _entry: cache)
+
+    async def fake_async_request_device_list(**_kwargs: Any) -> str:
+        return "hex"
+
+    monkeypatch.setattr(
+        nbe_list_devices, "async_request_device_list", fake_async_request_device_list
+    )
+    monkeypatch.setattr(
+        nbe_list_devices, "parse_device_list_protobuf", lambda _: "proto"
+    )
+    monkeypatch.setattr(
+        nbe_list_devices, "get_canonic_ids", lambda _: [("Tracker", "id-1")]
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "custom_components.googlefindmy.SpotApi.UploadPrecomputedPublicKeyIds.upload_precomputed_public_key_ids",
+        types.SimpleNamespace(refresh_custom_trackers=lambda _: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request",
+        types.SimpleNamespace(
+            get_location_data_for_device=fake_get_location_data_for_device,
+            LocationRequestNotAcceptedError=LocationRequestNotAcceptedError,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cli_reports_an_unaccepted_locate_and_keeps_the_loop_alive(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A 503 must cost one selection, not the whole interactive session.
+
+    Two failure modes are pinned here, and only the first is obvious. The
+    obvious one: the signal is an ordinary `Exception`, nothing in
+    ``_async_cli_main`` used to catch it, and ``list_devices()`` catches only
+    ``KeyboardInterrupt`` -- so a routine service failure ended the CLI on a
+    traceback instead of letting the user pick another device.
+
+    The second is the reason the wording is asserted rather than just the
+    survival. The empty-list path prints "the tracker may be out of range or the
+    request timed out", which for a 503 blames the wrong side entirely. Telling
+    those two apart is the whole point of the signal; printing the old sentence
+    for it would keep the defect while looking fixed.
+    """
+    cache = _DummyCache("entry-one")
+    calls: list[str] = []
+
+    async def fake_get_location_data_for_device(
+        canonic_id: str, name: str, **_kwargs: Any
+    ) -> list[dict[str, Any]]:
+        calls.append(canonic_id)
+        raise LocationRequestNotAcceptedError(stage="server_error", status=503)
+
+    _install_cli_stubs(monkeypatch, cache, fake_get_location_data_for_device)
+
+    # Select the tracker twice, then quit: the second selection is what proves
+    # the loop survived the first failure.
+    _inputs = iter(["1", "1", "q"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(_inputs))
+
+    await nbe_list_devices._async_cli_main("entry-one")
+
+    out = capsys.readouterr().out
+    assert calls == ["id-1", "id-1"], (
+        f"the loop did not survive the failed locate: {calls}"
+    )
+    assert "Goodbye!" in out, "the loop never reached its normal exit"
+    assert "not accepted" in out, out
+    assert "server_error" in out, "the printed line does not say what went wrong"
+    assert "503" in out, "the printed line does not carry the server's status"
+    assert "may be out of range" not in out, (
+        "the CLI blamed the tracker for a server-side failure, which is exactly "
+        "the conflation this signal exists to end"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cli_still_prints_the_out_of_range_line_for_an_empty_result(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The counter-weight: an accepted request with no report keeps its wording.
+
+    Without this, the test above could be satisfied by printing the failure line
+    for every empty outcome, which would trade one wrong message for another.
+    """
+    cache = _DummyCache("entry-one")
+
+    async def fake_get_location_data_for_device(
+        _canonic_id: str, _name: str, **_kwargs: Any
+    ) -> list[dict[str, Any]]:
+        return []
+
+    _install_cli_stubs(monkeypatch, cache, fake_get_location_data_for_device)
+    _inputs = iter(["1", "q"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(_inputs))
+
+    await nbe_list_devices._async_cli_main("entry-one")
+
+    out = capsys.readouterr().out
+    assert "may be out of range" in out, out
+    assert "not accepted" not in out, out

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1451,11 +1451,15 @@ async def test_a_cycle_of_only_empty_results_still_reports_success() -> None:
     the 429, the network error and the failed FCM registration now raise
     ``LocationRequestNotAcceptedError`` instead of flattening into ``{}``.
 
-    Largely, not entirely, and the difference is worth keeping straight. Three
+    Largely, not entirely, and the difference is worth keeping straight. Four
     pre-accept failures still arrive here as an empty dict, because they are
-    raised before the handler that would convert them: the FCM provider being
-    unregistered or returning ``None``, and a missing token cache. So an empty
-    dict is now WEAK evidence that the request was accepted, not proof of it.
+    raised before the handler that would convert them: an unregistered FCM
+    receiver provider, a provider that returns ``None``, a missing token cache,
+    and a failure while binding the lazily imported decrypt / eid-info modules.
+    Count the failure modes, not the clauses: an earlier revision of this
+    docstring grouped the two provider guards into one and wrote "three", which
+    contradicted the "four" at the head of this file. So an empty dict is now
+    WEAK evidence that the request was accepted, not proof of it.
 
     Its name and its meaning changed with that; its expectation deliberately did
     not. An account of BLE tags with no reporter nearby is the ordinary healthy

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1570,8 +1570,8 @@ async def test_a_cycle_where_no_request_was_accepted_reports_an_error() -> None:
 async def test_the_surfaced_error_names_which_counter_fired() -> None:
     """Two ways to reach the same verdict must not read as the same event.
 
-    A deleted tracker (the server's answer ABOUT that device) and an
-    unreachable server (no answer about the device at all) both leave the cycle
+    A deleted tracker (the server's answer ABOUT that device) and a request that
+    was never accepted (no answer about the device at all) both leave the cycle
     with nothing, but they need different answers from whoever reads the log:
     one is a configuration change, the other is an outage. The two guards are
     kept apart for exactly that, so this pins that the message says which one
@@ -1670,7 +1670,7 @@ async def test_a_single_unaccepted_device_still_marks_the_poll_result_failed() -
 async def test_a_mixed_cycle_of_rejection_and_unaccepted_siblings_now_surfaces() -> (
     None
 ):
-    """A deleted tracker plus an unreachable server: nothing got through.
+    """A deleted tracker plus a request never accepted: nothing got through.
 
     The mirror of
     ``test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent``, and the
@@ -1838,7 +1838,7 @@ async def test_an_unaccepted_device_does_not_hide_a_credential_failure() -> None
 
     assert recorded, "the cycle hid the credential failure entirely"
     assert getattr(recorded[-1], "status", None) == 401, (
-        "the cycle reported the unreachable server instead of the tracker whose "
+        "the cycle reported the unaccepted request instead of the tracker whose "
         f"sign-in expired: {recorded[-1]!r}"
     )
 

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -26,6 +26,9 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_
     SharedKeyMismatchError,
     StaleOwnerKeyError,
 )
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request import (
+    LocationRequestNotAcceptedError,
+)
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
     NovaAuthPermanentError,
@@ -1002,12 +1005,21 @@ async def test_a_rejected_device_never_clears_the_auth_state() -> None:
 async def test_an_empty_return_still_clears_the_counter() -> None:
     """Characterisation of the reset this change deliberately leaves alone.
 
-    An empty result still counts as success: the counter goes back to zero and
-    the auth state is cleared. That is true today for every 5xx and every 429,
-    it predates this work, and it is wrong on its own terms -- an empty result
-    proves only that nothing raised, not that the credentials work. It is
-    tracked as a finding of its own with its own approval gate. This test is
-    here so the day it changes, it changes on purpose.
+    An empty result USUALLY MEANS an accepted request that came back without a
+    report, and it still counts as success: the counter goes back to zero and
+    the auth state is cleared. The precision matters, because the sentence that
+    used to stand here -- "that is true today for every 5xx and every 429" -- is
+    no longer true. Those raise before they can reach this path, which is
+    exactly what the change did; the pair to this test is
+    ``test_an_unaccepted_request_no_longer_clears_the_counter``. "Usually" and
+    not "always", because four pre-accept faults still arrive as an empty dict;
+    they are enumerated at the post-loop guard in ``polling.py``.
+
+    What remains wrong on its own terms is the reset itself: an accepted request
+    that returned nothing proves only that nothing raised, not that the
+    credentials work. That is tracked as a finding of its own with its own
+    approval gate (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`). This test is here so
+    the day it changes, it changes on purpose.
     """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
     coordinator.api = _PerDeviceAPI({"dev-1": {}})
@@ -1307,20 +1319,17 @@ async def test_a_rejected_device_does_not_make_every_tracker_unavailable() -> No
     on every single poll until the device left the cached list. A rejection of
     one device says nothing about the others.
 
-    Note precisely what the sibling here does: it returns ``{}``, which at this
-    layer is indistinguishable from a 5xx. That is deliberate -- it is the
-    cheapest shape of the case, and it is also why the guard cannot be tightened
-    to require positive success. ``_any_device_got_data`` is the only positive
-    marker on the REQUEST path (``cycle_had_successful_decrypt`` is a positive
-    proof too, but about the shared key), and gating on it would turn THIS test
-    red. The two demands meet in one observable state, so the ambiguity has to
-    be resolved where the empty result is produced, not here.
+    Note precisely what the sibling here does: it returns ``{}``. When this test
+    was written that was indistinguishable from a 5xx, and the pair
+    ``test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent`` recorded
+    the same observable state read with the opposite expectation -- an ambiguity
+    that could only be resolved where the empty result is produced.
 
-    This test and ``test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent``
-    use the same stub and the same three assertions; only the display name
-    differs. That is not sloppiness left unnoticed but the very point: they are
-    the SAME observable state, read once as "must stay silent" and once as
-    "should have surfaced". Whoever resolves the ambiguity should merge them.
+    It has been, and the twin now reads the state the same way this one does: a
+    5xx raises ``LocationRequestNotAcceptedError`` instead of returning ``{}``,
+    so the two are no longer one state under two names. What this test still
+    holds is unchanged and unaffected by that: a rejected tracker must not take
+    the account offline while a sibling is answering.
     """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
     coordinator.api = _PerDeviceAPI({"dev-1": NovaAuthError(404, "gone"), "dev-2": {}})
@@ -1433,23 +1442,28 @@ async def test_a_cycle_where_every_device_is_rejected_still_reports_an_error() -
 
 
 @pytest.mark.asyncio
-async def test_known_gap_a_cycle_of_only_empty_results_reports_success() -> None:
-    """The reference measurement, with NOT ONE rejection involved.
+async def test_a_cycle_of_only_empty_results_still_reports_success() -> None:
+    """The reference case that must NOT flip: healthy idle tags stay successful.
 
-    ``api.async_get_device_location`` collapses four distinct outcomes into the
-    same empty dict: a 5xx, a 429, a protobuf decode failure and a Nova logic
-    error all ``return {}``, and so does the healthy idle BLE tag whose inner
-    FCM wait simply found no reporter nearby. The poll loop cannot tell them
-    apart, so a cycle in which every single request failed server-side reports
-    ``success`` and leaves every entity available with its cached position.
+    This test was the pinned known gap. It kept a cycle in which every request
+    had failed server-side at ``success``, because the empty dict could not be
+    told from a healthy idle BLE tag. The ambiguity is largely gone: the 5xx,
+    the 429, the network error and the failed FCM registration now raise
+    ``LocationRequestNotAcceptedError`` instead of flattening into ``{}``.
 
-    This is pre-existing and has nothing to do with the client-rejection branch
-    -- it is pinned here precisely so that claim stays checkable: any argument
-    that the neighbouring rejection branch should surface a mixed
-    rejection-plus-empty cycle has to explain why THIS cycle, in which just as
-    little worked, may stay silent. Deciding what an empty result may prove is
-    tracked as its own change (`PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE`); when it
-    lands, this test is expected to flip deliberately, not silently.
+    Largely, not entirely, and the difference is worth keeping straight. Three
+    pre-accept failures still arrive here as an empty dict, because they are
+    raised before the handler that would convert them: the FCM provider being
+    unregistered or returning ``None``, and a missing token cache. So an empty
+    dict is now WEAK evidence that the request was accepted, not proof of it.
+
+    Its name and its meaning changed with that; its expectation deliberately did
+    not. An account of BLE tags with no reporter nearby is the ordinary healthy
+    state, it produces exactly this cycle, and it must never be reported as a
+    failure. This is therefore the counter-weight to
+    ``test_a_cycle_where_no_request_was_accepted_reports_an_error``: the two
+    together are the claim that the outcomes became DISTINGUISHABLE, rather than
+    that everything was declared broken.
     """
     coordinator = _polling_coordinator({}, _TrackingFilter(), {})
     coordinator.api = _PerDeviceAPI({"dev-1": {}, "dev-2": {}})
@@ -1469,22 +1483,23 @@ async def test_known_gap_a_cycle_of_only_empty_results_reports_success() -> None
 
 
 @pytest.mark.asyncio
-async def test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent() -> (
-    None
-):
-    """One rejected tracker plus siblings that came back empty: still silent.
+async def test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent() -> None:
+    """One rejected tracker plus a sibling that came back empty: still silent.
 
-    The post-loop guard fires only when EVERY device was rejected. Here one was
-    and the other returned empty, so ``cycle_rejected_devices != len(devices)``
-    and the cycle surfaces nothing. Whether that empty sibling was a healthy
-    idle tag or a 5xx is not knowable at this layer, so the guard cannot lean on
-    it as evidence either way -- and the neighbouring decrypt verdict shows the
-    difference: it gates on ``cycle_had_successful_decrypt``, a positive proof
-    the request path has no counterpart for. ``_any_device_got_data`` is not
-    that counterpart: it records that a device COMMITTED data, so gating on it
-    would turn ``test_a_rejected_device_does_not_make_every_tracker_unavailable``
-    red -- which uses the same stub and the same assertions as this test, only
-    read with the opposite expectation. Two names, one observable state.
+    This too was a pinned known gap, and it too keeps its expectation while
+    losing its doubt. The old reasoning was that an empty sibling proves
+    nothing, so the guard could not lean on it either way. It leans on it only
+    in the safe direction, which is the only direction it may lean: an empty
+    sibling makes the guard STAY SILENT, and the guard is deliberately built so
+    that anything it fails to recognise has that effect. It is emphatically not
+    read as proof that the sibling's request was accepted. One deleted tracker plus one sibling that came back empty is not
+    grounds for taking the whole account offline.
+
+    The mirror case is
+    ``test_a_mixed_cycle_of_rejection_and_unaccepted_siblings_now_surfaces``:
+    same rejection, but the sibling never got through, and there the cycle
+    surfaces. The pair is what makes the two states distinguishable at this
+    layer instead of collapsed into one.
 
     Not silent everywhere, and that is the point: the rejection still sets
     ``cycle_failed``, so ``last_poll_result`` reports ``failed`` and the
@@ -1507,6 +1522,321 @@ async def test_known_gap_a_mixed_cycle_of_rejection_and_empty_siblings_stays_sil
     # The failure IS recorded, just not account-wide.
     assert coordinator.last_poll_result == "failed"
     assert coordinator.api.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_a_cycle_where_no_request_was_accepted_reports_an_error() -> None:
+    """The defect this whole change exists to remove, at the cycle level.
+
+    Every tracker hit a 5xx, so not one request was accepted. Before the
+    signal existed each of those collapsed into an empty dict, the loop read
+    that as an ordinary idle poll, and the coordinator reported ``success``
+    while it had delivered nothing at all -- every entity stayed available with
+    a cached position that could be hours old, and nothing anywhere said so.
+
+    The counter-weight is
+    ``test_a_cycle_of_only_empty_results_still_reports_success``: identical
+    shape, empty results instead of refusals, and it must stay green. Without
+    that pair this test could be satisfied by declaring every quiet cycle
+    broken, which is not a fix but a different defect.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {
+            "dev-1": LocationRequestNotAcceptedError(stage="server_error", status=503),
+            "dev-2": LocationRequestNotAcceptedError(stage="server_error", status=503),
+        }
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "A"}, {"id": "dev-2", "name": "B"}]
+    )
+
+    assert recorded, "no request was accepted and the cycle still reported success"
+    assert coordinator.last_poll_result == "failed"
+    # Reachability, so neither assertion can pass vacuously.
+    assert coordinator.api.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_the_surfaced_error_names_which_counter_fired() -> None:
+    """Two ways to reach the same verdict must not read as the same event.
+
+    A deleted tracker (the server's answer ABOUT that device) and an
+    unreachable server (no answer about the device at all) both leave the cycle
+    with nothing, but they need different answers from whoever reads the log:
+    one is a configuration change, the other is an outage. The two guards are
+    kept apart for exactly that, so this pins that the message says which one
+    fired instead of a single generic sentence.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {"dev-1": LocationRequestNotAcceptedError(stage="rate_limited", status=429)}
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "A"}])
+
+    assert recorded
+    message = str(recorded[-1])
+    assert "was accepted this cycle" in message, message
+    assert "1 not accepted" in message, message
+    # Not the rejection wording: that guard must not have claimed this cycle.
+    assert "was rejected by" not in message, message
+
+
+@pytest.mark.asyncio
+async def test_a_single_unaccepted_device_does_not_make_every_tracker_unavailable() -> (
+    None
+):
+    """One refused tracker with a sibling that got through stays a skip.
+
+    This is the guard rail against over-correcting. ``last_exception`` drives
+    ``async_set_update_error`` and with it entity availability, so recording it
+    per device would take the whole account offline whenever a single tracker
+    hit a transient 5xx. The sibling's empty dict is what refutes the
+    account-wide reading -- not because an empty dict proves the sibling's
+    request was accepted (it does not, see
+    ``test_a_cycle_of_only_empty_results_still_reports_success``), but because
+    the guard demands that EVERY device missed and this cycle does not meet
+    that.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {
+            "dev-1": LocationRequestNotAcceptedError(stage="server_error", status=503),
+            "dev-2": {},
+        }
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Refused"}, {"id": "dev-2", "name": "Idle"}]
+    )
+
+    assert not recorded, (
+        "one refused tracker failed the coordinator update, which makes every "
+        f"tracker entity unavailable: {recorded}"
+    )
+    # Reachability: both devices were requested and the cycle really did enter
+    # the not-accepted branch -- the empty success path of dev-2 leaves
+    # `cycle_failed` alone, so `failed` here can only come from dev-1.
+    assert coordinator.api.calls == 2
+    assert coordinator.last_poll_result == "failed"
+
+
+@pytest.mark.asyncio
+async def test_a_single_unaccepted_device_still_marks_the_poll_result_failed() -> None:
+    """The miss is recorded, it is only not made account-wide.
+
+    Same split as the rejection branch: ``cycle_failed`` writes the
+    ``last_poll_result`` diagnostic attribute that ``binary_sensor.py`` reads,
+    while ``last_exception`` drives availability. Keeping the former is what
+    stops the cycle from claiming it polled every device.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {
+            "dev-1": LocationRequestNotAcceptedError(stage="network_error"),
+            "dev-2": {},
+        }
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    coordinator.async_set_update_error = lambda _exc: None
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Refused"}, {"id": "dev-2", "name": "Idle"}]
+    )
+
+    assert coordinator.last_poll_result == "failed"
+
+
+@pytest.mark.asyncio
+async def test_a_mixed_cycle_of_rejection_and_unaccepted_siblings_now_surfaces() -> (
+    None
+):
+    """A deleted tracker plus an unreachable server: nothing got through.
+
+    The mirror of
+    ``test_a_mixed_cycle_of_rejection_and_empty_siblings_stays_silent``, and the
+    reason the guard sums the two counters instead of testing either alone.
+    Neither count reaches ``len(devices)`` here, so a guard on one of them would
+    stay silent through a cycle in which no device produced any evidence at all.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {
+            "dev-1": NovaAuthError(404, "gone"),
+            "dev-2": LocationRequestNotAcceptedError(stage="server_error", status=503),
+        }
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Gone"}, {"id": "dev-2", "name": "Refused"}]
+    )
+
+    assert recorded, "no request was accepted and the cycle still reported success"
+    message = str(recorded[-1])
+    assert "1 not accepted" in message and "1 rejected" in message, message
+    assert coordinator.api.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_an_unaccepted_device_does_not_touch_the_transient_auth_counter() -> None:
+    """Neither cleared nor raised: a refused request says nothing about credentials.
+
+    Two claims in one, and both matter. NOT CLEARED is the defect being fixed --
+    the success path runs ``_set_auth_state(failed=False)`` and zeroes the
+    counter before it looks at the result, so every 5xx used to wipe the
+    escalation budget on its way through. Raising skips that path entirely; the
+    branch does not undo the reset, it never happens.
+
+    NOT RAISED is the other half, and it is what a well-meant "treat it like the
+    transient-auth branch" edit would break. A server that is down is not a
+    credential that expired, and counting it towards the re-auth budget would
+    put a sign-in prompt in front of the user for an outage they cannot fix.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {"dev-1": LocationRequestNotAcceptedError(stage="server_error", status=503)}
+    )
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+    coordinator._consecutive_transient_auth_failures = 2
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Refused"}])
+
+    assert not auth_calls, f"the refused request touched the auth state: {auth_calls}"
+    assert coordinator._consecutive_transient_auth_failures == 2
+    # Reachability, and specifically that the NOT-ACCEPTED branch is what ran.
+    # `api.calls == 1` alone would not show that: the broad neighbour also leaves
+    # the auth state alone, so both assertions above would survive deleting the
+    # branch outright. The guard's own wording is the one observable that only
+    # this path produces.
+    assert coordinator.api.calls == 1
+    assert recorded and "was accepted this cycle" in str(recorded[-1]), recorded
+
+
+@pytest.mark.asyncio
+async def test_an_unaccepted_request_no_longer_clears_the_counter() -> None:
+    """The contract pair to ``test_an_empty_return_still_clears_the_counter``.
+
+    The two are deliberately adjacent claims about the same success path, read
+    from opposite sides. An ACCEPTED request that came back empty still clears
+    the counter -- that reset is wrong on its own terms and is tracked
+    separately (`PLAN_GFMY_AUTH_RESET_POSITIVE_PROOF`), so it is characterised,
+    not changed here. A request that was never accepted no longer reaches that
+    path at all. Splitting them is what makes the difference between the two
+    outcomes checkable instead of a matter of reading the branch.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {"dev-1": LocationRequestNotAcceptedError(stage="fcm_registration_failed")}
+    )
+    auth_calls: list[dict[str, Any]] = []
+    coordinator._set_auth_state = lambda **kwargs: auth_calls.append(kwargs)
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+    coordinator._consecutive_transient_auth_failures = 2
+
+    await coordinator._async_start_poll_cycle([{"id": "dev-1", "name": "Refused"}])
+
+    assert not [kw for kw in auth_calls if kw.get("failed") is False]
+    assert coordinator._consecutive_transient_auth_failures == 2
+    # See the sibling above: without this the broad neighbour satisfies the test.
+    assert recorded and "was accepted this cycle" in str(recorded[-1]), recorded
+
+
+@pytest.mark.asyncio
+async def test_an_all_rejected_cycle_still_uses_the_rejection_wording() -> None:
+    """The new guard must not quietly take over the old one's cases.
+
+    Both guards end in ``last_exception is not None``, so a test that only asks
+    "did the cycle surface" cannot tell which one fired -- and dropping the
+    ``cycle_unaccepted_devices`` term from the new condition would let it claim
+    every all-rejected cycle and report an outage where a tracker was deleted.
+    Reading the message is the only observable difference, so it is what is
+    pinned. The mirror is
+    ``test_the_surfaced_error_names_which_counter_fired``.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {"dev-1": NovaAuthError(404, "gone"), "dev-2": NovaAuthError(400, "bad")}
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Gone"}, {"id": "dev-2", "name": "Bad"}]
+    )
+
+    assert recorded
+    message = str(recorded[-1])
+    assert "Every device (2) was rejected by" in message, message
+    assert "not accepted" not in message, message
+
+
+@pytest.mark.asyncio
+async def test_an_unaccepted_device_does_not_hide_a_credential_failure() -> None:
+    """A cycle with an expired sign-in must report THAT, not the outage beside it.
+
+    What actually protects this is the SUM, not the guard's
+    ``last_exception is None`` term, and the distinction is worth stating
+    because the obvious reading gets it backwards. A credential failure
+    increments neither counter, so it breaks the equality and the guard never
+    runs at all. Measured: deleting the ``last_exception is None`` term leaves
+    this test green, because it is unreachable today -- every branch that sets
+    ``last_exception`` also keeps its device out of both counts.
+
+    So this pins the outcome the user sees ("your sign-in expired", and with it
+    the re-auth flow), and deliberately not the mechanism. If a future branch
+    both counts a device and reports an error, THAT is when the term starts
+    carrying weight, and a test for it can be written against a state that
+    exists.
+    """
+    coordinator = _polling_coordinator({}, _TrackingFilter(), {})
+    coordinator.api = _PerDeviceAPI(
+        {
+            "dev-1": NovaAuthError(401, "expired"),
+            "dev-2": LocationRequestNotAcceptedError(stage="server_error", status=503),
+        }
+    )
+    coordinator._set_auth_state = lambda **kwargs: None
+    coordinator.config_entry.async_start_reauth = MagicMock()
+    coordinator.note_error = MagicMock()
+    recorded: list[Exception] = []
+    coordinator.async_set_update_error = recorded.append
+
+    await coordinator._async_start_poll_cycle(
+        [{"id": "dev-1", "name": "Hub"}, {"id": "dev-2", "name": "Refused"}]
+    )
+
+    assert recorded, "the cycle hid the credential failure entirely"
+    assert getattr(recorded[-1], "status", None) == 401, (
+        "the cycle reported the unreachable server instead of the tracker whose "
+        f"sign-in expired: {recorded[-1]!r}"
+    )
 
 
 class TestTheDocumentedRejectionGuardStaysTrue:

--- a/tests/test_coordinator_semantic_mappings.py
+++ b/tests/test_coordinator_semantic_mappings.py
@@ -1859,6 +1859,15 @@ class TestTheDocumentedRejectionGuardStaysTrue:
     When the set legitimately changes, update BOTH the paragraph and nothing
     else -- this row reads the number out of the prose itself, so the prose
     stays the single source.
+
+    A second, wider row exists and is not a replacement:
+    `TestTheDocumentedExtentStaysTrue::test_every_test_name_the_component_contracts_cite_exists`
+    in `tests/test_nova_request.py` checks that EVERY name cited in any of the
+    component's contracts resolves, including class names and the lists this
+    sentence pattern does not match. It cannot read a stated number out of
+    prose, which is what this class does, so the two are kept apart on purpose.
+    Whoever widens one should look at the other first; a copy built without
+    knowing about its sibling is how this pair nearly became one.
     """
 
     _AGENTS = (

--- a/tests/test_location_request_cache_isolation.py
+++ b/tests/test_location_request_cache_isolation.py
@@ -421,7 +421,8 @@ async def test_locate_request_requires_namespace(
 
     That downstream failure now surfaces as ``LocationRequestNotAcceptedError``
     rather than as an empty list (PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE): the
-    request never reached the server. The assertion this test exists for is the
+    request never reached the accept point. The assertion this test exists for is
+    the
     NEGATIVE one -- no ``MissingNamespaceError``. ``pytest.raises`` carries it:
     the two classes are disjoint, so a regression to the namespace error fails
     the block rather than any assertion inside it. Spelling it out as a second

--- a/tests/test_location_request_cache_isolation.py
+++ b/tests/test_location_request_cache_isolation.py
@@ -14,6 +14,9 @@ from custom_components.googlefindmy.exceptions import (
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
     location_request,
 )
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request import (
+    LocationRequestNotAcceptedError,
+)
 from custom_components.googlefindmy.NovaApi.ExecuteAction.PlaySound import (
     start_sound_request,
     stop_sound_request,
@@ -406,12 +409,27 @@ def test_locate_request_requires_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     asyncio.run(_run())
 
 
-def test_locate_request_requires_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Caches with empty entry_id proceed without namespace prefix and may fail gracefully.
+@pytest.mark.asyncio
+async def test_locate_request_requires_namespace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caches with empty entry_id proceed without namespace prefix and fail downstream.
 
     The production code no longer raises MissingNamespaceError for empty
     entry_id caches.  Instead, it falls through to un-namespaced cache
-    access and the nova request may fail, returning an empty list.
+    access and the nova request fails there.
+
+    That downstream failure now surfaces as ``LocationRequestNotAcceptedError``
+    rather than as an empty list (PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE): the
+    request never reached the server. The assertion this test exists for is the
+    NEGATIVE one -- no ``MissingNamespaceError``. ``pytest.raises`` carries it:
+    the two classes are disjoint, so a regression to the namespace error fails
+    the block rather than any assertion inside it. Spelling it out as a second
+    ``isinstance`` check would look like the guard while never being able to fire.
+
+    Driven on pytest's managed loop instead of ``asyncio.run`` (tests/AGENTS.md:
+    "Never call ``asyncio.run()`` inside tests."); the surrounding module still
+    carries the older shape, which is a separate cleanup.
     """
 
     class _CacheWithoutEntry(FakeTokenCache):
@@ -424,18 +442,14 @@ def test_locate_request_requires_namespace(monkeypatch: pytest.MonkeyPatch) -> N
 
     cache = _CacheWithoutEntry()
 
-    async def _run() -> list:
-        result = await location_request.get_location_data_for_device(
+    with pytest.raises(LocationRequestNotAcceptedError) as excinfo:
+        await location_request.get_location_data_for_device(
             canonic_device_id="device-456",
             name="Tracker",
             cache=cache,
         )
-        return result
 
-    result = asyncio.run(_run())
-    # With an empty-namespace cache, the request proceeds but
-    # the downstream nova call fails; the function returns [].
-    assert result == []
+    assert excinfo.value.stage == "nova_request_failed"
 
 
 def test_create_location_request_rejects_a_blank_request_uuid() -> None:

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -37,15 +37,20 @@ from __future__ import annotations
 import ast
 import asyncio
 import inspect
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import aiohttp
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 import custom_components.googlefindmy.api as api_module
 from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
+    location_request as location_request_module,
+)
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
 )
@@ -53,7 +58,12 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location
     LOCATION_REQUEST_NOT_ACCEPTED_STAGES,
     LocationRequestNotAcceptedError,
 )
-from custom_components.googlefindmy.NovaApi.nova_request import NovaAuthError, NovaError
+from custom_components.googlefindmy.NovaApi.nova_request import (
+    NovaAuthError,
+    NovaError,
+    NovaHTTPError,
+    NovaRateLimitError,
+)
 from tests.helpers import drain_loop
 from tests.helpers.config_entries_stub import make_config_entry
 from tests.helpers.locate_mixin_stub import LocateStub
@@ -156,10 +166,10 @@ def test_no_sound_path_reaches_the_location_request_module() -> None:
     """The second failure mode is constructively absent, measured rather than asserted.
 
     The two sound-request handlers catch a fixed tuple with no broad fallback, so a
-    signal that reached them would propagate uncaught. It cannot, because every raise
-    site AP-3 adds sits inside ``get_location_data_for_device`` (today there are none
-    yet) and no module under ``PlaySound/`` reaches that function -- not by call, not
-    by import, not by a string handed to ``getattr``/``import_module``.
+    signal that reached them would propagate uncaught. It cannot, because all seven
+    raise sites sit inside ``get_location_data_for_device`` and no module under
+    ``PlaySound/`` reaches that function -- not by call, not by import, not by a
+    string handed to ``getattr``/``import_module``.
 
     Stated so it is not mistaken for a full reachability proof: the scan is one hop
     and package-local. Four routes pass it -- reaching the locate path THROUGH a third
@@ -214,26 +224,11 @@ def test_no_sound_path_reaches_the_location_request_module() -> None:
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "the raise sites are not armed yet; until then no stage marker is in use. "
-        "This is also the tripwire for the prose that is only true until they are: "
-        "when it flips to XPASS, re-read the 'as of this step' paragraphs in "
-        "api.async_get_device_location's Returns and Raises sections, its "
-        "LocationRequestNotAcceptedError pass-through comment, the class "
-        "docstring in location_request.py, the module comment above "
-        "LOCATION_REQUEST_NOT_ACCEPTED_STAGES (which asserts both that the flag "
-        "does not exist and that nothing enforces the set), and the 'Measured: "
-        "today' paragraph in coordinator/polling.py's handler. Nothing else "
-        "enforces those."
-    ),
-)
 def test_the_stage_markers_are_a_closed_set() -> None:
     """Every raise site uses a declared marker, and every declared marker is used."""
     stages = _raised_stages(_LOCATION_REQUEST_PY.read_text(encoding="utf-8"))
 
-    assert stages, "no raise site uses the signal yet"
+    assert stages, "no raise site uses the signal at all -- the sender is disarmed"
     assert set(stages) <= LOCATION_REQUEST_NOT_ACCEPTED_STAGES
     assert set(stages) == LOCATION_REQUEST_NOT_ACCEPTED_STAGES
     assert len(stages) == len(set(stages)), f"a marker is used twice: {stages}"
@@ -253,10 +248,13 @@ def test_the_stage_markers_are_a_closed_set() -> None:
 #
 # Injecting at the api seam rather than deep in ``location_request`` is deliberate
 # and mirrors ``tests/test_transient_owner_key_propagation.py``: the receivers must
-# be provably correct while the sender is still silent, because arming the sender
-# first would let the signal reach the poll loop's broad per-device handler, which
-# sets both ``cycle_failed`` and ``last_exception`` -- one 5xx on one tracker would
-# mark every entity of the account unavailable.
+# be provably correct while the sender is still silent. What that ordering buys is
+# NOT what it first looks like -- with no receiver anywhere, an armed sender would
+# have been inert, since ``api.py``'s own broad handler flattens the signal to
+# ``{}``. The state to avoid is the HALF-wired one, api pass-through installed and
+# coordinator branch not: there the signal reaches the poll loop's broad per-device
+# handler, which sets both ``cycle_failed`` and ``last_exception``, and one 5xx on
+# one tracker marks every entity of the account unavailable.
 # ===========================================================================
 
 
@@ -611,3 +609,374 @@ def test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict(
         drain_loop(sync_loop)
 
     assert result == {}
+
+
+# ===========================================================================
+# AP-3: the sender. Seven raise sites, two swallow guards, three empty returns
+# that must STAY empty.
+#
+# The two sections above pin the type and the receivers. This one pins the only
+# thing that makes either matter: that the seven pre-accept paths raise at all,
+# under the marker that names WHERE they are, and that the three post-accept
+# paths are untouched. Both halves are load-bearing -- a change that raised
+# everywhere would be just as wrong as one that raised nowhere, because it would
+# re-merge the accepted-but-idle outcome with the never-arrived one from the
+# other side.
+#
+# These tests drive the REAL ``get_location_data_for_device`` (no api-seam
+# injection): what is under test here is the function's own control flow.
+# ===========================================================================
+
+
+class _RaisingFcmReceiver:
+    """Receiver whose registration raises, exercising the fcm_registration path."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def async_register_for_location_updates(
+        self, _device_id: str, _callback: Any
+    ) -> str:
+        raise self._exc
+
+    async def async_unregister_for_location_updates(self, _device_id: str) -> None:
+        return None
+
+
+class _TokenFcmReceiver:
+    """Receiver whose registration yields a token; the locate fails downstream."""
+
+    def __init__(self, token: str = "fcm-token") -> None:
+        self._token = token
+
+    async def async_register_for_location_updates(
+        self, _device_id: str, _callback: Any
+    ) -> str:
+        return self._token
+
+    async def async_unregister_for_location_updates(self, _device_id: str) -> None:
+        return None
+
+
+class _SenderTokenCache:
+    """Minimal entry-scoped cache the locate flow accepts."""
+
+    def __init__(self, label: str = "entry-sender") -> None:
+        self.entry_id = label
+        self.values: dict[str, Any] = {}
+
+    async def async_get_cached_value(self, key: str) -> Any:
+        return self.values.get(key)
+
+    async def async_set_cached_value(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+    async def get(self, key: str) -> Any:
+        return self.values.get(key)
+
+    async def set(self, key: str, value: Any) -> None:
+        self.values[key] = value
+
+
+def _capture_ctx(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace the callback factory and hand back the context it was built with.
+
+    The post-accept tests need to drive ``ctx`` directly: the accept line is only
+    reachable with a Nova request that succeeds, and everything after it waits on
+    ``ctx.event``. Capturing the context the production code created is the only
+    way to reach those branches without a real FCM delivery.
+    """
+    captured: dict[str, Any] = {}
+
+    def _fake_make_callback(*, ctx: Any, **_: Any) -> Any:
+        captured["ctx"] = ctx
+        return lambda *_a: None
+
+    monkeypatch.setattr(
+        location_request_module, "_make_location_callback", _fake_make_callback
+    )
+    return captured
+
+
+async def _locate(**kwargs: Any) -> list[dict[str, Any]]:
+    """Call the real entry point with the fixed arguments every case below shares."""
+    return await location_request_module.get_location_data_for_device(
+        canonic_device_id="device-sender",
+        name="Tracker",
+        session=None,
+        username="user@example.com",
+        cache=_SenderTokenCache(),
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_fcm_token_raises_instead_of_returning_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registration that yields no token never reaches the server."""
+    monkeypatch.setattr(
+        location_request_module,
+        "_FCM_ReceiverGetter",
+        lambda *_a: _TokenFcmReceiver(token=""),
+    )
+    _capture_ctx(monkeypatch)
+
+    with pytest.raises(LocationRequestNotAcceptedError) as excinfo:
+        await _locate()
+
+    assert excinfo.value.stage == "no_fcm_token"
+    # No exception to chain from here: the falsy token is not an error object.
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.status is None
+
+
+@pytest.mark.asyncio
+async def test_fcm_registration_failed_raises_instead_of_returning_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising registration never reaches the server either."""
+    boom = RuntimeError("registration backend down")
+    monkeypatch.setattr(
+        location_request_module,
+        "_FCM_ReceiverGetter",
+        lambda *_a: _RaisingFcmReceiver(boom),
+    )
+    _capture_ctx(monkeypatch)
+
+    with pytest.raises(LocationRequestNotAcceptedError) as excinfo:
+        await _locate()
+
+    assert excinfo.value.stage == "fcm_registration_failed"
+    assert excinfo.value.__cause__ is boom
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("nova_exc", "expected_stage", "expected_status"),
+    [
+        (NovaRateLimitError("upstream quota exceeded"), "rate_limited", 429),
+        (NovaHTTPError(503, "backend unavailable"), "server_error", 503),
+        (aiohttp.ClientError("connection reset"), "network_error", None),
+        (RuntimeError("unclassified nova failure"), "nova_request_failed", None),
+    ],
+)
+async def test_the_nova_ladder_raises_instead_of_returning_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    nova_exc: Exception,
+    expected_stage: str,
+    expected_status: int | None,
+) -> None:
+    """Each rung of the Nova exception ladder carries its own marker.
+
+    The status column is the reason this is parametrised rather than four copies:
+    two rungs know a status and two do not, and a marker that silently lost its
+    status would otherwise look exactly like one that never had one. 429 is
+    asserted as a literal on purpose -- the production code reads it from the
+    transport's constant, and a test that imported the same constant would agree
+    with it by construction.
+    """
+    monkeypatch.setattr(
+        location_request_module, "_FCM_ReceiverGetter", lambda *_a: _TokenFcmReceiver()
+    )
+    _capture_ctx(monkeypatch)
+    monkeypatch.setattr(
+        location_request_module, "create_location_request", lambda *a, **k: "deadbeef"
+    )
+
+    async def _raise_nova(*_a: object, **_k: object) -> bytes:
+        raise nova_exc
+
+    monkeypatch.setattr(location_request_module, "async_nova_request", _raise_nova)
+
+    with pytest.raises(LocationRequestNotAcceptedError) as excinfo:
+        await _locate()
+
+    assert excinfo.value.stage == expected_stage
+    assert excinfo.value.status == expected_status
+    assert excinfo.value.__cause__ is nova_exc
+
+
+@pytest.mark.asyncio
+async def test_surfacing_before_accept_raises_instead_of_returning_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failure the outer handler catches BEFORE the accept line is not an idle result.
+
+    This is the marker that cannot be read off the file: the handler wraps the
+    whole body, so its own return sits after the accept line. Only the flag tells
+    the two sides apart.
+    """
+    boom = RuntimeError("payload build failed")
+    monkeypatch.setattr(
+        location_request_module, "_FCM_ReceiverGetter", lambda *_a: _TokenFcmReceiver()
+    )
+    _capture_ctx(monkeypatch)
+
+    def _boom(*_a: object, **_k: object) -> str:
+        raise boom
+
+    monkeypatch.setattr(location_request_module, "create_location_request", _boom)
+
+    with pytest.raises(LocationRequestNotAcceptedError) as excinfo:
+        await _locate()
+
+    assert excinfo.value.stage == "surfacing_before_accept"
+    assert excinfo.value.__cause__ is boom
+
+
+@pytest.mark.asyncio
+async def test_the_fcm_inner_handler_does_not_swallow_the_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The most load-bearing test of this step.
+
+    ``no_fcm_token`` raises INSIDE the inner try body, and the handler that closes
+    that body is a broad ``except Exception``. ``Exception`` is this type's base by
+    design, so without the explicit re-raise placed ahead of it the signal is
+    caught there, relabelled ``fcm_registration_failed`` and handed on -- or, in the
+    pre-guard shape, turned straight back into the empty list. Both outcomes leave
+    a green suite and an inert change.
+
+    The assertion is therefore on the MARKER, not merely on the type: the swallow
+    would produce the same class under a different stage, and a test that only
+    checked ``pytest.raises(LocationRequestNotAcceptedError)`` would pass through
+    it.
+
+    It also asserts on the RECORD, which is what keeps it from being a second copy
+    of ``test_no_fcm_token_raises_instead_of_returning_empty``: the swallow path
+    runs the registration handler's own ``FCM registration failed`` ERROR on its
+    way through. That record is present exactly when the guard is missing, so its
+    absence is an observation the sibling test does not make.
+    """
+    monkeypatch.setattr(
+        location_request_module,
+        "_FCM_ReceiverGetter",
+        lambda *_a: _TokenFcmReceiver(token=""),
+    )
+    _capture_ctx(monkeypatch)
+    caplog.set_level(logging.DEBUG, logger=location_request_module.__name__)
+
+    with pytest.raises(LocationRequestNotAcceptedError) as excinfo:
+        await _locate()
+
+    assert excinfo.value.stage == "no_fcm_token", (
+        "the inner broad handler swallowed the signal and re-raised it under its "
+        "own marker; the explicit re-raise ahead of it is gone or misordered"
+    )
+    assert not [
+        rec for rec in caplog.records if "FCM registration failed" in rec.getMessage()
+    ], "the registration handler ran, so the signal passed through it"
+
+
+def _wire_accepted_flow(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Wire a locate whose Nova request SUCCEEDS, so the accept line is reached."""
+    monkeypatch.setattr(
+        location_request_module, "_FCM_ReceiverGetter", lambda *_a: _TokenFcmReceiver()
+    )
+    captured = _capture_ctx(monkeypatch)
+    monkeypatch.setattr(
+        location_request_module, "create_location_request", lambda *a, **k: "deadbeef"
+    )
+
+    async def _ok(*_a: object, **_k: object) -> bytes:
+        return b""
+
+    monkeypatch.setattr(location_request_module, "async_nova_request", _ok)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_request_that_times_out_still_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The healthy idle outcome of a BLE tag: accepted, nobody in range, empty."""
+    _wire_accepted_flow(monkeypatch)
+    monkeypatch.setattr(location_request_module, "LOCATION_REQUEST_TIMEOUT_S", 0.01)
+
+    assert await _locate() == []
+
+
+@pytest.mark.asyncio
+async def test_an_accepted_request_with_no_matching_record_still_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accepted, delivered, nothing for this device: still an empty result."""
+    captured = _wire_accepted_flow(monkeypatch)
+    monkeypatch.setattr(location_request_module, "LOCATION_REQUEST_TIMEOUT_S", 5)
+
+    async def _deliver_nothing(*_a: object, **_k: object) -> bytes:
+        ctx = captured["ctx"]
+        ctx.data = []
+        ctx.event.set()
+        return b""
+
+    monkeypatch.setattr(location_request_module, "async_nova_request", _deliver_nothing)
+
+    assert await _locate() == []
+
+
+@pytest.mark.asyncio
+async def test_a_failure_after_the_accept_line_still_returns_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failure AFTER the accept line reaches the same broad handler and must not raise.
+
+    This is the other half of ``surfacing_before_accept`` and the reason the branch
+    exists at all: the same handler, the same exception type, opposite verdicts,
+    decided solely by the flag. Delivering a record that is not a mapping makes the
+    match check blow up after the accept line, which is a genuine post-accept
+    surfacing failure rather than a simulated one.
+    """
+    captured = _wire_accepted_flow(monkeypatch)
+    monkeypatch.setattr(location_request_module, "LOCATION_REQUEST_TIMEOUT_S", 5)
+
+    async def _deliver_garbage(*_a: object, **_k: object) -> bytes:
+        ctx = captured["ctx"]
+        ctx.data = [object()]  # no ``.get`` -- AttributeError past the accept line
+        ctx.event.set()
+        return b""
+
+    monkeypatch.setattr(location_request_module, "async_nova_request", _deliver_garbage)
+
+    assert await _locate() == []
+
+
+@pytest.mark.asyncio
+async def test_data_for_the_wrong_device_still_returns_empty_and_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The one post-accept branch that is a FAILURE and still returns empty.
+
+    Both the production comment at that branch and the ``Returns`` section of
+    ``api.async_get_device_location`` now single it out: it escapes this change not
+    because it is healthy but because the line drawn here is accepted-versus-not,
+    not healthy-versus-failed. A claim of that shape needs a test, or the next
+    change is free to turn the branch into a raise -- or to drop its WARNING -- with
+    a green suite.
+
+    It is deliberately NOT covered by the no-matching-record test above: that one
+    delivers an EMPTY list and takes the ``if not data`` arm (DEBUG), this one
+    delivers a record for a different device and takes the ``else`` arm (WARNING).
+    """
+    captured = _wire_accepted_flow(monkeypatch)
+    monkeypatch.setattr(location_request_module, "LOCATION_REQUEST_TIMEOUT_S", 5)
+    caplog.set_level(logging.DEBUG, logger=location_request_module.__name__)
+
+    async def _deliver_stranger(*_a: object, **_k: object) -> bytes:
+        ctx = captured["ctx"]
+        ctx.data = [{"canonic_id": "a-completely-different-device"}]
+        ctx.event.set()
+        return b""
+
+    monkeypatch.setattr(
+        location_request_module, "async_nova_request", _deliver_stranger
+    )
+
+    assert await _locate() == []
+    warnings = [rec for rec in caplog.records if rec.levelno == logging.WARNING]
+    assert any("unexpected device" in rec.getMessage() for rec in warnings), (
+        "the mismatch must stay visible; it is a failure, not an idle outcome"
+    )

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -416,8 +416,8 @@ def test_the_module_cli_reports_the_signal_and_exits_non_zero(
     It is the second of the two CLI edges. The first (the interactive selection
     loop in ``nbe_list_devices``) prints and continues, because there is a next
     prompt to return to. This one has none, so it prints and exits non-zero: a
-    script wrapping it has to be able to tell "no location" from "the request
-    never got out", and an exit code is the only channel it has.
+    script wrapping it has to be able to tell "no location" from "the request was
+    not accepted", and an exit code is the only channel it has.
 
     Driven through ``runpy`` because a guarded ``__main__`` block is otherwise
     unreachable from a test and is excluded from coverage
@@ -557,9 +557,9 @@ async def test_poll_treats_the_signal_as_a_per_device_skip_when_a_sibling_gets_t
     only ever a per-device skip, this test could let both devices raise and
     still expect ``last_update_success is True``. Once the cycle-level guard
     landed, that same input became an account-wide outage by definition -- no
-    device reached the server -- and the expectation flipped. It is pinned in
-    ``test_a_cycle_where_no_request_was_accepted_reports_an_error``, deliberately
-    and in the file that owns cycle semantics.
+    device's request was accepted -- and the expectation flipped. It is
+    pinned in ``test_a_cycle_where_no_request_was_accepted_reports_an_error``,
+    deliberately and in the file that owns cycle semantics.
 
     What is left here is the narrower claim this file is for: one refused
     tracker next to one that got through must not take the account offline. The

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -656,13 +656,29 @@ async def test_locate_returns_empty_on_the_signal_without_raising(
     an unexpected error, and the user already sees the honest outcome -- the locate
     found nothing -- so the visible behaviour is deliberately unchanged from today.
     What changes is invisible and sits in the next test.
+
+    Its COVERAGE is subsumed: measured, there is no change to the branch under which
+    this test goes red while the WARNING test below stays green. It is kept for the
+    named failure mode rather than for the assertion -- and it is the one test here
+    that a do-nothing ``async_locate_device`` would satisfy, which is why the control
+    at the end of this group exists.
     """
     coord = locate_coord
     coord.api.async_get_device_location = AsyncMock(
         side_effect=LocationRequestNotAcceptedError(stage="network_error")
     )
 
-    result = await coord.async_locate_device("dev-1")
+    # Caught rather than left to propagate, and the difference is legibility, not
+    # coverage: ``Exception`` is the signal's base class, so the branch below this
+    # one claims it the moment the two swap places and re-wraps it into exactly this
+    # error. An unguarded await would report that as an unhandled exception in a
+    # test about an empty dict; naming it says which branch ran.
+    try:
+        result = await coord.async_locate_device("dev-1")
+    except HomeAssistantError as err:  # pragma: no cover - failure path
+        pytest.fail(
+            f"the broad handler claimed the signal and raised a red toast: {err}"
+        )
 
     assert result == {}
 
@@ -693,6 +709,78 @@ async def test_locate_does_not_clear_the_auth_state_on_the_signal(
     coord._set_auth_state.assert_not_called()
     coord.config_entry.async_start_reauth.assert_not_called()
     coord.note_error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_locate_warns_and_returns_empty_on_an_unaccepted_request(
+    locate_coord: LocateStub,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The level is the branch's only visible output, so it is asserted, not assumed.
+
+    This path runs because someone asked for it -- a button, an automation, or the
+    ``locate_device`` service. DEBUG would mean asking, getting nothing, and finding
+    nothing in the log at the default level: the exact silence this plan exists to
+    remove, reintroduced one layer higher. The poll loop logs the same condition at
+    DEBUG on purpose, which is not an inconsistency but the same rule applied to an
+    unattended, repeating caller.
+
+    Deliberately NOT justified by the ``NovaRateLimitError`` / ``NovaHTTPError``
+    handlers a few branches up, which log at WARNING but are dead on this path --
+    ``api.py`` answers both with an empty dict of its own. The reasoning that does
+    hold is in the branch's own comment; the assertion here only pins the outcome.
+    """
+    coord = locate_coord
+    coord.api.async_get_device_location = AsyncMock(
+        side_effect=LocationRequestNotAcceptedError(stage="server_error")
+    )
+
+    with caplog.at_level(
+        logging.DEBUG, logger="custom_components.googlefindmy.coordinator.locate"
+    ):
+        result = await coord.async_locate_device("dev-1")
+
+    assert result == {}
+    records = [
+        record
+        for record in caplog.records
+        if "request not accepted" in record.getMessage()
+    ]
+    assert len(records) == 1, [record.getMessage() for record in caplog.records]
+    # Captured at DEBUG so a demotion is visible as a WRONG level rather than as an
+    # absent record: an assertion that only ran at WARNING could not tell "logged at
+    # DEBUG" from "not logged at all", and those call for different fixes.
+    assert records[0].levelno == logging.WARNING
+    assert "server_error" in records[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_locate_on_a_healthy_idle_tag_still_returns_empty_and_clears_auth_state(
+    locate_coord: LocateStub,
+) -> None:
+    """Drives the positive half of the rule, which no other test in the tree does.
+
+    Every other test here injects the signal, so all of them observe the branch that
+    SKIPS the auth reset. Measured, a stubbed-out ``async_locate_device`` that did
+    nothing at all would still satisfy ``test_locate_returns_empty_on_the_signal_without_raising``
+    -- an empty dict is what doing nothing returns. The other two are not vacuous
+    that way (one asserts a log record, one asserts ``note_error``), but none of the
+    three shows that the reset still HAPPENS when it should.
+
+    So this is the same seam driven with the outcome the plan protects: a BLE tag
+    whose request WAS accepted and had nothing to report. There the empty result
+    still means the credentials worked, and ``_set_auth_state(failed=False)`` must
+    run. Identical return value, opposite side effect -- that difference is the
+    whole change, and this is the only place it is pinned from the positive side.
+    """
+    coord = locate_coord
+    coord.api.async_get_device_location = AsyncMock(return_value={})
+
+    result = await coord.async_locate_device("dev-1")
+
+    assert result == {}
+    coord._set_auth_state.assert_called_once_with(failed=False)
+    coord.note_error.assert_not_called()
 
 
 def test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict(

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -9,8 +9,11 @@ read every non-raising return as positive proof that the credentials work
 (``PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE``).
 
 ``LocationRequestNotAcceptedError`` carries the second state across the
-``location_request.py`` boundary. This module pins what the CHOICE OF BASE CLASS can
-decide, and nothing beyond it: the signal must not inherit from a base that an existing
+``location_request.py`` boundary. This module has two halves, and mixing them up is
+how the change becomes inert.
+
+The FIRST half pins what the CHOICE OF BASE CLASS can decide, and nothing beyond
+it: the signal must not inherit from a base that an existing
 NARROW handler routes somewhere wrong (``RuntimeError``, ``DecryptionError``, the
 ``NovaError`` family, ``HomeAssistantError`` -- each has a measured counterpart), and it
 must not reach a handler that catches a fixed tuple without a broad fallback, where it
@@ -21,20 +24,28 @@ redundant with the other.
 What these tests deliberately do NOT show is that the signal survives a broad
 ``except Exception``. It does not: ``Exception`` is the base, so every broad handler
 catches it too. That property cannot be bought with a base class at all; it is bought
-with an explicit re-raise placed BEFORE each broad handler, which AP-2 and AP-3 install
-and the AST guard in ``tests/test_nova_request.py`` pins. Reading the base-class choice
-as the whole answer is the documented way for this change to become inert.
+with an explicit re-raise placed BEFORE each broad handler. Reading the base-class
+choice as the whole answer is the documented way for this change to become inert.
+
+The SECOND half, further down under its own banner, is exactly those re-raises: it
+drives the real seams with the signal injected at ``api.async_get_device_location``
+and pins where it comes out. Behaviour, not typing.
 """
 
 from __future__ import annotations
 
 import ast
+import asyncio
 import inspect
 from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 
+import custom_components.googlefindmy.api as api_module
+from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     DecryptionError,
 )
@@ -43,6 +54,9 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location
     LocationRequestNotAcceptedError,
 )
 from custom_components.googlefindmy.NovaApi.nova_request import NovaAuthError, NovaError
+from tests.helpers import drain_loop
+from tests.helpers.config_entries_stub import make_config_entry
+from tests.helpers.locate_mixin_stub import LocateStub
 
 _LOCATE_TRACKER_DIR = (
     Path(__file__).resolve().parents[1]
@@ -202,7 +216,18 @@ def test_no_sound_path_reaches_the_location_request_module() -> None:
 
 @pytest.mark.xfail(
     strict=True,
-    reason="AP-3 arms the raise sites; until then no stage marker is in use",
+    reason=(
+        "the raise sites are not armed yet; until then no stage marker is in use. "
+        "This is also the tripwire for the prose that is only true until they are: "
+        "when it flips to XPASS, re-read the 'as of this step' paragraphs in "
+        "api.async_get_device_location's Returns and Raises sections, its "
+        "LocationRequestNotAcceptedError pass-through comment, the class "
+        "docstring in location_request.py, the module comment above "
+        "LOCATION_REQUEST_NOT_ACCEPTED_STAGES (which asserts both that the flag "
+        "does not exist and that nothing enforces the set), and the 'Measured: "
+        "today' paragraph in coordinator/polling.py's handler. Nothing else "
+        "enforces those."
+    ),
 )
 def test_the_stage_markers_are_a_closed_set() -> None:
     """Every raise site uses a declared marker, and every declared marker is used."""
@@ -212,3 +237,376 @@ def test_the_stage_markers_are_a_closed_set() -> None:
     assert set(stages) <= LOCATION_REQUEST_NOT_ACCEPTED_STAGES
     assert set(stages) == LOCATION_REQUEST_NOT_ACCEPTED_STAGES
     assert len(stages) == len(set(stages)), f"a marker is used twice: {stages}"
+
+
+# ===========================================================================
+# AP-2: the receivers. Installed BEFORE anything raises, on purpose.
+#
+# The tests above are static: they pin what the choice of base class can decide.
+# The tests below are the opposite kind -- they drive the real seams with the
+# signal injected at ``api.async_get_device_location``, the single chokepoint both
+# coordinator sinks consume, and pin where it comes out. They are the reason the
+# base-class tests are not the whole answer: ``Exception`` IS the base, so every
+# broad handler on the path catches this type too, and only an explicit branch
+# placed BEFORE each of them changes that. This section is what fails if such a
+# branch is deleted, reordered behind its broad neighbour, or never installed.
+#
+# Injecting at the api seam rather than deep in ``location_request`` is deliberate
+# and mirrors ``tests/test_transient_owner_key_propagation.py``: the receivers must
+# be provably correct while the sender is still silent, because arming the sender
+# first would let the signal reach the poll loop's broad per-device handler, which
+# sets both ``cycle_failed`` and ``last_exception`` -- one 5xx on one tracker would
+# mark every entity of the account unavailable.
+# ===========================================================================
+
+
+class _DummyCache:
+    """Minimal cache stub for the real coordinator build."""
+
+    async def async_get_cached_value(self, _key: str):  # pragma: no cover - stub
+        return None
+
+    async def async_set_cached_value(self, _key: str, _value):  # pragma: no cover
+        return None
+
+
+class _DummyHass:
+    """Minimal HA stub exposing the loop and task helper the coordinator needs."""
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.loop = loop
+        self.data: dict = {}
+
+    def async_create_task(self, coro, *, name: str | None = None):  # noqa: D401
+        return self.loop.create_task(coro)
+
+
+class _NotAcceptedAPI:
+    """API stub whose per-device locate raises the signal, counting its calls.
+
+    The call count pins that the signal does not ABORT the cycle: the second
+    device is still requested. It deliberately does not claim more than that.
+    Measured, it cannot prove the ``continue`` itself, because the broad neighbour
+    it precedes carries neither ``continue`` nor ``raise`` -- after it the loop body
+    only reaches the inter-device delay and iterates on. The one observable
+    difference the ``continue`` makes is skipping that delay, which is what the
+    empty-result arm does today for the same 429 or 5xx.
+    """
+
+    def __init__(self, error: LocationRequestNotAcceptedError) -> None:
+        self._error = error
+        self.calls: list[str] = []
+
+    async def async_get_device_location(self, dev_id: str, _dev_name: str):
+        self.calls.append(dev_id)
+        raise self._error
+
+
+class _StubCache:
+    """Minimal cache the real ``GoogleFindMyAPI`` constructor accepts."""
+
+    entry_id = "entry-not-accepted"
+
+    async def async_get_cached_value(self, _key: str):  # pragma: no cover - stub
+        return None
+
+    async def async_set_cached_value(self, _key: str, _value):  # pragma: no cover
+        return None
+
+
+def _make_api() -> Any:
+    """Build a ``GoogleFindMyAPI`` through its real constructor.
+
+    Deliberately not the ``__new__``-plus-hand-set-attributes shortcut its nearest
+    sibling ``tests/test_api_transient_owner_key.py`` uses: that shape breaks with
+    an ``AttributeError`` -- not a statement about the subject -- the day the
+    constructor reads one more field. The locate seam is stubbed at the module
+    binding anyway, so nothing here needs the wiring to be absent.
+    """
+    return api_module.GoogleFindMyAPI(cache=_StubCache())
+
+
+def _make_coordinator(
+    monkeypatch: pytest.MonkeyPatch,
+    loop: asyncio.AbstractEventLoop,
+    api: object,
+    devices: list[dict[str, str]],
+):
+    """Build a real coordinator wired with stubs (mirrors the transient AP10 test)."""
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.GoogleFindMyCoordinator._async_load_stats",
+        AsyncMock(return_value=None),
+    )
+
+    hass = _DummyHass(loop)
+    coordinator = GoogleFindMyCoordinator(hass, cache=_DummyCache())
+    coordinator.config_entry = make_config_entry(
+        entry_id="entry-id", title="Test Entry"
+    )
+    coordinator.api = api
+    coordinator._get_google_home_filter = lambda: None
+    coordinator._is_fcm_ready_soft = lambda: True
+    coordinator._get_ignored_set = set
+    coordinator._last_device_list = list(devices)
+
+    coordinator.data = []
+    coordinator.last_update_success = True
+    coordinator.last_exception = None
+
+    def _set_update_error(exc: Exception) -> None:
+        coordinator.last_update_success = False
+        coordinator.last_exception = exc
+
+    def _set_updated_data(data):
+        coordinator.data = data
+        coordinator.last_update_success = True
+        coordinator.last_exception = None
+
+    coordinator.async_set_update_error = _set_update_error
+    coordinator.async_set_updated_data = _set_updated_data
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_api_passes_the_signal_through_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``api.async_get_device_location`` re-raises the signal, unchanged.
+
+    Two claims, and the second is the one that decays quietly. It must ARRIVE
+    (rather than being flattened into ``{}`` by the broad handler), and it must
+    arrive as the SAME object: a handler that caught and re-wrapped it would still
+    satisfy ``pytest.raises`` while destroying the stage marker the receivers read.
+    Identity is therefore asserted, not just the type.
+    """
+    signal = LocationRequestNotAcceptedError(stage="server_error", status=503)
+
+    async def _raise_signal(*_a: object, **_k: object) -> list[dict[str, Any]]:
+        raise signal
+
+    monkeypatch.setattr(api_module, "get_location_data_for_device", _raise_signal)
+
+    with pytest.raises(LocationRequestNotAcceptedError) as excinfo:
+        await _make_api().async_get_device_location("device-xyz", "Tracker")
+
+    assert excinfo.value is signal
+    assert excinfo.value.stage == "server_error"
+    assert excinfo.value.status == 503
+
+
+@pytest.mark.asyncio
+async def test_the_typeerror_cascade_does_not_retry_on_the_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The signal must not be re-sent by the legacy-signature fallback ladder.
+
+    ``async_get_device_location`` wraps its call in three nested ``except TypeError``
+    retries for older ``get_location_data_for_device`` signatures. That ladder is
+    keyed on TypeError alone, so it is blind to what a call actually did: were the
+    signal ever routed into it, one refused request would become four -- against a
+    server that just answered 429 or 5xx, which is the worst possible moment to
+    retry. One call is the whole assertion.
+    """
+    signal = LocationRequestNotAcceptedError(stage="rate_limited", status=429)
+    calls = 0
+
+    async def _raise_signal(*_a: object, **_k: object) -> list[dict[str, Any]]:
+        nonlocal calls
+        calls += 1
+        raise signal
+
+    monkeypatch.setattr(api_module, "get_location_data_for_device", _raise_signal)
+
+    with pytest.raises(LocationRequestNotAcceptedError):
+        await _make_api().async_get_device_location("device-xyz", "Tracker")
+
+    assert calls == 1
+
+
+def test_poll_treats_the_signal_as_a_per_device_skip_for_now(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The poll loop skips the device and keeps going; the cycle does not fail.
+
+    "For now" is load-bearing. Evaluating the signal cycle-wide is a later step;
+    at this point the correct outcome is deliberately the modest one, because the
+    broad handler this branch precedes would set ``cycle_failed`` AND
+    ``last_exception``, and that turns one refused tracker into an account-wide
+    ``unavailable``.
+
+    The load-bearing assertions are ``note_error`` and the two cycle fields, not
+    the call list. Without this branch the broad neighbour sets ``last_exception``,
+    the ``finally`` block feeds it to ``async_set_update_error``, and
+    ``last_update_success`` goes False -- that is what turns red. The call list
+    pins the weaker, still worth-having claim that the cycle was not aborted; it
+    is not the proof of the skip, and thinning out "redundant" assertions here
+    would remove the ones that carry the test.
+    """
+    loop = asyncio.new_event_loop()
+    devices = [
+        {"id": "dev-refused", "name": "Refused Tag"},
+        {"id": "dev-sibling", "name": "Sibling Tag"},
+    ]
+    api = _NotAcceptedAPI(
+        LocationRequestNotAcceptedError(stage="server_error", status=503)
+    )
+    coordinator = _make_coordinator(monkeypatch, loop, api, devices)
+    note_error = MagicMock(return_value=None)
+    coordinator.note_error = note_error
+
+    try:
+        loop.run_until_complete(
+            coordinator._async_start_poll_cycle(devices, force=True)
+        )
+    finally:
+        drain_loop(loop)
+        loop.close()
+
+    assert api.calls == ["dev-refused", "dev-sibling"]
+    assert coordinator.last_update_success is True
+    assert coordinator.last_exception is None
+    # The poll sink records nothing per-tracker here: unlike the manual path there
+    # is no user waiting on a verdict, and a per-device error record would show up
+    # in diagnostics as a fault the cycle did not commit to.
+    note_error.assert_not_called()
+
+
+def test_poll_does_not_clear_the_auth_state_on_the_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refused request must not be read as proof that the credentials work.
+
+    This is the defect itself, in miniature. Today the empty result reaches the
+    success path, which runs ``_set_auth_state(failed=False)`` and resets
+    ``_consecutive_transient_auth_failures`` -- so a 5xx wipes the transient-auth
+    counter on its way through, and the escalation budget never fills. The fix is
+    not that the branch below undoes the reset; it is that raising SKIPS the reset
+    entirely. Asserting the counter is untouched is what would catch a well-meant
+    "restore previous behaviour" edit putting it back.
+    """
+    loop = asyncio.new_event_loop()
+    devices = [{"id": "dev-refused", "name": "Refused Tag"}]
+    api = _NotAcceptedAPI(
+        LocationRequestNotAcceptedError(stage="fcm_registration_failed")
+    )
+    coordinator = _make_coordinator(monkeypatch, loop, api, devices)
+    set_auth_state = MagicMock(return_value=None)
+    coordinator._set_auth_state = set_auth_state
+    coordinator._consecutive_transient_auth_failures = 3
+    coordinator._consecutive_timeouts = 2
+
+    try:
+        loop.run_until_complete(
+            coordinator._async_start_poll_cycle(devices, force=True)
+        )
+    finally:
+        drain_loop(loop)
+        loop.close()
+
+    set_auth_state.assert_not_called()
+    assert coordinator._consecutive_transient_auth_failures == 3
+    # Nor may the branch invent a health signal the request never earned: today a
+    # failed request reaches the ``if not location:`` arm, which does NOT clear the
+    # timeout counter either. Most sibling handlers in that loop DO clear it
+    # (eight of ten unconditionally; ``TimeoutError`` increments it instead, and
+    # ``NovaAuthError`` clears it on one of its three exits), so the majority shape
+    # is a standing invitation to "fix" this asymmetry. This assertion is what
+    # turns that edit red.
+    assert coordinator._consecutive_timeouts == 2
+
+
+@pytest.fixture
+def locate_coord(monkeypatch: pytest.MonkeyPatch) -> LocateStub:
+    """A ``LocateStub`` past every cooldown gate so the api seam is reached."""
+    monkeypatch.setattr(
+        "custom_components.googlefindmy.coordinator.locate.time.monotonic",
+        lambda: 1000.0,
+    )
+    entry = make_config_entry(entry_id="not-accepted-locate-entry")
+    return LocateStub(config_entry=entry)
+
+
+@pytest.mark.asyncio
+async def test_locate_returns_empty_on_the_signal_without_raising(
+    locate_coord: LocateStub,
+) -> None:
+    """Manual locate degrades to an empty result instead of a user-facing error.
+
+    The broad handler this branch precedes re-wraps whatever reaches it into a
+    ``HomeAssistantError``, which surfaces as a red toast. A refused request is not
+    an unexpected error, and the user already sees the honest outcome -- the locate
+    found nothing -- so the visible behaviour is deliberately unchanged from today.
+    What changes is invisible and sits in the next test.
+    """
+    coord = locate_coord
+    coord.api.async_get_device_location = AsyncMock(
+        side_effect=LocationRequestNotAcceptedError(stage="network_error")
+    )
+
+    result = await coord.async_locate_device("dev-1")
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_locate_does_not_clear_the_auth_state_on_the_signal(
+    locate_coord: LocateStub,
+) -> None:
+    """The manual path carries the same ordering defect, and the same fix.
+
+    ``coordinator/locate.py`` calls ``_set_auth_state(failed=False)`` immediately
+    after the api call and BEFORE its empty-result guard, so a refused manual
+    locate clears the account's auth-failure state exactly as the poll loop does.
+    Raising skips it. ``note_error`` is the per-tracker DIAGNOSTIC hook, not a
+    counter, and the sibling transient handler calls it by design -- so its use
+    here is asserted as intended behaviour rather than tolerated.
+    """
+    coord = locate_coord
+    coord.note_error = MagicMock(return_value=None)
+    coord.config_entry.async_start_reauth = MagicMock()
+    coord.api.async_get_device_location = AsyncMock(
+        side_effect=LocationRequestNotAcceptedError(stage="nova_request_failed")
+    )
+
+    result = await coord.async_locate_device("dev-1")
+
+    assert result == {}
+    coord._set_auth_state.assert_not_called()
+    coord.config_entry.async_start_reauth.assert_not_called()
+    coord.note_error.assert_called_once()
+
+
+def test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A KNOWN, deliberately unclosed edge: the sync wrapper is not a receiver.
+
+    ``get_device_location`` is the sync entry point for non-HA contexts -- measured,
+    its only in-tree caller is the compatibility shim ``api.locate_device`` -- and
+    its ``_run_sync_helper`` catches every exception uniformly to return the
+    default.
+    The signal is therefore flattened right back into ``{}`` there -- the exact
+    shape this change removes everywhere else.
+
+    Pinned rather than fixed, and pinned HERE rather than left implicit, because an
+    unstated exception is indistinguishable from an oversight. No coordinator uses
+    this entry point; closing it belongs to the step that tightens the CLI edges.
+    If that step lands and forgets this test, the failure is the reminder.
+    """
+    signal = LocationRequestNotAcceptedError(stage="no_fcm_token")
+
+    async def _raise_signal(*_a: object, **_k: object) -> list[dict[str, Any]]:
+        raise signal
+
+    monkeypatch.setattr(api_module, "get_location_data_for_device", _raise_signal)
+
+    api = _make_api()
+    sync_loop = asyncio.new_event_loop()
+    api._sync_call_guard = lambda _message: False
+    api._resolve_sync_loop = lambda: sync_loop
+    try:
+        result = api.get_device_location("device-xyz", "Tracker")
+    finally:
+        sync_loop.close()
+
+    assert result == {}

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -288,15 +288,30 @@ class _NotAcceptedAPI:
     it precedes carries neither ``continue`` nor ``raise`` -- after it the loop body
     only reaches the inter-device delay and iterates on. The one observable
     difference the ``continue`` makes is skipping that delay, which is what the
-    empty-result arm does today for the same 429 or 5xx.
+    empty-result arm still does for a request the server accepted and answered
+    with nothing. It no longer does so for the 429 or the 5xx: those raise before
+    they reach it.
     """
 
-    def __init__(self, error: LocationRequestNotAcceptedError) -> None:
+    def __init__(
+        self,
+        error: LocationRequestNotAcceptedError,
+        healthy: set[str] | None = None,
+    ) -> None:
         self._error = error
+        # Device ids that answer with an empty dict instead of raising. That is
+        # the shape of a healthy idle BLE tag: a request the server took, with no
+        # reporter nearby to answer it. The cycle-level guard needs a device that
+        # is NOT counted as missed, so a stub that can only raise cannot express
+        # the per-device skip any more -- with every device raising, the cycle
+        # really is an account-wide outage and is supposed to surface.
+        self._healthy = healthy or set()
         self.calls: list[str] = []
 
     async def async_get_device_location(self, dev_id: str, _dev_name: str):
         self.calls.append(dev_id)
+        if dev_id in self._healthy:
+            return {}
         raise self._error
 
 
@@ -393,6 +408,62 @@ async def test_api_passes_the_signal_through_untouched(
 
 
 @pytest.mark.asyncio
+async def test_a_pre_accept_import_failure_still_arrives_as_an_empty_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The named limit of the signal, pinned so the claim stays checkable.
+
+    The cycle-level guard in ``polling.py`` documents that FOUR pre-accept faults
+    still reach the poll loop as an empty dict rather than as the signal, because
+    they are raised above ``get_location_data_for_device``'s outer ``try``. Three
+    are obvious from reading it (unregistered FCM provider, provider returning
+    ``None``, missing token cache); the fourth is not, and is the reason this test
+    exists: the lazy binding of the decrypt and eid-info modules sits above that
+    ``try`` too, even though the SAME import inside the FCM callback is guarded.
+
+    This does not assert that the current behaviour is desirable -- an
+    ``ImportError`` here is a packaging fault, not an operating state, which is
+    why it was left alone. It asserts that the enumeration is honest. Move those
+    bindings inside the ``try`` and this test turns red, which is the moment the
+    guard's comment and ``AGENTS.md`` have to be corrected with it.
+    """
+
+    calls = 0
+
+    def _boom() -> object:
+        nonlocal calls
+        calls += 1
+        raise ImportError("decrypt_locations unavailable")
+
+    # An FCM provider that resolves, so the RUN reaches the binding under test.
+    # Without this the call would fail earlier on the unregistered provider and
+    # return an empty dict for a different reason -- the assertion below would
+    # hold and prove nothing.
+    monkeypatch.setattr(
+        location_request_module, "_FCM_ReceiverGetter", lambda _entry: MagicMock()
+    )
+    monkeypatch.setattr(
+        location_request_module, "_import_decrypt_locations_module", _boom
+    )
+    monkeypatch.setattr(
+        api_module,
+        "get_location_data_for_device",
+        location_request_module.get_location_data_for_device,
+    )
+
+    result = await _make_api().async_get_device_location("device-xyz", "Tracker")
+
+    assert calls == 1, (
+        "the run never reached the lazy binding, so the empty dict below says "
+        "nothing about it"
+    )
+    assert result == {}, (
+        "the pre-accept import failure no longer flattens to an empty dict; the "
+        "enumeration at the post-loop guard in polling.py is now wrong"
+    )
+
+
+@pytest.mark.asyncio
 async def test_the_typeerror_cascade_does_not_retry_on_the_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -422,19 +493,28 @@ async def test_the_typeerror_cascade_does_not_retry_on_the_signal(
 
 
 @pytest.mark.asyncio
-async def test_poll_treats_the_signal_as_a_per_device_skip_for_now(
+async def test_poll_treats_the_signal_as_a_per_device_skip_when_a_sibling_gets_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The poll loop skips the device and keeps going; the cycle does not fail.
+    """The poll loop skips the device and keeps going; the account stays available.
 
-    "For now" is load-bearing. Evaluating the signal cycle-wide is a later step;
-    at this point the correct outcome is deliberately the modest one, because the
-    broad handler this branch precedes would set ``cycle_failed`` AND
-    ``last_exception``, and that turns one refused tracker into an account-wide
-    ``unavailable``.
+    "Stays available" and not "the cycle does not fail": the branch DOES set
+    ``cycle_failed``, so ``last_poll_result`` reports ``failed`` for this cycle.
+    What it must not set is ``last_exception``, because that is what drives
+    ``async_set_update_error`` and with it every entity's availability.
 
-    The load-bearing assertions are ``note_error`` and the two cycle fields, not
-    the call list. Without this branch the broad neighbour sets ``last_exception``,
+    The sibling is load-bearing and used to be scenery. While the signal was
+    only ever a per-device skip, this test could let both devices raise and
+    still expect ``last_update_success is True``. Once the cycle-level guard
+    landed, that same input became an account-wide outage by definition -- no
+    device reached the server -- and the expectation flipped. It is pinned in
+    ``test_a_cycle_where_no_request_was_accepted_reports_an_error``, deliberately
+    and in the file that owns cycle semantics.
+
+    What is left here is the narrower claim this file is for: one refused
+    tracker next to one that got through must not take the account offline. The
+    load-bearing assertions are ``note_error`` and the two cycle fields, not the
+    call list. Without this branch the broad neighbour sets ``last_exception``,
     the ``finally`` block feeds it to ``async_set_update_error``, and
     ``last_update_success`` goes False -- that is what turns red. The call list
     pins the weaker, still worth-having claim that the cycle was not aborted; it
@@ -447,7 +527,8 @@ async def test_poll_treats_the_signal_as_a_per_device_skip_for_now(
         {"id": "dev-sibling", "name": "Sibling Tag"},
     ]
     api = _NotAcceptedAPI(
-        LocationRequestNotAcceptedError(stage="server_error", status=503)
+        LocationRequestNotAcceptedError(stage="server_error", status=503),
+        healthy={"dev-sibling"},
     )
     coordinator = _make_coordinator(monkeypatch, loop, api, devices)
     note_error = MagicMock(return_value=None)

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -236,7 +236,7 @@ def test_the_stage_markers_are_a_closed_set() -> None:
 
 
 # ===========================================================================
-# AP-2: the receivers. Installed BEFORE anything raises, on purpose.
+# The receivers. Installed BEFORE anything raises, on purpose.
 #
 # The tests above are static: they pin what the choice of base class can decide.
 # The tests below are the opposite kind -- they drive the real seams with the
@@ -860,7 +860,7 @@ def test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict(
 
 
 # ===========================================================================
-# AP-3: the sender. Seven raise sites, two swallow guards, three empty returns
+# The sender. Seven raise sites, two swallow guards, three empty returns
 # that must STAY empty.
 #
 # The two sections above pin the type and the receivers. This one pins the only

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -423,7 +423,8 @@ async def test_the_typeerror_cascade_does_not_retry_on_the_signal(
     assert calls == 1
 
 
-def test_poll_treats_the_signal_as_a_per_device_skip_for_now(
+@pytest.mark.asyncio
+async def test_poll_treats_the_signal_as_a_per_device_skip_for_now(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The poll loop skips the device and keeps going; the cycle does not fail.
@@ -442,7 +443,7 @@ def test_poll_treats_the_signal_as_a_per_device_skip_for_now(
     is not the proof of the skip, and thinning out "redundant" assertions here
     would remove the ones that carry the test.
     """
-    loop = asyncio.new_event_loop()
+    loop = asyncio.get_running_loop()
     devices = [
         {"id": "dev-refused", "name": "Refused Tag"},
         {"id": "dev-sibling", "name": "Sibling Tag"},
@@ -454,13 +455,7 @@ def test_poll_treats_the_signal_as_a_per_device_skip_for_now(
     note_error = MagicMock(return_value=None)
     coordinator.note_error = note_error
 
-    try:
-        loop.run_until_complete(
-            coordinator._async_start_poll_cycle(devices, force=True)
-        )
-    finally:
-        drain_loop(loop)
-        loop.close()
+    await coordinator._async_start_poll_cycle(devices, force=True)
 
     assert api.calls == ["dev-refused", "dev-sibling"]
     assert coordinator.last_update_success is True
@@ -471,7 +466,8 @@ def test_poll_treats_the_signal_as_a_per_device_skip_for_now(
     note_error.assert_not_called()
 
 
-def test_poll_does_not_clear_the_auth_state_on_the_signal(
+@pytest.mark.asyncio
+async def test_poll_does_not_clear_the_auth_state_on_the_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A refused request must not be read as proof that the credentials work.
@@ -484,7 +480,7 @@ def test_poll_does_not_clear_the_auth_state_on_the_signal(
     entirely. Asserting the counter is untouched is what would catch a well-meant
     "restore previous behaviour" edit putting it back.
     """
-    loop = asyncio.new_event_loop()
+    loop = asyncio.get_running_loop()
     devices = [{"id": "dev-refused", "name": "Refused Tag"}]
     api = _NotAcceptedAPI(
         LocationRequestNotAcceptedError(stage="fcm_registration_failed")
@@ -495,13 +491,7 @@ def test_poll_does_not_clear_the_auth_state_on_the_signal(
     coordinator._consecutive_transient_auth_failures = 3
     coordinator._consecutive_timeouts = 2
 
-    try:
-        loop.run_until_complete(
-            coordinator._async_start_poll_cycle(devices, force=True)
-        )
-    finally:
-        drain_loop(loop)
-        loop.close()
+    await coordinator._async_start_poll_cycle(devices, force=True)
 
     set_auth_state.assert_not_called()
     assert coordinator._consecutive_transient_auth_failures == 3
@@ -592,6 +582,17 @@ def test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict(
     unstated exception is indistinguishable from an oversight. No coordinator uses
     this entry point; closing it belongs to the step that tightens the CLI edges.
     If that step lands and forgets this test, the failure is the reminder.
+
+    This test keeps a loop of its OWN, and that is deliberate rather than an
+    oversight the sibling poll tests already corrected. Those drive a coroutine and
+    therefore belong on pytest's managed loop (tests/AGENTS.md:94). This one drives
+    a SYNCHRONOUS entry point whose helper calls ``loop.run_until_complete`` itself
+    (api.py:713), behind a guard that returns the default unchanged when the target
+    loop is already running (api.py:705). Handing it the managed loop would take
+    that guard's exit: the test would stay green while never reaching
+    ``get_location_data_for_device`` at all, so it would stop witnessing the
+    flattening it exists to pin. Green for the wrong reason is worse than the
+    inconsistency, so the loop stays -- drained through the shared helper.
     """
     signal = LocationRequestNotAcceptedError(stage="no_fcm_token")
 
@@ -607,6 +608,6 @@ def test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict(
     try:
         result = api.get_device_location("device-xyz", "Tracker")
     finally:
-        sync_loop.close()
+        drain_loop(sync_loop)
 
     assert result == {}

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -1,0 +1,214 @@
+# tests/test_location_request_not_accepted.py
+"""Contract: a locate request that never reached the accept point is distinguishable.
+
+``location_request.get_location_data_for_device`` used to return ``[]`` both for a
+request the server ACCEPTED that had nothing to report (the healthy idle outcome of
+a BLE tag with no reporter in range) and for a request that never got that far.
+``api.async_get_device_location`` mapped both to ``{}``, so both coordinator callers
+read every non-raising return as positive proof that the credentials work
+(``PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE``).
+
+``LocationRequestNotAcceptedError`` carries the second state across the
+``location_request.py`` boundary. This module pins what the CHOICE OF BASE CLASS can
+decide, and nothing beyond it: the signal must not inherit from a base that an existing
+NARROW handler routes somewhere wrong (``RuntimeError``, ``DecryptionError``, the
+``NovaError`` family, ``HomeAssistantError`` -- each has a measured counterpart), and it
+must not reach a handler that catches a fixed tuple without a broad fallback, where it
+would propagate uncaught. Both failure modes are measured in
+``custom_components/googlefindmy/AGENTS.md``; they are opposite, so neither test is
+redundant with the other.
+
+What these tests deliberately do NOT show is that the signal survives a broad
+``except Exception``. It does not: ``Exception`` is the base, so every broad handler
+catches it too. That property cannot be bought with a base class at all; it is bought
+with an explicit re-raise placed BEFORE each broad handler, which AP-2 and AP-3 install
+and the AST guard in ``tests/test_nova_request.py`` pins. Reading the base-class choice
+as the whole answer is the documented way for this change to become inert.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
+    DecryptionError,
+)
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request import (
+    LOCATION_REQUEST_NOT_ACCEPTED_STAGES,
+    LocationRequestNotAcceptedError,
+)
+from custom_components.googlefindmy.NovaApi.nova_request import NovaAuthError, NovaError
+
+_LOCATE_TRACKER_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "googlefindmy"
+    / "NovaApi"
+    / "ExecuteAction"
+    / "LocateTracker"
+)
+_LOCATION_REQUEST_PY = _LOCATE_TRACKER_DIR / "location_request.py"
+# The two handlers that catch a fixed tuple with no broad fallback live here.
+_TUPLE_HANDLER_MODULES = frozenset({"start_sound_request.py", "stop_sound_request.py"})
+_LOCATE_ENTRYPOINT = "get_location_data_for_device"
+_PLAY_SOUND_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "googlefindmy"
+    / "NovaApi"
+    / "ExecuteAction"
+    / "PlaySound"
+)
+
+
+def _raised_stages(source: str) -> list[str]:
+    """Collect the ``stage=`` literal of every ``LocationRequestNotAcceptedError`` raise."""
+    stages: list[str] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
+            continue
+        func = node.exc.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+        if name != "LocationRequestNotAcceptedError":
+            continue
+        for keyword in node.exc.keywords:
+            if keyword.arg == "stage" and isinstance(keyword.value, ast.Constant):
+                stages.append(str(keyword.value.value))
+    return stages
+
+
+@pytest.mark.parametrize(
+    ("base", "why"),
+    [
+        (RuntimeError, "api.py's broad except RuntimeError would flatten it to {}"),
+        # DecryptionError subclasses RuntimeError, so this row cannot fail on its own.
+        # It is kept because the two bases fail for different measured reasons, and a
+        # future re-parenting of DecryptionError must not silently drop the second one.
+        (
+            DecryptionError,
+            "polling.py would route it into the account-wide reauth verdict",
+        ),
+        (NovaError, "ten try blocks catch that family, eight with a broad handler"),
+        (NovaAuthError, "same family, plus the transient-auth counter branches"),
+        (
+            HomeAssistantError,
+            "exceptions.py reserves that base for finished user-facing messages",
+        ),
+    ],
+)
+def test_the_signal_is_not_a_runtime_or_decryption_or_nova_error(
+    base: type[BaseException], why: str
+) -> None:
+    """Each rejected base class has a measured handler that would misroute the signal."""
+    assert not issubclass(LocationRequestNotAcceptedError, base), why
+
+
+def test_the_signal_carries_a_stage_and_no_device_name() -> None:
+    """R6: the payload is stage plus status -- never the raw device display name."""
+    error = LocationRequestNotAcceptedError(stage="server_error", status=503)
+
+    assert error.stage == "server_error"
+    assert error.status == 503
+    assert "503" in str(error)
+    assert set(vars(error)) == {"stage", "status"}
+
+    bare = LocationRequestNotAcceptedError(stage="no_fcm_token")
+    assert bare.status is None
+    assert "status" not in str(bare)
+
+    # Pin the constructor itself, not just an instance: the reason no device name can
+    # reach ``str(exc)``/``args[0]`` -- which is what travels into the coordinator log
+    # records, into ``note_error`` and into any re-wrapped user-facing error -- is that
+    # there is no parameter to pass one through. Asserting "the sample name is absent"
+    # on an instance built WITHOUT that name would be circular; the signature is not.
+    parameters = inspect.signature(LocationRequestNotAcceptedError).parameters
+    assert set(parameters) == {"stage", "status"}
+    assert all(p.kind is inspect.Parameter.KEYWORD_ONLY for p in parameters.values())
+
+    # And the message stays derived from those two, so a name cannot be baked in
+    # as a literal either (the mutation that check exists for).
+    assert (
+        str(error) == "Location request not accepted (stage=server_error, status=503)"
+    )
+    assert str(bare) == "Location request not accepted (stage=no_fcm_token)"
+
+
+def test_no_sound_path_reaches_the_location_request_module() -> None:
+    """The second failure mode is constructively absent, measured rather than asserted.
+
+    The two sound-request handlers catch a fixed tuple with no broad fallback, so a
+    signal that reached them would propagate uncaught. It cannot, because every raise
+    site AP-3 adds sits inside ``get_location_data_for_device`` (today there are none
+    yet) and no module under ``PlaySound/`` reaches that function -- not by call, not
+    by import, not by a string handed to ``getattr``/``import_module``.
+
+    Stated so it is not mistaken for a full reachability proof: the scan is one hop
+    and package-local. Four routes pass it -- reaching the locate path THROUGH a third
+    module (``api.py`` exposes it as ``async_get_device_location``), splitting the
+    identifier across two literals, binding it to a local name first
+    (``fn = module.get_location_data_for_device``), and calling a sound module from a
+    new helper outside this package. What it does cover is the direct route, which is
+    the one a future edit takes.
+
+    What the sound modules DO reference is measured and deliberately allowed:
+    ``_cli_helpers.py`` imports the location_request MODULE to read its
+    ``_fcm_receiver_state``/``_FCM_ReceiverGetter`` attribute, and
+    ``sound_request.py`` names it in a comment as a sibling builder. Neither can
+    produce the signal. Guarding on the module name instead of the function name
+    would therefore fail on an unrelated import and stop measuring reachability.
+    """
+    modules = sorted(_PLAY_SOUND_DIR.rglob("*.py"))
+    # Without these anchors a renamed or moved package makes rglob return nothing and
+    # the assertion below passes vacuously (tests/AGENTS.md names that failure mode).
+    # A count would not do it: the two modules that actually carry the fixed-tuple
+    # handlers have to be IN the scan, so they are named rather than counted.
+    assert _PLAY_SOUND_DIR.is_dir(), f"{_PLAY_SOUND_DIR} is gone; this test is blind"
+    scanned = {path.name for path in modules}
+    assert _TUPLE_HANDLER_MODULES <= scanned, (
+        f"the modules this test exists for are outside the scan: "
+        f"{sorted(_TUPLE_HANDLER_MODULES - scanned)}"
+    )
+
+    offenders: list[str] = []
+    for path in modules:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            hit = False
+            if isinstance(node, ast.Call):
+                func = node.func
+                name = (
+                    func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+                )
+                hit = name == _LOCATE_ENTRYPOINT
+            elif isinstance(node, ast.ImportFrom):
+                hit = any(alias.name == _LOCATE_ENTRYPOINT for alias in node.names)
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                # Covers getattr(module, "...") and any dynamic resolution by name.
+                hit = _LOCATE_ENTRYPOINT in node.value
+            if hit:
+                offenders.append(f"{path.name}:{node.lineno}")
+
+    assert offenders == [], (
+        f"a sound module now reaches {_LOCATE_ENTRYPOINT}: {offenders}; the "
+        "fixed-tuple handlers there have no broad fallback and would let the "
+        "signal propagate uncaught"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="AP-3 arms the raise sites; until then no stage marker is in use",
+)
+def test_the_stage_markers_are_a_closed_set() -> None:
+    """Every raise site uses a declared marker, and every declared marker is used."""
+    stages = _raised_stages(_LOCATION_REQUEST_PY.read_text(encoding="utf-8"))
+
+    assert stages, "no raise site uses the signal yet"
+    assert set(stages) <= LOCATION_REQUEST_NOT_ACCEPTED_STAGES
+    assert set(stages) == LOCATION_REQUEST_NOT_ACCEPTED_STAGES
+    assert len(stages) == len(set(stages)), f"a marker is used twice: {stages}"

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -38,6 +38,7 @@ import ast
 import asyncio
 import inspect
 import logging
+import runpy
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -407,6 +408,55 @@ async def test_api_passes_the_signal_through_untouched(
     assert excinfo.value.status == 503
 
 
+def test_the_module_cli_reports_the_signal_and_exits_non_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The module's own ``__main__`` block must not end on a traceback either.
+
+    It is the second of the two CLI edges. The first (the interactive selection
+    loop in ``nbe_list_devices``) prints and continues, because there is a next
+    prompt to return to. This one has none, so it prints and exits non-zero: a
+    script wrapping it has to be able to tell "no location" from "the request
+    never got out", and an exit code is the only channel it has.
+
+    Driven through ``runpy`` because a guarded ``__main__`` block is otherwise
+    unreachable from a test and is excluded from coverage
+    (``pyproject.toml``), which is exactly the combination in which an
+    unhandled raise survives unnoticed. The pattern is the one already used by
+    ``test_get_oauth_token.py``.
+    """
+
+    # ``runpy`` executes the file as a FRESH module, which has two consequences
+    # the seam has to respect. Patching attributes on the already-imported module
+    # would not be seen, so the seam sits on ``asyncio`` -- the one object the
+    # block reaches that the fresh execution does not rebind. And the fresh module
+    # defines its OWN ``LocationRequestNotAcceptedError`` class, so raising the
+    # one imported at the top of this file would sail straight past the
+    # ``except``: same name, different class object. The class is therefore taken
+    # from the coroutine's own globals, which are the fresh module's.
+    #
+    # The coroutine is closed rather than dropped, otherwise the run emits
+    # "coroutine was never awaited" and the test buys a warning it did not mean
+    # to introduce.
+    def _run_raising(coro: Any) -> Any:
+        fresh_signal_cls = coro.cr_frame.f_globals["LocationRequestNotAcceptedError"]
+        assert fresh_signal_cls is not LocationRequestNotAcceptedError, (
+            "runpy stopped duplicating the module; the indirection below is no "
+            "longer needed and this test can raise the imported class directly"
+        )
+        coro.close()
+        raise fresh_signal_cls(stage="server_error", status=503)
+
+    monkeypatch.setattr(asyncio, "run", _run_raising)
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(location_request_module.__file__, run_name="__main__")
+
+    assert excinfo.value.code == 1
+    out = capsys.readouterr().out
+    assert "not accepted" in out and "server_error" in out, out
+
+
 @pytest.mark.asyncio
 async def test_a_pre_accept_import_failure_still_arrives_as_an_empty_dict(
     monkeypatch: pytest.MonkeyPatch,
@@ -658,9 +708,13 @@ def test_the_sync_wrapper_still_flattens_the_signal_to_an_empty_dict(
     shape this change removes everywhere else.
 
     Pinned rather than fixed, and pinned HERE rather than left implicit, because an
-    unstated exception is indistinguishable from an oversight. No coordinator uses
-    this entry point; closing it belongs to the step that tightens the CLI edges.
-    If that step lands and forgets this test, the failure is the reminder.
+    unstated exception is indistinguishable from an oversight. The step that
+    tightened the CLI edges has landed and deliberately did NOT close this one:
+    the two are different things. Those were unguarded call sites that ended an
+    interactive session on a traceback; this is a documented contract for non-HA
+    callers, whose whole promise is that it never raises. Changing it is a
+    breaking change for anyone outside this repository, so it is tracked on its
+    own rather than folded into a CLI fix. No coordinator uses this entry point.
 
     This test keeps a loop of its OWN, and that is deliberate rather than an
     oversight the sibling poll tests already corrected. Those drive a coroutine and

--- a/tests/test_location_request_not_accepted.py
+++ b/tests/test_location_request_not_accepted.py
@@ -729,6 +729,18 @@ async def test_locate_warns_and_returns_empty_on_an_unaccepted_request(
     handlers a few branches up, which log at WARNING but are dead on this path --
     ``api.py`` answers both with an empty dict of its own. The reasoning that does
     hold is in the branch's own comment; the assertion here only pins the outcome.
+
+    The outcome has TWO halves, and asserting only the first is what let the first
+    revision of this step ship a leak. ``name`` falls back to the raw canonical
+    device id, which AGENTS.md section 5 keeps out of logs and the tree's "R6 /
+    Count@WARNING, Name@DEBUG" pattern keeps out of user-facing records in
+    particular. So the branch may raise the LEVEL without raising the IDENTIFIED
+    sentence with it: the WARNING carries the operation and the reason, the DEBUG
+    record carries the device. A test that pinned only "one record, at WARNING"
+    stayed green while the id sat in it, which is why the absence in that record
+    is asserted here as explicitly as the presence -- absence in the record, not
+    absence from the default channel, which the neighbouring branches still write
+    to and which this test does not claim to cover.
     """
     coord = locate_coord
     coord.api.async_get_device_location = AsyncMock(
@@ -746,12 +758,25 @@ async def test_locate_warns_and_returns_empty_on_an_unaccepted_request(
         for record in caplog.records
         if "request not accepted" in record.getMessage()
     ]
-    assert len(records) == 1, [record.getMessage() for record in caplog.records]
     # Captured at DEBUG so a demotion is visible as a WRONG level rather than as an
     # absent record: an assertion that only ran at WARNING could not tell "logged at
     # DEBUG" from "not logged at all", and those call for different fixes.
-    assert records[0].levelno == logging.WARNING
-    assert "server_error" in records[0].getMessage()
+    by_level = {record.levelno: record.getMessage() for record in records}
+    assert sorted(by_level) == [logging.DEBUG, logging.WARNING], [
+        record.getMessage() for record in caplog.records
+    ]
+    assert len(records) == 2, [record.getMessage() for record in caplog.records]
+
+    warning = by_level[logging.WARNING]
+    assert "server_error" in warning
+    assert "dev-1" not in warning
+    # The operation is the ONLY thing this record adds over the transport's own
+    # WARNING, which is written for the poll path in the same words. Without this
+    # assertion a later generalisation to "A location request failed (%s)" would
+    # stay green and leave the branch contributing nothing at all.
+    assert "Manual locate" in warning
+
+    assert "dev-1" in by_level[logging.DEBUG]
 
 
 @pytest.mark.asyncio

--- a/tests/test_location_request_r6_name_sweep.py
+++ b/tests/test_location_request_r6_name_sweep.py
@@ -44,6 +44,9 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_
     OwnerKeyLookupTransientError,
     StaleOwnerKeyError,
 )
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request import (
+    LocationRequestNotAcceptedError,
+)
 from custom_components.googlefindmy.NovaApi.nova_request import (
     NovaAuthError,
     NovaHTTPError,
@@ -156,18 +159,26 @@ async def test_nova_request_ladder_redacts_name(
     nova_exc: Exception,
 ) -> None:
     """RED pre-fix: rate-limit / HTTP / network / generic Nova failures logged the
-    raw device name at WARNING/ERROR. The name must move to DEBUG only."""
+    raw device name at WARNING/ERROR. The name must move to DEBUG only.
+
+    The four rungs no longer return empty -- each raises
+    ``LocationRequestNotAcceptedError`` (PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE), so
+    the call is wrapped. WHICH marker each rung carries is pinned in
+    ``tests/test_location_request_not_accepted.py``; this test is about the records,
+    and asserting the marker here too would tie the R6 sweep to a second contract it
+    does not own.
+    """
     _wire_nova_raises(monkeypatch, nova_exc=nova_exc)
     caplog.set_level(logging.DEBUG, logger=location_request.__name__)
 
-    result = await location_request.get_location_data_for_device(
-        canonic_device_id=_CANONIC,
-        name=_SENTINEL_NAME,
-        session=None,
-        username="user@example.com",
-        cache=_FakeTokenCache(),
-    )
-    assert result == []
+    with pytest.raises(LocationRequestNotAcceptedError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id=_CANONIC,
+            name=_SENTINEL_NAME,
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
     _assert_name_only_at_debug(caplog)
 
 
@@ -223,7 +234,12 @@ async def test_fcm_registration_failure_redacts_name(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """RED pre-fix: a failing FCM registration logged the raw device name at ERROR."""
+    """RED pre-fix: a failing FCM registration logged the raw device name at ERROR.
+
+    The branch now raises ``LocationRequestNotAcceptedError`` instead of returning
+    empty; the ERROR record it is swept for is emitted before that raise and is
+    unchanged.
+    """
 
     class _RaisingReceiver:
         async def async_register_for_location_updates(
@@ -244,14 +260,14 @@ async def test_fcm_registration_failure_redacts_name(
     )
     caplog.set_level(logging.DEBUG, logger=location_request.__name__)
 
-    result = await location_request.get_location_data_for_device(
-        canonic_device_id=_CANONIC,
-        name=_SENTINEL_NAME,
-        session=None,
-        username="user@example.com",
-        cache=_FakeTokenCache(),
-    )
-    assert result == []
+    with pytest.raises(LocationRequestNotAcceptedError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id=_CANONIC,
+            name=_SENTINEL_NAME,
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
     _assert_name_only_at_debug(caplog)
 
 
@@ -264,6 +280,11 @@ async def test_unregister_failure_in_finally_redacts_name(
     ``create_location_request`` is forced to raise so the flow lands in the broad
     surfacing handler (already R6-clean since PR #1129) and then runs ``finally``,
     where the raising unregister exercises the swept WARNING.
+
+    That failure happens BEFORE the accept line, so the surfacing handler now
+    re-raises it as ``LocationRequestNotAcceptedError`` instead of returning empty.
+    The ``finally`` block runs either way -- which is the point of asserting the
+    unregister WARNING through a raising exit rather than a returning one.
     """
     receiver = _TokenReceiver(unregister_exc=RuntimeError("unregister backend down"))
     monkeypatch.setattr(location_request, "_FCM_ReceiverGetter", lambda *_a: receiver)
@@ -279,14 +300,14 @@ async def test_unregister_failure_in_finally_redacts_name(
     monkeypatch.setattr(location_request, "create_location_request", _boom)
     caplog.set_level(logging.DEBUG, logger=location_request.__name__)
 
-    result = await location_request.get_location_data_for_device(
-        canonic_device_id=_CANONIC,
-        name=_SENTINEL_NAME,
-        session=None,
-        username="user@example.com",
-        cache=_FakeTokenCache(),
-    )
-    assert result == []
+    with pytest.raises(LocationRequestNotAcceptedError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id=_CANONIC,
+            name=_SENTINEL_NAME,
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
     assert any(
         "Error during FCM unregister" in rec.getMessage()
         for rec in caplog.records

--- a/tests/test_location_request_surfacing_diagnostics.py
+++ b/tests/test_location_request_surfacing_diagnostics.py
@@ -32,6 +32,9 @@ from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker import (
 from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.decrypt_locations import (
     OwnerKeyLookupTransientError,
 )
+from custom_components.googlefindmy.NovaApi.ExecuteAction.LocateTracker.location_request import (
+    LocationRequestNotAcceptedError,
+)
 from custom_components.googlefindmy.SpotApi.spot_request import SpotGrpcStatusError
 
 pytestmark = pytest.mark.asyncio
@@ -118,14 +121,19 @@ async def test_r6_surfacing_warning_omits_device_name_keeps_it_at_debug(
 
     caplog.set_level(logging.DEBUG, logger=location_request.__name__)
 
-    result = await location_request.get_location_data_for_device(
-        canonic_device_id="device-xyz",
-        name=_SENTINEL_NAME,
-        session=None,
-        username="user@example.com",
-        cache=_FakeTokenCache(),
-    )
-    assert result == []
+    # ``_wire_locate_flow`` breaks the payload build, i.e. BEFORE the accept line,
+    # so the surfacing handler re-raises as LocationRequestNotAcceptedError instead
+    # of returning empty (PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE). The records this
+    # test is about are emitted on both sides of that branch by design -- which side
+    # the failure fell on says nothing about whether an operator needs them.
+    with pytest.raises(LocationRequestNotAcceptedError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id="device-xyz",
+            name=_SENTINEL_NAME,
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
 
     user_facing = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
     assert user_facing, "expected at least one user-facing surfacing record"
@@ -166,14 +174,18 @@ async def test_r9c_surfacing_includes_nested_grpc_cause_detail(
 
     caplog.set_level(logging.DEBUG, logger=location_request.__name__)
 
-    result = await location_request.get_location_data_for_device(
-        canonic_device_id="device-xyz",
-        name="Tracker",
-        session=None,
-        username="user@example.com",
-        cache=_FakeTokenCache(),
-    )
-    assert result == []
+    # Raises rather than returns for the same reason as the test above; the cause
+    # chain is logged before the branch. Note the two chains are different objects:
+    # the one asserted on here is the one the RECORD carries, not the ``__cause__``
+    # of the signal, which merely wraps it.
+    with pytest.raises(LocationRequestNotAcceptedError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id="device-xyz",
+            name="Tracker",
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
 
     # Exclude the raw ``traceback.format_exc()`` dump: R9c requires the structured
     # cause chain in a dedicated surfacing record, not merely inside a stack trace.
@@ -342,6 +354,11 @@ async def test_missing_fcm_token_surfacing_redacts_name_and_defers_to_warning(
 
     RED before the fix: the branch logged ``"Failed to get FCM token for %s: ...
     (client/token unavailable or no coordinator)"`` with the raw name at ERROR.
+
+    The branch also no longer returns empty: a locate without an FCM token never
+    reaches the server, so it raises ``LocationRequestNotAcceptedError``
+    (PLAN_GFMY_EMPTY_RESULT_DISTINGUISHABLE). Both records asserted on below are
+    emitted before that raise.
     """
 
     def _fake_make_callback(
@@ -360,14 +377,14 @@ async def test_missing_fcm_token_surfacing_redacts_name_and_defers_to_warning(
 
     caplog.set_level(logging.DEBUG, logger=location_request.__name__)
 
-    result = await location_request.get_location_data_for_device(
-        canonic_device_id="device-xyz",
-        name=_SENTINEL_NAME,
-        session=None,
-        username="user@example.com",
-        cache=_FakeTokenCache(),
-    )
-    assert result == []
+    with pytest.raises(LocationRequestNotAcceptedError):
+        await location_request.get_location_data_for_device(
+            canonic_device_id="device-xyz",
+            name=_SENTINEL_NAME,
+            session=None,
+            username="user@example.com",
+            cache=_FakeTokenCache(),
+        )
 
     user_facing = [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
     assert user_facing, "expected a user-facing record for the skipped locate"

--- a/tests/test_nova_request.py
+++ b/tests/test_nova_request.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import ast
 import asyncio
 import logging
+import re
 import time
+from collections import Counter
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
@@ -3160,12 +3162,39 @@ class TestTheDocumentedExtentStaysTrue:
     deliberately AST-derived and not grep-derived: a comment mentioning the
     predicate must not count as a call site.
 
+    The class has since grown past that one paragraph, because the same shape
+    kept recurring: a load-bearing detail stated only in prose. It now also
+    derives the guard count in `LocationRequestNotAcceptedError`'s own
+    docstring (five broad handlers with a guard in front, a sixth deliberately
+    without) and checks that every test name cited in the component's
+    `AGENTS.md` files still resolves to a test. That last one overlaps with
+    `TestTheDocumentedRejectionGuardStaysTrue` in
+    `tests/test_coordinator_semantic_mappings.py`, which already guards one
+    named list and, unlike this class, verifies its stated COUNT; the row here
+    says what it adds instead of pretending the ground was bare. Numbers and
+    names fail the same way -- silently, with a green suite -- and they are
+    pinned here for the same reason.
+
     When the extent legitimately changes, update BOTH this test and the
     paragraph in the same commit. A failure here is not a bug in the code; it
     is the contract telling you it went stale.
     """
 
     _ROOT = Path(__file__).resolve().parents[1] / "custom_components" / "googlefindmy"
+
+    @staticmethod
+    def _handler_names(handler: ast.ExceptHandler) -> set[str]:
+        node = handler.type
+        if node is None:
+            return {"Exception"}
+        parts = node.elts if isinstance(node, ast.Tuple) else [node]
+        out: set[str] = set()
+        for part in parts:
+            if isinstance(part, ast.Name):
+                out.add(part.id)
+            elif isinstance(part, ast.Attribute):
+                out.add(part.attr)
+        return out
 
     def _modules(self) -> list[tuple[Path, ast.Module]]:
         return [
@@ -3209,26 +3238,13 @@ class TestTheDocumentedExtentStaysTrue:
         the reason that follow-up is not a one-liner, so both are pinned.
         """
 
-        def _names(handler: ast.ExceptHandler) -> set[str]:
-            node = handler.type
-            if node is None:
-                return {"Exception"}
-            parts = node.elts if isinstance(node, ast.Tuple) else [node]
-            out: set[str] = set()
-            for part in parts:
-                if isinstance(part, ast.Name):
-                    out.add(part.id)
-                elif isinstance(part, ast.Attribute):
-                    out.add(part.attr)
-            return out
-
         catching: list[str] = []
         with_broad: list[str] = []
         for path, tree in self._modules():
             for node in ast.walk(tree):
-                if not isinstance(node, ast.Try):
+                if not isinstance(node, (ast.Try, ast.TryStar)):
                     continue
-                handlers = [_names(h) for h in node.handlers]
+                handlers = [self._handler_names(h) for h in node.handlers]
                 if not any("NovaAuthError" in names for names in handlers):
                     continue
                 where = f"{path.relative_to(self._ROOT).as_posix()}:{node.lineno}"
@@ -3242,3 +3258,203 @@ class TestTheDocumentedExtentStaysTrue:
         assert len(catching) == 10, catching
         assert len(with_broad) == 8, with_broad
         assert len(catching) - len(with_broad) == 2, (catching, with_broad)
+
+    # --------------------------------------------------------------- #
+    # The second extent this file pins: the guards in front of the     #
+    # broad handlers on the LocationRequestNotAcceptedError path.      #
+    # --------------------------------------------------------------- #
+
+    def _guarded_broad_blocks(self) -> list[tuple[str, bool, bool]]:
+        """Every ``try`` that catches the signal AND has a broad handler.
+
+        Returns ``(location, guard_comes_first, guard_is_a_bare_reraise)``.
+        """
+
+        found: list[tuple[str, bool, bool]] = []
+        for path, tree in self._modules():
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.Try, ast.TryStar)):
+                    continue
+                handlers = [self._handler_names(h) for h in node.handlers]
+                broad = [
+                    i
+                    for i, names in enumerate(handlers)
+                    if "Exception" in names or "BaseException" in names
+                ]
+                guard = [
+                    i
+                    for i, names in enumerate(handlers)
+                    if "LocationRequestNotAcceptedError" in names
+                ]
+                if not broad or not guard:
+                    continue
+                body = node.handlers[guard[0]].body
+                bare = (
+                    len(body) == 1
+                    and isinstance(body[0], ast.Raise)
+                    and body[0].exc is None
+                )
+                where = f"{path.relative_to(self._ROOT).as_posix()}:{node.lineno}"
+                found.append((where, guard[0] < broad[0], bare))
+        return sorted(found)
+
+    def test_every_broad_handler_that_guards_the_signal_puts_the_guard_first(
+        self,
+    ) -> None:
+        """The class docstring counts five guards; nothing derived that five.
+
+        `LocationRequestNotAcceptedError` is an `Exception`, so every broad
+        `except Exception` on its path catches it as well and turns the raise
+        back into the empty result the type was introduced to replace. Its
+        docstring names five such blocks and asserts that all five carry a
+        guard placed BEFORE the broad handler. That was a hand-counted number
+        in prose, and the failure it guards against is the silent kind: moving
+        a guard behind its broad neighbour leaves every existing test green,
+        because the observable outcome is identical to the pre-change one.
+
+        What is pinned is ORDER, MEMBERSHIP and SHAPE -- not the handler body
+        beyond telling a bare re-raise from a dedicated branch. Three of the
+        five re-raise bare; the two coordinator blocks handle the signal in a
+        branch, which is the documented design, so requiring a bare `raise`
+        everywhere would be wrong. That three is derived here rather than
+        stated: an earlier revision of this docstring wrote "two", which is
+        the failure mode this whole class exists to catch, committed inside
+        the fix for it.
+
+        "Bare" is measured as SHAPE, not meaning: one statement, a `raise` with
+        no expression. Adding a log line ahead of an otherwise bare re-raise
+        therefore turns this row red even though the handler still only
+        re-raises. That direction is loud rather than silent, and the fix is
+        one word in the sentence above, so it is left strict on purpose.
+
+        One limit, stated so this is not read as more than it is: the row
+        cannot see a NEW broad handler introduced on the path WITHOUT a guard
+        -- such a block has no `except LocationRequestNotAcceptedError` and
+        therefore never enters this set. The seam tests in
+        `tests/test_location_request_not_accepted.py` cover that direction
+        behaviourally; this row covers the direction they cannot, which is a
+        guard that still exists but no longer runs first.
+        """
+
+        blocks = self._guarded_broad_blocks()
+        assert len(blocks) == 5, blocks
+        assert all(first for _, first, _ in blocks), blocks
+        assert Counter(where.split(":")[0] for where, _, _ in blocks) == Counter(
+            {
+                "NovaApi/ExecuteAction/LocateTracker/location_request.py": 2,
+                "api.py": 1,
+                "coordinator/locate.py": 1,
+                "coordinator/polling.py": 1,
+            }
+        ), blocks
+        assert Counter(
+            where.split(":")[0] for where, _, bare in blocks if bare
+        ) == Counter(
+            {
+                "NovaApi/ExecuteAction/LocateTracker/location_request.py": 2,
+                "api.py": 1,
+            }
+        ), blocks
+
+    def test_the_sync_helper_is_the_broad_handler_deliberately_left_unguarded(
+        self,
+    ) -> None:
+        """The sixth broad handler is a contract, not an oversight -- pin it.
+
+        `api._run_sync_helper` flattens every exception to the caller's
+        default, so `api.get_device_location` hands back `{}` for this signal
+        too. The class docstring says so explicitly and calls it documented
+        rather than missed. Adding a guard there would be a behaviour change at
+        a public sync entry point AND would make that paragraph false, so this
+        row fails first and sends whoever does it to the prose.
+        """
+
+        api = self._ROOT / "api.py"
+        tree = ast.parse(api.read_text(encoding="utf-8"))
+        helper = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_run_sync_helper"
+        )
+        broad = [
+            handler
+            for node in ast.walk(helper)
+            if isinstance(node, (ast.Try, ast.TryStar))
+            for handler in node.handlers
+            if "Exception" in self._handler_names(handler)
+        ]
+        assert broad, "the sync helper no longer has a broad handler"
+        guards = [
+            handler
+            for node in ast.walk(helper)
+            if isinstance(node, (ast.Try, ast.TryStar))
+            for handler in node.handlers
+            if "LocationRequestNotAcceptedError" in self._handler_names(handler)
+        ]
+        assert guards == [], "the sync helper grew a guard; update the class docstring"
+
+    def test_every_test_name_the_component_contracts_cite_exists(self) -> None:
+        """Contract prose pins behaviour by NAME; most of those names were loose.
+
+        `AGENTS.md` closes paragraphs with lists of test names. A rename or a
+        deletion leaves such a list pointing at nothing, and the reader cannot
+        tell a stale name from a test that merely lives elsewhere -- the prose
+        reads the same either way.
+
+        Part of this was already guarded and saying otherwise would repeat the
+        defect: `TestTheDocumentedRejectionGuardStaysTrue` in
+        `tests/test_coordinator_semantic_mappings.py` reads the sentence
+        "Eight tests pin this:" out of the same file and checks BOTH its number
+        against the list it prints AND that every listed name exists. That row
+        can do something this one cannot -- verify a stated count -- so it
+        stays; do not fold the two together. What was NOT covered, and is what
+        this row adds: the second list ("Three tests pin the current state"),
+        which that sentence pattern does not match; scattered one-off citations
+        outside any list; class names, including the class you are reading, on
+        which a whole paragraph rests; and the other AGENTS.md files under this
+        component, which no row read at all.
+
+        Module paths are excluded by CONTEXT, not by name: a citation preceded
+        by `tests/` or followed by `.py` is a file reference. The obvious
+        alternative -- drop any name that also exists as a file stem under
+        `tests/` -- was tried first and is a loophole, because four names in
+        this tree are BOTH a module stem and a test function. A stale citation
+        of one of those would be skipped in silence, and adding a new module
+        could retroactively blind an existing citation. The cost of the context
+        rule is that a citation of a FILE goes unchecked; renaming a test module
+        leaves such a reference dangling and no row here notices.
+
+        Scope is every `AGENTS.md` under the component (68 citations today, all
+        of them live). `tests/AGENTS.md` is deliberately NOT included: it cites
+        at least one name as a FORMER name on purpose, so folding it in needs a
+        way to declare a citation historical, which is a change of its own.
+
+        A name written into contract prose before the test exists fails this
+        row. That is the intended direction: the contract may not promise
+        coverage that is not there yet.
+        """
+
+        pattern = (
+            r"(?<!tests/)\b(?:test_[A-Za-z0-9_]+|Test[A-Z][A-Za-z0-9_]*)\b(?!\.py)"
+        )
+        cited: dict[str, str] = {}
+        for contract in sorted(self._ROOT.rglob("AGENTS.md")):
+            where = contract.relative_to(self._ROOT).as_posix()
+            for name in re.findall(pattern, contract.read_text(encoding="utf-8")):
+                cited.setdefault(name, where)
+
+        defined: set[str] = set()
+        for path in Path(__file__).resolve().parent.rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(
+                    node, (ast.FunctionDef, ast.AsyncFunctionDef)
+                ) and node.name.startswith("test_"):
+                    defined.add(node.name)
+                elif isinstance(node, ast.ClassDef):
+                    defined.add(node.name)
+
+        assert cited, "the contracts cite no test names any more; check the pattern"
+        assert [name for name in cited if name not in defined] == [], {
+            name: where for name, where in sorted(cited.items()) if name not in defined
+        }


### PR DESCRIPTION
## Problem

`location_request.get_location_data_for_device` returns `[]` for two states that have nothing in common:

- the server **accepted** the request and there was nothing to report (no reporter in range -- the healthy idle outcome of a BLE tag), and
- the request **never reached** that point: no FCM token, a failed FCM registration, a 429, a 5xx, an `aiohttp.ClientError`, an unclassified Nova failure, or a surfacing error before the accept line.

`api.async_get_device_location` maps both to `{}`, and both coordinator callers read every non-raising return as positive proof that the credentials work. Two measured consequences:

1. A poll cycle in which **every** request failed server-side reports `last_update_success = True`, and every entity stays available with its cached position (pinned today by `test_known_gap_a_cycle_of_only_empty_results_reports_success`).
2. The poll loop runs `_set_auth_state(failed=False)` and resets `_consecutive_transient_auth_failures` before the empty-result guard, so a 5xx wipes the transient-auth counter on its way through. `coordinator/locate.py` has the same ordering.

`custom_components/googlefindmy/AGENTS.md` already states where the fix belongs: the accepted-versus-failed outcome has to survive **across the `location_request.py` boundary** rather than be reconstructed downstream, and the layer that flattens it is `location_request.py` itself, not `api.py` -- an intervention confined to `api.py` would be inert, because `location_request` catches the 5xx, the 429, the protobuf decode failure and the Nova logic error itself.

## Approach

A dedicated signal type, `LocationRequestNotAcceptedError`, raised on the pre-accept paths and passed through to the coordinators. It claims a **position** in the flow, not a cause, so the classifier discipline of this layer is preserved.

Staged deliberately, receivers before sender:

- **Step 1 (this commit):** define the type and pin what the base-class choice can decide. Nothing raises it yet.
- **Step 2:** install the pass-through in `api.py` and the per-device branches in `polling.py` / `locate.py`, still behaviour-neutral.
- **Step 3:** arm the seven pre-accept paths together with a `request_accepted` flag set at the accept log line, plus re-raise guards in front of the two broad handlers that would otherwise swallow the signal. This fixes consequence (2).
- **Steps 4-7:** evaluate the signal in the coordinators (fixes consequence (1)), tighten the CLI edges, and bring the contract prose and the AST-enforced counts in line.

The reverse order would leave a window in which the new exception reaches `polling.py`'s broad handler, which sets both `cycle_failed` and `last_exception`, so a single 5xx on a single tracker would mark every entity of the account unavailable.

## Status

Draft, opened after step 1 so CI runs early. Do not merge yet.