### PR TITLE
docs: name both new IRR-CA anchors in the SoundDispatchOutcome docstring

### DIFF
--- a/custom_components/googlefindmy/const.py
+++ b/custom_components/googlefindmy/const.py
@@ -56,6 +56,17 @@ class SoundDispatchOutcome(StrEnum):
 
     Only ``TRANSPORT_FAILED`` justifies a push cooldown. Only ``ACCEPTED`` proves
     that the credentials worked.
+
+    See IRR-CA-SOUND-FAILURE-CLASS in ``docs/PLAY_SOUND_ARCHITECTURE.md`` for the
+    per-member "may a caller arm a push cooldown" table this type carries, and
+    IRR-CA-STOP-BREAKS-SELF-INFLICTED-COOLDOWN for the qualifier on the stop
+    path. There the readiness gate lets a stop through a running window when the
+    stop carries our own fresh cancel key, so a window armed by a play cannot
+    lock out a stop this integration can correlate; and when such a stop then
+    fails on the transport, the cooldown is reported through
+    ``_note_stop_transport_problem_without_extending()``, which puts a window
+    that was already running back instead of restarting it, so a stop cannot
+    feed the window it just broke through.
     """
 
     ACCEPTED = "accepted"


### PR DESCRIPTION
## What

Adds one paragraph to the class docstring of `SoundDispatchOutcome` in
`const.py`, pointing at the two anchors this type is the carrier of:

- `IRR-CA-SOUND-FAILURE-CLASS` for the per-member "may a caller arm a push
  cooldown" table;
- `IRR-CA-STOP-BREAKS-SELF-INFLICTED-COOLDOWN` for the stop-path qualifier.

Documentation only. No behaviour change, no signature change, no test change.

## Why

`SoundDispatchOutcome` exists because a bool cannot carry the state space, and
the rule that only `TRANSPORT_FAILED` may arm a push cooldown is the whole
point of the type. That rule and both of its anchors lived in
`docs/PLAY_SOUND_ARCHITECTURE.md` and in comments in `coordinator/locate.py`
and `api.py`, but not in the docstring a caller actually reads when they hover
the type. This repository already treats that shape as a defect class: see
`tests/test_stop_sound_correlation.py::test_api_docstrings_declare_no_ring_confirmation`,
which pins the same discipline for `api.py` ("a boundary that lives only in a
design document gets re-discovered as a bug").

This is the last open item of the DoD of AP-7 in the plan
`PLAN_GFMY_SOUND_FAILURE_CLASSIFICATION`. AP-1 to AP-7 shipped with #1262; only
this docstring reference was missed.

## Measured

- Anchor gate (every `IRR-CA-` anchor cited under `custom_components/` resolves
  in the architecture document): no `MISSING` line, before and after.
- `git diff --name-only origin/1.7` → `custom_components/googlefindmy/const.py`
  only, 11 added lines, nothing removed. `README.md` and `strings.json`
  untouched, as the DoD requires.
- `ruff check` and `ruff format --check`: clean.
- `pytest tests/test_stop_sound_correlation.py tests/test_sound_dispatch_contract.py tests/test_coordinator_sound_uuid.py tests/test_coordinator_locate_basics.py`
  → 123 passed.

## Review note

The first draft of this paragraph was wrong in a way worth recording: it tied
"a play cannot silence the stop its cancel key exists for" to
`_note_stop_transport_problem_without_extending()`. That function does
something else. The break-through happens at the readiness gate
(`coordinator/locate.py`, the `used_own_fresh_key and time.monotonic() <
self._push_cooldown_until` branch); the function only keeps a *running* window
from being restarted by a stop that already broke through, which is the
separate "it cannot feed itself" property. The paragraph now states both, in
the order the code has them, and no longer claims the window was necessarily
armed by the very play that stored the key -- the code says that is the common
case, not a proven one.
