### PR TITLE
fix(coordinator): let the stats writer see the load window

### DIFF
--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -203,6 +203,39 @@ create before the load resumes (`::test_a_live_claim_inside_the_window_still_def
 asserts that a sibling device's ring is NOT dropped) and
 `::test_a_purge_after_the_load_is_carried_by_the_pop_alone`.
 
+That rule is not the purge's private business, and it no longer lives at the call site.
+`_async_save_stats` reads the window itself: while `_stats_loaded` is False it records
+`_save_after_stats_load` and returns without writing. Of its four callers only the
+purge had learned the rule; the load's own `finally` is outside the window by
+construction, but the debounced writer (reached from `increment_stat`, from
+`_refresh_canonicless_drop_stats` and from the reset button) and the flush in
+`async_shutdown` used to reach it with nothing to stop them, and either one
+replaced the stored totals and every ring with pre-load values. A rule that one of its
+callers knows is not a rule. `_stats_loaded` is read with a default of True, so an object
+built without it writes as before - the opposite default would silence every such
+writer instead, which is why the counter-case is pinned too.
+
+Deferral needs somewhere to write later, and the unload is the one caller that has no
+later: `async_unload_entry` closes the entry-scoped cache immediately after
+`async_shutdown` returns, and a write arriving afterwards raises and is swallowed. So
+the unload does not defer, it CLOSES the window: `async_shutdown` waits for the load
+task - kept on `_stats_load_task` for that purpose, waited without cancelling and
+bounded by `_STATS_LOAD_SHUTDOWN_WAIT_S` - and only then flushes, at which point live
+state carries the merged record. If the bound is hit the flush defers as any other
+writer would and the stored record simply stays as it was, which is the safe direction.
+Pinned by `::test_a_write_inside_the_load_window_leaves_the_stored_record_alone` and
+`::test_the_deferred_write_reaches_the_store_after_the_merge`; the counter-cases that
+keep the guard from swallowing the ordinary path are
+`::test_a_write_after_the_load_still_writes` and
+`::test_a_coordinator_without_the_load_marker_writes_as_before`. The unload arm is
+pinned by `::test_an_unload_inside_the_load_window_writes_the_merged_record` (waits,
+then writes the merged record) and `::test_an_unload_whose_load_never_finishes_leaves_the_record_alone`
+(bound expires, defers, leaves the store untouched); that the wait has a handle to read
+at all is pinned by `::test_the_constructor_hands_the_load_task_to_the_unload`, because
+every other test installs the handle by hand and would stay green without it. The
+reset-inside-the-window chain is pinned by
+`::test_a_reset_inside_the_load_window_stays_durable`.
+
 Two properties of the persisted claim identity are load-bearing. The identity of a report with no
 timestamp is a **digest** of its position and radius, never the values themselves: this
 record is durable, and a position in durable state is the one thing this feature is
@@ -211,7 +244,8 @@ device-keyed caches, with a persist scheduled - otherwise a deleted device keeps
 entry indefinitely, and one re-added under the same id has its first matching
 measurement suppressed by a claim from its previous life. That write is immediate rather
 than debounced, but it is a task nobody awaits, so `async_shutdown` also writes the stats
-record on the way out. It does so UNCONDITIONALLY, and that word is the whole point:
+record on the way out. It does so without asking whether a debounced task is pending, and
+that independence is the whole point:
 gating the write on a pending debounced task skipped exactly the case it exists for,
 because the purge writes through a task `_stats_save_task` never holds. A condition that
 cannot see the more important of the two writers is not a condition. Two things ride on
@@ -221,7 +255,10 @@ came back. Pinned by
 `tests/test_cache_accuracy_gate.py::test_shutdown_writes_the_pending_stats_instead_of_dropping_them`,
 which uses a real pending task because a stub that only counts `cancel` calls stays green
 with the flush deleted, and by `::test_shutdown_writes_even_when_no_debounced_task_is_pending`,
-which is the one that discriminates the unconditional form from the gated one.
+which is the one that discriminates the debounce-independent form from the gated one. The
+flush does hold back on a second, unrelated axis - the stats load window - and rather than
+letting that shorten it, `async_shutdown` waits the window out first; see the paragraph on
+`_stats_loaded` above.
 
 A retained coarse fix is read for publication through `get_fresh_coarse_fix`, never
 through `get_coarse_fix`. Nothing removes a retained fix when time merely passes - the

--- a/custom_components/googlefindmy/AGENTS.md
+++ b/custom_components/googlefindmy/AGENTS.md
@@ -223,6 +223,12 @@ task - kept on `_stats_load_task` for that purpose, waited without cancelling an
 bounded by `_STATS_LOAD_SHUTDOWN_WAIT_S` - and only then flushes, at which point live
 state carries the merged record. If the bound is hit the flush defers as any other
 writer would and the stored record simply stays as it was, which is the safe direction.
+The whole probe sits inside a `try`, `done()` included, because an unload must not raise
+and the wait is only an optimisation of WHEN the flush writes
+(`::test_an_unusable_load_handle_does_not_break_the_unload`); the same holds for the
+scheduling of the deferred write in the load's `finally`, which must not abort the
+sound-UUID load that follows it
+(`::test_a_load_that_cannot_schedule_its_deferred_write_still_finishes`).
 Pinned by `::test_a_write_inside_the_load_window_leaves_the_stored_record_alone` and
 `::test_the_deferred_write_reaches_the_store_after_the_merge`; the counter-cases that
 keep the guard from swallowing the ordinary path are

--- a/custom_components/googlefindmy/coordinator/_mixin_typing.py
+++ b/custom_components/googlefindmy/coordinator/_mixin_typing.py
@@ -122,6 +122,15 @@ class _MixinBase:
     stats: dict[str, int]
     performance_metrics: dict[str, float]
     _propagating_location: bool
+    # Stats persistence. The load runs as a task created in the constructor, and the
+    # unload waits for it before flushing, so the handle has to be visible here too.
+    # The three flags around it travel with the same record: the load window, the
+    # deferral it hands to the load's `finally`, and the generation a reset starts.
+    _stats_load_task: asyncio.Task[None] | None
+    _stats_save_task: asyncio.Task[None] | None
+    _stats_loaded: bool
+    _save_after_stats_load: bool
+    _stats_epoch: int
 
     # Service device tracking
     _service_device_ready: bool

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -1237,11 +1237,18 @@ class GoogleFindMyCoordinator(
         # bound is hit the window is still open, the flush defers, and the record stays as
         # it was on disk.
         load_task = getattr(self, "_stats_load_task", None)
-        if load_task is not None and not load_task.done():
+        if load_task is not None:
+            # The whole probe is inside the try, not just the wait: `done()` is the first
+            # thing touched on an attribute read with `getattr`, and a value that is not a
+            # task fails there rather than in `asyncio.wait`. An unload must not raise, and
+            # this wait is an optimisation of WHEN the flush writes - never a reason for
+            # the unload to fail. Falling through leaves the window open, so the flush
+            # below defers and the stored record stays as it was.
             try:
-                await asyncio.wait({load_task}, timeout=_STATS_LOAD_SHUTDOWN_WAIT_S)
-            except Exception:
-                pass
+                if not load_task.done():
+                    await asyncio.wait({load_task}, timeout=_STATS_LOAD_SHUTDOWN_WAIT_S)
+            except Exception as err:
+                _LOGGER.debug("Could not wait for the stats load on unload: %s", err)
 
         stats_save_task = getattr(self, "_stats_save_task", None)
         if stats_save_task and not stats_save_task.done():
@@ -1928,7 +1935,7 @@ class GoogleFindMyCoordinator(
                 # the sound-UUID load below.
                 try:
                     self.hass.async_create_task(self._async_save_stats())
-                except Exception as err:  # pragma: no cover - loop teardown only
+                except Exception as err:
                     _LOGGER.debug(
                         "Deferred stats write could not be scheduled: %s", err
                     )

--- a/custom_components/googlefindmy/coordinator/main.py
+++ b/custom_components/googlefindmy/coordinator/main.py
@@ -252,6 +252,11 @@ _ALTITUDE_SIGNIFICANT_DELTA_M = 1.0
 # Predictive polling buffer to avoid requesting data before it is available server-side.
 _PREDICTION_BUFFER_S = 45
 
+# How long an unload waits for the startup stats load before flushing anyway. The load
+# reads two keys from an in-memory cache, so the ordinary case is sub-millisecond; the
+# bound exists so a cache that cannot answer delays the unload instead of hanging it.
+_STATS_LOAD_SHUTDOWN_WAIT_S = 5.0
+
 # Fields consumed by get_active_device_identities from cached payloads/anchors.
 _PERSISTED_METADATA_KEYS: tuple[str, ...] = (
     "battery_level",
@@ -935,8 +940,11 @@ class GoogleFindMyCoordinator(
         # persist live state that is still missing everything the load carries.
         self._save_after_stats_load: bool = False
 
-        # Load persistent statistics asynchronously (name the task for better debugging)
-        self.hass.async_create_task(
+        # Load persistent statistics asynchronously (name the task for better debugging).
+        # The handle is kept because `async_shutdown` waits for it: its flush writes the
+        # whole record from live state, which inside this window is missing everything
+        # the load has not merged yet.
+        self._stats_load_task: asyncio.Task[None] | None = self.hass.async_create_task(
             self._async_load_stats(), name=f"{DOMAIN}.load_stats"
         )
 
@@ -1201,18 +1209,40 @@ class GoogleFindMyCoordinator(
         # persisted record, and a device re-added under the same id would have its first
         # matching measurement suppressed by a claim from its previous life.
         #
-        # The write is therefore UNCONDITIONAL. Gating it on a pending debounced task was
-        # the first attempt and it missed exactly the case that matters most: the purge
-        # writes through a task this attribute never holds, so when only that one is in
-        # flight there is nothing here to find and the whole block was skipped. A
-        # condition that cannot see the more important of the two writers is not a
-        # condition, and the cost of dropping it is one write per unload.
+        # The write is therefore unconditional IN THAT RESPECT: it does not ask whether a
+        # debounced task is pending. Gating it on one was the first attempt and it missed
+        # exactly the case that matters most: the purge writes through a task this
+        # attribute never holds, so when only that one is in flight there is nothing here
+        # to find and the whole block was skipped. A condition that cannot see the more
+        # important of the two writers is not a condition, and the cost of dropping it is
+        # one write per unload.
+        #
+        # One condition does apply, and it lives in the writer rather than here: while the
+        # stats load is still in flight, `_async_save_stats` defers instead of writing,
+        # because inside that window live state is missing everything the load has not
+        # merged yet and a write would replace the stored record with it. That is a
+        # different axis from the one this comment is about.
         #
         # The pending task is still cancelled first, so its coroutine stops waiting out
         # its sleep. `_debounced_save_stats` swallows the cancellation and returns, so
         # the await settles it; if it was already past the sleep and inside the write,
         # the repeated write is the same record and costs nothing. Failures are swallowed
         # like the other shutdown steps: an unload must not raise.
+        # Let the startup load finish first, so the flush below is outside its window and
+        # writes the merged record rather than deferring. Waiting is what makes the write
+        # possible at all here: the entry-scoped cache is closed immediately after this
+        # method returns, so a write deferred to the load's `finally` would reach a closed
+        # store and be swallowed. Waited WITHOUT cancelling and with a bound, so a load
+        # that cannot finish delays the unload by seconds rather than hanging it; if the
+        # bound is hit the window is still open, the flush defers, and the record stays as
+        # it was on disk.
+        load_task = getattr(self, "_stats_load_task", None)
+        if load_task is not None and not load_task.done():
+            try:
+                await asyncio.wait({load_task}, timeout=_STATS_LOAD_SHUTDOWN_WAIT_S)
+            except Exception:
+                pass
+
         stats_save_task = getattr(self, "_stats_save_task", None)
         if stats_save_task and not stats_save_task.done():
             stats_save_task.cancel()
@@ -1891,8 +1921,19 @@ class GoogleFindMyCoordinator(
                 # than debounced, for the reason the purge path states: a reload or
                 # shutdown inside the debounce window cancels a pending write without
                 # flushing it.
-                self._save_after_stats_load = False
-                self.hass.async_create_task(self._async_save_stats())
+                # Cleared only once the task exists, so the flag is never cleared for
+                # a write that did not get scheduled. Nothing reads it again after this
+                # line - this is its only reader - so a stuck True has no effect; the
+                # point is that the exception does not escape this ``finally`` and abort
+                # the sound-UUID load below.
+                try:
+                    self.hass.async_create_task(self._async_save_stats())
+                except Exception as err:  # pragma: no cover - loop teardown only
+                    _LOGGER.debug(
+                        "Deferred stats write could not be scheduled: %s", err
+                    )
+                else:
+                    self._save_after_stats_load = False
 
         try:
             sound_request_uuids = await self._cache.async_get_cached_value(
@@ -2029,10 +2070,41 @@ class GoogleFindMyCoordinator(
         The claims travel under a reserved sub-key. The loader only copies keys it
         already knows into ``self.stats``, so the extra entry cannot become a phantom
         counter, and the name is asserted not to collide with a real one.
+
+        Nothing is written while the stats load is still in flight. This method
+        serialises the WHOLE record from live state, and inside that window live state
+        is missing everything the load has not merged yet - so a write there does not
+        add to the stored record, it REPLACES the persisted totals and every claim ring
+        with pre-load values, and the load then reads back what the write left. The
+        guard belongs here rather than at the call sites: of the four callers, one is
+        the load's own ``finally`` (by construction outside the window), one is
+        ``purge_device``, which had to learn the rule for itself, and two - the debounced
+        writer and the flush in ``async_shutdown`` - used to reach the window with
+        nothing to stop them. A rule that only one of its callers knows is not a rule.
+
+        The write is deferred, not dropped: the load's ``finally`` performs it once live
+        state carries the merged record, and that ``finally`` runs on the success path,
+        on the read-failure path and on the epoch-discard path alike.
+
+        Deferral only works while there is still somewhere to write. On an unload there
+        is not: the entry-scoped cache is closed right after ``async_shutdown`` returns,
+        and a write reaching it afterwards raises and is swallowed below. That is why
+        ``async_shutdown`` WAITS for the load task before it flushes, rather than relying
+        on the deferral - the wait closes the window, and the flush then writes the merged
+        record for real. Deferring is the answer for writers that have a future; for the
+        one that does not, the window is closed instead.
+
+        ``_stats_loaded`` defaults to True when absent, so a coordinator built without it
+        writes as before; defaulting to False would silence every such writer instead,
+        which is the mistake this direction is easy to make.
         """
         assert TALLY_CLAIMS_KEY not in self.stats, (
             f"{TALLY_CLAIMS_KEY} collides with a real counter"
         )
+        if not getattr(self, "_stats_loaded", True):
+            self._save_after_stats_load = True
+            _LOGGER.debug("Deferred a stats write issued inside the load window")
+            return
         claims = getattr(self, "_last_tallied_report_id", None) or {}
         record: dict[str, Any] = self.stats.copy()
         record[TALLY_CLAIMS_KEY] = {

--- a/tests/test_cache_accuracy_gate.py
+++ b/tests/test_cache_accuracy_gate.py
@@ -36,7 +36,7 @@ import asyncio
 import json
 import time
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -46,6 +46,7 @@ from custom_components.googlefindmy.const import (
     OPT_ACCURACY_GATE_ENABLED,
     OPT_STALE_THRESHOLD,
 )
+from custom_components.googlefindmy.coordinator import main as main_module
 from custom_components.googlefindmy.coordinator.cache import (
     MAX_ACCEPTED_LOCATION_FUTURE_DRIFT_S,
     CacheOperations,
@@ -2567,9 +2568,10 @@ async def test_shutdown_writes_even_when_no_debounced_task_is_pending() -> None:
     `purge_device` writes through a task of its own, which `_stats_save_task` never
     carries. Gating the shutdown flush on a pending debounced task therefore skipped
     exactly the case the flush exists for: only the purge write in flight, nothing in the
-    slot, the whole block passed over. The flush is unconditional for that reason, and
-    this is the case that says so - the sibling test above keeps passing under the
-    conditional version.
+    slot, the whole block passed over. The flush asks nothing about that slot for this
+    reason, and this is the case that says so - the sibling test above keeps passing
+    under the gated version. (It does ask about the load window, on a different axis:
+    see `::test_an_unload_inside_the_load_window_writes_the_merged_record`.)
     """
     from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
 
@@ -3384,3 +3386,311 @@ async def test_the_load_itself_opens_and_closes_the_purge_window() -> None:
     # The deferred correction runs here, where live state carries the merged record.
     assert coord.scheduled_saves, "the deferred write must fire after the merge"
     assert not coord._save_after_stats_load, "and must not fire a second time"
+
+
+# ---------------------------------------------------------------------------
+# The writer's own knowledge of the load window.
+#
+# ``purge_device`` learned this rule for itself, and for a while it was the only
+# caller that knew it. Of the four callers of ``_async_save_stats``, two reach the
+# window with nothing to stop them: the debounced writer behind ``increment_stat``
+# and the flush in ``async_shutdown``. Inside the window the writer
+# serialises live state, which is missing everything the load has not merged yet, so
+# such a write does not add to the stored record - it replaces the persisted totals
+# and every claim ring with pre-load values, and the load then reads back what the
+# write left. Measured before the fix: a stored ``background_updates`` of 10 came back
+# as 0 with an empty claim map.
+# ---------------------------------------------------------------------------
+
+
+def _windowed_writer(stored: dict[str, Any]) -> Any:
+    """A coordinator with the load still in flight and a cache holding a record."""
+    from types import SimpleNamespace
+
+    from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+
+    coord = GoogleFindMyCoordinator.__new__(GoogleFindMyCoordinator)
+    coord._device_location_data = {}
+    coord._device_coarse_fix = {}
+    coord.stats = {"background_updates": 0, "accuracy_bucket_coarse": 0}
+    coord._stats_epoch = 0
+    coord._stats_loaded = False
+    coord._purged_before_stats_load = set()
+    coord._save_after_stats_load = False
+
+    class _Cache:
+        def __init__(self) -> None:
+            self.store: dict[str, Any] = {"integration_stats": stored}
+
+        async def async_set_cached_value(self, key: str, value: Any) -> None:
+            self.store[key] = json.loads(json.dumps(value))
+
+        async def async_get_cached_value(self, key: str) -> Any:
+            return self.store.get(key)
+
+    coord._cache = _Cache()
+    coord.pending_tasks: list[Any] = []
+    coord.hass = SimpleNamespace(
+        async_create_task=lambda coro, **_k: coord.pending_tasks.append(coro)
+    )
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_a_write_inside_the_load_window_leaves_the_stored_record_alone() -> None:
+    """The stored totals and rings survive a writer that fires too early."""
+    stored = {
+        "background_updates": 10,
+        "accuracy_bucket_coarse": 4,
+        "_tally_claims": {"dev-a": [["fix", "abcdef0123456789"]]},
+    }
+    coord = _windowed_writer(dict(stored))
+
+    await coord._async_save_stats()
+
+    assert coord._cache.store["integration_stats"] == stored, (
+        "the write replaced the persisted record with pre-load live state; the load "
+        "would then read back its own erasure"
+    )
+    assert coord._save_after_stats_load is True, (
+        "the write must be deferred, not dropped - the increments it carries still "
+        "have to reach the store once the merge has happened"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_deferred_write_reaches_the_store_after_the_merge() -> None:
+    """Deferring is only correct if the load actually performs the write."""
+    coord = _windowed_writer(
+        {
+            "background_updates": 10,
+            "accuracy_bucket_coarse": 0,
+            "_tally_claims": {"dev-a": [["fix", "abcdef0123456789"]]},
+        }
+    )
+    coord.stats["background_updates"] = 3  # counted while the load was in flight
+
+    await coord._async_save_stats()
+    await coord._async_load_stats()
+    for coro in coord.pending_tasks:
+        await coro
+
+    record = coord._cache.store["integration_stats"]
+    assert record["background_updates"] == 13, (
+        "the stored total and the increments counted during the window are ADDED; "
+        "either one alone means a lost measurement"
+    )
+    assert "dev-a" in record["_tally_claims"], "and the stored ring must survive"
+
+
+@pytest.mark.asyncio
+async def test_a_write_after_the_load_still_writes() -> None:
+    """The counter-test: the guard must not swallow the ordinary path.
+
+    Without it the whole feature could be satisfied by never writing at all, and the
+    same mistake in the other direction - reading the flag with a default of False -
+    would silence every writer whose coordinator does not set the attribute.
+    """
+    coord = _windowed_writer({"background_updates": 10, "_tally_claims": {}})
+    coord._stats_loaded = True
+    coord.stats["background_updates"] = 7
+
+    await coord._async_save_stats()
+
+    assert coord._cache.store["integration_stats"]["background_updates"] == 7
+    assert coord._save_after_stats_load is False
+
+
+@pytest.mark.asyncio
+async def test_a_coordinator_without_the_load_marker_writes_as_before() -> None:
+    """Absent means loaded. Tests and older objects build without the attribute."""
+    coord = _windowed_writer({"background_updates": 10, "_tally_claims": {}})
+    del coord._stats_loaded
+    coord.stats["background_updates"] = 7
+
+    await coord._async_save_stats()
+
+    assert coord._cache.store["integration_stats"]["background_updates"] == 7
+
+
+@pytest.mark.asyncio
+def _shutdownable(coord: Any) -> Any:
+    """Everything ``async_shutdown`` touches on the way to the stats flush."""
+    coord._cancel_pending_subentry_repair = lambda: None  # type: ignore[method-assign]
+    coord._dr_unsub = None
+    coord._short_retry_cancel = None
+    coord._stats_save_task = None
+    coord._eid_refresh_debounce_handle = None
+    coord._eid_inline_refresh_debounce_handle = None
+
+    async def _unload() -> None:
+        return None
+
+    coord._async_unload = _unload  # type: ignore[method-assign]
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_an_unload_inside_the_load_window_writes_the_merged_record() -> None:
+    """The unload is the one caller that cannot defer, so it closes the window instead.
+
+    Deferring needs somewhere to write later, and after ``async_shutdown`` returns the
+    entry-scoped cache is closed; a write arriving then raises and is swallowed. So the
+    flush waits for the load task first and only then writes - by which time live state
+    carries the merged record. The two shutdown tests above stub ``_async_save_stats``
+    out entirely, so neither can see any of this; this one drives the unload end to end
+    against the real writer and reads what the cache holds.
+    """
+    stored = {
+        "background_updates": 10,
+        "accuracy_bucket_coarse": 4,
+        "_tally_claims": {"dev-a": [["fix", "abcdef0123456789"]]},
+    }
+    coord = _shutdownable(_windowed_writer(dict(stored)))
+    coord.stats["background_updates"] = 3  # counted before the load resumed
+    coord._stats_load_task = asyncio.create_task(coord._async_load_stats())
+
+    await coord.async_shutdown()
+    for coro in coord.pending_tasks:  # the load's own deferred write, if any
+        await coro
+
+    record = coord._cache.store["integration_stats"]
+    assert record["background_updates"] == 13, (
+        "the flush wrote pre-load live state over the persisted record instead of "
+        "waiting for the merge"
+    )
+    assert record["_tally_claims"] == stored["_tally_claims"], (
+        "and every stored ring must come through the unload"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unload_whose_load_never_finishes_leaves_the_record_alone() -> None:
+    """The bound must not turn into a write of pre-load state.
+
+    Waiting is bounded so a cache that cannot answer delays the unload rather than
+    hanging it. When that bound is hit the window is still open, so the flush has to
+    defer like any other writer and leave the stored record exactly as it was - the safe
+    direction. Without the guard this is the case that silently erases it.
+    """
+    stored = {"background_updates": 10, "_tally_claims": {"dev-a": [["fix", "ab"]]}}
+    coord = _shutdownable(_windowed_writer(dict(stored)))
+    inner = coord._cache.async_get_cached_value
+
+    async def _never(key: str) -> Any:
+        if key == "integration_stats":
+            await asyncio.sleep(3600)
+        return await inner(key)
+
+    coord._cache.async_get_cached_value = _never  # type: ignore[method-assign]
+    coord._stats_load_task = asyncio.create_task(coord._async_load_stats())
+
+    with patch.object(main_module, "_STATS_LOAD_SHUTDOWN_WAIT_S", 0.01):
+        await coord.async_shutdown()
+
+    assert coord._cache.store["integration_stats"] == stored, (
+        "the bound expired and the flush wrote pre-load live state anyway"
+    )
+    # Read before the teardown below: cancelling the load runs its ``finally``, which
+    # consumes this very flag to schedule the deferred write.
+    assert coord._save_after_stats_load is True
+
+    coord._stats_load_task.cancel()
+    # Awaited, not just cancelled: the cancellation reaches the load's ``finally`` only
+    # on the next pass, and that ``finally`` schedules the deferred write into the
+    # double's list. Close what nobody will run, so the loop stays quiet.
+    await asyncio.gather(coord._stats_load_task, return_exceptions=True)
+    for coro in coord.pending_tasks:
+        coro.close()
+
+
+@pytest.mark.asyncio
+async def test_a_reset_inside_the_load_window_stays_durable() -> None:
+    """Deferral must not hand the discarded generation back at the next start.
+
+    The epoch makes the loader DROP the stored record, so after a reset inside the
+    window nothing restores the old counters - but something still has to WRITE the new,
+    zeroed ones, or the store keeps the generation the user discarded. Before the guard
+    the debounced write did that by accident, clobbering the store on its way past. Now
+    it is the deferral that carries it, and this pins the whole chain: reset, deferred
+    write, epoch-discarding load, write.
+    """
+    coord = _windowed_writer(
+        {
+            "background_updates": 10,
+            "accuracy_bucket_coarse": 4,
+            "_tally_claims": {"dev-a": [["fix", "abcdef0123456789"]]},
+        }
+    )
+    coord.stats["background_updates"] = 3
+    coord._last_tallied_report_id = {"dev-a": [("ts", 1.0)]}
+
+    # The button is pressed while the load is suspended in its read, which is the only
+    # arrangement in which the epoch does any work: the loader samples it BEFORE that
+    # await, so a reset that precedes the loader is invisible to it - the sample would
+    # already carry the new value, the comparison would match, and the discarded
+    # generation would be merged back in. That arrangement fails against every
+    # implementation and would therefore pin nothing.
+    inner = coord._cache.async_get_cached_value
+    pressed: list[bool] = []
+
+    async def _get(key: str) -> Any:
+        if key == "integration_stats":
+            # Recorded rather than asserted: this runs inside the loader's ``try``,
+            # whose ``except Exception`` would swallow an AssertionError and turn a
+            # broken precondition into a confusing counter mismatch further down.
+            pressed.append(coord.begin_new_stats_epoch())
+            await coord._async_save_stats()  # the persist the button schedules
+        return await inner(key)
+
+    coord._cache.async_get_cached_value = _get  # type: ignore[method-assign]
+
+    await coord._async_load_stats()
+    for coro in coord.pending_tasks:
+        await coro
+
+    assert pressed == [True], "the reset must have run inside the loader's await"
+    record = coord._cache.store["integration_stats"]
+    assert record["background_updates"] == 0, (
+        "the discarded generation came back: the load must drop the stored record on "
+        "the epoch AND the deferred write must persist the zeroed one"
+    )
+    assert record["_tally_claims"] == {}, "the cleared claims must be durable too"
+
+
+@pytest.mark.asyncio
+async def test_the_constructor_hands_the_load_task_to_the_unload() -> None:
+    """The wait in ``async_shutdown`` is only as good as the handle it reads.
+
+    Every test above installs ``_stats_load_task`` by hand, so all of them stay green
+    if the constructor stops storing it - and the wait would then be a no-op in
+    production while the suite reported the feature as covered. This one drives the real
+    constructor and asks what it left behind.
+    """
+    from custom_components.googlefindmy.coordinator import GoogleFindMyCoordinator
+
+    class _Cache:
+        async def async_get_cached_value(self, _key: str) -> None:
+            return None
+
+        async def async_set_cached_value(self, _key: str, _value: Any) -> None:
+            return None
+
+    class _Hass:
+        def __init__(self) -> None:
+            self.loop = asyncio.get_running_loop()
+            self.data: dict[str, Any] = {}
+
+        def async_create_task(self, coro: Any, *, name: str | None = None) -> Any:
+            return self.loop.create_task(coro, name=name)
+
+    coord = GoogleFindMyCoordinator(_Hass(), cache=_Cache())
+
+    task = getattr(coord, "_stats_load_task", None)
+    assert task is not None, (
+        "the constructor did not keep the load task, so the unload has nothing to wait "
+        "for and flushes inside the window"
+    )
+    assert task.get_coro().__qualname__.endswith("_async_load_stats")
+
+    await asyncio.gather(task, return_exceptions=True)

--- a/tests/test_cache_accuracy_gate.py
+++ b/tests/test_cache_accuracy_gate.py
@@ -3694,3 +3694,48 @@ async def test_the_constructor_hands_the_load_task_to_the_unload() -> None:
     assert task.get_coro().__qualname__.endswith("_async_load_stats")
 
     await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_a_load_that_cannot_schedule_its_deferred_write_still_finishes() -> None:
+    """The teardown branch, tested rather than excluded from coverage.
+
+    Scheduling the deferred write fails when the loop is going away. That must not
+    escape the load's ``finally`` - the sound-UUID load runs after it - and must not
+    clear the flag for a write that was never scheduled.
+    """
+    coord = _windowed_writer({"background_updates": 10, "_tally_claims": {}})
+    coord._save_after_stats_load = True
+
+    def _refuse(coro: Any, **_k: Any) -> Any:
+        coro.close()
+        raise RuntimeError("event loop is closed")
+
+    coord.hass.async_create_task = _refuse
+
+    await coord._async_load_stats()  # must not raise
+
+    assert coord._stats_loaded is True, "the window must still close"
+    assert coord._save_after_stats_load is True, (
+        "the flag was cleared for a write that never got scheduled"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_load_handle_does_not_break_the_unload() -> None:
+    """An unload must not raise, and waiting is not worth breaking that rule for.
+
+    ``_stats_load_task`` is read with ``getattr`` and can be anything a test double or
+    an older object left there; ``asyncio.wait`` rejects a non-awaitable with a
+    ``TypeError``. The wait is an optimisation of WHEN the flush writes, never a reason
+    for the unload to fail, so the failure falls through to the flush - which then
+    defers, because the window is still open.
+    """
+    stored = {"background_updates": 10, "_tally_claims": {}}
+    coord = _shutdownable(_windowed_writer(dict(stored)))
+    coord._stats_load_task = object()  # not awaitable
+
+    await coord.async_shutdown()  # must not raise
+
+    assert coord._cache.store["integration_stats"] == stored
+    assert coord._save_after_stats_load is True


### PR DESCRIPTION
## Why

`_async_save_stats` serialises the **whole** stats record from live state. While the
startup load is still in flight, live state is missing everything the load has not merged
yet, so a write in that window does not add to the stored record — it **replaces** the
persisted totals and every tally-claim ring with pre-load values, and the load then reads
back its own erasure.

`custom_components/googlefindmy/AGENTS.md` already said exactly this, but it assigned the
rule to `purge_device`. Of the writer's four callers only that one knew it:

| caller | in the window? | protected before |
|---|---|---|
| the load's own `finally` | no, by construction | n/a |
| `purge_device` | yes | yes (defers) |
| the debounced writer (`increment_stat`, `_refresh_canonicless_drop_stats`, reset button) | yes | **no** |
| the flush in `async_shutdown` | yes | **no** |

Measured on `1.7` before the fix: a stored `background_updates` of 10 with one claim ring
came back as `0` with an empty claim map after a single early write.

## What changed

**The guard moved into the writer.** While `_stats_loaded` is False, `_async_save_stats`
records `_save_after_stats_load` and returns; the load's `finally` performs the write once
live state carries the merged record. `_stats_loaded` is read with a default of `True`, so
an object built without it writes as before.

**The unload closes the window instead of deferring.** Deferral needs somewhere to write
later, and the unload is the one caller that has none: `async_unload_entry` closes the
entry-scoped cache immediately after `async_shutdown` returns, and a write arriving then
raises and is swallowed. So the constructor keeps the load task on `_stats_load_task` and
`async_shutdown` waits for it — without cancelling, bounded by
`_STATS_LOAD_SHUTDOWN_WAIT_S` — before flushing. If the bound expires, the flush defers
like any other writer and the stored record stays as it was, which is the safe direction.

## Tests

Ten new cases in `tests/test_cache_accuracy_gate.py`, all mutation-checked:

* the two directions of the guard, plus two counter-cases so it cannot swallow the
  ordinary path or the default;
* the unload arm end to end through the real `async_shutdown` and the real writer (the two
  existing shutdown tests stub the writer out and are structurally blind to this);
* the bound-expired case;
* the reset-inside-the-window chain (reset fires inside the loader's await, so the epoch
  is actually exercised);
* that the constructor stores the load task at all — without this one, removing that
  assignment leaves the whole suite green while the wait becomes a no-op in production;
* the two teardown branches (`asyncio.wait` on a handle that is not a task, and a
  scheduling failure in the load's `finally`), added after Codex and Codecov both pointed
  at them; writing the first found a real defect, since the probe `not load_task.done()`
  sat outside the `try` that keeps the unload from raising.

`_MixinBase` also gained the five stats-persistence attributes the scoped typing contract
requires. Four of them were already missing; they are one fact split across five
attributes, so declaring only the new one would have been the smaller of two
inconsistencies rather than a fix. Worth recording: **51 of the 100** attributes assigned
in `GoogleFindMyCoordinator.__init__` are still unmirrored after this, and nothing
measures that — a separate change, better done together with a guard.

## Follow-up from #1271

This is the neighbouring case named in
https://github.com/jleinenbach/GoogleFindMy-HA/pull/1271 and left for a follow-up.
