### PR TITLE
fix(token-cache): delete the legacy secrets bundle only once it is on disk

### DIFF
--- a/custom_components/googlefindmy/Auth/token_cache.py
+++ b/custom_components/googlefindmy/Auth/token_cache.py
@@ -147,7 +147,17 @@ class TokenCache:
     # ------------------------------ Migration --------------------------------
 
     async def _migrate_legacy_file(self, legacy_path: str) -> None:
-        """Migrate an old JSON file to the Store (merge) and remove it once, process-wide."""
+        """Migrate an old JSON file to the Store (merge) and remove it once, process-wide.
+
+        Removing the legacy file is irreversible, and until it happens the file is
+        the only copy of the credentials that survives a restart. It is therefore
+        gated on a positive proof that the merged data is on disk: neither a
+        returning ``async_save`` nor a scheduled ``async_delay_save`` is one.
+        Home Assistant logs and swallows write errors instead of raising
+        (``helpers/storage.py``, ``_async_handle_write_data``), and the delayed
+        write happens later, outside this call. Every path that cannot prove the
+        write leaves the legacy file untouched and lets the migration run again.
+        """
         if _STATE["legacy_migration_done"] != _LEGACY_MIGRATION_DONE:
             _set_legacy_migration_flag(_LEGACY_MIGRATION_DONE)
         if _legacy_migration_done():
@@ -181,11 +191,24 @@ class TokenCache:
                     merged["fcm_credentials"]
                 )
 
-            if merged != self._data:
+            needs_save = merged != self._data
+            if needs_save:
                 self._data = merged
-                if self._is_valid_snapshot():
-                    self._store.async_delay_save(self._snapshot, 1.0)
                 _LOGGER.info("googlefindmy: Merged legacy cache into the Store.")
+
+        # Outside the lock: the Store holds its own write lock.
+        if needs_save:
+            await self._async_save_migrated_snapshot()
+
+        if not await self._async_store_contains_keys(frozenset(normalized_legacy)):
+            _LOGGER.warning(
+                "googlefindmy: Keeping the legacy cache file %s because the merged "
+                "credentials are not on disk yet; the migration will run again.",
+                legacy_path,
+            )
+            # Allow another attempt in this process instead of stranding the file.
+            _set_legacy_migration_flag(False)
+            return
 
         def _remove_legacy() -> None:
             try:
@@ -197,6 +220,66 @@ class TokenCache:
                 )
 
         await self._hass.async_add_executor_job(_remove_legacy)
+
+    async def _async_save_migrated_snapshot(self) -> None:
+        """Write the merged snapshot immediately, without trusting the outcome.
+
+        ``async_save`` is used rather than ``async_delay_save`` because only the
+        former can be awaited. It is deliberately not gated on ``CoreState``: while
+        Home Assistant is stopping, ``async_save`` registers the final-write
+        listener that still persists the data, and skipping the call would drop it.
+        The caller verifies the result on disk either way.
+        """
+
+        if not self._is_valid_snapshot():
+            return
+        try:
+            await self._store.async_save(self._snapshot())
+        except Exception:
+            _LOGGER.exception(
+                "googlefindmy: Failed to persist the migrated cache for entry '%s'",
+                self.entry_id,
+            )
+
+    async def _async_store_contains_keys(self, expected: frozenset[str]) -> bool:
+        """Return whether the Store file on disk holds every expected key.
+
+        The file is the only evidence that survives a restart, so it is read back
+        rather than inferred from a return value. Anything that leaves the answer
+        open (no path, no file, unreadable content, unexpected envelope) counts as
+        "not proven" and keeps the legacy file.
+        """
+
+        if not expected:
+            return True
+
+        raw_path = getattr(self._store, "path", None)
+        if not isinstance(raw_path, str) or not raw_path:
+            _LOGGER.debug(
+                "googlefindmy: Store exposes no path; migration cannot be verified."
+            )
+            return False
+        store_path: str = raw_path
+
+        def _read_persisted_keys() -> set[str]:
+            with open(store_path, encoding="utf-8") as handle:
+                payload = json.load(handle)
+            data = payload["data"]
+            if not isinstance(data, dict):
+                raise TypeError("Store envelope carries no data mapping")
+            return {key for key in data if isinstance(key, str)}
+
+        try:
+            persisted = await self._hass.async_add_executor_job(_read_persisted_keys)
+        except (OSError, ValueError, TypeError, KeyError):
+            _LOGGER.debug(
+                "googlefindmy: Could not read back the Store file at %s",
+                store_path,
+                exc_info=True,
+            )
+            return False
+
+        return bool(expected.issubset(persisted))
 
     # ------------------------------- Get/Set ---------------------------------
 

--- a/custom_components/googlefindmy/Auth/token_cache.py
+++ b/custom_components/googlefindmy/Auth/token_cache.py
@@ -246,12 +246,19 @@ class TokenCache:
             )
 
     async def _async_store_contains_keys(self, expected: frozenset[str]) -> bool:
-        """Return whether the Store file on disk holds every expected key.
+        """Return whether the migrated values are readable in the Store file on disk.
 
         The file is the only evidence that survives a restart, so it is read back
-        rather than inferred from a return value. Anything that leaves the answer
-        open (no path, no file, unreadable content, unexpected envelope) counts as
-        "not proven" and keeps the legacy file.
+        rather than inferred from a return value. The proof is deliberately not
+        "the key names are somewhere in that file": a stale or foreign envelope
+        can carry the same names while the current values never reached the disk,
+        and an envelope Home Assistant cannot load on restart is worth nothing
+        either. Checked are therefore the envelope identity (``key``), the schema
+        version, and the value behind every expected key.
+
+        Anything that leaves the answer open (no path, no file, unreadable
+        content, unexpected envelope, mismatching value) counts as "not proven"
+        and keeps the legacy file.
         """
 
         if not expected:
@@ -264,17 +271,43 @@ class TokenCache:
             )
             return False
         store_path: str = raw_path
+        store_key = getattr(self._store, "key", None)
 
-        def _read_persisted_keys() -> set[str]:
+        # Compare against the JSON round trip of our own values, not against the
+        # in-memory objects: a tuple is written as a list, and comparing the two
+        # would fail a migration that in fact persisted correctly.
+        wanted = json.loads(json.dumps({key: self._data[key] for key in expected}))
+
+        def _envelope_holds_values() -> bool:
             with open(store_path, encoding="utf-8") as handle:
                 payload = json.load(handle)
+            if not isinstance(payload, dict):
+                raise TypeError("Store file carries no envelope")
+            if payload.get("version") != STORAGE_VERSION:
+                _LOGGER.debug(
+                    "googlefindmy: Store file %s carries version %r, expected %r",
+                    store_path,
+                    payload.get("version"),
+                    STORAGE_VERSION,
+                )
+                return False
+            if isinstance(store_key, str) and payload.get("key") != store_key:
+                _LOGGER.debug(
+                    "googlefindmy: Store file %s belongs to key %r, expected %r",
+                    store_path,
+                    payload.get("key"),
+                    store_key,
+                )
+                return False
             data = payload["data"]
             if not isinstance(data, dict):
                 raise TypeError("Store envelope carries no data mapping")
-            return {key for key in data if isinstance(key, str)}
+            return all(
+                key in data and data[key] == value for key, value in wanted.items()
+            )
 
         try:
-            persisted = await self._hass.async_add_executor_job(_read_persisted_keys)
+            proven = await self._hass.async_add_executor_job(_envelope_holds_values)
         except (OSError, ValueError, TypeError, KeyError):
             _LOGGER.debug(
                 "googlefindmy: Could not read back the Store file at %s",
@@ -283,7 +316,8 @@ class TokenCache:
             )
             return False
 
-        return expected.issubset(persisted)
+        # Cast: hass.async_add_executor_job widens the callable's return to Any.
+        return bool(proven)
 
     # ------------------------------- Get/Set ---------------------------------
 

--- a/custom_components/googlefindmy/Auth/token_cache.py
+++ b/custom_components/googlefindmy/Auth/token_cache.py
@@ -272,23 +272,27 @@ class TokenCache:
             return False
         store_path: str = raw_path
         store_key = getattr(self._store, "key", None)
-
-        # Compare against the JSON round trip of our own values, not against the
-        # in-memory objects: a tuple is written as a list, and comparing the two
-        # would fail a migration that in fact persisted correctly.
-        wanted = json.loads(json.dumps({key: self._data[key] for key in expected}))
+        # Both envelope fields come from the store itself, so a later migration
+        # that moves the store to another version cannot make the two disagree.
+        store_version = getattr(self._store, "version", STORAGE_VERSION)
 
         def _envelope_holds_values() -> bool:
+            # Inside the guarded call on purpose: building this can raise, and the
+            # promise of this method is that an open question keeps the file.
+            # Compare against the JSON round trip of our own values rather than the
+            # in-memory objects: a tuple is written as a list, and comparing the two
+            # would fail a migration that in fact persisted correctly.
+            wanted = json.loads(json.dumps({key: self._data[key] for key in expected}))
             with open(store_path, encoding="utf-8") as handle:
                 payload = json.load(handle)
             if not isinstance(payload, dict):
                 raise TypeError("Store file carries no envelope")
-            if payload.get("version") != STORAGE_VERSION:
+            if payload.get("version") != store_version:
                 _LOGGER.debug(
                     "googlefindmy: Store file %s carries version %r, expected %r",
                     store_path,
                     payload.get("version"),
-                    STORAGE_VERSION,
+                    store_version,
                 )
                 return False
             if isinstance(store_key, str) and payload.get("key") != store_key:
@@ -316,7 +320,7 @@ class TokenCache:
             )
             return False
 
-        # Cast: hass.async_add_executor_job widens the callable's return to Any.
+        # hass.async_add_executor_job widens the callable's return type to Any.
         return bool(proven)
 
     # ------------------------------- Get/Set ---------------------------------

--- a/custom_components/googlefindmy/Auth/token_cache.py
+++ b/custom_components/googlefindmy/Auth/token_cache.py
@@ -22,6 +22,7 @@ Key properties:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -164,22 +165,29 @@ class TokenCache:
             return
         _set_legacy_migration_flag(True)
 
-        def _read_legacy() -> Mapping[str, Any] | None:
+        def _read_legacy() -> tuple[Mapping[str, Any], str] | None:
             if not os.path.exists(legacy_path):
                 return None
             try:
-                with open(legacy_path, encoding="utf-8") as f:
-                    data = json.load(f)
+                with open(legacy_path, "rb") as f:
+                    raw = f.read()
+                data = json.loads(raw.decode("utf-8"))
                 if isinstance(data, dict):
-                    return cast(Mapping[str, Any], data)
+                    # The digest identifies the exact bytes this migration is
+                    # about, so the removal further down can tell them apart from
+                    # a bundle the login container wrote in the meantime.
+                    return cast(Mapping[str, Any], data), hashlib.sha256(
+                        raw
+                    ).hexdigest()
                 return None
             except Exception:
                 _LOGGER.exception("Failed to read legacy cache file at %s", legacy_path)
                 return None
 
-        legacy_data = await self._hass.async_add_executor_job(_read_legacy)
-        if legacy_data is None:
+        legacy_read = await self._hass.async_add_executor_job(_read_legacy)
+        if legacy_read is None:
             return
+        legacy_data, legacy_digest = legacy_read
 
         normalized_legacy = self._coerce_cache_state(legacy_data)
 
@@ -215,6 +223,34 @@ class TokenCache:
             return
 
         def _remove_legacy() -> None:
+            # Re-read inside the same executor job and unlink only while the file
+            # still holds the bytes this migration proved. The standalone login
+            # replaces this file atomically, and the awaits above leave it a
+            # window; deleting a bundle that was never migrated would cost the
+            # user the full Google login. The same re-read guard is used before
+            # `os.remove` in `config_flow._async_delete_watched_secrets`.
+            try:
+                with open(legacy_path, "rb") as handle:
+                    current = handle.read()
+            except FileNotFoundError:
+                return
+            except OSError:
+                _LOGGER.warning(
+                    "Failed to re-read legacy cache file before removal: %s",
+                    legacy_path,
+                )
+                return
+
+            if hashlib.sha256(current).hexdigest() != legacy_digest:
+                # Not ours to delete. The discovery watcher polls this path and
+                # picks the new bundle up on its next scan.
+                _LOGGER.info(
+                    "googlefindmy: Legacy cache file %s changed while it was being "
+                    "migrated; keeping the newer bundle.",
+                    legacy_path,
+                )
+                return
+
             try:
                 os.remove(legacy_path)
             except OSError:

--- a/custom_components/googlefindmy/Auth/token_cache.py
+++ b/custom_components/googlefindmy/Auth/token_cache.py
@@ -156,7 +156,7 @@ class TokenCache:
         Home Assistant logs and swallows write errors instead of raising
         (``helpers/storage.py``, ``_async_handle_write_data``), and the delayed
         write happens later, outside this call. Every path that cannot prove the
-        write leaves the legacy file untouched and lets the migration run again.
+        write leaves the legacy file untouched, to be retried after a restart.
         """
         if _STATE["legacy_migration_done"] != _LEGACY_MIGRATION_DONE:
             _set_legacy_migration_flag(_LEGACY_MIGRATION_DONE)
@@ -196,18 +196,22 @@ class TokenCache:
                 self._data = merged
                 _LOGGER.info("googlefindmy: Merged legacy cache into the Store.")
 
-        # Outside the lock: the Store holds its own write lock.
+        # The Store brings its own write lock, so the save runs outside ours.
         if needs_save:
             await self._async_save_migrated_snapshot()
 
         if not await self._async_store_contains_keys(frozenset(normalized_legacy)):
             _LOGGER.warning(
                 "googlefindmy: Keeping the legacy cache file %s because the merged "
-                "credentials are not on disk yet; the migration will run again.",
+                "credentials for entry '%s' are not on disk; a restart will retry "
+                "the migration.",
                 legacy_path,
+                self.entry_id,
             )
-            # Allow another attempt in this process instead of stranding the file.
-            _set_legacy_migration_flag(False)
+            # The migration sentinel deliberately stays set. It is also the only
+            # guard against migrating this shared file into a second config entry,
+            # and that entry would then own another account's credentials while the
+            # first entry still has none. A restart clears the sentinel anyway.
             return
 
         def _remove_legacy() -> None:
@@ -279,7 +283,7 @@ class TokenCache:
             )
             return False
 
-        return bool(expected.issubset(persisted))
+        return expected.issubset(persisted)
 
     # ------------------------------- Get/Set ---------------------------------
 

--- a/tests/test_token_cache_legacy_durability.py
+++ b/tests/test_token_cache_legacy_durability.py
@@ -315,3 +315,78 @@ async def test_failed_verification_does_not_migrate_into_a_second_entry(
     assert legacy_path.exists(), "Second entry deleted the first entry's legacy file"
     assert second_store.save_calls == 0
     assert second_store.stored_keys() == set()
+
+
+def _write_envelope(
+    path: Path,
+    data: dict[str, Any],
+    *,
+    key: str = "googlefindmy_cache",
+    version: int = 1,
+) -> None:
+    """Write a store envelope directly, bypassing the double's own save path."""
+
+    path.write_text(
+        json.dumps({"version": version, "minor_version": 1, "key": key, "data": data}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_values_under_the_same_keys_keep_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: the file carries the right key names but older values.
+
+    Key names alone are not a proof. A store file left over from an earlier run
+    can name every migrated key while the current values never reached the disk.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+    store_file = tmp_path / "store.json"
+    _write_envelope(
+        store_file, {"oauth_token": "stale-token", "username": "stale@example.com"}
+    )
+    store = _DiskStore(store_file, persists=False)
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-stale-values", str(legacy_path))
+
+    assert legacy_path.exists(), "Legacy file deleted on stale values"
+
+
+@pytest.mark.asyncio
+async def test_foreign_store_envelope_keeps_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: the envelope on disk belongs to a different store key."""
+
+    legacy_path = _write_legacy(tmp_path)
+    store_file = tmp_path / "store.json"
+    _write_envelope(store_file, dict(_LEGACY_PAYLOAD), key="some_other_store")
+    store = _DiskStore(store_file, persists=False)
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-foreign-key", str(legacy_path))
+
+    assert legacy_path.exists(), "Legacy file deleted on a foreign envelope"
+
+
+@pytest.mark.asyncio
+async def test_unloadable_storage_version_keeps_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: the envelope carries a version this build cannot load.
+
+    Data that Home Assistant refuses on the next start is not persisted data.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+    store_file = tmp_path / "store.json"
+    _write_envelope(store_file, dict(_LEGACY_PAYLOAD), version=99)
+    store = _DiskStore(store_file, persists=False)
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-bad-version", str(legacy_path))
+
+    assert legacy_path.exists(), "Legacy file deleted on an unloadable envelope"

--- a/tests/test_token_cache_legacy_durability.py
+++ b/tests/test_token_cache_legacy_durability.py
@@ -390,3 +390,70 @@ async def test_unloadable_storage_version_keeps_legacy_file(
     await TokenCache.create(_StubHass(), "entry-bad-version", str(legacy_path))
 
     assert legacy_path.exists(), "Legacy file deleted on an unloadable envelope"
+
+
+@pytest.mark.asyncio
+async def test_unserializable_migrated_value_keeps_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: a migrated key holds a value that cannot be serialized.
+
+    The promise of the verification is that an open question keeps the file, so
+    building the comparison must not be able to escape as an exception either.
+    `TokenCache.create` is called unguarded during setup.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+    store = _DiskStore(tmp_path / "store.json")
+    store.loaded = {"oauth_token": object()}
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-unserializable", str(legacy_path))
+
+    assert legacy_path.exists(), "Legacy file deleted although nothing was persisted"
+
+
+@pytest.mark.asyncio
+async def test_migration_verifies_against_the_home_assistant_serializer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The proof must hold for what Home Assistant really writes, not for json.dumps.
+
+    Home Assistant serializes store payloads with orjson, which turns a tuple into
+    a list and encodes non-ASCII directly. A verification comparing in-memory
+    objects would fail a migration that in fact persisted correctly.
+    """
+
+    from homeassistant.helpers.json import json_bytes
+
+    class _OrjsonStore(_DiskStore):
+        async def async_save(self, data: dict[str, Any]) -> None:
+            self.save_calls += 1
+            envelope = {
+                "version": self.version,
+                "minor_version": self.minor_version,
+                "key": self.key,
+                "data": data,
+            }
+            Path(self.path).write_bytes(json_bytes(envelope))
+
+    payload = {
+        "oauth_token": "legacy-oauth-token",
+        "username": "légacy@example.com",
+        "fcm_credentials": {
+            "gcm": {"android_id": "111", "security_token": "222"},
+            "fcm": {"registration": {"token": "ünïcode-täken"}},
+        },
+        "counters": [1, 2, 3],
+    }
+    legacy_path = tmp_path / "secrets.json"
+    legacy_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    store = _OrjsonStore(tmp_path / "store.json")
+    _install_store(monkeypatch, store)
+
+    cache = await TokenCache.create(_StubHass(), "entry-orjson", str(legacy_path))
+
+    assert not legacy_path.exists(), "Legacy file kept although the data is on disk"
+    assert store.stored_keys() >= set(payload)
+    assert await cache.get("username") == "légacy@example.com"

--- a/tests/test_token_cache_legacy_durability.py
+++ b/tests/test_token_cache_legacy_durability.py
@@ -117,8 +117,19 @@ def _write_legacy(tmp_path: Path) -> Path:
     return legacy_path
 
 
-def _install_store(monkeypatch: pytest.MonkeyPatch, store: _DiskStore) -> None:
+def _install_store(monkeypatch: pytest.MonkeyPatch, store: Any) -> None:
     monkeypatch.setattr(token_cache, "Store", lambda *_a, **_kw: store)
+
+
+def _install_store_sequence(monkeypatch: pytest.MonkeyPatch, stores: list[Any]) -> None:
+    """Hand out one store per TokenCache, in order, for multi-entry setups."""
+
+    remaining = list(stores)
+
+    def _next_store(*_a: Any, **_kw: Any) -> Any:
+        return remaining.pop(0)
+
+    monkeypatch.setattr(token_cache, "Store", _next_store)
 
 
 @pytest.mark.asyncio
@@ -204,3 +215,103 @@ async def test_delayed_save_is_not_used_for_migration(
 
     assert store.delay_save_calls == 0, "Migration must not use the debounced save"
     assert store.save_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_store_without_path_keeps_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: the store exposes no path, so nothing can be read back."""
+
+    class _PathlessStore:
+        def __init__(self) -> None:
+            self.saved: list[dict[str, Any]] = []
+
+        async def async_load(self) -> dict[str, Any] | None:
+            return None
+
+        def async_delay_save(
+            self, writer: Callable[[], Any], delay: float = 0.0
+        ) -> None:
+            raise AssertionError("Migration must not use the debounced save")
+
+        async def async_save(self, data: dict[str, Any]) -> None:
+            self.saved.append(data)
+
+    legacy_path = _write_legacy(tmp_path)
+    store = _PathlessStore()
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-pathless", str(legacy_path))
+
+    assert store.saved, "The snapshot should still be handed to the store"
+    assert legacy_path.exists(), (
+        "Legacy file deleted although nothing could be verified"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unreadable_store_envelope_keeps_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: the file on disk is not a store envelope."""
+
+    legacy_path = _write_legacy(tmp_path)
+    store_file = tmp_path / "store.json"
+    store = _DiskStore(store_file, persists=False)
+    store_file.write_text("not json at all", encoding="utf-8")
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-broken-envelope", str(legacy_path))
+
+    assert legacy_path.exists(), "Legacy file deleted on an unreadable store file"
+
+
+@pytest.mark.asyncio
+async def test_already_persisted_keys_remove_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: the store already holds the legacy keys, so no write is due.
+
+    Covers the deletion that happens without any write attempt: the merge changes
+    nothing, and the proof still has to come from the file.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+    store = _DiskStore(tmp_path / "store.json")
+    store.loaded = dict(_LEGACY_PAYLOAD)
+    await store.async_save(dict(_LEGACY_PAYLOAD))
+    store.save_calls = 0
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-already-there", str(legacy_path))
+
+    assert store.save_calls == 0, "Nothing changed, so nothing should be written"
+    assert not legacy_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_failed_verification_does_not_migrate_into_a_second_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed migration must not hand the file to the next config entry.
+
+    ``legacy_path`` is one shared module path for every entry, so the process-wide
+    sentinel is also the guard against a second entry adopting the first entry's
+    credentials. Clearing it on failure would delete the file after all, one
+    instance later, and put another account's token into the second store.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+    failing_store = _DiskStore(tmp_path / "store_a.json", persists=False)
+    second_store = _DiskStore(tmp_path / "store_b.json")
+    _install_store_sequence(monkeypatch, [failing_store, second_store])
+
+    await TokenCache.create(_StubHass(), "entry-a", str(legacy_path))
+    assert legacy_path.exists()
+
+    await TokenCache.create(_StubHass(), "entry-b", str(legacy_path))
+
+    assert legacy_path.exists(), "Second entry deleted the first entry's legacy file"
+    assert second_store.save_calls == 0
+    assert second_store.stored_keys() == set()

--- a/tests/test_token_cache_legacy_durability.py
+++ b/tests/test_token_cache_legacy_durability.py
@@ -457,3 +457,37 @@ async def test_migration_verifies_against_the_home_assistant_serializer(
     assert not legacy_path.exists(), "Legacy file kept although the data is on disk"
     assert store.stored_keys() >= set(payload)
     assert await cache.get("username") == "légacy@example.com"
+
+
+@pytest.mark.asyncio
+async def test_legacy_file_replaced_during_migration_is_kept(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: a newer bundle lands while the migration is awaiting.
+
+    The standalone login replaces this exact file atomically and the discovery
+    watcher polls it, so the window between reading and deleting is a real
+    producer race. What gets deleted must be the bytes that were proved, not
+    whatever happens to be at the path afterwards.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+
+    class _RacingStore(_DiskStore):
+        async def async_save(self, data: dict[str, Any]) -> None:
+            # Stands in for the login container writing a fresh bundle into the
+            # window the awaited save opens.
+            legacy_path.write_text(
+                json.dumps({"oauth_token": "brand-new-token"}), encoding="utf-8"
+            )
+            await super().async_save(data)
+
+    store = _RacingStore(tmp_path / "store.json")
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-racing", str(legacy_path))
+
+    assert legacy_path.exists(), "A bundle that was never migrated got deleted"
+    assert json.loads(legacy_path.read_text(encoding="utf-8")) == {
+        "oauth_token": "brand-new-token"
+    }

--- a/tests/test_token_cache_legacy_durability.py
+++ b/tests/test_token_cache_legacy_durability.py
@@ -1,0 +1,206 @@
+# tests/test_token_cache_legacy_durability.py
+"""Durability contract for the legacy ``Auth/secrets.json`` migration.
+
+``TokenCache._migrate_legacy_file`` deletes the legacy credential file. The
+deletion is irreversible and the file is the only remaining copy of the
+credentials, so it may only happen once the merged data is provably on disk.
+
+Two return paths make "no exception" a useless proof here, both read in
+``homeassistant/helpers/storage.py`` (2026.1.3):
+
+* ``async_delay_save`` is a ``@callback`` returning ``None``; the write happens
+  up to ``delay`` seconds later and cannot be awaited (``:456-495``).
+* ``_async_handle_write_data`` catches ``SerializationError`` and ``WriteError``
+  and only logs them (``:563-566``), so a full disk returns cleanly from
+  ``async_save``.
+
+Each test below isolates exactly one of the ways the store can fail to persist
+and asserts the same thing: the legacy file survives. The error direction is
+"orphaned legacy file", never "lost credentials".
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from custom_components.googlefindmy.Auth import token_cache
+from custom_components.googlefindmy.Auth.token_cache import TokenCache
+
+_LEGACY_PAYLOAD: dict[str, Any] = {
+    "oauth_token": "legacy-oauth-token",
+    "username": "legacy@example.com",
+}
+
+
+class _DiskStore:
+    """Store double that persists a real HA envelope to a real path.
+
+    Mirrors ``Store`` closely enough for the durability question: ``path`` is a
+    real file, ``async_save`` writes the ``{"version", "minor_version", "key",
+    "data"}`` envelope, and ``async_delay_save`` records the call *without*
+    writing, which is what the debounced timer looks like before it fires.
+    """
+
+    version = 1
+    minor_version = 1
+
+    def __init__(self, path: Path, *, persists: bool = True) -> None:
+        self.path = str(path)
+        self.key = "googlefindmy_cache"
+        self.persists = persists
+        self.loaded: dict[str, Any] | None = None
+        self.delay_save_calls = 0
+        self.save_calls = 0
+
+    async def async_load(self) -> dict[str, Any] | None:
+        return self.loaded
+
+    def async_delay_save(self, writer: Callable[[], Any], delay: float = 0.0) -> None:
+        """Record a debounced save. Nothing reaches disk until the timer fires."""
+
+        self.delay_save_calls += 1
+
+    async def async_save(self, data: dict[str, Any]) -> None:
+        """Write the envelope, or return cleanly without writing anything.
+
+        ``persists=False`` reproduces the swallowed ``WriteError``: the caller
+        sees a successful coroutine and an empty disk.
+        """
+
+        self.save_calls += 1
+        if not self.persists:
+            return
+        envelope = {
+            "version": self.version,
+            "minor_version": self.minor_version,
+            "key": self.key,
+            "data": data,
+        }
+        Path(self.path).write_text(json.dumps(envelope), encoding="utf-8")
+
+    def stored_keys(self) -> set[str]:
+        """Return the keys actually present in the file on disk."""
+
+        store_file = Path(self.path)
+        if not store_file.exists():
+            return set()
+        payload = json.loads(store_file.read_text(encoding="utf-8"))
+        return set(payload["data"])
+
+
+class _StubHass:
+    """Home Assistant stub that runs executor jobs inline."""
+
+    async def async_add_executor_job(
+        self, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Any:
+        return func(*args, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _reset_legacy_migration_flag() -> Iterator[None]:
+    """Clear the process-wide migration sentinel around every test."""
+
+    token_cache._set_legacy_migration_flag(False)
+    yield
+    token_cache._set_legacy_migration_flag(False)
+
+
+def _write_legacy(tmp_path: Path) -> Path:
+    legacy_path = tmp_path / "secrets.json"
+    legacy_path.write_text(json.dumps(_LEGACY_PAYLOAD), encoding="utf-8")
+    return legacy_path
+
+
+def _install_store(monkeypatch: pytest.MonkeyPatch, store: _DiskStore) -> None:
+    monkeypatch.setattr(token_cache, "Store", lambda *_a, **_kw: store)
+
+
+@pytest.mark.asyncio
+async def test_invalid_snapshot_keeps_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: the snapshot is not serializable, so no save is issued.
+
+    The unrelated key is deliberate. ``_is_valid_snapshot`` judges the whole
+    cache, not the keys being migrated, so a single foreign object suppresses
+    the migration write while the legacy file would still be deleted.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+    store = _DiskStore(tmp_path / "store.json")
+    store.loaded = {"unrelated_key": object()}
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-invalid-snapshot", str(legacy_path))
+
+    assert legacy_path.exists(), "Legacy file deleted although nothing was persisted"
+    assert store.stored_keys() == set()
+
+
+@pytest.mark.asyncio
+async def test_store_write_failure_keeps_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: ``async_save`` returns cleanly but writes nothing.
+
+    This is the only test that separates "await the save" from "verify the
+    result": a fix that merely awaits ``async_save`` and trusts the missing
+    exception still deletes the file here.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+    store = _DiskStore(tmp_path / "store.json", persists=False)
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-write-failure", str(legacy_path))
+
+    assert store.save_calls == 1, "Migration must attempt an immediate, awaited save"
+    assert legacy_path.exists(), "Legacy file deleted although the write was lost"
+    assert store.stored_keys() == set()
+
+
+@pytest.mark.asyncio
+async def test_successful_migration_removes_legacy_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: the merged data is on disk, so the deletion may run.
+
+    Guards the other direction. A verification that can never succeed would
+    keep every legacy file forever and pass all three tests above.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+    store = _DiskStore(tmp_path / "store.json")
+    _install_store(monkeypatch, store)
+
+    cache = await TokenCache.create(_StubHass(), "entry-happy", str(legacy_path))
+
+    assert store.stored_keys() >= set(_LEGACY_PAYLOAD)
+    assert not legacy_path.exists(), "Legacy file kept although the data is on disk"
+    assert await cache.get("oauth_token") == _LEGACY_PAYLOAD["oauth_token"]
+
+
+@pytest.mark.asyncio
+async def test_delayed_save_is_not_used_for_migration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Isolated condition: the migration never routes through the debounce.
+
+    ``async_delay_save`` cannot be awaited, so any use of it in this path makes
+    the subsequent verification a race against a timer.
+    """
+
+    legacy_path = _write_legacy(tmp_path)
+    store = _DiskStore(tmp_path / "store.json")
+    _install_store(monkeypatch, store)
+
+    await TokenCache.create(_StubHass(), "entry-no-debounce", str(legacy_path))
+
+    assert store.delay_save_calls == 0, "Migration must not use the debounced save"
+    assert store.save_calls == 1

--- a/tests/test_token_cache_secrets.py
+++ b/tests/test_token_cache_secrets.py
@@ -36,8 +36,16 @@ class _StubHass:
         return func(*args, **kwargs)
 
 
-def _install_recording_store(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
-    """Replace the Store stub with a recorder capturing writes and freshness."""
+def _install_recording_store(
+    monkeypatch: pytest.MonkeyPatch, storage_dir: Path
+) -> list[Any]:
+    """Replace the Store stub with a recorder capturing writes and freshness.
+
+    The double owns a real ``path`` and writes the real Home Assistant envelope,
+    because the legacy migration now reads the Store file back before it deletes
+    the legacy bundle. A recorder that only remembers calls would report a
+    migration as unpersisted.
+    """
 
     storage_module = sys.modules["homeassistant.helpers.storage"]
     instances: list[Any] = []
@@ -47,19 +55,30 @@ def _install_recording_store(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
             self._data: dict[str, Any] | None = None
             self.saved_snapshots: list[dict[str, Any]] = []
             self.fresh = False
+            self.key = f"googlefindmy_cache_{len(instances)}"
+            self.path = str(storage_dir / f"{self.key}.json")
             instances.append(self)
 
         async def async_load(self) -> dict[str, Any] | None:
             return self._data
 
-        def async_delay_save(self, writer: Any, _delay: float) -> None:
-            snapshot = writer()
+        def _persist(self, snapshot: dict[str, Any]) -> None:
             self.saved_snapshots.append(snapshot)
             self._data = snapshot
             self.fresh = True
+            envelope = {
+                "version": 1,
+                "minor_version": 1,
+                "key": self.key,
+                "data": snapshot,
+            }
+            Path(self.path).write_text(json.dumps(envelope), encoding="utf-8")
+
+        def async_delay_save(self, writer: Any, _delay: float) -> None:
+            self._persist(writer())
 
         async def async_save(self, data: dict[str, Any]) -> None:
-            self._data = data
+            self._persist(data)
 
     monkeypatch.setattr(storage_module, "Store", _RecordingStore)
     monkeypatch.setattr(token_cache, "Store", _RecordingStore)
@@ -110,7 +129,7 @@ async def test_token_cache_create_migrates_legacy_bundle(
     """Legacy secrets JSON migrates into the Store via TokenCache.create()."""
 
     monkeypatch.setattr(token_cache, "_LEGACY_MIGRATION_DONE", False, raising=False)
-    stores = _install_recording_store(monkeypatch)
+    stores = _install_recording_store(monkeypatch, tmp_path)
 
     hass = _StubHass()
     legacy_path = tmp_path / "legacy_secrets.json"
@@ -153,7 +172,7 @@ async def test_token_cache_migration_runs_only_once(
     """_LEGACY_MIGRATION_DONE avoids deleting later legacy cache files."""
 
     monkeypatch.setattr(token_cache, "_LEGACY_MIGRATION_DONE", False, raising=False)
-    stores = _install_recording_store(monkeypatch)
+    stores = _install_recording_store(monkeypatch, tmp_path)
 
     hass = _StubHass()
     legacy_first = tmp_path / "legacy_first.json"


### PR DESCRIPTION
## Problem

`TokenCache._migrate_legacy_file` deletes `Auth/secrets.json` after merging it into the entry Store. The deletion ran unconditionally, while the merged data was only handed to `Store.async_delay_save(self._snapshot, 1.0)`, and only when `_is_valid_snapshot()` happened to be true. Three paths therefore deleted the last remaining copy of the credentials without persisting anything:

1. **The debounced write had not run.** `async_delay_save` is a `@callback` returning `None` (`homeassistant/helpers/storage.py`); the write is scheduled via `hass.loop.call_at` and cannot be awaited. Deleting the source one line later is a race against a timer.
2. **`_is_valid_snapshot()` judges the whole cache, not the keys being migrated.** One unrelated unserializable value suppressed the write entirely, and the file was removed anyway.
3. **A failing write returns cleanly.** `_async_handle_write_data` catches `SerializationError` and `WriteError` and only calls `_LOGGER.error`, so a full disk or a permission error is indistinguishable from success at the call site.

This is not a dormant legacy path. `legacy_path` is set on every setup (`__init__.py`) and points at the shipped `Auth/secrets.json`; a discovery watcher polls that exact file so the login container can hand a fresh bundle over, and the error messages in `decrypt_locations.py` name it as the repair route. Losing it costs the user the full Google login including 2FA.

Measured against Home Assistant 2026.1.3.

## What this changes

Migrate with an awaited `async_save`, then prove the result against the file itself before removing anything:

- `_async_save_migrated_snapshot()` writes immediately instead of scheduling.
- `_async_store_contains_keys()` reads the Store file back and checks the envelope, not a set of names: `key` must be this store's, `version` must be the store's own, and every migrated key must carry the value that was merged. Values are compared against the JSON round trip of our own data, so a tuple persisted as a list does not fail a migration that succeeded.
- `_remove_legacy()` re-reads the legacy file inside the same executor job that unlinks it and only unlinks while its SHA-256 still matches the bytes that were read and proved. The same guard sits in front of `os.remove` in `config_flow._async_delete_watched_secrets`, for the same producer race.
- The legacy file is removed only on that positive proof. Anything that leaves the answer open (no `path`, no file, unreadable content, foreign or unloadable envelope, mismatching value, changed file) counts as unproven, keeps the file, and logs it with the path and the entry.

The error direction is now strictly "orphaned legacy file", never "lost credentials".

Two deliberate non-changes, both with a reason:

- **No `CoreState.stopping` gate before the save.** During shutdown `async_save` registers the final-write listener that still persists the data; skipping the call would drop it. The on-disk check keeps the legacy file either way, so the gate would only remove a working path.
- **The process-wide migration sentinel stays set when the proof fails.** `legacy_path` is one shared module path for every config entry, so that sentinel is also the only guard against a second entry adopting the same file. Clearing it to allow a retry reintroduced the loss one instance later: entry A kept the file, entry B then migrated it, B's store ended up holding A's `aas_token`, the file was deleted after all, and A had the credentials neither in its store nor on disk. Pinned by `test_failed_verification_does_not_migrate_into_a_second_entry`. A restart clears the sentinel and retries.

## Options considered

| Option | Verdict |
|---|---|
| Replace `async_delay_save` with `async_save` and delete when no exception is raised | Rejected. Closes the timing window only. The swallowed `WriteError` still reports success on a full disk. |
| Rename the legacy file instead of deleting it | Rejected as the primary mechanism. `_read_legacy` only looks at the exact `legacy_path`, so a renamed file would never be re-migrated and the self-healing path would be gone. |
| Delete only after an on-disk proof (**this PR**) | Closes all three silent-return paths, and every failure of the proof itself falls to the safe side. |

## Tests

`tests/test_token_cache_legacy_durability.py` (new, 14 tests). The store double owns a real `path` and writes a real envelope, so the assertions are about the file rather than about a recorded call.

| Test | Isolated condition | What it kills |
|---|---|---|
| `test_invalid_snapshot_keeps_legacy_file` | an unrelated unserializable value suppresses the write | removing the snapshot check |
| `test_store_write_failure_keeps_legacy_file` | `async_save` returns cleanly, writes nothing | the "just await it" fix; the only test separating it from the on-disk proof |
| `test_successful_migration_removes_legacy_file` | happy path | a proof that can never succeed and keeps every file forever |
| `test_delayed_save_is_not_used_for_migration` | the debounce counter is 0 | a relapse to `async_delay_save` |
| `test_store_without_path_keeps_legacy_file` | the store exposes no `path` | treating "cannot verify" as verified |
| `test_unreadable_store_envelope_keeps_legacy_file` | the file is not an envelope | as above |
| `test_already_persisted_keys_remove_legacy_file` | nothing to write, keys already on disk | a proof coupled to the write instead of to the file |
| `test_failed_verification_does_not_migrate_into_a_second_entry` | shared `legacy_path`, two entries | clearing the sentinel on failure |
| `test_stale_values_under_the_same_keys_keep_legacy_file` | right key names, older values | reducing the proof to a name set |
| `test_foreign_store_envelope_keeps_legacy_file` | envelope belongs to another store key | as above |
| `test_unloadable_storage_version_keeps_legacy_file` | version this build cannot load | accepting data HA will quarantine on restart |
| `test_unserializable_migrated_value_keeps_legacy_file` | the comparison itself cannot be built | letting that raise out of `TokenCache.create` |
| `test_migration_verifies_against_the_home_assistant_serializer` | written through HA's orjson path | a round-trip claim pinned only by `json.dumps` |
| `test_legacy_file_replaced_during_migration_is_kept` | a fresh bundle lands during the awaits | deleting bytes that were never migrated |

**Red before green.** The first four were committed before the fix and all four failed against the unchanged implementation, each with its own reason:

```
AssertionError: Legacy file deleted although nothing was persisted   (assert False)
AssertionError: Migration must attempt an immediate, awaited save    (assert 0 == 1)
AssertionError: assert set() >= {'oauth_token', 'username'}
AssertionError: Migration must not use the debounced save            (assert 1 == 0)
```

Every later test was mutation-checked the same way: reverting the single line it guards makes that test, and only that test, fail.

`tests/test_token_cache_secrets.py`: the recorder gains a real `path` and writes a real envelope, because a double that only remembers calls now reports a successful migration as unpersisted. No assertion was changed, weakened or removed; the diff only adds capabilities to the double.

## Known limits, stated rather than hidden

- The proof reads with `json.load` while Home Assistant reads with orjson. That parser accepts `NaN`/`Infinity` literals and nesting beyond 1024, which orjson rejects, so a store file from a *foreign* writer could pass this check and still be quarantined as `.corrupt.<timestamp>` on the next start. Not reachable from anything this integration writes.
- A `NaN` inside the legacy bundle would strand that bundle: `json.load` accepts the literal, orjson writes `null`, and `nan != nan` in any case. The direction is safe (file kept, warning logged) and a Google `secrets.json` does not contain one.
- The residual race is the gap between the digest re-read and `os.remove`, which POSIX offers no atomic primitive for. This is the same limit `_async_delete_watched_secrets` documents for itself.
- `minor_version` is not compared. In `_async_load_data` a differing minor version is treated as recoverable and the payload is returned unchanged once `version` matches, while a differing major version propagates: `version` is the field whose mismatch makes the file unloadable.

## Verification

`ruff check .`, `ruff format --check .` and `mypy --strict custom_components/googlefindmy/` are clean on the head commit, as is the whole `token_cache` test family. CI ran the full suite on every pushed commit across three interpreter lines, all green. The last *local* full run was on `f00bb3dd` and reached 78.69 % total coverage against the unchanged `fail_under = 78`; the commits after it only add tests and narrow the deletion condition. `pyproject.toml` is untouched.

Two review rounds by a separate reviewer and three Codex rounds ran on this branch. Each finding is answered in the thread, and each fix carries the test that is red without it.
