### PR TITLE
docs(uwt): map the unwanted tracking protection mode onto the DULT separated state

### DIFF
--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -921,28 +921,62 @@ class GoogleFindMyConnectivitySensor(GoogleFindMyEntity, BinarySensorEntity):
 class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
     """Per-device binary sensor for the FMDN unwanted tracking protection mode.
 
-    Semantics (per the Find Hub Network Accessory Specification, section
-    "Hashed flags", retrieved 2026-08-04:
+    Semantics (per the Find Hub Network Accessory Specification, sections
+    "Hashed flags" and "Unwanted tracking prevention", retrieved 2026-09-03:
     https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn):
         - ``on``  → The beacon reports that unwanted tracking protection mode
           is active: spec bit 7 of the hashed-flags byte is set. Note that the
           specification numbers hashed-flags bits MSB-first, so spec bit 7 is
           standard bit 0; the resolver mask is therefore ``0x01`` and not
           ``0x80`` (see ``eid_resolver.py``, which marks ``0x80`` as an
-          anti-pattern). The mode is entered and left by COMMAND (Data ID 0x07
-          activates it, 0x08 deactivates it), not by elapsed time.
+          anti-pattern).
         - ``off`` → The beacon reports normal operation.
         - ``None`` → No hashed-flags byte has been decoded for this device.
           The byte is optional: a beacon without battery indication that is not
           in unwanted tracking protection mode may omit it entirely.
 
-    Not what this sensor means: the specification's "24 hours" figure refers to
-    the reduced MAC address rotation frequency WHILE the mode is active, not to
-    a separation duration. An earlier docstring here claimed that the sensor
-    turns on after a fixed separation window; no such window exists in the
-    specification, and the claim caused misdirected automations and bug reports
-    (BSkando#210). A separation-based anti-stalking chime is a DULT platform
-    behaviour and is not what this bit reports.
+    How the mode is entered and left. The specification maps it onto DULT
+    verbatim: '"Unwanted tracking protection mode" defined in this document
+    maps to the "separated state" defined by the DULT spec', and certified
+    devices "must also meet the requirements in the implementation version of
+    the cross-platform specification for Detecting Unwanted Location Trackers
+    (DULT)". DULT defines that state autonomously, not by command: the
+    accessory "SHALL transition from near-owner mode to separated mode" once it
+    is "physically separated from the owner device for more than 30 minutes",
+    and back to near-owner mode on reunion
+    (``draft-detecting-unwanted-location-trackers-01``, sections 3.4.4 and
+    3.4.5). Data ID 0x07 (activate) and 0x08 (deactivate) on the Beacon Actions
+    characteristic are an ADDITIONAL, seeker-driven path over GATT, not the only
+    way in and out; both are authenticated with the unwanted tracking protection
+    key derived from the EIK, so neither is available to a party without the
+    owner's key material. Two consequences for automations. The mode can appear
+    and disappear with no command sent by anyone -- that follows directly from
+    the transition above. And a deactivation over GATT plausibly would not hold
+    while the separation that produced the state persists -- that is an
+    INFERENCE from the standing condition in DULT section 3.4.4, not a
+    specification statement; neither document says what happens when 0x08 meets
+    a still-separated device.
+
+    Two 24-hour figures exist and they are not the same figure:
+        - DULT ``T_(SEPARATED_UT_TIMEOUT)``, a "random value between 8-24 hours
+          chosen from a uniform distribution", after which the accessory "MUST
+          enable the motion detector" while separated and then plays a sound on
+          detected motion (DULT section 3.12.2.1 with table 16; section 3.4.4
+          carries the state transition only, not the detector). This is
+          normative, and it gates the motion-triggered chime, not the setting of
+          this bit. An earlier docstring here first claimed the sensor turns on
+          after that window, and was then corrected into denying the window
+          exists at all; both were wrong, and it is the second error that this
+          paragraph replaces (BSkando#210).
+        - The Find Hub specification's own "24 hours", which is the reduced MAC
+          address rotation period WHILE the mode is active.
+
+    A separation-based anti-stalking chime is therefore device behaviour in
+    exactly the state this bit reports, so the two are related rather than
+    unrelated. What the bit does not carry is whether the motion detector is
+    already armed: that depends on ``T_(SEPARATED_UT_TIMEOUT)``, which is not
+    observable from the advertisement. This sensor is consequently not a
+    separation timer and cannot be turned into one.
 
     Why the mode is nonetheless relevant to reports of spurious ringing:
     activation (Data ID 0x07) takes an optional control flag, ``0x01``

--- a/custom_components/googlefindmy/binary_sensor.py
+++ b/custom_components/googlefindmy/binary_sensor.py
@@ -964,10 +964,12 @@ class GoogleFindMyUWTModeSensor(GoogleFindMyDeviceEntity, BinarySensorEntity):
           detected motion (DULT section 3.12.2.1 with table 16; section 3.4.4
           carries the state transition only, not the detector). This is
           normative, and it gates the motion-triggered chime, not the setting of
-          this bit. An earlier docstring here first claimed the sensor turns on
-          after that window, and was then corrected into denying the window
-          exists at all; both were wrong, and it is the second error that this
-          paragraph replaces (BSkando#210).
+          this bit. Two earlier revisions of this docstring misplaced the figure
+          in opposite directions; both are withdrawn, and the correction of
+          record is the attribution stated here (BSkando#210). Neither is
+          restated, so the guards in
+          ``tests/test_uwt_mode_binary_sensor.py`` need no exception for this
+          paragraph.
         - The Find Hub specification's own "24 hours", which is the reduced MAC
           address rotation period WHILE the mode is active.
 

--- a/docs/PLAY_SOUND_ARCHITECTURE.md
+++ b/docs/PLAY_SOUND_ARCHITECTURE.md
@@ -472,7 +472,7 @@ use case where the caller does NOT own the tracker.
 | CCCD Descriptor | `00002902-0000-1000-8000-00805F9B34FB` |
 | Byte Order | **Little endian** (opposite of FMDN Beacon Actions!) |
 | Authentication | **None** |
-| Availability | **Separated state only**; the unauthenticated sound is enabled 8-24 hours after separation (figure from DULT/AirTag field reports, not from the FMDN specification; see `docs/TRIGGER_MECHANISMS.md` sections 4.1 and 8) |
+| Availability | **Separated state only**; the accessory enters that state after roughly 30 minutes without an owner device and enables the unauthenticated motion-gated sound a further 8-24 hours later (DULT `T_(SEPARATED_UT_TIMEOUT)`, a randomised value from a uniform distribution: `draft-detecting-unwanted-location-trackers-01` sections 3.4.4 and 3.12.2.1, table 16; see `docs/TRIGGER_MECHANISMS.md` sections 4.1 and 8) |
 
 ### DULT Opcodes (Little-Endian Wire Format)
 
@@ -540,18 +540,31 @@ Source: `seemoo-lab/AirGuard` — `GoogleFindMyNetwork.kt`
 account). In near-owner state, the tracker responds to DULT Sound_Start with
 `Invalid_command (0xFFFF)`.
 
-DULT only works when the tracker enters "separated state" — 8-24 hours away from any
-device logged into the owner's Google account. This is the opposite of our use case.
+DULT only works when the tracker is in "separated state". It enters that state after
+roughly 30 minutes away from any device logged into the owner's Google account, and the
+unauthenticated motion-gated sound becomes available only a further 8-24 hours later.
+This is the opposite of our use case.
 
-> **Provenance of the 8-24 hour figure:** it comes from DULT/AirTag field reports and
-> describes a *platform* behaviour (see `docs/TRIGGER_MECHANISMS.md` sections 4.1 and 8
-> for the per-device figures and their sources). It is **not** in the FMDN
-> specification, and it is **not** what the FMDN unwanted tracking protection mode
-> reports: that mode is entered and left by command (Data ID `0x07` / `0x08`), per the
-> Find Hub Network Accessory Specification, section "Beacon Actions"
-> (<https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>,
-> retrieved 2026-08-04). Do not use the `uwt_mode` binary sensor as a separation timer
-> ([BSkando#210](https://github.com/BSkando/GoogleFindMy-HA/issues/210)).
+> **Provenance of both figures, corrected 2026-09-03:** they are normative DULT, not
+> field reports. The 30 minutes are the near-owner → separated transition, `SHALL` in
+> `draft-detecting-unwanted-location-trackers-01` section 3.4.4 with table 2 (section
+> 3.4.5 governs the way back, on reunion); the 8-24
+> hours are `T_(SEPARATED_UT_TIMEOUT)`, a "random value between 8-24 hours chosen from a
+> uniform distribution", after which the accessory "MUST enable the motion detector"
+> (section 3.12.2.1, table 16).
+>
+> **The FMDN mode is that same state, not a separate command-only concept.** The Find
+> Hub Network Accessory Specification says so in its section "Unwanted tracking
+> prevention": `"Unwanted tracking protection mode" defined in this document maps to the
+> "separated state" defined by the DULT spec`, and certified devices "must also meet the
+> requirements" of DULT (<https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>, retrieved 2026-09-03). Data ID `0x07` / `0x08`
+> on the Beacon Actions characteristic are an **additional**, seeker-driven path into and
+> out of the mode, not the only one. An earlier revision of this block claimed the
+> opposite; that claim is withdrawn.
+>
+> What survives unchanged is the operational point: the 8-24 hours gate the autonomous
+> chime, not the flag bit, so the `uwt_mode` binary sensor must not be used as a
+> separation timer ([BSkando#210](https://github.com/BSkando/GoogleFindMy-HA/issues/210)).
 
 **We must use FMDN Beacon Actions (authenticated ring)** because:
 1. We have the EIK → can derive the ring key
@@ -749,7 +762,7 @@ The ring key is currently only used during device registration
 | **Beacon Actions** | FMDN GATT characteristic (`FE2C1238`) for owner-authenticated commands (ring, UTP); ring authentication can be waived for the duration of UTP mode by control flag `0x01` at activation |
 | **DULT** | Detecting Unwanted Location Trackers — IETF specification for anti-stalking |
 | **ANOS** | Accessory Non-Owner Service — DULT GATT service (`15190001-12F4`) for unauthenticated commands |
-| **Separated State** | DULT platform state, entered after roughly 30 minutes without an owner device; the unauthenticated DULT sound is enabled only after a further 8-24 hours (both figures from DULT drafts and field reports, not from the FMDN specification; see `docs/TRIGGER_MECHANISMS.md` sections 4.1 and 8). **Not** the same as the FMDN unwanted tracking protection mode, which is command-driven (Data ID `0x07` / `0x08`) and is what the `uwt_mode` binary sensor reports |
+| **Separated State** | DULT accessory state, entered after roughly 30 minutes without an owner device and left on reunion (DULT sections 3.4.4 / 3.4.5); the unauthenticated DULT sound is enabled only after a further 8-24 hours (`T_(SEPARATED_UT_TIMEOUT)`, section 3.12.2.1 and table 16). Both figures are normative DULT. The Find Hub specification **maps** its unwanted tracking protection mode onto this state, so the `uwt_mode` binary sensor reports it; Data ID `0x07` / `0x08` are an additional GATT path in and out, not the only one. The 8-24 hours gate the motion-triggered chime, not the flag bit |
 | **GATT** | Generic Attribute Profile — BLE protocol for read/write operations |
 | **CCCD** | Client Characteristic Configuration Descriptor — enables BLE notifications/indications |
 | **ADM** | Android Device Management — Google auth token type |

--- a/docs/TRIGGER_MECHANISMS.md
+++ b/docs/TRIGGER_MECHANISMS.md
@@ -71,18 +71,28 @@ The ecosystem for Android—comprising devices like the Chipolo One Point, Chipo
 Unlike the proprietary obscurity of Apple's initial launch, the DULT specification¹ clearly defines the device states. FMDN trackers maintain a state variable that dictates their advertising payload.
 
 * **Near-Owner State:** In this state, the tracker assumes it is safe. It advertises a rotating MAC address and an Ephemeral ID (EID) that changes frequently—typically every 15 minutes or 1024 seconds. This rapid rotation is a privacy feature to prevent third-party scanning infrastructure (like retail beacons) from tracking the owner.¹⁶  
-* **Separated State:** The transition to the Separated state occurs when the tracker fails to connect to the bonded owner device for a relatively short duration, often defined as **30 minutes** in the DULT drafts.¹⁶ However, entering the Separated *state* does not immediately trigger the alarm; it merely starts the countdown for the "Unwanted Tracking" mode.
+* **Separated State:** The transition to the Separated state occurs when the tracker fails to connect to the bonded owner device for a relatively short duration, defined as **30 minutes** in the DULT drafts.¹⁶ That figure is normative, not a field report: `draft-detecting-unwanted-location-trackers-01` section 3.4.4 with table 2 makes the transition a `SHALL`, and section 3.4.5 the way back. However, entering the Separated *state* does not immediately trigger the alarm; it merely starts the countdown for the "Unwanted Tracking" mode.
 
 ### **4.2 Unwanted Tracking (UT) Mode**
 
-> **Not the same thing as the `uwt_mode` binary sensor.** This section describes the
-> DULT *platform* behaviour, which is reached by elapsed time. The FMDN *unwanted
-> tracking protection mode*, which bit 7 of the hashed-flags byte reports and which the
-> `uwt_mode` entity exposes, is entered and left by command (Data ID `0x07` / `0x08`)
-> per the Find Hub Network Accessory Specification
-> (<https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>,
-> retrieved 2026-08-04). Do not read this section as documentation of that sensor, and
-> do not build separation timers on it ([BSkando#210](https://github.com/BSkando/GoogleFindMy-HA/issues/210)). See
+> **What the `uwt_mode` binary sensor does and does not report, corrected 2026-09-03.**
+> The FMDN *unwanted tracking protection mode* that bit 7 of the hashed-flags byte
+> carries **is** the DULT separated state of section 4.1 -- not a separate command-only
+> concept, and not the post-timeout phase this section 4.2 calls "UT Mode". Mind that
+> difference: the bit follows the state, which begins after 30 minutes of separation,
+> whereas everything below begins `T_(SEPARATED_UT_TIMEOUT)` later. The specification
+> wording is: `"Unwanted tracking protection mode" defined in this document maps to the
+> "separated state" defined by the DULT spec` (Find Hub Network Accessory Specification,
+> section "Unwanted tracking prevention",
+> <https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn>, retrieved 2026-09-03), and
+> certified devices must also meet the DULT requirements. Data ID `0x07` / `0x08` are an
+> additional, seeker-driven GATT path into and out of the mode. An earlier revision of
+> this block claimed the two were unrelated; that claim is withdrawn.
+>
+> What still does **not** follow is a separation timer. The 8-24 hours below are
+> `T_(SEPARATED_UT_TIMEOUT)` and gate the *motion detector*, not the flag bit, and the
+> advertisement does not say whether that timer has expired. Do not build separation
+> timers on this sensor ([BSkando#210](https://github.com/BSkando/GoogleFindMy-HA/issues/210)). See
 > `custom_components/googlefindmy/binary_sensor.py::GoogleFindMyUWTModeSensor`.
 
 The UT Mode is the critical operational phase for anti-stalking alerts. When a device has been in the Separated state for an extended period, it alters its behavior to become more visible to detection networks.
@@ -94,7 +104,7 @@ The UT Mode is the critical operational phase for anti-stalking alerts. When a d
 
 The DULT specification mandates that trackers support an audible alert to locate the device. For autonomous triggering (i.e., the tracker beeping without a phone command), the FMDN implementation mirrors the Apple logic to ensure cross-compatibility and safety.
 
-* **Time Window:** The standard window for enabling the autonomous motion-gated sound is **8 to 24 hours** of separation.¹⁵  
+* **Time Window:** The standard window for enabling the autonomous motion-gated sound is **8 to 24 hours** of separation.¹⁵ For FMDN this figure is normative rather than a field report: it is DULT `T_(SEPARATED_UT_TIMEOUT)`, a "random value between 8-24 hours chosen from a uniform distribution" (section 3.12.2.1 with table 16).  
 * **Motion Trigger:** Similar to AirTags, FMDN trackers utilize accelerometer interrupts to wake the device and play a sound. The specific hardware implementation varies by manufacturer, but the logic remains consistent: If (State == UT_MODE && Time > Alert_Window && Motion == Detected) -> Play_Sound().
 
 ## **5. Hardware Anatomy and Sensor Specifics**

--- a/docs/TRIGGER_MECHANISMS.md
+++ b/docs/TRIGGER_MECHANISMS.md
@@ -71,21 +71,22 @@ The ecosystem for Android—comprising devices like the Chipolo One Point, Chipo
 Unlike the proprietary obscurity of Apple's initial launch, the DULT specification¹ clearly defines the device states. FMDN trackers maintain a state variable that dictates their advertising payload.
 
 * **Near-Owner State:** In this state, the tracker assumes it is safe. It advertises a rotating MAC address and an Ephemeral ID (EID) that changes frequently—typically every 15 minutes or 1024 seconds. This rapid rotation is a privacy feature to prevent third-party scanning infrastructure (like retail beacons) from tracking the owner.¹⁶  
-* **Separated State:** The transition to the Separated state occurs when the tracker fails to connect to the bonded owner device for a relatively short duration, defined as **30 minutes** in the DULT drafts.¹⁶ That figure is normative, not a field report: `draft-detecting-unwanted-location-trackers-01` section 3.4.4 with table 2 makes the transition a `SHALL`, and section 3.4.5 the way back. However, entering the Separated *state* does not immediately trigger the alarm; it merely starts the countdown for the "Unwanted Tracking" mode.
+* **Separated State:** The transition to the Separated state occurs when the tracker fails to connect to the bonded owner device for a relatively short duration, defined as **30 minutes** in the DULT drafts.¹⁶ That figure is normative, not a field report: `draft-detecting-unwanted-location-trackers-01` section 3.4.4 with table 2 makes the transition a `SHALL`, and section 3.4.5 the way back. However, entering the Separated *state* does not immediately trigger the alarm; it merely starts the countdown to **motion-detector activation** (`T_(SEPARATED_UT_TIMEOUT)`, section 4.2). The state and that later event are two things, and this document formerly called the later one "Unwanted Tracking mode", which is the FMDN term for the state itself.
 
-### **4.2 Unwanted Tracking (UT) Mode**
+### **4.2 Motion-Detector Activation in the Separated State**
 
 > **What the `uwt_mode` binary sensor does and does not report, corrected 2026-09-03.**
 > The FMDN *unwanted tracking protection mode* that bit 7 of the hashed-flags byte
 > carries **is** the DULT separated state of section 4.1 -- not a separate command-only
-> concept, and not the post-timeout phase this section 4.2 calls "UT Mode". Mind that
+> concept, and not the motion-detector activation this section describes. Mind that
 > difference: the bit follows the state, which begins after 30 minutes of separation,
 > whereas the *autonomous motion-triggered sound* of section 4.3 begins
 > `T_(SEPARATED_UT_TIMEOUT)` later. Not everything in this section sits on that later
 > clock. The static-MAC bullet below does not: the Find Hub specification ties the
-> reduced rotation to the mode being active, hence to the separated state, and this
-> section's "UT Mode" wording conflates the state with the post-timeout phase. The
-> specification
+> reduced rotation to the mode being active, hence to the separated state. Sections
+> 4.1 to 4.3 formerly used "UT Mode" for the post-timeout event, which is the FMDN
+> term for the state itself; they now name the later event motion-detector
+> activation, so the two timelines no longer collide. The specification
 > wording is: `"Unwanted tracking protection mode" defined in this document maps to the
 > "separated state" defined by the DULT spec` (Find Hub Network Accessory Specification,
 > section "Unwanted tracking prevention",
@@ -100,9 +101,9 @@ Unlike the proprietary obscurity of Apple's initial launch, the DULT specificati
 > timers on this sensor ([BSkando#210](https://github.com/BSkando/GoogleFindMy-HA/issues/210)). See
 > `custom_components/googlefindmy/binary_sensor.py::GoogleFindMyUWTModeSensor`.
 
-The UT Mode is the critical operational phase for anti-stalking alerts. When a device has been in the Separated state for an extended period, it alters its behavior to become more visible to detection networks.
+This later event is the critical operational phase for anti-stalking alerts. When a device has been in the Separated state for `T_(SEPARATED_UT_TIMEOUT)`, it enables its motion detector, and it is already advertising in a way that makes it more visible to detection networks.
 
-* **Static MAC Address:** Crucially, upon entering the mode, the tracker ceases the rapid rotation of its MAC address. Per the Find Hub Network Accessory Specification this follows the *mode being active*, that is the separated state of section 4.1, and not the expiry of `T_(SEPARATED_UT_TIMEOUT)`; the "UT Mode" wording of this section conflates the two. The MAC address rotation slows significantly, often persisting for **24 hours**. This allows the "Unknown Tracker Alert" algorithms on Android and iOS devices to recognize the device as a persistent companion rather than a series of transient devices passing by.¹⁷  
+* **Static MAC Address:** Crucially, upon entering the mode, the tracker ceases the rapid rotation of its MAC address. Per the Find Hub Network Accessory Specification this follows the *mode being active*, that is the separated state of section 4.1, and not the expiry of `T_(SEPARATED_UT_TIMEOUT)`. It is therefore the one item in this section that is not gated by the timeout. The MAC address rotation slows significantly, often persisting for **24 hours**. This allows the "Unknown Tracker Alert" algorithms on Android and iOS devices to recognize the device as a persistent companion rather than a series of transient devices passing by.¹⁷  
 * **The UT Flag:** The Bluetooth Low Energy advertising payload includes a specific bit—DULT_ACCESSORY_CAPABILITY_MOTION_DETECTOR_UT_BIT_POS—that signals to scanning devices that this tracker is in a separated/lost state and supports motion-detected sound.¹⁸
 
 ### **4.3 Autonomous Sound Logic in DULT Devices**

--- a/docs/TRIGGER_MECHANISMS.md
+++ b/docs/TRIGGER_MECHANISMS.md
@@ -80,7 +80,12 @@ Unlike the proprietary obscurity of Apple's initial launch, the DULT specificati
 > carries **is** the DULT separated state of section 4.1 -- not a separate command-only
 > concept, and not the post-timeout phase this section 4.2 calls "UT Mode". Mind that
 > difference: the bit follows the state, which begins after 30 minutes of separation,
-> whereas everything below begins `T_(SEPARATED_UT_TIMEOUT)` later. The specification
+> whereas the *autonomous motion-triggered sound* of section 4.3 begins
+> `T_(SEPARATED_UT_TIMEOUT)` later. Not everything in this section sits on that later
+> clock. The static-MAC bullet below does not: the Find Hub specification ties the
+> reduced rotation to the mode being active, hence to the separated state, and this
+> section's "UT Mode" wording conflates the state with the post-timeout phase. The
+> specification
 > wording is: `"Unwanted tracking protection mode" defined in this document maps to the
 > "separated state" defined by the DULT spec` (Find Hub Network Accessory Specification,
 > section "Unwanted tracking prevention",
@@ -97,7 +102,7 @@ Unlike the proprietary obscurity of Apple's initial launch, the DULT specificati
 
 The UT Mode is the critical operational phase for anti-stalking alerts. When a device has been in the Separated state for an extended period, it alters its behavior to become more visible to detection networks.
 
-* **Static MAC Address:** Crucially, upon entering UT Mode, the tracker ceases the rapid rotation of its MAC address. The MAC address rotation slows significantly, often persisting for **24 hours**. This allows the "Unknown Tracker Alert" algorithms on Android and iOS devices to recognize the device as a persistent companion rather than a series of transient devices passing by.¹⁷  
+* **Static MAC Address:** Crucially, upon entering the mode, the tracker ceases the rapid rotation of its MAC address. Per the Find Hub Network Accessory Specification this follows the *mode being active*, that is the separated state of section 4.1, and not the expiry of `T_(SEPARATED_UT_TIMEOUT)`; the "UT Mode" wording of this section conflates the two. The MAC address rotation slows significantly, often persisting for **24 hours**. This allows the "Unknown Tracker Alert" algorithms on Android and iOS devices to recognize the device as a persistent companion rather than a series of transient devices passing by.¹⁷  
 * **The UT Flag:** The Bluetooth Low Energy advertising payload includes a specific bit—DULT_ACCESSORY_CAPABILITY_MOTION_DETECTOR_UT_BIT_POS—that signals to scanning devices that this tracker is in a separated/lost state and supports motion-detected sound.¹⁸
 
 ### **4.3 Autonomous Sound Logic in DULT Devices**

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1037,11 +1037,24 @@ continues to guard localized device names.
 
 `tests/test_uwt_mode_binary_sensor.py::TestUWTModeSensorDocumentationMatchesSpec`
 introduces a guard family that pins *documentation* rather than behaviour: it
-reads docstrings via `inspect.getdoc` and asserts that a specific, previously
-wrong claim cannot return and that the specification reference stays present.
-It exists because the UWT-mode sensor documented a separation duration the Find
-Hub Network Accessory Specification never defines, which produced misdirected
-automations and bug reports (BSkando#210) without a single failing test.
+reads docstrings via `inspect.getdoc` and asserts that a withdrawn claim cannot
+return, that the corrected statement stays present, and that the specification
+reference stays discoverable. It exists because the UWT-mode sensor documented a
+separation window as its own trigger, which produced misdirected automations and
+bug reports (BSkando#210) without a single failing test.
+
+**Pin the statement, not a token (correction of 2026-09-03).** The first version
+of this family forbade the figure "8-24 hours" as such. That figure turned out to
+be normative DULT (`T_(SEPARATED_UT_TIMEOUT)`), only attached to the wrong thing,
+so the guard was pinning the *replacement* error in place: the docstring had gone
+on to deny that the FMDN mode is the DULT separated state, which the Find Hub
+specification asserts in so many words. A forbidden-token guard cannot tell a
+wrong number from a misattributed one. The family now forbids the withdrawn
+*statements* (normalised for case and line wrapping, each with its subject in the
+pattern so a true sentence using the same words still passes) and requires the
+corrected attribution in the same paragraph as the figure. Read that as the rule
+for new members: name what must not be said and what must be said instead, and
+never make a guard out of a term that a correct sentence would also need.
 
 Use this pattern in one of exactly two situations, and keep four properties:
 

--- a/tests/test_uwt_mode_binary_sensor.py
+++ b/tests/test_uwt_mode_binary_sensor.py
@@ -369,19 +369,29 @@ class TestUWTModeSensorDocumentationMatchesSpec:
         re.IGNORECASE,
     )
 
-    #: Claims withdrawn on 2026-09-03 against the specification wording, in
-    #: normalised form (lowercase, whitespace collapsed) so that recasing or
-    #: rewrapping the old paragraph does not walk past the guard.
+    #: Claims withdrawn on 2026-09-03 against the specification wording, as
+    #: patterns rather than spellings (property 1 in ``tests/AGENTS.md``). They
+    #: run against the docstring normalised to lowercase with whitespace
+    #: collapsed, so recasing or rewrapping the old paragraph does not walk
+    #: past them, and they cover the two claims in both their directions: that
+    #: the mode is command-only, and that the sensor follows a separation
+    #: window.
     #:
-    #: Each entry carries its subject on purpose. The bare phrase "is not what
-    #: this bit reports" is a *true* statement about the motion detector, which
-    #: the corrected docstring needs; only the claim about the chime was
-    #: withdrawn, so the chime is named in the pattern.
-    WITHDRAWN_CLAIMS = (
-        "not by elapsed time",
-        "no such window exists in the specification",
-        "mode is entered and left by command",
-        "chime is a dult platform behaviour and is not what this bit reports",
+    #: Subjects are carried on purpose. The bare phrase "is not what this bit
+    #: reports" is a *true* statement about the motion detector, which the
+    #: corrected docstring needs, so only the withdrawn claim about the chime is
+    #: matched. Per property 2 the guarded docstrings do not restate either
+    #: withdrawn claim, which is what lets these patterns stay broad without an
+    #: exception for the paragraph that mentions the history.
+    WITHDRAWN_CLAIM_PATTERNS = (
+        r"not by elapsed time",
+        r"command[-\s]driven",
+        r"(?:mode|it)\s+is\s+(?:entered and left|only entered)\s+by\s+command",
+        r"only\s+by\s+command",
+        r"no\s+such\s+window\s+exists",
+        r"(?:sensor|bit|entity|it)\s+turns\s+on\s+after",
+        r"chime\s+is\s+a\s+dult\s+platform\s+behaviour",
+        r"is\s+not\s+the\s+(?:dult\s+)?separated\s+state",
     )
 
     @staticmethod
@@ -392,7 +402,16 @@ class TestUWTModeSensorDocumentationMatchesSpec:
     def test_docstring_does_not_reassert_the_withdrawn_command_only_claim(
         self,
     ) -> None:
-        """The mode is not command-only, and the docstrings must not say it is."""
+        """The mode is not command-only, and the docstrings must not say it is.
+
+        Case (a) in ``tests/AGENTS.md``, corrective: the withdrawn claim shipped
+        and produced misdirected automations (BSkando#210).
+
+        Retirement condition: the DULT mapping has survived a release cycle
+        unchanged, or BSkando#210 has closed. Either makes this a historical
+        note rather than a live correction, and the positive guard below is
+        then the only one still earning its place.
+        """
         docs = {
             "class": inspect.getdoc(GoogleFindMyUWTModeSensor) or "",
             "is_on": inspect.getdoc(GoogleFindMyUWTModeSensor.is_on.fget) or "",
@@ -401,11 +420,14 @@ class TestUWTModeSensorDocumentationMatchesSpec:
 
         for name, doc in docs.items():
             normalised = self._normalise(doc)
-            for claim in self.WITHDRAWN_CLAIMS:
-                assert claim not in normalised, (
-                    f"{name} docstring reasserts a withdrawn claim: {claim!r}. "
-                    "The FMDN mode maps onto the DULT separated state, which a "
-                    "device enters autonomously after 30 minutes of separation."
+            for pattern in self.WITHDRAWN_CLAIM_PATTERNS:
+                match = re.search(pattern, normalised)
+                assert match is None, (
+                    f"{name} docstring reasserts a withdrawn claim "
+                    f"({pattern!r} matched {match.group(0)!r}). The FMDN mode "
+                    "maps onto the DULT separated state, which a device enters "
+                    "autonomously after 30 minutes of separation, and the 8-24 "
+                    "hour figure gates the motion detector rather than this bit."
                 )
 
     def test_docstring_names_the_dult_mapping_and_its_timer(self) -> None:
@@ -414,6 +436,11 @@ class TestUWTModeSensorDocumentationMatchesSpec:
         Deleting the withdrawn claim without putting the mapping in its place
         would satisfy the negative guard above and still leave the reader with
         no way to find out how the mode is actually entered.
+
+        Retirement condition: this one outlives the negative guard. It becomes
+        obsolete only when the mapping stops being load-bearing for readers of
+        this sensor, that is when the entity itself is removed or the mapping is
+        stated somewhere a docstring edit cannot silently drop.
         """
         class_doc = inspect.getdoc(GoogleFindMyUWTModeSensor) or ""
 
@@ -440,6 +467,10 @@ class TestUWTModeSensorDocumentationMatchesSpec:
         whole text would pass on a docstring that states the figure in one place
         and mentions the motion detector in an unrelated one, which is the shape
         the original error had.
+
+        Retirement condition: the figure disappears from these docstrings
+        altogether, at which point the guard is inert by construction, or
+        BSkando#210 closes with the attribution unchallenged across a release.
         """
         docs = {
             "class": inspect.getdoc(GoogleFindMyUWTModeSensor) or "",

--- a/tests/test_uwt_mode_binary_sensor.py
+++ b/tests/test_uwt_mode_binary_sensor.py
@@ -388,11 +388,20 @@ class TestUWTModeSensorDocumentationMatchesSpec:
     the right keywords. Widen them when a regression slips past, not before.
     """
 
-    #: Matches the separation figure in its common spellings, including
-    #: hyphen/en-dash/em-dash variants, "8 to 24" and the spelled-out form. The
-    #: figure itself is no longer forbidden; see the attribution guard below.
+    #: Matches the separation figure in its common spellings: hyphen, en-dash
+    #: and em-dash variants, "8 to 24", "8 and 24", the "between ... and ..."
+    #: frame, and the spelled-out forms of both. The figure itself is no longer
+    #: forbidden; see the attribution guard below.
+    #:
+    #: Widened on 2026-09-03 after a review found that
+    #: "separated for between eight and twenty-four hours" matched neither this
+    #: expression nor any withdrawn-claim pattern, so the original false
+    #: duration could return in an ordinary rephrasing with every guard green.
     SEPARATION_FIGURE_RE = re.compile(
-        r"8\s*[-\u2010-\u2015]\s*24\s*h|8\s+to\s+24\s+h|eight\s+to\s+twenty[- ]four",
+        r"8\s*(?:[-\u2010-\u2015]|to|and)\s*24\s*h"
+        r"|between\s+8\s*(?:[-\u2010-\u2015]|to|and)\s*24"
+        r"|eight\s+(?:to|and)\s+twenty[- ]four"
+        r"|between\s+eight\s+and\s+twenty[- ]four",
         re.IGNORECASE,
     )
 
@@ -422,7 +431,11 @@ class TestUWTModeSensorDocumentationMatchesSpec:
             r"only\s+(?:entered|set|activated)\s+by\s+command",
             r"only\s+by\s+command",
             r"no\s+such\s+window\s+exists",
-            r"turns\s+on\s+after",
+            r"turns\s+on\s+(?:after|once|when)",
+            r"(?:becomes|goes)\s+active\s+(?:after|once|when)",
+            r"(?:switches|flips)\s+(?:to\s+)?on\s+(?:after|once|when)",
+            r"activates\s+(?:after|once|when)",
+            r"(?:set|reported)\s+after\s+(?:a|the)?\s*separation",
             r"chime\s+is\s+a\s+dult\s+platform\s+behaviour",
             r"is\s+not\s+the\s+(?:dult\s+)?separated\s+state",
         )

--- a/tests/test_uwt_mode_binary_sensor.py
+++ b/tests/test_uwt_mode_binary_sensor.py
@@ -339,6 +339,33 @@ class TestUWTModeSensorCoordinatorUpdate:
 # ===========================================================================
 
 
+#: Subjects the withdrawn claims were made about. A claim pattern only fires
+#: when one of these stands in the same clause, so that a true sentence about a
+#: different mechanism -- the "Skip ringing authentication" control flag, say --
+#: does not trip a guard written for the mode semantics.
+_UWT_SUBJECT = (
+    r"(?:uwt|unwanted tracking protection mode|\bmode\b|this bit|the bit"
+    r"|this sensor|the sensor|separated state|separation window)"
+)
+
+#: Gap between subject and claim. Bounded, and it may not cross a sentence or
+#: clause boundary, so an unrelated neighbouring sentence cannot supply the
+#: subject for a claim it has nothing to do with.
+_CLAUSE_GAP = r"[^.;:]{0,60}"
+
+
+def _scoped_to_uwt_subject(claim: str) -> tuple[str, str]:
+    """Return *claim* anchored to a UWT subject, in both clause orders.
+
+    Both orders are needed because English puts the subject on either side:
+    "the mode is command-driven" and "a command-driven mode".
+    """
+    return (
+        rf"{_UWT_SUBJECT}{_CLAUSE_GAP}{claim}",
+        rf"{claim}{_CLAUSE_GAP}{_UWT_SUBJECT}",
+    )
+
+
 class TestUWTModeSensorDocumentationMatchesSpec:
     """Guard the docstrings against the semantics drift around BSkando#210.
 
@@ -370,28 +397,36 @@ class TestUWTModeSensorDocumentationMatchesSpec:
     )
 
     #: Claims withdrawn on 2026-09-03 against the specification wording, as
-    #: patterns rather than spellings (property 1 in ``tests/AGENTS.md``). They
-    #: run against the docstring normalised to lowercase with whitespace
-    #: collapsed, so recasing or rewrapping the old paragraph does not walk
-    #: past them, and they cover the two claims in both their directions: that
-    #: the mode is command-only, and that the sensor follows a separation
-    #: window.
+    #: patterns rather than spellings (property 1 in ``tests/AGENTS.md``), each
+    #: scoped to a UWT subject by :func:`_scoped_to_uwt_subject`. They run
+    #: against the docstring normalised to lowercase with whitespace collapsed,
+    #: so recasing or rewrapping the old paragraph does not walk past them, and
+    #: they cover both withdrawn claims in both directions: that the mode is
+    #: command-only, and that the sensor follows a separation window.
     #:
-    #: Subjects are carried on purpose. The bare phrase "is not what this bit
-    #: reports" is a *true* statement about the motion detector, which the
-    #: corrected docstring needs, so only the withdrawn claim about the chime is
-    #: matched. Per property 2 the guarded docstrings do not restate either
-    #: withdrawn claim, which is what lets these patterns stay broad without an
-    #: exception for the paragraph that mentions the history.
-    WITHDRAWN_CLAIM_PATTERNS = (
-        r"not by elapsed time",
-        r"command[-\s]driven",
-        r"(?:mode|it)\s+is\s+(?:entered and left|only entered)\s+by\s+command",
-        r"only\s+by\s+command",
-        r"no\s+such\s+window\s+exists",
-        r"(?:sensor|bit|entity|it)\s+turns\s+on\s+after",
-        r"chime\s+is\s+a\s+dult\s+platform\s+behaviour",
-        r"is\s+not\s+the\s+(?:dult\s+)?separated\s+state",
+    #: Subjects are load-bearing twice over. "is not what this bit reports" is a
+    #: *true* statement about the motion detector, so only the withdrawn claim
+    #: about the chime is matched; and "only by command" or "no such window
+    #: exists" can be true of a different mechanism, which is why none of these
+    #: fires without a UWT subject in the same clause.
+    #:
+    #: Per property 2 the guarded docstrings do not restate either withdrawn
+    #: claim, which is what lets these patterns stay broad without an exception
+    #: for the paragraph that mentions the history.
+    WITHDRAWN_CLAIM_PATTERNS = tuple(
+        pattern
+        for claim in (
+            r"not by elapsed time",
+            r"command[-\s]driven",
+            r"is\s+entered\s+and\s+left\s+by\s+command",
+            r"only\s+(?:entered|set|activated)\s+by\s+command",
+            r"only\s+by\s+command",
+            r"no\s+such\s+window\s+exists",
+            r"turns\s+on\s+after",
+            r"chime\s+is\s+a\s+dult\s+platform\s+behaviour",
+            r"is\s+not\s+the\s+(?:dult\s+)?separated\s+state",
+        )
+        for pattern in _scoped_to_uwt_subject(claim)
     )
 
     @staticmethod

--- a/tests/test_uwt_mode_binary_sensor.py
+++ b/tests/test_uwt_mode_binary_sensor.py
@@ -340,42 +340,128 @@ class TestUWTModeSensorCoordinatorUpdate:
 
 
 class TestUWTModeSensorDocumentationMatchesSpec:
-    """Guard the docstrings against the semantics drift fixed for BSkando#210.
+    """Guard the docstrings against the semantics drift around BSkando#210.
 
-    The class docstring once claimed a fixed separation window that the Find Hub
-    Network Accessory Specification does not define, which produced misdirected
-    automations and bug reports.
+    Two errors, in sequence, are what these guards exist for. The docstring
+    first claimed the sensor turns on after a fixed 8-24 hour separation window.
+    The correction then overshot and denied the window exists at all, and denied
+    that the FMDN mode is the DULT separated state. Both denials are refuted by
+    the specifications in their own words: the Find Hub Network Accessory
+    Specification maps its unwanted tracking protection mode onto the DULT
+    separated state, and ``T_(SEPARATED_UT_TIMEOUT)`` is a normative DULT value.
+
+    A figure guard alone pinned the second error in place: it forbade the number
+    as such, and the number is correct. So the guard moved from the *number* to
+    the *statement*. Forbidden are the withdrawn claims; required is the DULT
+    mapping, and the figure is allowed exactly when it is attributed to the
+    motion detector rather than to this bit.
 
     Scope and blind spot, stated plainly: these are pattern and presence checks,
-    not prose review. They pin that the debunked figure stays out (in any of its
-    common spellings) and that the specification reference stays discoverable.
-    They cannot tell a well-written docstring from a bag of the right keywords.
-    Widen them when a regression slips past, not before.
+    not prose review. They cannot tell a well-written docstring from a bag of
+    the right keywords. Widen them when a regression slips past, not before.
     """
 
-    #: Matches the debunked separation figure in its common spellings, including
-    #: hyphen/en-dash/em-dash variants, "8 to 24" and the spelled-out form.
+    #: Matches the separation figure in its common spellings, including
+    #: hyphen/en-dash/em-dash variants, "8 to 24" and the spelled-out form. The
+    #: figure itself is no longer forbidden; see the attribution guard below.
     SEPARATION_FIGURE_RE = re.compile(
         r"8\s*[-\u2010-\u2015]\s*24\s*h|8\s+to\s+24\s+h|eight\s+to\s+twenty[- ]four",
         re.IGNORECASE,
     )
 
-    def test_docstring_does_not_claim_a_separation_duration(self) -> None:
-        """The debunked separation figure must not reappear in the docstrings."""
-        class_doc = inspect.getdoc(GoogleFindMyUWTModeSensor) or ""
-        is_on_doc = inspect.getdoc(GoogleFindMyUWTModeSensor.is_on.fget) or ""
-        icon_doc = inspect.getdoc(GoogleFindMyUWTModeSensor.icon.fget) or ""
+    #: Claims withdrawn on 2026-09-03 against the specification wording, in
+    #: normalised form (lowercase, whitespace collapsed) so that recasing or
+    #: rewrapping the old paragraph does not walk past the guard.
+    #:
+    #: Each entry carries its subject on purpose. The bare phrase "is not what
+    #: this bit reports" is a *true* statement about the motion detector, which
+    #: the corrected docstring needs; only the claim about the chime was
+    #: withdrawn, so the chime is named in the pattern.
+    WITHDRAWN_CLAIMS = (
+        "not by elapsed time",
+        "no such window exists in the specification",
+        "mode is entered and left by command",
+        "chime is a dult platform behaviour and is not what this bit reports",
+    )
 
-        for name, doc in (
-            ("class", class_doc),
-            ("is_on", is_on_doc),
-            ("icon", icon_doc),
+    @staticmethod
+    def _normalise(doc: str) -> str:
+        """Return *doc* lowercased with all whitespace runs collapsed."""
+        return " ".join(doc.split()).lower()
+
+    def test_docstring_does_not_reassert_the_withdrawn_command_only_claim(
+        self,
+    ) -> None:
+        """The mode is not command-only, and the docstrings must not say it is."""
+        docs = {
+            "class": inspect.getdoc(GoogleFindMyUWTModeSensor) or "",
+            "is_on": inspect.getdoc(GoogleFindMyUWTModeSensor.is_on.fget) or "",
+            "icon": inspect.getdoc(GoogleFindMyUWTModeSensor.icon.fget) or "",
+        }
+
+        for name, doc in docs.items():
+            normalised = self._normalise(doc)
+            for claim in self.WITHDRAWN_CLAIMS:
+                assert claim not in normalised, (
+                    f"{name} docstring reasserts a withdrawn claim: {claim!r}. "
+                    "The FMDN mode maps onto the DULT separated state, which a "
+                    "device enters autonomously after 30 minutes of separation."
+                )
+
+    def test_docstring_names_the_dult_mapping_and_its_timer(self) -> None:
+        """The corrected semantics must stay stated, not merely un-denied.
+
+        Deleting the withdrawn claim without putting the mapping in its place
+        would satisfy the negative guard above and still leave the reader with
+        no way to find out how the mode is actually entered.
+        """
+        class_doc = inspect.getdoc(GoogleFindMyUWTModeSensor) or ""
+
+        for token in (
+            "DULT",
+            "separated state",
+            "30 minutes",
+            "3.4.4",
+            "T_(SEPARATED_UT_TIMEOUT)",
         ):
-            match = self.SEPARATION_FIGURE_RE.search(doc)
-            assert match is None, (
-                f"{name} docstring reintroduces the debunked separation figure: "
-                f"{match.group(0)!r}"
+            assert token in class_doc, (
+                f"class docstring no longer names {token!r}; the DULT mapping "
+                "that replaced the command-only claim is not discoverable."
             )
+
+    def test_separation_figure_is_attributed_to_the_motion_detector(self) -> None:
+        """If the 8-24 hour figure appears, it must gate the chime, not the bit.
+
+        The figure is normative DULT and may be named. What must not return is
+        the original error of tying it to this sensor turning on, so naming it
+        obliges the docstring to name what it actually gates.
+
+        The check is per PARAGRAPH, not per docstring. A presence check over the
+        whole text would pass on a docstring that states the figure in one place
+        and mentions the motion detector in an unrelated one, which is the shape
+        the original error had.
+        """
+        docs = {
+            "class": inspect.getdoc(GoogleFindMyUWTModeSensor) or "",
+            "is_on": inspect.getdoc(GoogleFindMyUWTModeSensor.is_on.fget) or "",
+            "icon": inspect.getdoc(GoogleFindMyUWTModeSensor.icon.fget) or "",
+        }
+
+        for name, doc in docs.items():
+            for paragraph in re.split(r"\n\s*\n", doc):
+                if self.SEPARATION_FIGURE_RE.search(paragraph) is None:
+                    continue
+                normalised = self._normalise(paragraph)
+                assert "motion detector" in normalised, (
+                    f"{name} docstring names the 8-24 hour figure in a paragraph "
+                    "that does not name the motion detector it gates; that is "
+                    "the original BSkando#210 error."
+                )
+                assert "t_(separated_ut_timeout)" in normalised, (
+                    f"{name} docstring names the 8-24 hour figure without its "
+                    "DULT identifier alongside it, so a reader cannot check the "
+                    "attribution."
+                )
 
     def test_docstring_names_spec_term_and_source(self) -> None:
         """The docstrings must name the specification term, source and mechanism."""
@@ -388,8 +474,9 @@ class TestUWTModeSensorDocumentationMatchesSpec:
             in class_doc
         )
         assert "unwanted tracking protection mode" in is_on_doc
-        # The mode is command-driven; both Data IDs must stay named, otherwise the
-        # "not by elapsed time" statement loses its evidence.
+        # Both Data IDs must stay named: they are the additional, seeker-driven
+        # GATT path into and out of the mode, and the "Skip ringing
+        # authentication" caveat below hangs off 0x07.
         assert "0x07" in class_doc
         assert "0x08" in class_doc
 


### PR DESCRIPTION
## What this fixes

The UWT-mode documentation in this repository asserted three things that the specifications contradict in their own words:

1. that the FMDN *unwanted tracking protection mode* is entered and left **by command only** (Data ID `0x07` / `0x08`),
2. that it is **not** the DULT `separated state`,
3. that **no** 8-24 hour window exists in the specification.

All three are withdrawn here. PR #1232 replaced one wrong statement with another: the original docstring claimed the sensor turns on after a fixed separation window, and the correction overshot into denying the window exists at all.

## Evidence, verbatim

**Find Hub Network Accessory Specification**, section "Unwanted tracking prevention" ([source](https://developers.google.com/nearby/fast-pair/specifications/extensions/fmdn), retrieved 2026-09-03):

> `"Unwanted tracking protection mode" defined in this document maps to the "separated state" defined by the DULT spec.`

and, normatively:

> `Certified FHN devices must also meet the requirements in the implementation version of the cross-platform specification for Detecting Unwanted Location Trackers (DULT).`

**DULT** (`draft-detecting-unwanted-location-trackers-01`):

| Section | Wording | What it governs |
|---|---|---|
| 3.4.4 + table 2 | `The accessory SHALL transition from near-owner mode to separated mode` when `physically separated from the owner device for more than 30 minutes` | Entering the state, autonomously |
| 3.4.5 | `SHALL transition from separated to near-owner mode if it has reunited with the owner device` | Leaving the state |
| 3.12.2.1 + table 16 | `T_(SEPARATED_UT_TIMEOUT)` = `random value between 8-24 hours chosen from a uniform distribution`; afterwards the accessory `MUST enable the motion detector` | The motion-gated chime, **not** the flag bit |

So the 8-24 hour figure was never fictional, only misattributed, and `0x07` / `0x08` are an **additional** owner-authenticated GATT path into and out of the mode rather than the only one.

## What survives from the earlier correction

The operational point, unchanged: **the sensor is not a separation timer.** The advertisement carries the state, not whether `T_(SEPARATED_UT_TIMEOUT)` has expired, so nothing in the payload tells an automation whether the motion detector is armed.

Also unchanged for BSkando#210 specifically: because entry requires **more than 30 minutes** of separation, the reported episodes of 38 and 57 seconds remain incompatible with DULT section 3.4.4. This correction therefore strengthens the decode hypothesis behind PR #1234 rather than weakening it.

## Changes

| File | Change |
|---|---|
| `custom_components/googlefindmy/binary_sensor.py` | `GoogleFindMyUWTModeSensor` class docstring rewritten around the DULT mapping. Retains the MSB-first bit numbering caveat, the `0x01` mask / `0x80` anti-pattern, the "Skip ringing authentication" control-flag mechanism, the BSkando#195 reference and the no-GATT-write statement. Separates the two distinct 24-hour figures and marks the single inference in the text as an inference. |
| `docs/PLAY_SOUND_ARCHITECTURE.md` | ANOS availability row, the provenance block under "Why DULT Is NOT Suitable For Us", and the `Separated State` glossary entry. Both figures are normative DULT, not field reports. |
| `docs/TRIGGER_MECHANISMS.md` | Section 4.2 warning block rewritten; it now points at the separated state of **section 4.1** rather than at this section's post-timeout "UT Mode" phase, which are not the same thing. DULT identifiers attached to the figures in sections 4.1 and 4.3. |
| `tests/test_uwt_mode_binary_sensor.py` | Guard family moved from the *number* to the *statement*. |
| `tests/AGENTS.md` | Description of the guard family corrected, plus the rule the episode produced. |

## Why the test guard had to change

`test_docstring_does_not_claim_a_separation_duration` forbade the string `8-24 h` in any spelling. The figure is correct, so that guard was **pinning the replacement error in place**: a forbidden-token guard cannot tell a wrong number from a misattributed one.

The family now:

* forbids the withdrawn **statements**, normalised for case and line wrapping so recasing or rewrapping the old paragraph does not walk past the guard, and each pattern carries its subject so that a *true* sentence reusing the same words still passes (`is not what this bit reports` is true of the motion detector; only the claim about the chime was withdrawn);
* requires the DULT mapping to be **stated**, not merely un-denied, so that deleting the withdrawn claim without replacing it fails;
* requires the figure, when named, to be attributed to the motion detector **in the same paragraph** — a whole-docstring presence check would pass on exactly the shape the original error had.

The guards remain presence and pattern checks and are trivially satisfiable by a bag of the right keywords. That limit is stated in the test class docstring rather than papered over.

## Verification

* `tests/test_uwt_mode_binary_sensor.py` (28), `tests/test_ble_battery_sensor.py`, `tests/test_stop_sound_correlation.py`: pass.
* **Red run:** with the previous `binary_sensor.py` restored, `test_docstring_does_not_reassert_the_withdrawn_command_only_claim` and `test_docstring_names_the_dult_mapping_and_its_timer` both fail. The attribution guard does not fire there, correctly, because the old revision does not name the figure.
* `ruff check` and `ruff format --check` clean on both changed Python files.
* Repository-wide grep for the withdrawn phrasings over `custom_components/`, `docs/`, `tests/` and `README.md` returns only the test's own forbidden-pattern list.
* `README.md` needs no change: it does not mention the mode.

No runtime behaviour change.

Refs BSkando#210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
